### PR TITLE
Apalache.tla: the standard module for Apalache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Unreleased #unstable
+ * introduced the tool module `Apalache.tla`, see #183
  * Lookup for modules using TLA_PATH, see #187
  * Simplify JSON format to make it suitable for JsonPath queries, see #153
 

--- a/bin/apalache-mc
+++ b/bin/apalache-mc
@@ -32,18 +32,23 @@ case `cat $DISTS | wc -l | sed 's/[[:space:]]*//g'` in
 esac
 rm -f "$DISTS"
 
+# an additional lookup list for the TLA+ modules
+TLA_LIB="$DIR/src/tla"
+
+# This is a temporary solution for handling TLA_PATH via a Java variable.
+# See apalache/#187.
+# Once tlaplus/#490,#493 are released, remove this workaround.
+test -z "$TLA_PATH" || TLA_LIB="$TLA_LIB:$TLA_PATH"
+
 # set LD_LIBRARY_PATH to find z3 libraries
 export LD_LIBRARY_PATH="$DIR/3rdparty/lib:${LD_LIBRARY_PATH}"
 # 1. The maximum heap size, Z3 will use much more as a native library.
 # 2. Duplicating LD_LIBRARY_PATH, tell JVM to find the third-party libraries.
-JVM_ARGS="-Xmx4096m -Djava.library.path=$DIR/3rdparty/lib"
+JVM_ARGS="-Xmx4096m -Djava.library.path=$DIR/3rdparty/lib "
 # uncomment to track memory usage with: jcmd <pid> VM.native_memory summary
 #JVM_ARGS="${JVM_ARGS} -XX:NativeMemoryTracking=summary"
 
-# This is a temporary solution for handling TLA_PATH via a Java variable.
-# See apalache/#187.
-# Once tlaplus/#490,#493 are release, remove this workaround.
-test -z "$TLA_PATH" || JVM_ARGS="$JVM_ARGS -DTLA-Library=$TLA_PATH"
+JVM_ARGS="$JVM_ARGS -DTLA-Library=$TLA_LIB"
 
 echo "# JVM args: $JVM_ARGS"
 echo "#"

--- a/bin/apalache-mc
+++ b/bin/apalache-mc
@@ -38,7 +38,7 @@ TLA_LIB="$DIR/src/tla"
 # This is a temporary solution for handling TLA_PATH via a Java variable.
 # See apalache/#187.
 # Once tlaplus/#490,#493 are released, remove this workaround.
-test -z "$TLA_PATH" || TLA_LIB="$TLA_LIB:$TLA_PATH"
+(test -z "$TLA_PATH" && TLA_PATH="$TLA_LIB") || TLA_PATH="TLA_LIB:$TLA_PATH" 
 
 # set LD_LIBRARY_PATH to find z3 libraries
 export LD_LIBRARY_PATH="$DIR/3rdparty/lib:${LD_LIBRARY_PATH}"
@@ -67,4 +67,3 @@ trap sigterm SIGTERM SIGINT
 java $JVM_ARGS -jar "$JAR" "$@" &
 child=$!
 wait "$child"
