### PR TITLE
Make Dockerfile staged

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased #unstable
 
+ * Use a staged docker build, reducing container size ~70%, see #195
+
 ## 0.7.2 [RELEASE]
 
  * fixed an omitted version number update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM maven:3.6.3-jdk-8-slim AS thirdparty
+# This is image for building vendored dependencies
+#
 # We build the vendored dependencies in their own image so we only need to
 # rebuild this image when those dependencies change, and so we don't need to
 # keep their build dependencies.
@@ -19,7 +21,9 @@ ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
 
 RUN 3rdparty/install-local.sh --nocache
 
-FROM maven:3.6.3-jdk-8-slim
+FROM maven:3.6.3-jdk-8-slim AS builder
+
+# This is the image for building apalache itself
 
 ADD . /opt/apalache/
 WORKDIR /opt/apalache/
@@ -31,18 +35,64 @@ COPY --from=thirdparty /opt/apalache/3rdparty/lib /opt/apalache/3rdparty/lib
 # The maven repository
 COPY --from=thirdparty /root/.m2 /root/.m2
 
+# Workaround for Surefire not finding ForkedBooter
+# (see https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class)
+ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
+
 ENV LD_LIBRARY_PATH="/opt/apalache/3rdparty/lib/:${LD_LIBRARY_PATH}"
 
 # clean the leftovers from the previous non-docker builds and build the package
 RUN mvn clean package
 
+FROM openjdk:8-slim
+
+# This is the app image
+#
+# To prepare it, we
+#
+# - copy over all the artifacts needed to run
+# - prepare the enviroment
+# - declare the entrypoint
+
+WORKDIR /opt/apalache/
+
+# Vendored binaries
+COPY --from=builder \
+    /opt/apalache/3rdparty/bin/ \
+    /opt/apalache/3rdparty/bin/
+# Vendored libraies
+COPY --from=builder \
+    /opt/apalache/3rdparty/lib/ \
+    /opt/apalache/3rdparty/lib/
+# Executable script entrypoints
+COPY --from=builder \
+    /opt/apalache/bin/ \
+    /opt/apalache/bin/
+# Workaround for broken docker behavior on staged builds with multiple COPY commands
+# see https://github.com/moby/moby/issues/37965#issuecomment-426853382
+RUN true
+# The jars
+COPY --from=builder \
+    /opt/apalache/mod-distribution/target/ \
+    /opt/apalache/mod-distribution/target/
+# Apalache's .tla libraries
+COPY --from=builder \
+    /opt/apalache/src/ \
+    /opt/apalache/src/
+
+# Workaround for Surefire not finding ForkedBooter
+# (see https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class)
+ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
+
+ENV LD_LIBRARY_PATH="/opt/apalache/3rdparty/lib/:${LD_LIBRARY_PATH}"
+
+# make apalache-mc available in PATH
+ENV PATH="/usr/local/openjdk-8/bin/:/opt/apalache/bin:${PATH}"
+
 # TLA parser requires all specification files to be in the same directory
 # We assume the user bind-mounted the spec dir into /var/apalache
 # In case the directory was not bind-mounted, we create one
 RUN mkdir /var/apalache 2>/dev/null
