### PR TITLE
Fix TLA_PATH

### DIFF
--- a/bin/apalache-mc
+++ b/bin/apalache-mc
@@ -38,7 +38,7 @@ TLA_LIB="$DIR/src/tla"
 # This is a temporary solution for handling TLA_PATH via a Java variable.
 # See apalache/#187.
 # Once tlaplus/#490,#493 are released, remove this workaround.
-(test -z "$TLA_PATH" && TLA_PATH="$TLA_LIB") || TLA_PATH="TLA_LIB:$TLA_PATH" 
+(test -z "$TLA_PATH" && TLA_PATH="$TLA_LIB") || TLA_PATH="$TLA_LIB:$TLA_PATH"
 
 # set LD_LIBRARY_PATH to find z3 libraries
 export LD_LIBRARY_PATH="$DIR/3rdparty/lib:${LD_LIBRARY_PATH}"
@@ -48,7 +48,7 @@ JVM_ARGS="-Xmx4096m -Djava.library.path=$DIR/3rdparty/lib "
 # uncomment to track memory usage with: jcmd <pid> VM.native_memory summary
 #JVM_ARGS="${JVM_ARGS} -XX:NativeMemoryTracking=summary"
 
-JVM_ARGS="$JVM_ARGS -DTLA-Library=$TLA_LIB"
+JVM_ARGS="$JVM_ARGS -DTLA-Library=$TLA_PATH"
 
 echo "# JVM args: $JVM_ARGS"
 echo "#"

--- a/test/run-integration
+++ b/test/run-integration
@@ -140,6 +140,9 @@ check "027-Rec9" --length=5 --inv=Inv Rec9.tla \
     && expect_ok
 check "028-ExistsAsValue" --inv=Inv ExistsAsValue.tla \
     && expect_ok
+TLA_PATH=./tla-path-tests \
+    check "029-set-TLA_PATH" ./tla-path-tests/ImportingModule.tla \
+    && expect_ok
 
 cat "$LOGFILE"
 

--- a/test/tla/tla-path-tests/ImportedModule.tla
+++ b/test/tla/tla-path-tests/ImportedModule.tla
@@ -1,0 +1,13 @@
+---- MODULE ImportedModule -----------------------------------------------------
+(* This trivial MODULE is just to be extended *)
+
+VARIABLES x
+
+Init ==
+    x = TRUE
+
+Next ==
+    x' = TRUE
+
+(* Inv == x *)
+================================================================================

--- a/test/tla/tla-path-tests/ImportingModule.tla
+++ b/test/tla/tla-path-tests/ImportingModule.tla
@@ -1,0 +1,13 @@
+---- MODULE ImportingModule ----------------------------------------------------
+(* This MODULE just checks whether it can import ImportedModule.
+
+   It is meant to be run from outside of the tla-path-tests directory, with
+
+     TLA_PATH=./tla-path-tests apalache-mc check ./tla-path-tests/ImportingModule.tla
+
+   If checking succeeds, THEN TLA_PATH has worked as expected.
+*)
+
+EXTENDS ImportedModule
+
+================================================================================


### PR DESCRIPTION
We ended up muddling some of the bash variable handling in #188, and this sets that right.

It also introduces an integration test that uses the `TLA_PATH`, and fails if it doesn't work as expected to put dependent modules in context.