### PR TITLE
Add operators for type annotated empty collections

### DIFF
--- a/src/tla/Typing.tla
+++ b/src/tla/Typing.tla
@@ -46,4 +46,16 @@ AssumeType(name, tp) == TRUE
 (****************************************************************************)
 type_str :> ex == ex
 
+(****************************************************************************)
+(* Produce an empty set, whose elements have the type tp.                   *)
+(* Use this operator, if the type checker cannot infer the type of { }.     *)
+(****************************************************************************)
+EmptySet(tp) == { }
+
+(****************************************************************************)
+(* Produce an empty sequence, whose elements have the type tp.              *)
+(* Use this operator, if the type checker cannot infer the type of << >>.   *)
+(****************************************************************************)
+EmptySeq(tp) == << >>
+
 =============================================================================

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -73,7 +73,9 @@ object StandardLibrary {
       ("Apalache", "Expand") -> BmcOper.expand,
       ("Apalache", "ConstCardinality") -> BmcOper.constCard,
       ("Typing", "AssumeType") -> TypingOper.assumeType,
-      ("Typing", ":>") -> TypingOper.withType
+      ("Typing", ":>") -> TypingOper.withType,
+      ("Typing", "EmptySet") -> TypingOper.emptySet,
+      ("Typing", "EmptySeq") -> TypingOper.emptySeq
     )////
 
   val globalOperators: Map[String, TlaOper] =

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -105,21 +105,21 @@ object TlaFunOper {
     *
     * <p>
     * `TlaOperDecl("Fact", List(),
-    * OperEx(recFunDef,
-    * OperEx(TlaControlOper.ifThenElse,
-    * (* n <= 1 *),
-    * (* 1 *),
-    * OperEx(Tla.ArithOper.mult,
-    * NameEx("n"),
-    * OperEx(TlaFunOper.app,
-    * OperEx(recFunRef),
-    * OperEx(TlaArithOper.minus, NameEx(n), ValEx(TlaInt(1)))
-    * )
-    * )
-    * ),
-    * NameEx("n"),
-    * TlaIntSet
-    * )
+    *   OperEx(recFunDef,
+    *     OperEx(TlaControlOper.ifThenElse,
+    *       (* n <= 1 *),
+    *       (* 1 *),
+    *       OperEx(Tla.ArithOper.mult,
+    *         NameEx("n"),
+    *         OperEx(TlaFunOper.app,
+    *           OperEx(recFunRef),
+    *           OperEx(TlaArithOper.minus, NameEx(n), ValEx(TlaInt(1)))
+    *         )
+    *       )
+    *     ),
+    *     NameEx("n"),
+    *     TlaIntSet
+    *   )
     * )`
     * </p>
     */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TypingOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TypingOper.scala
@@ -31,6 +31,35 @@ object TypingOper {
     override val precedence: (Int, Int) = (100, 100)
   }
 
+  /**
+    * <p>Produce an empty set, whose elements have the type tp. Use this operator, if you are running the type checker.
+    * It is impossible to infer the type of an empty set without additional context.</p>
+    *
+    * <p>The only argument of this operator should be of shape `ValEx(TlaStr(text))`, where `text` is a type annotation
+    * in Type System 1.</p>
+    */
+  val emptySet: TypingOper = new TypingOper {
+    override def name: String = "Typing!EmptySet"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override def precedence: (Int, Int) = (100, 100)
+  }
+
+  /**
+    * <p>Produce an empty sequence, whose elements have the type tp. Use this operator, if you are running the
+    * type checker. It is impossible to infer the type of an empty set without additional context.</p>
+    *
+    * <p>The only argument of this operator should be of shape `ValEx(TlaStr(text))`, where `text` is a type annotation
+    * in Type System 1.</p>
+    */
+  val emptySeq: TypingOper = new TypingOper {
+    override def name: String = "Typing!EmptySeq"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override def precedence: (Int, Int) = (100, 100)
+  }
 }
 
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/package.scala
@@ -28,6 +28,7 @@ package oper {
     /** this operator is defined by the user and unknown to TLA+ */
     val User: Interpretation.Value = Value
     /** this operator does not have any definition but is used as a signature, e.g., f(_, _) in operator parameters */
+      // Igor (28.08.2020): this interpretation is no longer in use. Remove.
     val Signature: Interpretation.Value = Value
   }
 
@@ -103,12 +104,38 @@ package oper {
     }
 
     /**
-      * Operator application by name, e.g, OperEx(apply, f, x, y) calls f(x, y).
+      * <p>Operator application by name, e.g, <code>OperEx(apply, f, x, y)</code> calls <code>f(x, y)</code>.
+      * This operator is similar to a function call in the programming languages.
+      * </p>
       *
-      * This is an operator that you will not find in TLA+ code.
-      * The only case where this operator is used are the level 2 user-defined operators,
-      * that is, when one defines A(f(_), i) == f(i), the A's body is defined as
-      * OperEx(apply, NameEx("f"), NameEx("i")).
+      * <p>This is an operator that you will not find in TLA+ code.
+      * This operator appears in IR in two cases:
+      * (1) when a user-defined operator is called, either defined with a top-level definition or LET-IN, and
+      * (2) when a parameter of a user-defined operator is an operator itself, and it is applied to an argument.</p>
+      *
+      * <p>
+      * Examples:
+      * <ol>
+      *  <li>Consider two top-level definitions:
+      *
+      *  <pre>
+      * A(i) == i + 1
+      * B(j) == A(j)
+      *  </pre>
+      *
+      * The body of B is represented as <code>OperEx(apply, NameEx("A"), NameEx("j"))</code>
+      *
+      *  </li>
+      *  <li>Consider a top-level definition:
+      *
+      *  <pre>
+      * A(f(_), i) == f(i)
+      *  </pre>
+      *
+      *      The body of A is represented as <code>OperEx(apply, NameEx("f"), NameEx("i"))</code>
+      *  </li>
+      * </ol>
+      * </p>
       *
       * @see TestSanyImporter.test("level-2 operators")
       */
@@ -150,7 +177,11 @@ package oper {
       override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
     }
 
-    /** The CHOOSE idiom: CHOOSE x : x \notin S */
+    /**
+      * The CHOOSE idiom: CHOOSE x : x \notin S.
+      *
+      * Igor (28.08.2020): having this operator in the IR is a hack. We should just remove it.
+      */
     val chooseIdiom: TlaOper = new TlaOper {
       // TODO: move this operator to TlaBoolOper? (Igor)
       override val name: String = "CHOOSEI"


### PR DESCRIPTION
Broken out of #244

See
https://github.com/informalsystems/apalache/blob/unstable/docs/adr/002adr-types.md#23-dealing-with-bound-variables
for the motivation

Original Author: Igor Konnov <igor@informal.systems>