### PR TITLE
Use github actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build the docker image
         run: docker build -t apalache/mc:ci .
       - name: Run integration tests in docker container
-        run: make
+        run: ./test/run-integration
         env:
           USE_DOCKER: true
           APALACHE_TAG: ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+on: [push]
+
+name: Apalache Continuous Integration
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and test
+        run: make integration
+
+  docker-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the docker image
+        run: docker build -t apalache/mc:ci .
+      - name: Run integration tests in docker container
+        run: make
+        env:
+          USE_DOCKER: true
+          APALACHE_TAG: ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM maven:3.6.3-jdk-8-slim AS builder
 ADD . /opt/apalache/
 WORKDIR /opt/apalache/
 
-# clean the leftovers from the previous non-docker builds and build the package
-RUN mvn package
+# --batch-mode because we are running non-interactive
+# skipTests because we check the test in CI, not when packaing the container
+RUN mvn --batch-mode -DskipTests package
 
 FROM openjdk:8-slim
 


### PR DESCRIPTION
Closes #220, #221

Contributes to #192 and #237

Aside from removing dependency on an external service provider and being able to make use of the github actions ecosystem, this PR also adds the following features to our CI:

- Add macOS to our build matrix
- Run and (integration) test the Dockerfile 