### PR TITLE
Run integration tests in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on: [push]
 name: Apalache Continuous Integration
 
 jobs:
-  build-and-test:
+  unit-tests:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
@@ -21,10 +21,33 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build and test
-        run: make integration
+      - name: Build and Unit Test
+        run: mvn --batch-mode --no-transfer-progress test
 
-  docker-test:
+  integration-tests:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build without unit tests
+        run: mvn --batch-mode --no-transfer-progress -DskipTests package
+      - name: Run Integration tests
+        run: NO_MVN=true test/run-integration
+
+  docker-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Towards #172 

This is an attempt to improve iteration time by reducing the time of our CI pipeline.

Instead of running the unit tests and integration sequentially on each platform, this breaks the unit tests and integration tests into two separate jobs, each running in parallel. 

- When running the unit tests, we use `mvn test`. This job is clocking in at around 5 minutes. If this does fail, we'll likely end up with quicker feedback than we've been receiving.
- When running integration tests, we run `mvn package` with `skipTests`, to get the artifacts as quickly as possible, and then run the integration tests using `NO_MVN`. This job is coming in at 12 mins on ubuntu and 15 mins (fastest times so far) on macOs

My unscientific observations so far indicate that this *might* save us about 3 minutes, and the faster feedback on unit tests could be helpful. But I'm not sure it's worth the added complexity in the build configuration.

Opening this just to get feedback from others on whether it seems worth merging in.