### PR TITLE
Fix logging for integration tests

### DIFF
--- a/test/mdx-test.py
+++ b/test/mdx-test.py
@@ -101,8 +101,6 @@ if __name__ == "__main__":
 
     args = cli_parser(working_dir).parse_args()
 
-    configure_logger(args.debug)
-
     # The file holding the integration tests
     test_file = args.test_file.resolve()
 
@@ -117,6 +115,9 @@ if __name__ == "__main__":
     working_dir_str = str(working_dir)
     test_file_str = str(corrected_file)
     corrected_file_str = str(test_file)
+
+    # Must come after the `test_target_dir` is created
+    configure_logger(args.debug)
 
     # Run the mdx tests to generate the corrected file
     cmd = [

--- a/test/mdx-test.py
+++ b/test/mdx-test.py
@@ -21,8 +21,10 @@ import os
 import sys
 
 from pathlib import Path
-from subprocess import run, PIPE
+from subprocess import run, Popen, PIPE, STDOUT
 
+logger = logging.getLogger("integration test logger")
+logger.setLevel(logging.DEBUG)
 
 # NOTE: The script assumes the /.envrc file in this repo's root has been loaded
 
@@ -39,15 +41,21 @@ def get_target_dir() -> Path:
     return Path(target_dir_str) / "test"
 
 
-def configure_logger() -> None:
+def configure_logger(debug: bool) -> None:
+    formatter = logging.Formatter("[%(asctime)s] %(levelname)s:%(message)s")
+
+    console_handler_level = logging.DEBUG if debug else logging.WARNING
     console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.WARNING)
-    logging.basicConfig(
-        format="[%(asctime)s] %(levelname)s:%(message)s",
-        filename=log_file,
-        level=logging.DEBUG,
-        handlers=[console_handler],
-    )
+    console_handler.setLevel(console_handler_level)
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(logging.DEBUG)
+
+    for h in (console_handler, file_handler):
+        h.setFormatter(formatter)
+        logger.addHandler(h)
+
+    logger.debug(f"Output level: {logging.getLevelName(console_handler_level)}")
 
 
 def cli_parser(working_dir) -> argparse.ArgumentParser:
@@ -65,6 +73,13 @@ def cli_parser(working_dir) -> argparse.ArgumentParser:
         default=None,
         nargs="?",
         help="Test to run. Determined by markdown section headers",
+    )
+    parser.add_argument(
+        "--debug",
+        "-d",
+        action="store_true",
+        default=False,
+        help="Enable debugging output",
     )
     return parser
 
@@ -86,6 +101,8 @@ if __name__ == "__main__":
 
     args = cli_parser(working_dir).parse_args()
 
+    configure_logger(args.debug)
+
     # The file holding the integration tests
     test_file = args.test_file.resolve()
 
@@ -105,6 +122,8 @@ if __name__ == "__main__":
     cmd = [
         "ocaml-mdx",
         "test",
+        "--verbosity",
+        "info",
         "--root",
         working_dir_str,
         "--output",
@@ -121,11 +140,14 @@ if __name__ == "__main__":
             )
             sys.exit(1)
 
-    result = run(cmd, stdout=PIPE, stderr=PIPE)
-    logging.debug(f"command args: {result.args}")
+    process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
+    logger.debug(f"running command: {process.args}")
+    while process.poll() is None:
+        line = process.stdout.readline().rstrip()
+        logger.info(line)
 
-    if result.returncode != 0:
-        logging.error(f"Failed to run test. Check {log_file}. Result: {result}")
+    if process.returncode != 0:
+        logger.error(f"Failed to run test. Check {log_file}. Result: {result}")
         sys.exit(1)
 
     # Run diff to check the corrected results against the expected results


### PR DESCRIPTION
This is a followup to #250 -- I had misconfigured the logger,
and so nothing was being logged to the files our stdout.'

Thanks to @konnov  for reporting the broken behavior.

Also adds a flag to enable debugging output to stdout

With this change, `test/mdx-test.py` can be run with the `--debug` flag to get streaming output like the following:

```
[sf@comp apalache-core]$ ./test/mdx-test.py "check Bug20190118 succeeds" --debug
[2020-10-12 16:13:04,922] DEBUG:Output level: DEBUG
[2020-10-12 16:13:04,923] DEBUG:running command: ['ocaml-mdx', 'test', '--verbosity', 'info', '--root', '/home/sf/Sync/informal-systems/apalache/apalache-core/test/tla', '--output', '/home/sf/Sync/informal-systems/apalache/apalache-core/target/test/tla/cli-integration-tests.md.corrected', '/home/sf/Sync/informal-systems/apalache/apalache-core/test/tla/cli-integration-tests.md', '--section', 'check Bug20190118 succeeds']
[2020-10-12 16:13:04,996] INFO:b'ocaml-mdx-test: [INFO] exec: "apalache-mc check --length=1 --init=Init --next=Next --inv=Inv Bug20190118.tla | sed \'s/I@.*//\'"'
[2020-10-12 16:13:07,556] INFO:b'ocaml-mdx-test: [INFO] exec: "apalache-mc check --length=1 Bug20190118.tla | sed \'s/I@.*//\'"'
[2020-10-12 16:13:10,128] INFO:b''
```

It's not the prettiest, and it doesn't include the output of the apalache in real time. This latter is something we can work towards, if we decide its important, but I'd like to get some clarity on the use case that makes the latter necessary before we spend any time on it.