### PR TITLE
Specify surefire version

### DIFF
--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -64,6 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
                 <configuration>
                     <!-- we have to tell SANY the location of Apalache modules -->
                     <systemPropertyVariables>


### PR DESCRIPTION
Removes the following warning from the build output:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for at.forsyte.apalache:tla-import:jar:0.7.3-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 64, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```