### PR TITLE
Use Z3-TurnKey instead of a bespoke Z3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,20 @@ matrix:
   include:
     - os: linux
       jdk: openjdk8
-      
+
 # first, fix the issues with the dynamic libraries
 #    - os: osx
 #      osx_image: xcode9.3 # the latest image compatible with JDK8
 
 python:
-    - "2.7"
+  - "2.7"
 
 # required to compile z3
 addons:
   apt:
     packages:
-    - gcc-4.7
-    - g++-4.7
+      - gcc-4.7
+      - g++-4.7
 
 cache:
   directories:
@@ -26,10 +26,8 @@ cache:
 
 # locally compile z3 and make it available via LD_LIBRARY_PATH
 before_install:
-    - pushd 3rdparty
-    - ./install-local.sh
-    - popd
-    #- pip install release-me
+  - make deps
+  #- pip install release-me
 
 #after_success:
 #- sudo pip install --upgrade pip
@@ -42,12 +40,10 @@ before_install:
 #  - unstable
 
 script:
-    - make integration
+  - make integration
 
 notifications:
-    email:
-      recipients:
-        apalache-build@forsyte.at andrey@informal.systems
-      on_success: change
-      on_failure: always
-
+  email:
+    recipients: apalache-build@forsyte.at andrey@informal.systems
+    on_success: change
+    on_failure: always

--- a/3rdparty/README.md
+++ b/3rdparty/README.md
@@ -1,15 +1,9 @@
-Third-party libraries
-=====================
+# Third-party libraries
 
 APALACHE requires the following libraries that are not available from
 the central Maven repository:
 
