### PR TITLE
Add Apalache logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# APALACHE project
+![Apalache Logo](./logo-apalache.svg)
+
+# APALACHE
 
 A symbolic model checker for TLA+
 
-__master__: [![Build Status](https://travis-ci.org/informalsystems/apalache.svg?branch=master)](https://travis-ci.org/informalsystems/apalache)
+**master**: [![Build Status](https://travis-ci.org/informalsystems/apalache.svg?branch=master)](https://travis-ci.org/informalsystems/apalache)
 &nbsp;&nbsp;&nbsp;
-__unstable__: [![Build Status](https://travis-ci.org/informalsystems/apalache.svg?branch=unstable)](https://travis-ci.org/informalsystems/apalache)
+**unstable**: [![Build Status](https://travis-ci.org/informalsystems/apalache.svg?branch=unstable)](https://travis-ci.org/informalsystems/apalache)
 
 Apalache translates TLA+ in the logic supported by the SMT solvers, for instance, [Microsoft Z3](https://github.com/Z3Prover/z3). Apalache can check inductive invariants (for fixed or bounded parameters) and check safety of bounded executions (bounded model checking). To see the list of supported
 TLA+ constructs, check the [supported features](docs/features.md). In general,

--- a/logo-apalache.svg
+++ b/logo-apalache.svg
@@ -1,0 +1,3 @@
+<svg width="98" height="98" viewBox="0 0 98 98" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 83L24.3666 52.4212M94 83L68.1506 44.4194M24.3666 52.4212L45.2806 22.1144C47.2963 19.1934 51.6288 19.2438 53.576 22.211L68.1506 44.4194M24.3666 52.4212L46.0511 44.4194V54.0339L68.1506 44.4194" stroke="#073387" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Adds the Apalache logo from informal.systems to the README.

It also includes some auto-formatting, which I didn't bother suppressing. Let me know if you'd like me to.

Looks like this:

![2020-09-23-154542_2080x707_scrot](https://user-images.githubusercontent.com/19820422/94061940-0ea73080-fdb4-11ea-8bc6-43573948876a.png)
