### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased #unstable
 
+ * fixed an omitted version number update
+
 ## 0.7.1 [RELEASE]
 
  * safe checks for the user options in ConfigurationPassImpl, see #193

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased #unstable
 
+## 0.7.2 [RELEASE]
+
  * fixed an omitted version number update
 
 ## 0.7.1 [RELEASE]

--- a/mod-distribution/pom.xml
+++ b/mod-distribution/pom.xml
@@ -8,11 +8,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>apalache-pkg</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>pom</packaging>
 
     <name>apalache-pkg</name>

--- a/mod-distribution/pom.xml
+++ b/mod-distribution/pom.xml
@@ -8,11 +8,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>apalache-pkg</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>apalache-pkg</name>

--- a/mod-infra/pom.xml
+++ b/mod-infra/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>infra</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>infra</name>

--- a/mod-infra/pom.xml
+++ b/mod-infra/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>infra</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>infra</name>

--- a/mod-tool/pom.xml
+++ b/mod-tool/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <!--
         All command line tooling and option parsing goes here... and nothing else!
     -->
     <artifactId>tool</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tool</name>

--- a/mod-tool/pom.xml
+++ b/mod-tool/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <!--
         All command line tooling and option parsing goes here... and nothing else!
     -->
     <artifactId>tool</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tool</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>at.forsyte.apalache</groupId>
     <artifactId>apalache</artifactId>
     <packaging>pom</packaging>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.7.2-RELEASE</version>
 
     <name>APALACHE project</name>
     <url>https://github.com/informalsystems/apalache</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>at.forsyte.apalache</groupId>
     <artifactId>apalache</artifactId>
     <packaging>pom</packaging>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.2-SNAPSHOT</version>
 
     <name>APALACHE project</name>
     <url>https://github.com/informalsystems/apalache</url>

--- a/script/release-0.7.2.txt
+++ b/script/release-0.7.2.txt
@@ -1,0 +1,3 @@
+## 0.7.2 [RELEASE]
+
+ * fixed an omitted version number update

--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-assignments</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-assignments</name>

--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>tla-assignments</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tla-assignments</name>

--- a/tla-bmcmt/pom.xml
+++ b/tla-bmcmt/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-bmcmt</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-bmcmt</name>

--- a/tla-bmcmt/pom.xml
+++ b/tla-bmcmt/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>tla-bmcmt</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tla-bmcmt</name>

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-import</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-import</name>

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>tla-import</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tla-import</name>

--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>tla-pp</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tla-pp</name>

--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-pp</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-pp</name>

--- a/tla-types/pom.xml
+++ b/tla-types/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>tla-types</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tla-types</name>

--- a/tla-types/pom.xml
+++ b/tla-types/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-types</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-types</name>

--- a/tlair/pom.xml
+++ b/tlair/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tlair</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tlair</name>

--- a/tlair/pom.xml
+++ b/tlair/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     </parent>
 
     <artifactId>tlair</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>tlair</name>


### PR DESCRIPTION
## 0.7.2 [RELEASE]

 * fixed an omitted version number update

--- 

**Note** that this cherry picks in just the bug fixes and changelog updates from unstable, and does not merge all of unstable into master.