### PR TITLE
Use GitHub action badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 on: [push]
 
-name: Apalache Continuous Integration
+name: build
 
 jobs:
   unit-tests:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 A symbolic model checker for TLA+
 
-**master**: [![Build Status](https://travis-ci.org/informalsystems/apalache.svg?branch=master)](https://travis-ci.org/informalsystems/apalache)
-&nbsp;&nbsp;&nbsp;
-**unstable**: [![Build Status](https://travis-ci.org/informalsystems/apalache.svg?branch=unstable)](https://travis-ci.org/informalsystems/apalache)
+|             master             |              unstable              |
+| :----------------------------: | :--------------------------------: |
+| [![master badge][]][master-ci] | [![unstable badge][]][unstable-ci] |
+
+[master badge]: https://travis-ci.org/informalsystems/apalache.svg?branch=master
+[master-ci]: https://travis-ci.org/github/informalsystems/apalache/branches
+[unstable badge]: https://github.com/informalsystems/apalache/workflows/build/badge.svg
+[unstable-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Aunstable
 
 Apalache translates TLA+ in the logic supported by the SMT solvers, for instance, [Microsoft Z3](https://github.com/Z3Prover/z3). Apalache can check inductive invariants (for fixed or bounded parameters) and check safety of bounded executions (bounded model checking). To see the list of supported
 TLA+ constructs, check the [supported features](docs/features.md). In general,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A symbolic model checker for TLA+
 [master badge]: https://travis-ci.org/informalsystems/apalache.svg?branch=master
 [master-ci]: https://travis-ci.org/github/informalsystems/apalache/branches
 [unstable badge]: https://github.com/informalsystems/apalache/workflows/build/badge.svg
-[unstable-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Aunstable
+[unstable-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Aunstable+workflow%3Abuild
 
 Apalache translates TLA+ in the logic supported by the SMT solvers, for instance, [Microsoft Z3](https://github.com/Z3Prover/z3). Apalache can check inductive invariants (for fixed or bounded parameters) and check safety of bounded executions (bounded model checking). To see the list of supported
 TLA+ constructs, check the [supported features](docs/features.md). In general,


### PR DESCRIPTION
Followup to #241 

Looks like

![2020-09-24-142510_814x806_scrot](https://user-images.githubusercontent.com/19820422/94184381-d0704680-fe71-11ea-833a-fc40885fb4de.png)

Will need a followup right before we cut the next release, to point master to it's github action pipelines.