- * TLA+2 Tools: tla2tools.jar. Available from:
-    [TLA+ Tools page](https://lamport.azurewebsites.net/tla/tools.html "TLA+ Tools").
-
- * Z3 Java bindings and Z3 shared libraries. The source code is available
- from [Z3 Github page](https://github.com/Z3Prover/z3 "Z3 Github page").
-   Check below how one to compile Z3 libraries.
+- Box: Available from [GitHub](https://github.com/Kukovec).
 
 In order to download, build and use the above libraries,
 execute the following shell command:
@@ -18,16 +12,14 @@ execute the following shell command:
 $ ./install-local.sh
 ```
 
-The above command downloads and compiles z3, downloads TLA2Tools and
-installs the both libraries in your local Maven
-cache. Once it is done, you do not have to worry about these libraries
-anymore, they will be automatically retrieved by our build system.
+The command downloads and compiles the libraries and installs them in your
+local Maven cache. Once it is done, you do not have to worry about these
+libraries anymore, they will be automatically retrieved by our build system.
 
-After the command has finished, add the following line to
-your ```~/.bashrc``` or ```~/.zshrc```:
+Unless you are using `direnv`, as recommended in
+[CONTRIBUTING.md](../CONTRIBUTING.md), then add the following line to your
+`~/.bashrc` or `~/.zshrc`:
 
 ```
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$APALACHE/3rdparty
 ```
-
-(The above command is needed to load the Z3 shared libraries.)

--- a/3rdparty/install-local.sh
+++ b/3rdparty/install-local.sh
@@ -7,7 +7,6 @@
 set -e
 
 D=`dirname $0` && D=`cd $D; pwd`
-Z3_DIR="$D/z3-4.8.7"
 CACHE=$1 # either empty, or --nocache
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -16,26 +15,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     echo "Assuming that you are using Linux..."
     OST="linux"
-fi
-
-if [ "$CACHE" == "--nocache" ]; then
-    echo "Cleaning the build cache"
-    rm -rf "${Z3_DIR}" "$D/Box"
-fi
-
-if [ -f "${Z3_DIR}/configure" ]; then
-    echo "Using a cached Z3 build..."
-else
-    echo "Checking out z3..."
-    git clone https://github.com/Z3Prover/z3.git ${Z3_DIR}
-    pushd ${Z3_DIR}
-    git checkout z3-4.8.7
-    echo "Configuring z3 locally (Linux)..."
-    python scripts/mk_make.py --java -p $D/
-    echo "Compiling z3..."
-    cd build
-    make
-    popd
 fi
 
 BOXHASH=77feaf4fc873990b72b31273985e2c88b8f2f502
@@ -48,14 +27,6 @@ pushd $D/Box
 git reset --hard $BOXHASH
 popd
 
-# install Z3 libraries
-echo "Compiling and installing z3..."
-pushd ${Z3_DIR}
-cd build
-make install # install *.so and *.jar in 3rdparty
-popd
-echo "Done with z3"
-
 echo "Installing Box..."
 pushd $D/Box/Box
 mvn install
@@ -63,21 +34,11 @@ cp target/box-1.0-SNAPSHOT.jar $D/lib/box.jar
 popd
 echo "Done with Box"
 
-echo "Installing Z3 in your local maven cache..."
-
-mvn -f $D/z3-pom.xml install install:install-file \
-    "-Dfile=$D/lib/com.microsoft.z3.jar" "-DpomFile=$D/z3-pom.xml"
-
 #mvn -f $D/tla2tools-pom.xml install install:install-file \
 #    "-Dfile=$D/tla2tools.jar" "-DpomFile=$D/tla2tools-pom.xml"
 
 mvn -f $D/box-pom.xml install install:install-file \
     "-Dfile=$D/lib/box.jar" "-DpomFile=$D/box-pom.xml"
-
-if [ "$CACHE" == "--nocache" ]; then
-    echo "Cleaning the build cache"
-    rm -rf "${Z3_DIR}" "$D/Box"
-fi
 
 cat <<EOF
 1. To build Apalache, just use make.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ## Unreleased #unstable
 
  * Use a staged docker build, reducing container size ~70%, see #195
+ * Use [Z3-TurnKey](https://github.com/tudo-aqua/z3-turnkey) instead of a
+   bespoke Z3 build, see #219
+ * Use Z3 version 4.8.7.1, see #219
 
 ## 0.7.2 [RELEASE]
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,13 @@ QUICK_MAVEN_OPTS := "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:non
 # - run up to 4 threads per core (4C): https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
 QUICK_MAVEN_ARGS := -DskipTests -Dscoverage.skip=true -T 4C
 
-.PHONY: all apalache compile build-quick test integration clean
+.PHONY: all apalache compile build-quick test integration clean deps
 
 all: apalache
 
-apalache: $(DEPS)
+deps: $(DEPS)
+
+apalache: deps
 	# tell maven to load the binary libraries and build the package
 	$(ENV) mvn package
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # a good old Makefile for the end users, as Maven is too much pain
 
 DEPDIR=3rdparty
-DEPS=$(DEPDIR)/lib/com.microsoft.z3.jar $(DEPDIR)/lib/box.jar
+DEPS=$(DEPDIR)/lib
 ENV=JAVA_LIBRARY_PATH="$(abspath $(DEPDIR)/lib)" NO_MVN=1 LD_LIBRARY_PATH="$(abspath $(DEPDIR)/lib)"
 
 # See https://www.jrebel.com/blog/how-to-speed-up-your-maven-build
@@ -43,11 +43,7 @@ integration: apalache
 clean:
 	mvn clean
 
-$(DEPDIR)/lib/com.microsoft.z3.jar:
-	# install microsoft z3
-	cd "$(DEPDIR)" && ./install-local.sh
-
-$(DEPDIR)/lib/box.jar:
+$(DEPDIR)/lib:
+	mkdir -p $(DEPDIR)/lib
 	# install box by Jure (fix in the future!)
 	cd "$(DEPDIR)" && ./install-local.sh
-

--- a/bin/apalache-mc
+++ b/bin/apalache-mc
@@ -40,11 +40,12 @@ TLA_LIB="$DIR/src/tla"
 # Once tlaplus/#490,#493 are released, remove this workaround.
 (test -z "$TLA_PATH" && TLA_PATH="$TLA_LIB") || TLA_PATH="$TLA_LIB:$TLA_PATH"
 
-# set LD_LIBRARY_PATH to find z3 libraries
 export LD_LIBRARY_PATH="$DIR/3rdparty/lib:${LD_LIBRARY_PATH}"
+
 # 1. The maximum heap size, Z3 will use much more as a native library.
 # 2. Duplicating LD_LIBRARY_PATH, tell JVM to find the third-party libraries.
 JVM_ARGS="-Xmx4096m -Djava.library.path=$DIR/3rdparty/lib "
+
 # uncomment to track memory usage with: jcmd <pid> VM.native_memory summary
 #JVM_ARGS="${JVM_ARGS} -XX:NativeMemoryTracking=summary"
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -194,8 +194,8 @@ $ docker image build -t apalache:0.7.0 .
    - On Arch: `sudo pacman -Syu maven`
 4. Clone the git repository: `git clone https://github.com/informalsystems/apalache.git`.
 5. Change into the project directory: `cd apalache`.
-7. Run `make`. This command will install Microsoft Z3, compile Apalache
-   and assemble the package.
+7. Run `make`. This command will install third party dependencies, compile
+   Apalache, and assemble the package.
 6. *Optionally* install [direnv][] and run `direnv allow`
 8. Confirm you can run the executable. It should print the inline CLI help message.
    - If you used `direnv`, then `apalache-mc` will be in your path.

--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,12 @@
                 <version>1.6.0-SNAPSHOT</version>
             </dependency>
 
-            <!-- Dependencies that are not available from the Maven repository, see 3rdparty/README.md -->
-
+            <!-- Z3-TurnKey provides Z3 and the integration of its Java API in
+                 a portable way. See https://github.com/tudo-aqua/z3-turnkey -->
             <dependency>
-                <groupId>com.microsoft</groupId>
-                <artifactId>z3</artifactId>
-                <version>4.8.7</version>
+                <groupId>io.github.tudo-aqua</groupId>
+                <artifactId>z3-turnkey</artifactId>
+                <version>4.8.7.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>tla2tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft</groupId>
-            <artifactId>z3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -58,6 +54,10 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scalaBinaryVersion}</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.tudo-aqua</groupId>
+            <artifactId>z3-turnkey</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/tla-bmcmt/pom.xml
+++ b/tla-bmcmt/pom.xml
@@ -52,8 +52,8 @@
             <artifactId>tla2tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft</groupId>
-            <artifactId>z3</artifactId>
+            <groupId>io.github.tudo-aqua</groupId>
+            <artifactId>z3-turnkey</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -47,8 +47,8 @@
             <artifactId>tla2tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft</groupId>
-            <artifactId>z3</artifactId>
+            <groupId>io.github.tudo-aqua</groupId>
+            <artifactId>z3-turnkey</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -42,8 +42,8 @@
             <artifactId>tla2tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft</groupId>
-            <artifactId>z3</artifactId>
+            <groupId>io.github.tudo-aqua</groupId>
+            <artifactId>z3-turnkey</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/tla-types/pom.xml
+++ b/tla-types/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>tla2tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft</groupId>
-            <artifactId>z3</artifactId>
+            <groupId>io.github.tudo-aqua</groupId>
+            <artifactId>z3-turnkey</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Closes #213 (I hope!)

Our bespoke build and local installation of the Z3 API dependency adds a lot of configuration overhead and brittleness 
to our build. While investigating #213, I read about Z3-Turnkey on https://stackoverflow.com/a/62015869/1187277. The purpose of this library is to provide a Java artifact that

> 1. ships its own native libraries,
> 2. can use them without administrative privileges, and
> 3. can be obtained using Maven.

I'm hopeful that it can simplify our build overall, and address #213.