-
-# make apalache-mc available in PATH
-ENV PATH="/usr/local/openjdk-8/bin/:/opt/apalache/bin:${PATH}"
 
 # what to run
 ENTRYPOINT ["/opt/apalache/bin/run-in-docker-container"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,6 @@ RUN apt-get update && apt-get install -y wget \
 ADD ./3rdparty /opt/apalache/3rdparty
 WORKDIR /opt/apalache/
 
-# Workaround for Surefire not finding ForkedBooter
-# (see https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class)
-ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
-
 RUN 3rdparty/install-local.sh --nocache
 
 FROM maven:3.6.3-jdk-8-slim AS builder
@@ -34,10 +30,6 @@ COPY --from=thirdparty /opt/apalache/3rdparty/bin /opt/apalache/3rdparty/bin
 COPY --from=thirdparty /opt/apalache/3rdparty/lib /opt/apalache/3rdparty/lib
 # The maven repository
 COPY --from=thirdparty /root/.m2 /root/.m2
-
-# Workaround for Surefire not finding ForkedBooter
-# (see https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class)
-ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
 
 ENV LD_LIBRARY_PATH="/opt/apalache/3rdparty/lib/:${LD_LIBRARY_PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,14 @@ FROM openjdk:8-slim
 
 WORKDIR /opt/apalache/
 
+COPY --from=builder \
+    /opt/apalache/LICENSE \
+    /opt/apalache/LICENSE
 # Vendored binaries
 COPY --from=builder \
     /opt/apalache/3rdparty/bin/ \
     /opt/apalache/3rdparty/bin/
-# Vendored libraies
+# Vendored libraries
 COPY --from=builder \
     /opt/apalache/3rdparty/lib/ \
     /opt/apalache/3rdparty/lib/
@@ -73,12 +76,12 @@ COPY --from=builder \
 RUN true
 # The jars
 COPY --from=builder \
-    /opt/apalache/mod-distribution/target/ \
+    /opt/apalache/mod-distribution/target/apalache-pkg-*.jar \
     /opt/apalache/mod-distribution/target/
 # Apalache's .tla libraries
 COPY --from=builder \
-    /opt/apalache/src/ \
-    /opt/apalache/src/
+    /opt/apalache/src/tla \
+    /opt/apalache/src/tla
 
 # Workaround for Surefire not finding ForkedBooter
 # (see https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM maven:3.6.3-jdk-8-slim
+FROM maven:3.6.3-jdk-8-slim AS thirdparty
+# We build the vendored dependencies in their own image so we only need to
+# rebuild this image when those dependencies change, and so we don't need to
+# keep their build dependencies.
 
 RUN apt-get update && apt-get install -y wget \
     g++ \
@@ -7,7 +10,7 @@ RUN apt-get update && apt-get install -y wget \
     git \
     python
 
-ADD . /opt/apalache/
+ADD ./3rdparty /opt/apalache/3rdparty
 WORKDIR /opt/apalache/
 
 # Workaround for Surefire not finding ForkedBooter
@@ -15,17 +18,31 @@ WORKDIR /opt/apalache/
 ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
 
 RUN 3rdparty/install-local.sh --nocache
+
+FROM maven:3.6.3-jdk-8-slim
+
+ADD . /opt/apalache/
+WORKDIR /opt/apalache/
+
+# Vendored binaries
+COPY --from=thirdparty /opt/apalache/3rdparty/bin /opt/apalache/3rdparty/bin
+# Vendored libraies
+COPY --from=thirdparty /opt/apalache/3rdparty/lib /opt/apalache/3rdparty/lib
+# The maven repository
+COPY --from=thirdparty /root/.m2 /root/.m2
+
 ENV LD_LIBRARY_PATH="/opt/apalache/3rdparty/lib/:${LD_LIBRARY_PATH}"
 
-# clean the leftovers from the previous non-docker builds
-RUN mvn clean
-# build the package
-RUN mvn package
+# clean the leftovers from the previous non-docker builds and build the package
+RUN mvn clean package
+
 # TLA parser requires all specification files to be in the same directory
 # We assume the user bind-mounted the spec dir into /var/apalache
 # In case the directory was not bind-mounted, we create one
 RUN mkdir /var/apalache 2>/dev/null
+
 # make apalache-mc available in PATH
 ENV PATH="/usr/local/openjdk-8/bin/:/opt/apalache/bin:${PATH}"
+
 # what to run
 ENTRYPOINT ["/opt/apalache/bin/run-in-docker-container"]

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -115,6 +115,18 @@ The following docker parameters are used:
 - `<args>` are the tool arguments as described in
   [Running the tool](#running).
 
+We provide a convenience wrapper for this docker command in
+`script/run-docker.sh`. To run the `latest` image using the script, execute
+
+```bash
+$ $APALACHE_HOME/script/run-docker.sh <args>
+```
+
+To specify a different image, set `APALACHE_TAG` like so:
+
+```bash
+$ APALACHE_TAG=foo $APALACHE_HOME/script/run-docker.sh <args>
+```
 
 ### Setting an alias
 

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+default_tag=latest
+
+APALACHE_TAG=${APALACHE_TAG:-}
+
+if [ -z "$APALACHE_TAG" ]
+then
+    >&2 echo "# No docker image supplied. Defaulting to '$default_tag'"
+    >&2 echo "# To run a specific docker tag set APALACHE_TAG."
+    img="apalache/mc:${default_tag}"
+else
+    img="apalache/mc:${APALACHE_TAG}"
+fi
+
+cmd="docker run -e TLA_PATH --rm -v $(pwd):/var/apalache ${img} ${@}"
+>&2 echo "# running command: ${cmd}"
+$cmd

--- a/test/run-integration
+++ b/test/run-integration
@@ -22,7 +22,7 @@ function check() {
     OUTF="$TEST.out"
     ERRF="$TEST.err"
     shift
-    "$DIR"/bin/apalache-mc check $@ 2>"$ERRF" | tee "$OUTF"
+    "$CMD" check $@ 2>"$ERRF" | tee "$OUTF"
 
     if grep -q "The outcome is: NoError" "$OUTF"; then
         RES=1
@@ -68,6 +68,15 @@ function expect_fail() {
         nfail=$((nfail+1))
     fi
 }
+
+if [[ "$USE_DOCKER" == "true" ]]
+then
+    echo "# Using docker..."
+    CMD="${DIR}/script/run-docker.sh"
+    NO_MVN="true"
+else
+    CMD="${DIR}/bin/apalache-mc"
+fi
 
 
 cd "$DIR"


### PR DESCRIPTION
This builds the vendored dependencies and apalache itself in two
separate stages (as per https://docs.docker.com/develop/develop-images/multistage-build/). 
This lets us reuse previously built images for
z3 and box, so long as the content of the ./3rdparty direcotry
hasn't been changed. In those cases, this reduces the time for building an 
image for our code considerably.