### PR TITLE
Add distclean target to remove 3rd party artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,13 @@ integration: apalache
 clean:
 	mvn clean
 
+distclean: clean
+	rm -rf $(DEPDIR)/lib
+	rm -rf $(DEPDIR)/bin
+	rm -rf $(DEPDIR)/include
+	rm -rf $(DEPDIR)/traget
+	rm -rf $(DEPDIR)/z3-*/
+
 $(DEPDIR)/lib:
 	mkdir -p $(DEPDIR)/lib
-	# install box by Jure (fix in the future!)
 	cd "$(DEPDIR)" && ./install-local.sh


### PR DESCRIPTION
Eventually this target should return the project to the
state of a fresh install (removing test artifacts etc),
but this at least handles the case of needing to clean build
our vendored deps.