### PR TITLE
Add changelong entry for version number bug fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased #unstable
 
+ * fixed an omitted version number update
+
 ## 0.7.1 [RELEASE]
 
  * safe checks for the user options in ConfigurationPassImpl, see #193


### PR DESCRIPTION
Trivial followup to 0539ec285ed3e2e1cbf6f7eaccfb6bee9a77cee8, I'm only opening a PR to ensure this is consistent with @konnov's intention. I do think we want the bug fix recorded in the changelog before releasing the fix, just not sure how we want it recorded.