### PR TITLE
Add parser position to TLCConfigurationError message

### DIFF
--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -126,7 +126,7 @@ class ConfigurationPassImpl @Inject()(val options: WriteablePassOptions,
           throw new TLCConfigurationError("  > Could not find TLC config file " + basename + " given via --config option")
         }
       case e: TlcConfigParseError =>
-        throw new TLCConfigurationError("  > Could not parse TLC configuration in " + basename + ": " + e.msg)
+        throw new TLCConfigurationError("  > Could not parse TLC configuration in " + basename + " at position " + e.pos.toString() + ": " + e.msg)
     }
 
     // rewrite constants and declarations


### PR DESCRIPTION
Useful for users and for us when debugging (as in the case of  #208).

With this change, lexer errors now look like:

```
Configuration error (see the manual):   > Could not parse TLC configuration in BlockingQueue.cfg at position 4.17: string matching regex '\z' expected but '{' found E@00:14:23.070
```