### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ tla-bmcmt/profile-rules.txt
 
 # Ignore directories where test artifacts are stored
 x/
+
+# Ignore backup files created by `mvn versions`
+*.versionsBackup

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ QUICK_MAVEN_OPTS := "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:non
 # - run up to 4 threads per core (4C): https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
 QUICK_MAVEN_ARGS := -DskipTests -Dscoverage.skip=true -T 4C
 
-.PHONY: all, apalache, build, test, integration, clean
+.PHONY: all, apalache, compile, build, test, integration, clean
 
 all: apalache
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ QUICK_MAVEN_OPTS := "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:non
 # - run up to 4 threads per core (4C): https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
 QUICK_MAVEN_ARGS := -DskipTests -Dscoverage.skip=true -T 4C
 
-.PHONY: all, apalache, compile, build, test, integration, clean
+.PHONY: all, apalache, compile, build-quick, test, integration, clean
 
 all: apalache
 
@@ -28,7 +28,7 @@ compile: $(DEPS)
 	MAVEN_OPTS=$(QUICK_MAVEN_OPTS) mvn $(QUICK_MAVEN_ARGS) compile
 
 # Build with quick settings, but and skip the tests
-build: $(DEPS)
+build-quick: $(DEPS)
 	MAVEN_OPTS=$(QUICK_MAVEN_OPTS) mvn $(QUICK_MAVEN_ARGS) package
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,32 @@ DEPDIR=3rdparty
 DEPS=$(DEPDIR)/lib/com.microsoft.z3.jar $(DEPDIR)/lib/box.jar
 ENV=JAVA_LIBRARY_PATH="$(abspath $(DEPDIR)/lib)" NO_MVN=1 LD_LIBRARY_PATH="$(abspath $(DEPDIR)/lib)"
 
-.PHONY: all, apalache, test, integration, clean
+# See https://www.jrebel.com/blog/how-to-speed-up-your-maven-build
+#
+# - verify:none disables bytecode verification giving a speed boost, but should
+#   not be used for releases or productin. See https://blogs.oracle.com/buck/never-disable-bytecode-verification-in-a-production-system
+QUICK_MAVEN_OPTS := "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none"
+
+# - skip the tests
+# - tell scoverage to skip: http://scoverage.github.io/scoverage-maven-plugin/1.4.0/report-mojo.html#skip
+# - run up to 4 threads per core (4C): https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
+QUICK_MAVEN_ARGS := -DskipTests -Dscoverage.skip=true -T 4C
+
+.PHONY: all, apalache, build, test, integration, clean
 
 all: apalache
 
 apalache: $(DEPS)
 	# tell maven to load the binary libraries and build the package
 	$(ENV) mvn package
+
+# Just compile with quick settings
+compile: $(DEPS)
+	MAVEN_OPTS=$(QUICK_MAVEN_OPTS) mvn $(QUICK_MAVEN_ARGS) compile
+
+# Build with quick settings, but and skip the tests
+build: $(DEPS)
+	MAVEN_OPTS=$(QUICK_MAVEN_OPTS) mvn $(QUICK_MAVEN_ARGS) package
 
 test:
 	mvn test

--- a/mod-tool/pom.xml
+++ b/mod-tool/pom.xml
@@ -112,12 +112,12 @@
         <dependency>
             <groupId>org.backuity.clist</groupId>
             <artifactId>clist-core_2.12</artifactId>
-            <version>3.2.2</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.backuity.clist</groupId>
             <artifactId>clist-macros_2.12</artifactId>
-            <version>3.2.2</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <!-- configurations in property files -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scoverage.plugin.version>1.4.0</scoverage.plugin.version>
         <scoverage.aggregate>true</scoverage.aggregate>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <repositories>
@@ -73,7 +74,7 @@
                 <dependency>
                     <groupId>org.scala-lang.modules</groupId>
                     <artifactId>scala-parser-combinators_${scalaBinaryVersion}</artifactId>
-                    <version>1.0.4</version>
+                    <version>1.1.2</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -85,19 +86,42 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
-                <version>4.2.2</version>
+                <version>4.2.3</version>
+            </dependency>
+
+            <!-- Logging -->
+            <!-- This dependency configuration is to prevent
+                 http://www.slf4j.org/codes.html#StaticLoggerBinder
+                 See https://stackoverflow.com/a/56089477/1187277 -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>1.1.8</version>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+
+            <!-- <dependency> -->
+            <!--     <groupId>org.slf4j</groupId> -->
+            <!--     <artifactId>slf4j-simple</artifactId> -->
+            <!--     <version>1.7.30</version> -->
+            <!-- </dependency> -->
+
 
             <dependency>
                 <groupId>com.typesafe.scala-logging</groupId>
                 <artifactId>scala-logging_${scalaBinaryVersion}</artifactId>
-                <version>3.5.0</version>
+                <version>3.9.2</version>
             </dependency>
 
             <dependency>
@@ -109,7 +133,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>4.13</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -124,7 +148,7 @@
             <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
-                <version>3.5.1</version>
+                <version>4.2</version>
                 <scope>test</scope>
             </dependency>
 
@@ -202,7 +226,7 @@
                 -->
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.0</version>
                     <configuration>
                         <descriptors>
                             <descriptor>src/assembly/bin.xml</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.0.2</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scoverage.plugin.version>1.3.0</scoverage.plugin.version>
+        <scoverage.plugin.version>1.4.0</scoverage.plugin.version>
         <scoverage.aggregate>true</scoverage.aggregate>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,6 @@
                 </dependency>
                 <dependency>
                     <groupId>org.scala-lang.modules</groupId>
-                    <artifactId>scala-xml_${scalaBinaryVersion}</artifactId>
-                    <version>1.0.5</version> <!-- required by scalatest 3.0.5 -->
-                </dependency>
-                <dependency>
-                    <groupId>org.scala-lang.modules</groupId>
                     <artifactId>scala-parser-combinators_${scalaBinaryVersion}</artifactId>
                     <version>1.1.2</version>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>4.4.0</version>
 
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -106,13 +106,6 @@
                 <version>1.7.30</version>
             </dependency>
 
-            <!-- <dependency> -->
-            <!--     <groupId>org.slf4j</groupId> -->
-            <!--     <artifactId>slf4j-simple</artifactId> -->
-            <!--     <version>1.7.30</version> -->
-            <!-- </dependency> -->
-
-
             <dependency>
                 <groupId>com.typesafe.scala-logging</groupId>
                 <artifactId>scala-logging_${scalaBinaryVersion}</artifactId>

--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.7</version>
         </dependency>
 
         <dependency>

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.7</version>
         </dependency>
 
         <dependency>

--- a/tla-types/pom.xml
+++ b/tla-types/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.7</version>
         </dependency>
 
         <dependency>

--- a/tlair/pom.xml
+++ b/tlair/pom.xml
@@ -41,21 +41,21 @@
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-core_2.12</artifactId>
-            <version>7.3.0-M24</version>
+            <version>7.3.2</version>
         </dependency>
 
         <!-- pretty printing with kiama -->
         <dependency>
             <groupId>org.bitbucket.inkytonik.kiama</groupId>
             <artifactId>kiama_2.12</artifactId>
-            <version>2.2.1</version>
+            <version>2.3.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.lihaoyi/upickle -->
         <dependency>
             <groupId>com.lihaoyi</groupId>
             <artifactId>ujson_2.12</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This PR updates most of our dependencies, as well as the maven-compiler and scala-maven plugins.

See c101e3a for details on the dependency upgrades.

This also adds two new phony make targets, optimized for quicker build/compile times.