### PR TITLE
Enable dependabot for automatic dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Automatically update dependencies
+# See https://docs.github.com/en/github/administering-a-repository/about-github-dependabot-version-updates
+
+version: 2
+updates:
+  # Enable version updates for maven
+  - package-ecosystem: "maven"
+    # Look for the `pom.xml` file in the `root` directory
+    directory: "/"
+    # Check maven central for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should help us keep our dependencies up to date.

See https://docs.github.com/en/github/administering-a-repository/about-github-dependabot-version-updates

(When we switch to SBT we can instead use https://github.com/scala-steward-org/scala-steward)