-

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1158,7 +1158,7 @@ operator.
 Similar to the `TLC` module, we provide the module called `Apalache`, which can
 be found in
 [src/tla](https://github.com/informalsystems/apalache/tree/unstable/src/tla).
-Most of the operators in that modules are introduce internally by Apalache,
+Most of the operators in that modules are introduced internally by Apalache,
 when it is rewriting a TLA+ specification.  It is useful to read the comments
 to the operators defined in `Apalache.tla`, as they will help you in
 understanding the [detailed output](#detailed) produced by the tool, see.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -41,6 +41,7 @@ Apalache is working under the following assumptions:
     1. [Assignments and symbolic transitions](#assignments)
     1. [Type annotations](#types)
     1. [Recursive operators and functions](#recursion)
+ 1. [The Apalache module](#apalacheMod)
  1. [Five minutes of theory](#theory5)
  1. [Supported language features](#features)
 
@@ -611,16 +612,16 @@ VARIABLE hasLicense
 ASSUME(80 \in 0 .. 99)
 ASSUME(18 \in 1 .. 99)
 
-Init$0 == year' <- 80 /\ hasLicense' <- FALSE
-Next$0 == year' <- ((year + 1) % 100) /\ (hasLicense' <- hasLicense)
-Next$1 == year - 80 >= 18 /\ hasLicense' <- TRUE /\ (year' <- year)
+Init$0 == year' := 80 /\ hasLicense' := FALSE
+Next$0 == year' := ((year + 1) % 100) /\ (hasLicense' := hasLicense)
+Next$1 == year - 80 >= 18 /\ hasLicense' := TRUE /\ (year' := year)
 ===============
 ```
 
 As you can see, the model checker did two things:
 
-1. It has translated several expressions that look like `x' = e` into `x' <- e`.
-   For instance, you can see `year' <- 80` and `hasLicense' <- FALSE` in
+1. It has translated several expressions that look like `x' = e` into `x' := e`.
+   For instance, you can see `year' := 80` and `hasLicense' := FALSE` in
    `Init$0`. We call these expressions **assignments**.
 1. It has factored the operator `Next` into two operators `Next$0` and `Next$1`.
    We call these operators **symbolic transitions**.
@@ -646,7 +647,7 @@ The main contract between the assignments and symbolic transitions is as
 follows:
 
 > For every variable `x` declared with `VARIABLE`, there is exactly one
-> assignment of the form `x' <- e` in every symbolic transition `A_n`.
+> assignment of the form `x' := e` in every symbolic transition `A_n`.
 
 If Apalache cannot find expressions with the above properties, it fails.
 Consider the example
@@ -1152,8 +1153,27 @@ cardinality does not require `2^|NUMS|` constraints, when using a recursive
 operator.
 
 
+<a name="apalacheMod"></a>
+# 9. The Apalache module
+
+Similar to the `TLC` module, we provide the module called `Apalache`, which can
+be found in
+[src/tla](https://github.com/informalsystems/apalache/tree/unstable/src/tla).
+Most of the operators in that modules are introduce internally by Apalache,
+when it is rewriting a TLA+ specification.  It is useful to read the comments
+to the operators defined in `Apalache.tla`, as they will help you in
+understanding the [detailed output](#detailed) produced by the tool, see.
+Perhaps, the most interesting operator in `Apalache` is the type assignment
+operator that is defined as follows:
+
+```tla
+x := e == x = e
+```
+
+See the [discussion](#assignments) on the role of assignments in Apalache.
+
 <a name="theory5"></a>
-# 9. Five minutes of theory
+# 10. Five minutes of theory
 
 **You can safely skip this section**
 
@@ -1190,7 +1210,7 @@ delivered at OOPSLA19](https://dl.acm.org/doi/10.1145/3360549).
 
 <a name="features"></a>
 
-# 10. Supported language features
+# 11. Supported language features
 
 Check the [supported features](features.md), [KerA+](kera.md), and
 [preprocessing steps](preprocessing.md).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -513,7 +513,7 @@ Apalache uses [the SANY
 parser](https://lamport.azurewebsites.net/tla/tools.html), which is the
 standard parser of TLC and TLA+ Toolbox. By default, SANY is looking for the
 modules in the current working directory and in the Java package
-`tla2sany.StandardModules`, which is usually provided by `tla2tools.jar` that is
+`tla2sany.StandardModules`, which is usually provided by the `tla2tools.jar` that is
 included in the Java classpath.
 
 Additionally, Apalache includes the directory `$APALACHE_HOME/src/tla` into the

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -516,13 +516,12 @@ modules in the current working directory and in the Java package
 `tla2sany.StandardModules`, which is usually provided by the `tla2tools.jar` that is
 included in the Java classpath.
 
-Additionally, Apalache includes the directory `$APALACHE_HOME/src/tla` into the
-SANY lookup list via the Java system variable called `TLA-Library`. (The script
-`bin/apalache-mc` automatically sets `APALACHE_HOME` to its parent directory.)
+In addition to the modules in the current working directory, Appalache provides
 
-On top of that, Apalache adds all the directories specified in the environment
-variable `TLA_PATH` into the SANY lookup list. See [issue
-187](https://github.com/informalsystems/apalache/issues/187).
+- a small standard library (located in `$APALACHE_HOME/src/tla`), and
+- support for additional source directories specified in the environment variable `TLA_PATH`. `TLA_PATH` should be a list of paths to directories separated by `:`. 
+
+(Directories in the `TLA_PATH` are provided to SANY via the `TLA-Library` Java system variable.)    
 
 So the module lookup order in Apalache is as follows:
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,6 +1,6 @@
 # Apalache manual
 
-**Version 0.7.0 (unstable)** :fireworks:
+**Version 0.7.1 (unstable)** :fireworks:
 
 **Authors: Igor Konnov, Jure Kukovec, Andrey Kuprianov, Shon Feder**
 
@@ -505,8 +505,38 @@ State14 ==
 InvariantViolation == hasLicense /\ year - BIRTH_YEAR < LICENSE_AGE
 ```
 
+<a name="lookup"></a>
+## 6.3. Module lookup
+
+Apalache uses [the SANY
+parser](https://lamport.azurewebsites.net/tla/tools.html), which is the
+standard parser of TLC and TLA+ Toolbox. By default, SANY is looking for the
+modules in the current working directory and in the Java package
+`tla2sany.StandardModules`, which is usually provided by `tla2tools.jar` that is
+included in the Java classpath.
+
+Additionally, Apalache includes the directory `$APALACHE_HOME/src/tla` into the
+SANY lookup list via the Java system variable called `TLA-Library`. (The script
+`bin/apalache-mc` automatically sets `APALACHE_HOME` to its parent directory.)
+
+On top of that, Apalache adds all the directories specified in the environment
+variable `TLA_PATH` into the SANY lookup list. See [issue
+187](https://github.com/informalsystems/apalache/issues/187).
+
+So the module lookup order in Apalache is as follows:
+
+1. The current working directory.
+1. The directory `$APALACHE_HOME/src/tla`.
+1. The directories specified in the environment variable `TLA_PATH`.
+1. The Java package `tla2sany.StandardModules`.
+
+__Note:__ To let TLA+ Toolbox and TLC know about the Apalache modules, include
+`$APALACHE_HOME/src/tla` in the lookup directories, as explained by Markus
+Kuppe for the [TLA+ Community
+Modules](https://github.com/tlaplus/CommunityModules).
+
 <a name="detailed"></a>
-## 6.3. Detailed output
+## 6.4. Detailed output
 
 The tool will display only important messages on stdout, but a detailed log can
 be found in `detailed.log`.
@@ -535,7 +565,7 @@ the run-specific directory `x/hh.mm-DD.MM.YYYY-<id>`:
     marking Skolemizable expressions and expressions to be expanded.
 
 <a name="parsing"></a>
-## 6.4. Parsing and pretty-printing
+## 6.5. Parsing and pretty-printing
 
 If you'd like to check that your TLA+ specification is syntactically correct,
 without running the model checker, you can run the following command:

--- a/src/tla/Apalache.tla
+++ b/src/tla/Apalache.tla
@@ -1,0 +1,63 @@
+--------------------------- MODULE Apalache -----------------------------------
+(*****************************************************************************)
+(* This is a standard module for use with the Apalache model checker.        *)
+(* The meaning of the operators is explained in the comments.                *)
+(* Many of the operators serve as additional annotations of their arguments. *)
+(* As we like to preserve compatibility with TLC and TLAPS, we define the    *)
+(* operator bodies by erasure. The actual interpretation of the operators is *)
+(* encoded inside Apalache. For the moment, these operators are mirrored in  *)
+(* the class at.forsyte.apalache.tla.lir.oper.BmcOper.                       *)
+(*                                                                           *)
+(* Igor Konnov, 2020                                                         *)
+(*****************************************************************************)
+
+(*****************************************************************************)
+(* An assignment of an expression e to a state variable x. Typically, one    *)
+(* uses the non-primed version of x in the initializing predicate Init and   *)
+(* the primed version of x (that is, x') in the transition predicate Next.   *)
+(* Although TLA+ does not have a concept of a variable assignment, we find   *)
+(* this concept extremely useful for symbolic model checking. In pure TLA+,  *)
+(* one would simply write x = e, or x \in {e}.                               *)
+(*                                                                           *)
+(* Apalache automatically converts some expressions of the form              *)
+(* x = e or x \in {e} into assignments. However, if you like to annotate     *)
+(* assignments by hand, you can use this operator.                           *)
+(*                                                                           *)
+(* For a further discussion on that matter, see:                             *)
+(* https://github.com/informalsystems/apalache/blob/ik/idiomatic-tla/docs/idiomatic/assignments.md *)
+(*****************************************************************************)
+x := e == x = e
+
+(*****************************************************************************)
+(* Annotating an expression \E x \in S: P as Skolemizable. That is, it can   *)
+(* be replaced with an expression c \in S /\ P(c) for a fresh constant c.    *)
+(* Not every exisential can be replaced with a constant, this should be done *)
+(* with care. Apalache detects Skolemizable expressions by static analysis.  *)
+(*****************************************************************************)
+Skolem(e) == e
+
+(*****************************************************************************)
+(* A hint to the model checker to expand a set S, instead of dealing         *)
+(* with it symbolically. Apalache finds out which sets have to be expanded   *)
+(* by static analysis.                                                       *)
+(*****************************************************************************)
+Expand(S) == S
+
+(*****************************************************************************)
+(* A hint to the model checker to replace its argument Cardinality(S) >= k   *)
+(* with a series of existential quantifiers for a constant k.                *)
+(* Similar to Skolem, this has to be done carefully. Apalache automatically  *)
+(* places this hint by static analysis.                                      *)
+(*****************************************************************************)
+ConstCardinality(cardExpr) == cardExpr
+
+(****************************************************************************)
+(* Apalache internally defines the operator Distinct that requires all its  *)
+(* arguments to be distinct from each other. We do not know how to write    *)
+(* such an operator in a TLA+ module.                                       *)
+(****************************************************************************)
+(*
+Distinct(e1, ..., ek) == ...
+*)
+
+===============================================================================

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -56,4 +56,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+
+    <build>
+        <plugins>
+            <!-- unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- we have to tell SANY the location of Apalache modules -->
+                    <systemPropertyVariables>
+                        <TLA-Library>${project.parent.basedir}/src/tla</TLA-Library>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
 </project>

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -16,7 +16,7 @@ object StandardLibrary {
     * operator definitions from the user modules. (Moreover, the standard modules sometimes contain garbage
     * or complex definitions that should not be analyzed by our tool.)
     */
-  val standardModules: Set[String] = Set("Naturals", "Integers", "Sequences", "TLC", "FiniteSets", "Reals")
+  val standardModules: Set[String] = Set("Naturals", "Integers", "Sequences", "TLC", "FiniteSets", "Reals", "Apalache")
 
   val libraryValues: Map[Tuple2[String, String], TlaValue] =
     Map(
@@ -66,11 +66,16 @@ object StandardLibrary {
       ("TLC", "TLCSet") -> TlcOper.tlcSet,
       ("TLC", "ToString") -> TlcOper.tlcToString,
       ("TLC", "Print") -> TlcOper.print,
-      ("TLC", "PrintT") -> TlcOper.printT
+      ("TLC", "PrintT") -> TlcOper.printT,
+      ("Apalache", ":=") -> BmcOper.assign,
+      ("Apalache", "Skolem") -> BmcOper.skolem,
+      ("Apalache", "Expand") -> BmcOper.expand,
+      ("Apalache", "ConstCardinality") -> BmcOper.constCard
     )////
 
   val globalOperators: Map[String, TlaOper] =
     Map[String, TlaOper](
+      // TODO: this operator should be replaced with <: in Types
       "<:" -> BmcOper.withType
     )////
 }

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1957,45 +1957,28 @@ class TestSanyImporter extends FunSuite {
     assert(13 == root.declarations.size)
   }
 
-
-  /*
-  TODO: we need a good way to propagate this module to the standard library
-
-  test("module BMC") {
-    // check that the module BMC is imported properly
+  test("EXTENDS Apalache") {
     val text =
-      """---- MODULE bmc ----
-        |EXTENDS BMC
-        |
-        |VARIABLES i
-        |
-        |AWithType == WithType(i, "IntT")
+      """---- MODULE root ----
+        |EXTENDS Apalache
         |================================
-        |""".stripMargin
+      """.stripMargin
 
-    val (rootName, modules) = new SanyImporter().loadFromSource("bmc", Source.fromString(text))
-    assert(2 == modules.size) // our module
-    // the root module and naturals
-    val root = modules(rootName)
+    // We have to set TLA-Library, in order to look up for Apalache.tla. This is done automatically in pom.xml.
+    // If you run this test in an IDE, and the test fails, add the following line to the VM parameters
+    // (don't forget to replace <APALACHE_HOME> with the directory where you checked out the project):
+    //
+    // -DTLA-Library=<APALACHE_HOME>/src/tla
+    System.out.println("TLA-Library = %s".format(System.getProperty("TLA-Library")))
 
-    def assertTlaDecl(expectedName: String, body: TlaEx): Unit = {
-      root.declarations.find {
-        _.name == expectedName
-      } match {
-        case Some(d: TlaOperDecl) =>
-          assert(expectedName == d.name)
-          assert(0 == d.formalParams.length)
-          assert(body == d.body)
+    val locationStore = new SourceStore
+    val (rootName, modules) = new SanyImporter(locationStore)
+      .loadFromSource("root", Source.fromString(text))
+    assert(2 == modules.size) // Apalache and root
 
-        case _ =>
-          fail("Expected a TlaDecl")
-      }
-    }
-
-    assertTlaDecl("AWithType",
-      OperEx(BmcOper.withType, name("i"), str("IntT")))
+    val root = modules("root")
+    assert(4 == root.declarations.size)
   }
-  */
 
   test("assumptions") {
     // checking that the assumptions are imported properly

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1975,7 +1975,7 @@ class TestSanyImporter extends FunSuite {
         |================================
       """.stripMargin
 
-    // We have to set TLA-Library, in order to look up for Apalache.tla. This is done automatically in pom.xml.
+    // We have to set TLA-Library, in order to look up Apalache.tla. This is done automatically in pom.xml.
     // If you run this test in an IDE, and the test fails, add the following line to the VM parameters
     // (don't forget to replace <APALACHE_HOME> with the directory where you checked out the project):
     //

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/BmcOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/BmcOper.scala
@@ -1,9 +1,10 @@
 package at.forsyte.apalache.tla.lir.oper
 
 /**
-  * The operators defined in the BMC module. This module give the users a facility to provide hints.
-  * To use this module, the user would have to copy the module somewhere. As our tool is not widely used,
-  * we just hijack some operators during the import stage, e.g., <:
+  * The operators defined in the module Apalache.tla. This module gives the users a facility to provide hints.
+  * The module Apalache is automatically looked up when Apalache is running.
+  *
+  * TODO: rename this class to ApalacheOper, once ik/multicore is merged into unstable.
   *
   * @author konnov
  */
@@ -64,7 +65,9 @@ object BmcOper {
 
   /**
     * The distinct operator that is equivalent to (distinct ...) in SMT-LIB.
-    * Formally, BMC!Distinct(x_1, ..., x_n) is equivalent to \A i, j \in 1..n: i /= j => x_i /= x_j
+    * Formally, BMC!Distinct(x_1, ..., x_n) is equivalent to \A i, j \in 1..n: i /= j => x_i /= x_j.
+    *
+    * XXX: there seems to be no way of defining a user-defined variadic operator in Apalache.tla.
     */
   val distinct: BmcOper = new BmcOper {
     override def name: String = "BMC!Distinct"

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/BmcOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/BmcOper.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.lir.oper
 
 /**
   * The operators defined in the module Apalache.tla. This module gives the users a facility to provide hints.
-  * The module Apalache is automatically looked up when Apalache is running.
+  * The "Apalache" module is automatically looked up when Apalache is running.
   *
   * TODO: rename this class to ApalacheOper, once ik/multicore is merged into unstable.
   *
@@ -75,5 +75,4 @@ object BmcOper {
     override def precedence: (Int, Int) = (5, 5)
   }
 }
-
 


### PR DESCRIPTION
Following #183, this PR introduces the standard module `Apalache.tla` that gives the user access to (almost all of) internal operators introduced by Apalache. Most importantly, it introduces the assignment operator `x := e`. This opens the way to deal with #181.