### PR TITLE
Update the github URL to reflect move to Informal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
  * Using `z3` version `4.8.7`
 
  * A 2-8x speedup for 5 out 16
-   [benchmarks](https://github.com/konnov/apalache-tests),
+   [benchmarks](https://github.com/informalsystems/apalache-tests),
    due to the optimizations and maybe switching to z3 4.8.x.
  
  * Distributing the releases with docker as `apalache/mc`
@@ -120,13 +120,13 @@
 
  * speed up by using constants instead of uninterpreted functions
 
- * options for fine tuning with `--fine-tuning`, see [tuning](https://github.com/konnov/apalache/blob/unstable/docs/tuning.md)
+ * options for fine tuning with `--fine-tuning`, see [tuning](https://github.com/informalsystems/apalache/blob/unstable/docs/tuning.md)
 
  * bugfix in logback configuration
 
 ## 0.4.0-pre1
 
- * type annotations and very simple type inference, see the [notes](https://github.com/konnov/apalache/blob/unstable/docs/types-and-annotations.md)
+ * type annotations and very simple type inference, see the [notes](https://github.com/informalsystems/apalache/blob/unstable/docs/types-and-annotations.md)
 
  * a dramatic speed up of many operators by using a `QF_NIA` theory and cherry pick
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Apalache runs under the same assumptions as TLC.
 
 ## Releases
 
-Check the [releases page](https://github.com/konnov/apalache/releases).
+Check the [releases page](https://github.com/informalsystems/apalache/releases).
 
 We recommend you to run the latest docker image `apalache/mc:latest` and
 checkout the source code from
-[master](https://github.com/konnov/apalache/tree/master), which accumulate
+[master](https://github.com/informalsystems/apalache/tree/master), which accumulate
 bugfixes over the latest release, see the [manual](docs/manual.md#useDocker).
 To try the latest cool features, check the [unstable
-branch](https://github.com/konnov/apalache/tree/unstable).
+branch](https://github.com/informalsystems/apalache/tree/unstable).
 
 ## Getting started
 
@@ -27,11 +27,11 @@ Read the [user manual](docs/manual.md).
 
 ## Performance
 
-We are collecting [apalache benchmarks](https://github.com/konnov/apalache-tests).
+We are collecting [apalache benchmarks](https://github.com/informalsystems/apalache-tests).
 See the Apalache performance when
-[checking inductive invariants](https://github.com/konnov/apalache-tests/blob/master/results/001indinv-report.md)
+[checking inductive invariants](https://github.com/informalsystems/apalache-tests/blob/master/results/001indinv-report.md)
 and running
-[bounded model checking](https://github.com/konnov/apalache-tests/blob/master/results/002bmc-report.md). Version 0.6.0 is a major improvement over version 0.5.2
+[bounded model checking](https://github.com/informalsystems/apalache-tests/blob/master/results/002bmc-report.md). Version 0.6.0 is a major improvement over version 0.5.2
 (the version [reported at OOPSLA19](https://dl.acm.org/doi/10.1145/3360549)).
 
 ## Academic papers

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -45,8 +45,8 @@ We recommend to start with TLC. It is mature, well-documented, and well-integrat
 
 # 2. System requirements
 
-Every commit to [master](https://github.com/konnov/apalache) and
-[unstable](https://github.com/konnov/apalache/tree/unstable) is built with
+Every commit to [master](https://github.com/informalsystems/apalache) and
+[unstable](https://github.com/informalsystems/apalache/tree/unstable) is built with
 [Travis CI](https://travis-ci.org/konnov/apalache) on MacOS (xcode9.3 and JDK
 1.8.0) and Linux (OpenJDK8). If you like to run Apalache in Windows, use a
 docker image. Check the [Docker
@@ -118,9 +118,9 @@ $ alias apalache="docker run --rm -v $(pwd):/var/apalache apalache/mc"
 The development of Apalache proceeds at a high pace, and we introduce a
 substantial number of improvements in the unstable branch before the next
 stable release biweekly.  Please refer to [Unstable
-Changes](https://github.com/konnov/apalache/blob/unstable/CHANGES.md) and
+Changes](https://github.com/informalsystems/apalache/blob/unstable/CHANGES.md) and
 [Unstable
-Manual](https://github.com/konnov/apalache/blob/unstable/docs/manual.md) for
+Manual](https://github.com/informalsystems/apalache/blob/unstable/docs/manual.md) for
 the description of new features.  **We recommend using the unstable version if
 you want to try all the exciting new features of Apalache. But be warned: It is
 called "unstable" for a reason**. To use `unstable`, just type
@@ -159,7 +159,7 @@ $ docker image build -t apalache:0.7.0 .
 ## 3.2.  Building from sources
 
 1. Install `git`.
-2. Clone the git repository: `git clone https://github.com/konnov/apalache.git`
+2. Clone the git repository: `git clone https://github.com/informalsystems/apalache.git`
 3. Install OpenJDK8 or
 [Zulu JDK8](https://www.azul.com/downloads/zulu-community/?&architecture=x86-64-bit&package=jdk).
 **You have to install version 8, otherwise Scala will not compile! See
@@ -503,7 +503,7 @@ In this case, Apalache performs the following steps:
 
 1. It parses the specification with [SANY](https://lamport.azurewebsites.net/tla/tools.html).
 
-1. It translates SANY semantic nodes into [Apalache IR](https://github.com/konnov/apalache/blob/master/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala).
+1. It translates SANY semantic nodes into [Apalache IR](https://github.com/informalsystems/apalache/blob/master/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala).
 
 1. It pretty-prints the IR into `out-parser.tla`, see [Section 6.3](#detailed).
 
@@ -579,7 +579,7 @@ Apalache reports an error as follows:
 ...
 PASS #6: TransitionFinderPass                                     I@09:39:33.527
 To understand the error, check the manual:
-[https://github.com/konnov/apalache/blob/unstable/docs/manual.md#assignments]
+[https://github.com/informalsystems/apalache/blob/unstable/docs/manual.md#assignments]
 Assignment error: Failed to find assignments and symbolic transitions in InitPrimed E@09:39:33.676
 It took me 0 days  0 hours  0 min  1 sec                          I@09:39:33.678
 Total time: 1.88 sec                                              I@09:39:33.678
@@ -589,7 +589,7 @@ EXITCODE: ERROR (99)
 This error is cryptic. It does not indicate which parts of the specification
 have caused the problem. In the future, we will add better diagnostic in the
 assignment finder, see [the open
-issue](https://github.com/konnov/apalache/issues/111). Our current approach is
+issue](https://github.com/informalsystems/apalache/issues/111). Our current approach is
 to debug assignments by running TLC first. If running TLC takes too long, you
 may try to comment out parts of the specification to find the problematic
 action. Although this is tedious, it allows one to find missing assignments
@@ -996,18 +996,18 @@ Inv ==
 ```
 
 Check other examples in
-[`test/tla`](https://github.com/konnov/apalache/tree/unstable/test/tla) that
+[`test/tla`](https://github.com/informalsystems/apalache/tree/unstable/test/tla) that
 start with the prefix `Rec`.
 
 **Why you should avoid recursive functions.** Sometimes, recursive functions
 concisely describe the function that you need. The nice examples are the
 factorial function (see above) and Fibonacci numbers (see
-[Rec3](https://github.com/konnov/apalache/tree/unstable/test/tla/Rec3.tla)).
+[Rec3](https://github.com/informalsystems/apalache/tree/unstable/test/tla/Rec3.tla)).
 However, when you define a recursive function over sets, the complexity gets
 ugly really fast.
 
 Consider the example
-[Rec9](https://github.com/konnov/apalache/tree/unstable/test/tla/Rec9.tla),
+[Rec9](https://github.com/informalsystems/apalache/tree/unstable/test/tla/Rec9.tla),
 which computes set cardinality. Here is a fragment of the spec:
 
 ```tla

--- a/mod-distribution/pom.xml
+++ b/mod-distribution/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <name>apalache-pkg</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <dependencies>
         <dependency>

--- a/mod-infra/pom.xml
+++ b/mod-infra/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>infra</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <dependencies>
         <dependency>

--- a/mod-tool/pom.xml
+++ b/mod-tool/pom.xml
@@ -15,7 +15,7 @@
     <packaging>jar</packaging>
 
     <name>tool</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <build>
         <plugins>

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
   * @author Igor Konnov
   */
 object Tool extends App with LazyLogging {
-  lazy val ISSUES_LINK: String = "[https://github.com/konnov/apalache/issues]"
+  lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
   lazy val ERROR_EXIT_CODE = 99
   lazy val OK_EXIT_CODE = 0
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>0.7.0-SNAPSHOT</version>
 
     <name>APALACHE project</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
 
     <name>tla-assignments</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <dependencies>
         <dependency>

--- a/tla-bmcmt/pom.xml
+++ b/tla-bmcmt/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>tla-bmcmt</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
     
     <dependencies>
         <dependency>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class CheckerExceptionAdapter @Inject()(sourceStore: SourceStore,
                                         changeListener: ChangeListener) extends ExceptionAdapter with LazyLogging {
-  private lazy val ISSUES_LINK: String = "[https://github.com/konnov/apalache/issues]"
+  private lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
 
   override def toMessage: PartialFunction[Exception, ErrorMessage] = {
     // normal errors
@@ -32,7 +32,7 @@ class CheckerExceptionAdapter @Inject()(sourceStore: SourceStore,
 
     case err: AssignmentException =>
       logger.info("To understand the error, read the manual:")
-      logger.info("  [https://github.com/konnov/apalache/blob/unstable/docs/manual.md#assignments]")
+      logger.info("  [https://github.com/informalsystems/apalache/blob/unstable/docs/manual.md#assignments]")
       NormalErrorMessage("Assignment error: " + err.getMessage)
 
     case err: TypeInferenceError =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/package.scala
@@ -25,7 +25,7 @@ package object bmcmt {
     * A theory used to evaluate a TLA+ expression: cells, Booleans, and integers.
     *
     * This concept is obsolete and will be removed in the future.
-    * See the <a href="https://github.com/konnov/apalache/issues/22">issue</a>.
+    * See the <a href="https://github.com/informalsystems/apalache/issues/22">issue</a>.
     */
   sealed abstract class Theory {
     /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
@@ -70,7 +70,7 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
   }
 
   // This translation is sound only in the happy scenario, that is, when CHOOSE is defined on its argument.
-  // It should be used only after resolving the issue #95: https://github.com/konnov/apalache/issues/95
+  // It should be used only after resolving the issue #95: https://github.com/informalsystems/apalache/issues/95
   private def happyChoose(state: SymbState, varName: String, set: TlaEx, pred: TlaEx): SymbState = {
     // rewrite the bounding set
     val nextState = rewriter.rewriteUntilDone(state.setTheory(CellTheory()).setRex(set))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRule.scala
@@ -48,7 +48,7 @@ class SetInRule(rewriter: SymbStateRewriter) extends RewritingRule {
         rewriter.coerce(rewriter.rewriteUntilDone(finalState), state.theory)
 
       case OperEx(TlaSetOper.in, elem, set) =>
-        // TODO: remove theories, see https://github.com/konnov/apalache/issues/22
+        // TODO: remove theories, see https://github.com/informalsystems/apalache/issues/22
         // switch to cell theory
         val elemState = rewriter.rewriteUntilDone(state.setTheory(CellTheory()).setRex(elem))
         val elemCell = elemState.asCell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/eager/TrivialTypeFinder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/eager/TrivialTypeFinder.scala
@@ -707,7 +707,7 @@ class TrivialTypeFinder extends TypeFinder[CellT] with TransformationListener {
     case ex @ OperEx(TlaFunOper.recFunRef) =>
       // no annotation met, produce an error
       error(ex,"Reference to a recursive function needs type annotation, see:" +
-      " https://github.com/konnov/apalache/blob/unstable/docs/manual.md#ref-fun")
+      " https://github.com/informalsystems/apalache/blob/unstable/docs/manual.md#ref-fun")
 
     case ex@OperEx(op@TlaFunOper.except, e, bindings@_*) =>
       val funType = argTypes.head

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>tla-import</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <dependencies>
         <dependency>

--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>tla-pp</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <dependencies>
         <dependency>

--- a/tla-types/pom.xml
+++ b/tla-types/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
 
     <name>tla-types</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
     <dependencies>
         <dependency>

--- a/tlair/pom.xml
+++ b/tlair/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>tlair</name>
-    <url>https://github.com/konnov/apalache</url>
+    <url>https://github.com/informalsystems/apalache</url>
 
 
     <dependencies>

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/CounterexampleWriter.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/CounterexampleWriter.scala
@@ -93,7 +93,7 @@ class TlaCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
 
     writer.println("\n\n%s".format("=" * 80))
     writer.println("\\* Created by Apalache on %s".format(Calendar.getInstance().getTime))
-    writer.println("\\* https://github.com/konnov/apalache")
+    writer.println("\\* https://github.com/informalsystems/apalache")
     writer.close()
   }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestCounterexampleWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestCounterexampleWriter.scala
@@ -42,7 +42,7 @@ class TestCounterexampleWriter extends FunSuite {
         |
         |================================================================================
         |\* Created by Apalache on DATETIME
-        |\* https://github.com/konnov/apalache
+        |\* https://github.com/informalsystems/apalache
         |""".stripMargin
     )
   }
@@ -81,7 +81,7 @@ class TestCounterexampleWriter extends FunSuite {
           |
           |================================================================================
           |\* Created by Apalache on DATETIME
-          |\* https://github.com/konnov/apalache
+          |\* https://github.com/informalsystems/apalache
           |""".stripMargin
       )
     }
@@ -123,7 +123,7 @@ class TestCounterexampleWriter extends FunSuite {
         |
         |================================================================================
         |\* Created by Apalache on DATETIME
-        |\* https://github.com/konnov/apalache
+        |\* https://github.com/informalsystems/apalache
         |""".stripMargin
     )
   }


### PR DESCRIPTION
These changes include the CHANGES.md (since this is a published
document), the manual, the readme, and numerous `pom.xml` files.

Since I'm still getting oriented on this project, I wanted to call out those locations, to make sure there's a sanity check on whether they should be changed. I did *not* include two instances in the `scripts` dir: 

```
[sf@comp apalache]$ rg 'github\.com/konnov'
script/release-0.6.0.txt
6:   [benchmarks](https://github.com/konnov/apalache-tests),

script/release-0.5.0.txt
24: * options for fine tuning with `--fine-tuning`, see [tuning](https://github.com/konnov/apalache/blob/unstable/docs/tuning.md)
```

under the assumption that these are not published.