### PR TITLE
a slice from ik/multicore: operators made Serializable

### DIFF
--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/identifiers.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/identifiers.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicLong
   *
   * @param id the value of the identifier.
   */
-class UID protected(val id: Long) {
+class UID protected(val id: Long) extends Serializable {
 
   override def hashCode(): Int = id.hashCode()
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/BmcOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/BmcOper.scala
@@ -16,7 +16,7 @@ object BmcOper {
   /**
     * A type annotation of an expression with another expression that encodes a type.
     */
-  val withType: BmcOper = new BmcOper {
+  object withType extends BmcOper {
     override def name: String = "BMC!<:"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (100, 100)
@@ -25,7 +25,7 @@ object BmcOper {
   /**
     * An operator x <- e that is interpreted as an assignment of e to x (the variable can have a prime too).
     */
-  val assign: BmcOper = new BmcOper {
+  object assign extends BmcOper {
     override def name: String = "BMC!:="
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (100, 100)
@@ -35,7 +35,7 @@ object BmcOper {
     * Skolemization hint. In an expression Skolem(\E x \in S: e), the existential may be skolemized, that is, translated
     * into a constant.
     */
-  val skolem: BmcOper = new BmcOper {
+  object skolem extends BmcOper {
     override def name: String = "BMC!Skolem"
     override def arity: OperArity = FixedArity(1)
     override def precedence: (Int, Int) = (100, 100)
@@ -46,7 +46,7 @@ object BmcOper {
     * to expand the underlying expression into a finite set. Since, such an expansion results in an exponential
     * blow up, this should be done carefully (and avoided as much as possible).
     */
-  val expand: BmcOper = new BmcOper {
+  object expand extends BmcOper {
     override def name: String = "BMC!Expand"
     override def arity: OperArity = FixedArity(1)
     override def precedence: (Int, Int) = (100, 100)
@@ -57,7 +57,7 @@ object BmcOper {
     * Similar to BMC!Skolem, this optimization has to be applied carefully, as it is not sound, when the cardinality
     * test is located under negation.
     */
-  val constCard: BmcOper = new BmcOper {
+  object constCard extends BmcOper {
     override def name: String = "BMC!ConstCardinality"
     override def arity: OperArity = FixedArity(1)
     override def precedence: (Int, Int) = (100, 100)
@@ -69,7 +69,7 @@ object BmcOper {
     *
     * XXX: there seems to be no way of defining a user-defined variadic operator in Apalache.tla.
     */
-  val distinct: BmcOper = new BmcOper {
+  object distinct extends BmcOper {
     override def name: String = "BMC!Distinct"
     override def arity: OperArity = AnyArity()
     override def precedence: (Int, Int) = (5, 5)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaActionOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaActionOper.scala
@@ -11,7 +11,7 @@ object TlaActionOper {
   /**
     * The prime operator. By the TLA+ restrictions, we cannot apply it twice, e.g., (x')' is illegal.
     */
-  val prime = new TlaActionOper {
+  object prime extends TlaActionOper {
     override val name: String = "'"
 
     override def arity: OperArity = FixedArity(1)
@@ -22,7 +22,7 @@ object TlaActionOper {
   /**
     * The operator that executes an action or keeps the variable values.
     */
-  val stutter = new TlaActionOper {
+  object stutter extends TlaActionOper {
     override val name: String = "[A]_e"
 
     override def arity: OperArity = FixedArity(2)
@@ -33,7 +33,7 @@ object TlaActionOper {
   /**
     * The operator that executes an action and enforces the values to change.
     */
-  val nostutter = new TlaActionOper {
+  object nostutter extends TlaActionOper {
     override val name: String = "<A>_e"
 
     override def arity: OperArity = FixedArity(2)
@@ -44,7 +44,7 @@ object TlaActionOper {
   /**
     * The ENABLED operator.
     */
-  val enabled = new TlaActionOper {
+  object enabled extends TlaActionOper {
     override val name: String = "ENABLED"
 
     override def arity: OperArity = FixedArity(1)
@@ -55,7 +55,7 @@ object TlaActionOper {
   /**
     * The operator that executes an action or keeps the variable values.
     */
-  val unchanged = new TlaActionOper {
+  object unchanged extends TlaActionOper {
     override val name: String = "UNCHANGED"
 
     override def arity: OperArity = FixedArity(1)
@@ -69,7 +69,7 @@ object TlaActionOper {
     * Jure@17.11.16: Arity 2?
     * Igor@12.03.17: Arity 2. Fixed.
     */
-  val composition = new TlaActionOper {
+  object composition extends TlaActionOper {
     override val name: String = "\\cdot"
     override def arity: OperArity = FixedArity(2)
     override def precedence: (Int, Int) = (13, 13)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaArithOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaArithOper.scala
@@ -28,7 +28,7 @@ object TlaArithOper {
   /**
     * An n-ary sum, that is, Sum(x_1, ..., x_n) = x_1 + ... + x_n.
     */
-  val sum = new TlaArithOper {
+  object sum extends TlaArithOper {
     override val arity = AnyArity()
     // Empty sum = 0
     override val name = "SUM"
@@ -38,7 +38,7 @@ object TlaArithOper {
   /**
     * A binary addition.
     */
-  val plus = new TlaArithOper {
+  object plus extends TlaArithOper {
     override val arity = FixedArity(2)
     override val name = "(+)"
     override val precedence: (Int, Int) = (10, 10)
@@ -47,7 +47,7 @@ object TlaArithOper {
   /**
     * A unary minus. Note that Naturals do not have unary minus.
     */
-  val uminus = new TlaArithOper {
+  object uminus extends TlaArithOper {
     override val arity = FixedArity(1)
     override val name = "-."
     override val precedence: (Int, Int) = (12, 12)
@@ -56,7 +56,7 @@ object TlaArithOper {
   /**
     * A binary minus.
     */
-  val minus = new TlaArithOper {
+  object minus extends TlaArithOper {
     override val arity = FixedArity(2)
     override val name = "(-)"
     override val precedence: (Int, Int) = (11, 11)
@@ -65,7 +65,7 @@ object TlaArithOper {
   /**
     * An n-ary product of the arguments, that is, Prod(x_1, ..., x_n) = x_1 * ... * x_n.
     */
-  val prod = new TlaArithOper {
+  object prod extends TlaArithOper {
     override def arity = AnyArity()
     // empty prod = 1
     override val name = "PROD"
@@ -75,7 +75,7 @@ object TlaArithOper {
   /**
     * A multiplication.
     */
-  val mult = new TlaArithOper {
+  object mult extends TlaArithOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(*)"
     override val precedence: (Int, Int) = (13, 13)
@@ -84,7 +84,7 @@ object TlaArithOper {
   /**
     * Integer division.
     */
-  val div = new TlaArithOper {
+  object div extends TlaArithOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(\\div)"
     override val precedence: (Int, Int) = (13, 13)
@@ -93,7 +93,7 @@ object TlaArithOper {
   /**
     * Remainder of an integer division.
     */
-  val mod = new TlaArithOper {
+  object mod extends TlaArithOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(%)"
     override val precedence: (Int, Int) = (10, 11)
@@ -102,7 +102,7 @@ object TlaArithOper {
   /**
     * Real division.
     */
-  val realDiv = new TlaArithOper {
+  object realDiv extends TlaArithOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(/)"
     override val precedence: (Int, Int) = (13, 13)
@@ -111,7 +111,7 @@ object TlaArithOper {
   /**
     * Exponent, i.e., x^y gives us x multiplied by itself (y-1) times.
     **/
-  val exp = new TlaArithOper {
+  object exp extends TlaArithOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(^)"
     override val precedence: (Int, Int) = (14, 14)
@@ -120,7 +120,7 @@ object TlaArithOper {
   /**
     * An integer/natural range, that is, a..b = {a,...,b}
     */
-  val dotdot = new TlaArithOper {
+  object dotdot extends TlaArithOper {
     override val arity = FixedArity(2)
     override val name = "_.._"
     override val precedence: (Int, Int) = (9, 9)
@@ -129,7 +129,7 @@ object TlaArithOper {
   /**
     * Less than.
     */
-  val lt = new TlaArithOper {
+  object lt extends TlaArithOper {
     /* the number of arguments the operator has */
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(<)"
@@ -139,7 +139,7 @@ object TlaArithOper {
   /**
     * Greater than.
     */
-  val gt = new TlaArithOper {
+  object gt extends TlaArithOper {
     /* the number of arguments the operator has */
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(>)"
@@ -149,7 +149,7 @@ object TlaArithOper {
   /**
     * Less than or equals.
     */
-  val le = new TlaArithOper {
+  object le extends TlaArithOper {
     /* the number of arguments the operator has */
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(<=)"
@@ -159,11 +159,10 @@ object TlaArithOper {
   /**
     * Greater than or equals.
     */
-  val ge = new TlaArithOper {
+  object ge extends TlaArithOper {
     /* the number of arguments the operator has */
     override def arity: OperArity = FixedArity(2)
     override val name: String = "(>=)"
     override val precedence: (Int, Int) = (5, 5)
   }
-
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaBoolOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaBoolOper.scala
@@ -15,7 +15,7 @@ object TlaBoolOper {
     * By convention, it should be evaluated to TRUE, when the argument list is empty.
     * Note that TLC interprets a conjunction A /\ B as IF A THEN B ELSE FALSE.
     */
-  val and = new TlaBoolOper {
+  object and extends TlaBoolOper {
     override def arity = AnyArity()
     override val name = "/\\"
     override val precedence: (Int, Int) = (3, 3)
@@ -27,7 +27,7 @@ object TlaBoolOper {
     * Note that TLC interprets a state-level disjunction A \/ B as
     * IF A THEN TRUE ELSE B.
     */
-  val or = new TlaBoolOper {
+  object or extends TlaBoolOper {
     override def arity: OperArity = AnyArity()
     override val name: String = "\\/"
     override val precedence: (Int, Int) = (3, 3)
@@ -36,7 +36,7 @@ object TlaBoolOper {
   /**
     * A negation.
     */
-  val not = new TlaBoolOper {
+  object not extends TlaBoolOper {
     override def arity: OperArity = FixedArity(1)
     override val name: String = "~"
     override val precedence: (Int, Int) = (4, 4)
@@ -45,7 +45,7 @@ object TlaBoolOper {
   /**
     * An implication A => B. For all the purposes, it should be thought of as being equivalent to ~A \/ B.
     */
-  val implies = new TlaBoolOper {
+  object implies extends TlaBoolOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "=>"
     override val precedence: (Int, Int) = (1, 1)
@@ -54,35 +54,35 @@ object TlaBoolOper {
   /**
     * An equivalence A <=> B.
     */
-  val equiv = new TlaBoolOper {
+  object equiv extends TlaBoolOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "<=>"
     override val precedence: (Int, Int) = (2, 2)
   }
 
   /** \A x \in S : p */
-  val forall = new TlaBoolOper {
+  object forall extends TlaBoolOper {
     override def arity: OperArity = FixedArity(3)
     override val name: String = "\\A3"
     override val precedence: (Int, Int) = (0, 0) // Section 15.2.1
   }
 
   /** \A x : p */
-  val forallUnbounded = new TlaBoolOper {
+  object forallUnbounded extends TlaBoolOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "\\A2"
     override val precedence: (Int, Int) = (0, 0) // Section 15.2.1
   }
 
   /** \E x \in S : p */
-  val exists = new TlaBoolOper {
+  object exists extends TlaBoolOper {
     override def arity: OperArity = FixedArity(3)
     override val name: String = "\\E3"
     override val precedence: (Int, Int) = (0, 0) // Section 15.2.1
   }
 
   /** \E x : p */
-  val existsUnbounded = new TlaBoolOper {
+  object existsUnbounded extends TlaBoolOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "\\E2"
     override val precedence: (Int, Int) = (0, 0) // Section 15.2.1

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaControlOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaControlOper.scala
@@ -14,7 +14,7 @@ object TlaControlOper {
     * A case operator without the OTHER option. The arguments are always an even-length list
     * of the following structure: guard_1, eff_1, guard_2, eff_2, ..., guard_k, eff_k.
     */
-  val caseNoOther = new TlaControlOper {
+  object caseNoOther extends TlaControlOper {
     override val name: String = "CASE"
     override val arity: OperArity = MinimalArity(2) && AnyEvenArity()  //new OperArity( k => k >= 2 && k % 2 == 0 )
     override val interpretation: Interpretation.Value = Interpretation.Predefined
@@ -27,7 +27,7 @@ object TlaControlOper {
     * That is, the first expression is the expression matching the OTHER option.
     * The rationale is that by using args.tail, one obtains a list similar to the caseOper.
     */
-  val caseWithOther = new TlaControlOper {
+  object caseWithOther extends TlaControlOper {
     override val name: String = "CASE-OTHER"
     override val arity: OperArity = MinimalArity(3) && AnyOddArity() //new OperArity( k => k >= 3 && k % 2 == 1 )
     override val interpretation: Interpretation.Value = Interpretation.Predefined
@@ -37,7 +37,7 @@ object TlaControlOper {
   /**
     * The "IF A THEN B ELSE C" operator. The arguments have the following structure: A, B, C.
     */
-  val ifThenElse = new TlaControlOper {
+  object ifThenElse extends TlaControlOper {
     override val name: String = "IF-THEN-ELSE"
     override val arity: OperArity = FixedArity(3)
     override val interpretation: Interpretation.Value = Interpretation.Predefined

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFiniteSetOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFiniteSetOper.scala
@@ -13,7 +13,7 @@ object TlaFiniteSetOper {
   /**
     * The operator that checks, whether a set is finite.
     */
-  val isFiniteSet = new TlaFiniteSetOper {
+  object isFiniteSet extends TlaFiniteSetOper {
     override val arity = FixedArity(1)
     override val name = "IsFiniteSet"
     override val precedence: (Int, Int) = (16, 16) // as the function application
@@ -22,7 +22,7 @@ object TlaFiniteSetOper {
   /**
     * The operator that returns the cardinality of a finite set.
     */
-  val cardinality = new TlaFiniteSetOper {
+  object cardinality extends TlaFiniteSetOper {
     override val arity = FixedArity(1)
     override val name = "Cardinality"
     override val precedence: (Int, Int) = (16, 16) // as the function application

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.lir.oper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
 
 /**
- * Function operators.
- */
+  * Function operators.
+  */
 abstract class TlaFunOper extends TlaOper {
   override def interpretation: Interpretation.Value = Interpretation.Predefined
 }
@@ -23,8 +23,8 @@ object TlaFunOper {
   }
 
   /**
-  Define a tuple by listing its elements, i.e., < e_1, ..., e_k >.
-    One can use enum to achieve the same effect.
+    * Define a tuple by listing its elements, i.e., < e_1, ..., e_k >.
+    * One can use enum to achieve the same effect.
     */
   object tuple extends TlaFunOper {
     override val arity = AnyArity()
@@ -144,17 +144,28 @@ object TlaFunOper {
   }
 
   /**
-    * A function update, e.g., [f EXCEPT ![i_1] = e_1, ![i_2] = e_2, ..., ![i_k] = e_k].
-    * The order of the arguments is as follows: (f, i_1, e_1, ..., i_k, e_k).
+    * <p>A function update, e.g., [f EXCEPT ![i_1] = e_1, ![i_2] = e_2, ..., ![i_k] = e_k].
+    * The order of the arguments is as follows: (f, i_1, e_1, ..., i_k, e_k).</p>
     *
-    * Note that all indices i_1, ..., i_k are tuples. For one-dimensional functions,
+    * <p>Note that all indices i_1, ..., i_k are tuples. For one-dimensional functions,
     * they are singleton tuples, whereas for multidimensional functions the indices are
     * tuples of arbitrary length. This is the design choice that comes from SANY.
     * When you write f[<<1>>] in TLA+, expect to deal with (except (tuple (tuple 1))) here.
+    * The method `unpackIndex` maps singleton tuples to their contents.
+    * </p>
     */
   object except extends TlaFunOper {
     override def arity: OperArity = new OperArity( k => k >= 3 && k % 2 == 1 )
     override val name: String = "EXCEPT"
     override val precedence: (Int, Int) = (16, 16) // as the function application
+
+    /**
+      * SANY always packs an EXCEPT accessor in a tuple, even if the index is one-dimensional.
+      * Unpack the one-dimensional index.
+      */
+    def unpackIndex: TlaEx => TlaEx = {
+      case OperEx(TlaFunOper.tuple, one) => one
+      case e => e
+    }
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -3,30 +3,30 @@ package at.forsyte.apalache.tla.lir.oper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
 
 /**
-  * Function operators.
-  */
+ * Function operators.
+ */
 abstract class TlaFunOper extends TlaOper {
   override def interpretation: Interpretation.Value = Interpretation.Predefined
 }
 
 object TlaFunOper {
+
   /**
     * A function constructor like the one for the records: [ k_1 |-> v_1, ..., k_n |-> v_n ].
     * The order of the arguments is: (k_1, v_1, ..., k_n, v_n).
     * Note that in case of records, k_1, ..., k_n are strings, that is, ValEx(TlaStr(...)), not NameEx.
     */
-  val enum = new TlaFunOper {
-    override def arity: OperArity = new OperArity(k => k >= 2 && k % 2 == 0)
-
+  object enum extends TlaFunOper {
+    override def arity: OperArity = new OperArity( k => k >= 2 && k % 2 == 0 )
     override val name: String = "fun-enum"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
   /**
-    * Define a tuple by listing its elements, i.e., < e_1, ..., e_k >.
-    * One can use enum to achieve the same effect.
+  Define a tuple by listing its elements, i.e., < e_1, ..., e_k >.
+    One can use enum to achieve the same effect.
     */
-  val tuple = new TlaFunOper {
+  object tuple extends TlaFunOper {
     override val arity = AnyArity()
     override val name = "<<...>>"
     override val precedence: (Int, Int) = (16, 16) // as the function application
@@ -47,14 +47,14 @@ object TlaFunOper {
     * A function application, e.g., f[e].
     * The order of the arguments is: (f, e).
     */
-  val app = new TlaFunOper {
+  object app extends TlaFunOper {
     override val arity: OperArity = FixedArity(2)
     override val name: String = "fun-app"
     override val precedence: (Int, Int) = (16, 16)
   }
 
   /** DOMAIN f */
-  val domain = new TlaFunOper {
+  object domain extends TlaFunOper {
     override val arity: OperArity = FixedArity(1)
     override val name: String = "DOMAIN"
     override val precedence: (Int, Int) = (9, 9)
@@ -70,9 +70,8 @@ object TlaFunOper {
     * The arguments are always an odd-length list
     * of the following structure: body, x_1, S_1, ..., x_k, S_k.
     */
-  val funDef = new TlaFunOper {
-    override def arity: OperArity = new OperArity(k => k >= 3 && k % 2 == 1)
-
+  object funDef extends TlaFunOper {
+    override def arity: OperArity = new OperArity( k => k >= 3 && k % 2 == 1 )
     override val name: String = "fun-def"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
@@ -82,15 +81,15 @@ object TlaFunOper {
     * We introduce a three-argument operator, whose arguments are as follows:</p>
     *
     * <ul>
-    * <li>function body of type TlaEx that may refer to the function via recFunRef,</li>
-    * <li>NameEx(variableName),</li>
-    * <li>variable domain of type TlaEx.</li>
+    *   <li>function body of type TlaEx that may refer to the function via recFunRef,</li>
+    *   <li>NameEx(variableName),</li>
+    *   <li>variable domain of type TlaEx.</li>
     * </ul>
     *
     * <p>Hence, a declaration of a recursive operator looks like a nullary operator declaration,
-    * whose body contains the constructor of a recursive function. The body of a recursive function may
-    * refer to the function itself by using the operator recFunRef (see below).
-    * Note that the output methods should convert this intermediate representation to the standard TLA+ form.</p>
+    *    whose body contains the constructor of a recursive function. The body of a recursive function may
+    *    refer to the function itself by using the operator recFunRef (see below).
+    *    Note that the output methods should convert this intermediate representation to the standard TLA+ form.</p>
     *
     * <p>There is a reason for defining a recursive function with two operators, rather than by introducing
     * a special case of `TlaDecl`. In TLA+, the operator bodies (as well as function bodies) may refer only to
@@ -123,11 +122,9 @@ object TlaFunOper {
     * )`
     * </p>
     */
-  val recFunDef = new TlaFunOper {
+  object recFunDef extends TlaFunOper {
     override def arity: OperArity = FixedArity(3)
-
     override def name: String = "rec-fun-def"
-
     override def precedence: (Int, Int) = (100, 100) // as the operator declaration
   }
 
@@ -136,43 +133,28 @@ object TlaFunOper {
     *
     * @see TlaFunOper.recFunDef
     */
-  val recFunRef = new TlaFunOper {
+  object recFunRef extends TlaFunOper {
     /**
       * A unique name that can be used to refer to a recursive function inside its body.
       */
     val uniqueName = "$recFun"
-
     override def name: String = "rec-fun-ref"
-
     override def arity: OperArity = FixedArity(0)
-
     override def precedence: (Int, Int) = (16, 16) // as function application
   }
 
   /**
-    * <p>A function update, e.g., [f EXCEPT ![i_1] = e_1, ![i_2] = e_2, ..., ![i_k] = e_k].
-    * The order of the arguments is as follows: (f, i_1, e_1, ..., i_k, e_k).</p>
+    * A function update, e.g., [f EXCEPT ![i_1] = e_1, ![i_2] = e_2, ..., ![i_k] = e_k].
+    * The order of the arguments is as follows: (f, i_1, e_1, ..., i_k, e_k).
     *
-    * <p>Note that all indices i_1, ..., i_k are tuples. For one-dimensional functions,
+    * Note that all indices i_1, ..., i_k are tuples. For one-dimensional functions,
     * they are singleton tuples, whereas for multidimensional functions the indices are
     * tuples of arbitrary length. This is the design choice that comes from SANY.
     * When you write f[<<1>>] in TLA+, expect to deal with (except (tuple (tuple 1))) here.
-    * The method `unpackIndex` maps singleton tuples to their contents.
-    * </p>
     */
-  val except = new TlaFunOper {
-    override def arity: OperArity = new OperArity(k => k >= 3 && k % 2 == 1)
-
+  object except extends TlaFunOper {
+    override def arity: OperArity = new OperArity( k => k >= 3 && k % 2 == 1 )
     override val name: String = "EXCEPT"
     override val precedence: (Int, Int) = (16, 16) // as the function application
-
-    /**
-      * SANY always packs an EXCEPT accessor in a tuple, even if the index is one-dimensional.
-      * Unpack the one-dimensional index.
-      */
-    def unpackIndex: TlaEx => TlaEx = {
-      case OperEx(TlaFunOper.tuple, one) => one
-      case e => e
-    }
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
@@ -53,12 +53,38 @@ object TlaOper {
   }
 
   /**
-    * Operator application by name, e.g, OperEx(apply, f, x, y) calls f(x, y).
+    * <p>Operator application by name, e.g, <code>OperEx(apply, f, x, y)</code> calls <code>f(x, y)</code>.
+    * This operator is similar to a function call in the programming languages.
+    * </p>
     *
-    * This is an operator that you will not find in TLA+ code.
-    * The only case where this operator is used are the level 2 user-defined operators,
-    * that is, when one defines A(f(_), i) == f(i), the A's body is defined as
-    * OperEx(apply, NameEx("f"), NameEx("i")).
+    * <p>This is an operator that you will not find in TLA+ code.
+    * This operator appears in IR in two cases:
+    * (1) when a user-defined operator is called, either defined with a top-level definition or LET-IN, and
+    * (2) when a parameter of a user-defined operator is an operator itself, and it is applied to an argument.</p>
+    *
+    * <p>
+    * Examples:
+    * <ol>
+    *  <li>Consider two top-level definitions:
+    *
+    *  <pre>
+    * A(i) == i + 1
+    * B(j) == A(j)
+    *  </pre>
+    *
+    * The body of B is represented as <code>OperEx(apply, NameEx("A"), NameEx("j"))</code>
+    *
+    *  </li>
+    *  <li>Consider a top-level definition:
+    *
+    *  <pre>
+    * A(f(_), i) == f(i)
+    *  </pre>
+    *
+    *      The body of A is represented as <code>OperEx(apply, NameEx("f"), NameEx("i"))</code>
+    *  </li>
+    * </ol>
+    * </p>
     *
     * @see TestSanyImporter.test("level-2 operators")
     */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
@@ -126,7 +126,11 @@ object TlaOper {
     override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
   }
 
-  /** The CHOOSE idiom: CHOOSE x : x \notin S */
+  /**
+    * The CHOOSE idiom: CHOOSE x : x \notin S.
+    * 
+    * Igor (28.08.2020): having this operator in the IR is a hack. We should just remove it.
+    */
   object chooseIdiom extends TlaOper {
     // TODO: move this operator to TlaBoolOper? (Igor)
     override val name: String = "CHOOSEI"

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
@@ -1,0 +1,151 @@
+package at.forsyte.apalache.tla.lir.oper
+
+import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.values.TlaStr
+
+/** An abstract operator */
+trait TlaOper extends Serializable {
+  def name: String
+
+  def interpretation: Interpretation.Value
+
+  /* the number of arguments the operator is allowed to have */
+  def arity: OperArity
+
+  /**
+    * Operator precedence. See: Lamport. Specifying Systems, 2004, p. 271, Table 6.
+    * @return the range that defines operator precedence [a, b].
+    */
+  def precedence: (Int, Int)
+
+  /**
+    * Is the operator allowed to have that many arguments?
+    * @param a the number of arguments
+    * @return true, if this number of arguments is allowed.
+    */
+  def isCorrectArity(a: Int): Boolean = arity.cond(a)
+
+  /**
+    * Do the operator arguments satisfy the operator invariant?
+    * For instance, some operators only allow name expressions in certain positions.
+    *
+    * @param args operator arguments
+    * @return true, if the invariant is satisfied
+    */
+  def permitsArgs(args: Seq[TlaEx]): Boolean = { true }
+}
+
+object TlaOper {
+  /** Equality of two TLA+ objects */
+  object eq extends TlaOper {
+    val name = "="
+    val interpretation: Interpretation.Value = Interpretation.Predefined
+    val arity = FixedArity(2)
+    override val precedence: (Int, Int) = (5, 5)
+  }
+
+  /** Inequality of two TLA+ objects */
+  object ne extends TlaOper {
+    val name = "/="
+    val interpretation: Interpretation.Value = Interpretation.Predefined
+    val arity = FixedArity(2)
+    override val precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+    * Operator application by name, e.g, OperEx(apply, f, x, y) calls f(x, y).
+    *
+    * This is an operator that you will not find in TLA+ code.
+    * The only case where this operator is used are the level 2 user-defined operators,
+    * that is, when one defines A(f(_), i) == f(i), the A's body is defined as
+    * OperEx(apply, NameEx("f"), NameEx("i")).
+    *
+    * @see TestSanyImporter.test("level-2 operators")
+    */
+  object apply extends TlaOper {
+    override def arity: OperArity = AnyPositiveArity()
+
+    override def interpretation: Interpretation.Value = Interpretation.Predefined
+    override val name: String = "_()"
+    override val precedence: (Int, Int) = (16, 16)
+  }
+
+  /**
+    * The CHOOSE operator: CHOOSE x \in S: p
+    */
+  object chooseBounded extends TlaOper {
+    // TODO: move this operator to TlaBoolOper? (Igor)
+    /* the number of arguments the operator has */
+    override val name: String = "CHOOSE3"
+
+    override def arity: OperArity = FixedArity(3)
+
+    override def interpretation: Interpretation.Value = Interpretation.Predefined
+
+    override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
+  }
+
+  /**
+    * The CHOOSE operator: CHOOSE x : p
+    */
+  object chooseUnbounded extends TlaOper {
+    // TODO: move this operator to TlaBoolOper? (Igor)
+    /* the number of arguments the operator has */
+    override val name: String = "CHOOSE2"
+
+    override def arity: OperArity = FixedArity(2)
+
+    override def interpretation: Interpretation.Value = Interpretation.Predefined
+
+    override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
+  }
+
+  /** The CHOOSE idiom: CHOOSE x : x \notin S */
+  object chooseIdiom extends TlaOper {
+    // TODO: move this operator to TlaBoolOper? (Igor)
+    override val name: String = "CHOOSEI"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override def interpretation: Interpretation.Value = Interpretation.Predefined
+
+    override val precedence: (Int, Int) = (0, 0) // Section 15.2.1
+  }
+
+  /**
+    * <p>An operator that decorates an expression with a label, e.g., l3(a, b) :: ex.
+    * The order of the arguments is as follows: (1) the decorated expression, e.g., ex,
+    * (2) the label, e.g., ValEx(TlaStr("l3")), and (3 to k) the label arguments,
+    * which must be strings, e.g., ValEx(TlaStr("a")) and ValEx(TlaStr("b")).</p>
+    *
+    * <p>To get more info about labels, see
+    * <a href="http://research.microsoft.com/en-us/um/people/lamport/tla/tla2-guide.pdf">TLA+2 Preliminary Guide</a>.</p>
+    *
+    * <p>Technically, a label is not an operator in TLA+, but a special form of an expression.
+    * As the labels are rarely used, we have decided to introduce a new operator instead of
+    * extending TlaEx with a new case class (it would have been annoying to take care of LabelEx
+    * in the pattern-matching code).</p>
+    */
+  object label extends TlaControlOper {
+    override val name: String = "LABEL"
+
+    override def arity: OperArity = MinimalArity(2)
+
+    override val interpretation: Interpretation.Value = Interpretation.Predefined
+
+    override val precedence: (Int, Int) = (16, 16) // similar to function application
+
+    /**
+      * Do the operator arguments satisfy the operator invariant?
+      * For instance, some operators only allow name expressions in certain positions.
+      *
+      * @param args operator arguments
+      * @return true, if the invariant is satisfied
+      */
+    override def permitsArgs(args: Seq[TlaEx]): Boolean = {
+      val isNameEx: PartialFunction[TlaEx, Boolean] = { case ValEx(TlaStr(_)) => true }
+      args.tail.forall(isNameEx.isDefinedAt)
+    }
+  }
+
+}

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSeqOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSeqOper.scala
@@ -18,43 +18,43 @@ abstract class TlaSeqOper extends TlaOper {
   */
 object TlaSeqOper {
 
-  val head = new TlaSeqOper {
+  object head extends TlaSeqOper {
     override val arity = FixedArity(1)
     override val name = "Head"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
-  val tail = new TlaSeqOper {
+  object tail extends TlaSeqOper {
     override val arity = FixedArity(1)
     override val name = "Tail"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
-  val append = new TlaSeqOper {
+  object append extends TlaSeqOper {
     override val arity = FixedArity(2)
     override val name = "Append"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
-  val concat = new TlaSeqOper {
+  object concat extends TlaSeqOper {
     override val arity = FixedArity(2)
     override val name = "\\o"
     override val precedence: (Int, Int) = (13, 13)
   }
 
-  val len = new TlaSeqOper {
+  object len extends TlaSeqOper {
     override val arity = FixedArity(1)
     override val name = "Len"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
-  val subseq = new TlaSeqOper {
+  object subseq extends TlaSeqOper {
     override val arity = FixedArity(3)
     override val name = "SubSeq"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
-  val selectseq = new TlaSeqOper {
+  object selectseq extends TlaSeqOper {
     override val arity = FixedArity(2)
     override val name = "SelectSeq"
     override val precedence: (Int, Int) = (16, 16) // as the function application

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSetOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSetOper.scala
@@ -9,20 +9,20 @@ abstract class TlaSetOper extends TlaOper {
 
 object TlaSetOper {
   /**
-    Define a set by enumerating its elements, i.e., {e_1, ..., e_k}
+  Define a set by enumerating its elements, i.e., {e_1, ..., e_k}
     Note that we explicitly forbid to construct an empty set using this operator.
     To construct an empty set, use emptySet.
-   */
-  val enumSet = new TlaSetOper {
+    */
+  object enumSet extends TlaSetOper {
     override val arity = AnyArity() // FIX: we allow zero arguments as well
     override val name = "{...}"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
   /**
-   * Construct a set of functions from a set S to a set T, i.e., [S -> T].
-   */
-  val funSet = new TlaSetOper {
+    * Construct a set of functions from a set S to a set T, i.e., [S -> T].
+    */
+  object funSet extends TlaSetOper {
     override def arity: OperArity = FixedArity(2)
     override val name: String = "[S -> T]"
     override val precedence: (Int, Int) = (16, 16) // as the function application
@@ -34,7 +34,7 @@ object TlaSetOper {
     * The field names f_1, ..., f_k are string constants,
     * that is, ValEx(TlaStr("...")) and not NameEx("...")
     */
-  val recSet = new TlaSetOper {
+  object recSet extends TlaSetOper {
     override def arity: OperArity = AnyEvenArity()
     override val name: String = "$SetOfRcds"
     override val precedence: (Int, Int) = (16, 16) // as the function application
@@ -43,38 +43,38 @@ object TlaSetOper {
   /**
     * Construct a set of sequences from a set S i.e., Seq(S).
     */
-  val seqSet = new TlaSetOper {
+  object seqSet extends TlaSetOper {
     override def arity: OperArity = FixedArity(1)
     override val name: String = "Seq"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
-  val in = new TlaSetOper {
+  object in extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\in"
     override val precedence: (Int, Int) = (5, 5)
   }
 
-  val notin = new TlaSetOper {
+  object notin extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\notin"
     override val precedence: (Int, Int) = (5, 5)
   }
 
-  val cup = new TlaSetOper {
+  object cup extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\union"
     override val precedence: (Int, Int) = (8, 8)
   }
 
-  val cap = new TlaSetOper {
+  object cap extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\intersect"
     override val precedence: (Int, Int) = (8, 8)
   }
 
   /** the standard \subseteq operator */
-  val subseteq = new TlaSetOper {
+  object subseteq extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\subseteq"
     override val precedence: (Int, Int) = (5, 5)
@@ -85,28 +85,27 @@ object TlaSetOper {
     *
     * WARNING: Do not confuse with SUBSET that is implemented by TlaSetOper.powerset.
     */
-  val subsetProper = new TlaSetOper {
+  object subsetProper extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\subset"
     override val precedence: (Int, Int) = (5, 5)
   }
 
-  /** the standard \supset operator */
-  val supsetProper = new TlaSetOper {
+  object supsetProper extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\supset"
     override val precedence: (Int, Int) = (5, 5)
   }
 
   /** the standard \supseteq operator */
-  val supseteq = new TlaSetOper {
+  object supseteq extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\supseteq"
     override val precedence: (Int, Int) = (5, 5)
   }
 
   /** the standard set difference */
-  val setminus = new TlaSetOper {
+  object setminus extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "\\setminus"
     override val precedence: (Int, Int) = (8, 8)
@@ -116,7 +115,7 @@ object TlaSetOper {
     * A restricted set comprehension: { x \in S : p }.
     * The argument order is: (x, S, p). Note that x may be a tuple.
     */
-  val filter = new TlaSetOper {
+  object filter extends TlaSetOper {
     // Jure, 24.11.2017:
     // Should we unify notation with TlaFunOper.funDef? funDef has args (e, (x, S)+ )
     //
@@ -132,7 +131,7 @@ object TlaSetOper {
     * A set mapping: { e: x_1 \in S_1, ..., x_k \in S_k }.
     * The argument order is: (e, x_1, S_1, ..., x_k, S_k)
     */
-  val map = new TlaSetOper {
+  object map extends TlaSetOper {
     override val arity = new OperArity( k => k >= 3 && k % 2 == 1 )
     override val name = "map"
     override val precedence: (Int, Int) = (16, 16)
@@ -141,7 +140,7 @@ object TlaSetOper {
   /** TLA SUBSET, i.e., the set of all subsets (of a given set).
     We use the name 'powerset' to avoid confusion with \subset and \subseteq.
     */
-  val powerset = new TlaSetOper {
+  object powerset extends TlaSetOper {
     override val arity = FixedArity(1)
     override val name = "SUBSET"
     override val precedence: (Int, Int) = (8, 8)
@@ -158,7 +157,7 @@ object TlaSetOper {
 
     WARNING: use it when you really need it. In all other cases, use \cup.
     */
-  val union = new TlaSetOper {
+  object union extends TlaSetOper {
     override val arity = FixedArity(1)
     override val name = "UNION"
     override val precedence: (Int, Int) = (8, 8)
@@ -169,7 +168,7 @@ object TlaSetOper {
     Note that we explicitly forbid to construct an empty set using this operator.
     To construct an empty set, use enumSet with no arguments.
     */
-  val times = new TlaSetOper {
+  object times extends TlaSetOper {
     override val arity = AnyArity()
     override val name = "\\times"
     override val precedence: (Int, Int) = (10, 13)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaTempOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaTempOper.scala
@@ -9,28 +9,28 @@ abstract class TlaTempOper extends TlaOper {
 
 object TlaTempOper {
   /** The LTL box operator */
-  val box = new TlaTempOper {
+  object box extends TlaTempOper {
     override val name: String = "[]"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (4, 15)
   }
 
   /** The LTL diamond operator */
-  val diamond = new TlaTempOper {
+  object diamond extends TlaTempOper {
     override val name: String = "<>"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (4, 15)
   }
 
   /** The leads-to operator */
-  val leadsTo = new TlaTempOper {
+  object leadsTo extends TlaTempOper {
     override val name: String = "~>"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (2, 2)
   }
 
   /** The 'guarantees' operator */
-  val guarantees = new TlaTempOper {
+  object guarantees extends TlaTempOper {
     override val name: String = "-+->"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (2, 2)
@@ -39,7 +39,7 @@ object TlaTempOper {
   /**
     * The weak fairness operator WF_x(A). The argument order is: (x, A).
     */
-  val weakFairness = new TlaTempOper {
+  object weakFairness extends TlaTempOper {
     override val name: String = "WF"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (4, 15)
@@ -48,21 +48,21 @@ object TlaTempOper {
   /**
     * The strong fairness operator SF_x(A). The argument order is: (x, A)
     */
-  val strongFairness = new TlaTempOper {
+  object strongFairness extends TlaTempOper {
     override val name: String = "SF"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (4, 15)
   }
 
   /** The temporal existential quantification (hiding) operator */
-  val EE = new TlaTempOper {
+  object EE extends TlaTempOper {
     override val name: String = "\\EE"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (0, 0) // Sec 15.2.1, Undelimited Constructs
   }
 
   /** The temporal universal quantification operator */
-  val AA = new TlaTempOper {
+  object AA extends TlaTempOper {
     override val name: String = "\\AA"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (0, 0) // Sec 15.2.1, Undelimited Constructs

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlcOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlcOper.scala
@@ -13,7 +13,7 @@ object TlcOper {
   /**
     * Print(out, val) from TLC.
     */
-  val print: TlcOper = new TlcOper {
+  object print extends TlcOper {
     override def name: String = "TLC!Print"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (16, 16)
@@ -22,7 +22,7 @@ object TlcOper {
   /**
     * PrintT(out) from TLC.
     */
-  val printT: TlcOper = new TlcOper {
+  object printT extends TlcOper {
     override def name: String = "TLC!PrintT"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (16, 16)
@@ -31,7 +31,7 @@ object TlcOper {
   /**
     * Assert(out, val) from TLC.
     */
-  val assert: TlcOper = new TlcOper {
+  object assert extends TlcOper {
     override def name: String = "TLC!Assert"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (16, 16)
@@ -40,7 +40,7 @@ object TlcOper {
   /**
     * JavaTime from TLC.
     */
-  val javaTime: TlcOper = new TlcOper {
+  object javaTime extends TlcOper {
     override def name: String = "TLC!javaTime"
     override def arity: OperArity = FixedArity(0)
     override val precedence: (Int, Int) = (16, 16)
@@ -49,7 +49,7 @@ object TlcOper {
   /**
     * TLCGet(i) from TLC.
     */
-  val tlcGet: TlcOper = new TlcOper {
+  object tlcGet extends TlcOper {
     override def name: String = "TLC!TLCGet"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (16, 16)
@@ -58,7 +58,7 @@ object TlcOper {
   /**
     * TLCSet(i, v) from TLC.
     */
-  val tlcSet: TlcOper = new TlcOper {
+  object tlcSet extends TlcOper {
     override def name: String = "TLC!TLCSet"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (16, 16)
@@ -67,7 +67,7 @@ object TlcOper {
   /**
     * _ :> _ from TLC.
     */
-  val colonGreater: TlcOper = new TlcOper {
+  object colonGreater extends TlcOper {
     override def name: String = "TLC!:>"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (7, 7)
@@ -76,7 +76,7 @@ object TlcOper {
   /**
     * _ @@ _ from TLC.
     */
-  val atat: TlcOper = new TlcOper {
+  object atat extends TlcOper {
     override def name: String = "TLC!@@"
     override def arity: OperArity = AnyArity()
     override val precedence: (Int, Int) = (6, 6)
@@ -85,7 +85,7 @@ object TlcOper {
   /**
     * Permutations(S) from TLC.
     */
-  val permutations: TlcOper = new TlcOper {
+  object permutations extends TlcOper {
     override def name: String = "TLC!Permutations"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (16, 16)
@@ -94,7 +94,7 @@ object TlcOper {
   /**
     * SortSeq(s, Op(_, _)) from TLC.
     */
-  val sortSeq: TlcOper = new TlcOper {
+  object sortSeq extends TlcOper {
     override def name: String = "TLC!SortSeq"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (16, 16)
@@ -103,7 +103,7 @@ object TlcOper {
   /**
     * RandomElement(S) from TLC.
     */
-  val randomElement: TlcOper = new TlcOper {
+  object randomElement extends TlcOper {
     override def name: String = "TLC!RandomElement"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (16, 16)
@@ -112,7 +112,7 @@ object TlcOper {
   /**
     * any from TLC.
     */
-  val any: TlcOper = new TlcOper {
+  object any extends TlcOper {
     override def name: String = "TLC!Any"
     override def arity: OperArity = FixedArity(0)
     override val precedence: (Int, Int) = (16, 16)
@@ -121,7 +121,7 @@ object TlcOper {
   /**
     * ToString(S) from TLC.
     */
-  val tlcToString: TlcOper = new TlcOper {
+  object tlcToString extends TlcOper {
     override def name: String = "TLC!ToString"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (16, 16)
@@ -130,7 +130,7 @@ object TlcOper {
   /**
     * TLCEval(v) from TLC.
     */
-  val tlcEval: TlcOper = new TlcOper {
+  object tlcEval extends TlcOper {
     override def name: String = "TLC!TLCEval"
     override def arity: OperArity = FixedArity(1)
     override val precedence: (Int, Int) = (16, 16)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TypingOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TypingOper.scala
@@ -15,7 +15,7 @@ object TypingOper {
     * This operator should be used in the top-level operator TypeAssumptions.
     * The first argument should be NameEx(_), and the second argument should be ValEx(TlaStr(_)).
     */
-  val assumeType: TypingOper = new TypingOper {
+  object assumeType extends TypingOper {
     override def name: String = "Typing!AssumeType"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (100, 100)
@@ -25,41 +25,12 @@ object TypingOper {
     * Annotate an operator body (or the body of a recursive function) with a type.
     * The first argument should be ValEx(TlaStr(_)), and the second argument should be TlaEx (operator body).
     */
-  val withType: TypingOper = new TypingOper {
+  object withType extends TypingOper {
     override def name: String = "Typing!:>"
     override def arity: OperArity = FixedArity(2)
     override val precedence: (Int, Int) = (100, 100)
   }
 
-  /**
-    * <p>Produce an empty set, whose elements have the type tp. Use this operator, if you are running the type checker.
-    * It is impossible to infer the type of an empty set without additional context.</p>
-    *
-    * <p>The only argument of this operator should be of shape `ValEx(TlaStr(text))`, where `text` is a type annotation
-    * in Type System 1.</p>
-    */
-  val emptySet: TypingOper = new TypingOper {
-    override def name: String = "Typing!EmptySet"
-
-    override def arity: OperArity = FixedArity(1)
-
-    override def precedence: (Int, Int) = (100, 100)
-  }
-
-  /**
-    * <p>Produce an empty sequence, whose elements have the type tp. Use this operator, if you are running the
-    * type checker. It is impossible to infer the type of an empty set without additional context.</p>
-    *
-    * <p>The only argument of this operator should be of shape `ValEx(TlaStr(text))`, where `text` is a type annotation
-    * in Type System 1.</p>
-    */
-  val emptySeq: TypingOper = new TypingOper {
-    override def name: String = "Typing!EmptySeq"
-
-    override def arity: OperArity = FixedArity(1)
-
-    override def precedence: (Int, Int) = (100, 100)
-  }
 }
 
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TypingOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TypingOper.scala
@@ -31,6 +31,31 @@ object TypingOper {
     override val precedence: (Int, Int) = (100, 100)
   }
 
+  /**
+    * <p>Produce an empty set, whose elements have the type tp. Use this operator, if you are running the type checker.
+    * It is impossible to infer the type of an empty set without additional context.</p>
+    *
+    * <p>The only argument of this operator should be of shape `ValEx(TlaStr(text))`, where `text` is a type annotation
+    * in Type System 1.</p>
+    */
+  object emptySet extends TypingOper {
+    override def name: String = "Typing!EmptySet"
+    override def arity: OperArity = FixedArity(1)
+    override def precedence: (Int, Int) = (100, 100)
+  }
+
+  /**
+    * <p>Produce an empty sequence, whose elements have the type tp. Use this operator, if you are running the
+    * type checker. It is impossible to infer the type of an empty set without additional context.</p>
+    *
+    * <p>The only argument of this operator should be of shape `ValEx(TlaStr(text))`, where `text` is a type annotation
+    * in Type System 1.</p>
+    */
+  object emptySeq extends TypingOper {
+    override def name: String = "Typing!EmptySeq"
+    override def arity: OperArity = FixedArity(1)
+    override def precedence: (Int, Int) = (100, 100)
+  }
 }
 
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/package.scala
@@ -26,6 +26,7 @@ package oper {
     /** this operator is defined by the user and unknown to TLA+ */
     val User: Interpretation.Value = Value
     /** this operator does not have any definition but is used as a signature, e.g., f(_, _) in operator parameters */
+      // Igor (28.08.2020): this interpretation is no longer in use. Remove.
     val Signature: Interpretation.Value = Value
   }
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/package.scala
@@ -5,8 +5,6 @@ package at.forsyte.apalache.tla.lir
   */
 package oper {
 
-  import at.forsyte.apalache.tla.lir.values.TlaStr
-
   /**
     * The levels of the operators as defined in the TLA+ book:
     * Constant (contains only primitive operations and constants), State (reasons about current state),
@@ -28,11 +26,10 @@ package oper {
     /** this operator is defined by the user and unknown to TLA+ */
     val User: Interpretation.Value = Value
     /** this operator does not have any definition but is used as a signature, e.g., f(_, _) in operator parameters */
-      // Igor (28.08.2020): this interpretation is no longer in use. Remove.
     val Signature: Interpretation.Value = Value
   }
 
-  class OperArity(private val m_cond: Int => Boolean) {
+  class OperArity(private val m_cond: Int => Boolean) extends Serializable {
     def cond(n: Int): Boolean = if (n < 0) false else m_cond(n)
 
     def &&(other: OperArity): OperArity = new OperArity(i => m_cond(i) && other.m_cond(i))
@@ -53,182 +50,4 @@ package oper {
   sealed case class AnyEvenArity() extends OperArity(_ % 2 == 0)
 
   sealed case class AnyPositiveArity() extends OperArity(_ > 0)
-
-  /** An abstract operator */
-  trait TlaOper {
-    def name: String
-
-    def interpretation: Interpretation.Value
-
-    /* the number of arguments the operator is allowed to have */
-    def arity: OperArity
-
-    /**
-      * Operator precedence. See: Lamport. Specifying Systems, 2004, p. 271, Table 6.
-      * @return the range that defines operator precedence [a, b].
-      */
-    def precedence: (Int, Int)
-
-    /**
-      * Is the operator allowed to have that many arguments?
-      * @param a the number of arguments
-      * @return true, if this number of arguments is allowed.
-      */
-    def isCorrectArity(a: Int): Boolean = arity.cond(a)
-
-    /**
-      * Do the operator arguments satisfy the operator invariant?
-      * For instance, some operators only allow name expressions in certain positions.
-      *
-      * @param args operator arguments
-      * @return true, if the invariant is satisfied
-      */
-    def permitsArgs(args: Seq[TlaEx]): Boolean = { true }
-  }
-
-  object TlaOper {
-    /** Equality of two TLA+ objects */
-    val eq: TlaOper = new TlaOper {
-      val name = "="
-      val interpretation: Interpretation.Value = Interpretation.Predefined
-      val arity = FixedArity(2)
-      override val precedence: (Int, Int) = (5, 5)
-    }
-
-    /** Inequality of two TLA+ objects */
-    val ne: TlaOper = new TlaOper {
-      val name = "/="
-      val interpretation: Interpretation.Value = Interpretation.Predefined
-      val arity = FixedArity(2)
-      override val precedence: (Int, Int) = (5, 5)
-    }
-
-    /**
-      * <p>Operator application by name, e.g, <code>OperEx(apply, f, x, y)</code> calls <code>f(x, y)</code>.
-      * This operator is similar to a function call in the programming languages.
-      * </p>
-      *
-      * <p>This is an operator that you will not find in TLA+ code.
-      * This operator appears in IR in two cases:
-      * (1) when a user-defined operator is called, either defined with a top-level definition or LET-IN, and
-      * (2) when a parameter of a user-defined operator is an operator itself, and it is applied to an argument.</p>
-      *
-      * <p>
-      * Examples:
-      * <ol>
-      *  <li>Consider two top-level definitions:
-      *
-      *  <pre>
-      * A(i) == i + 1
-      * B(j) == A(j)
-      *  </pre>
-      *
-      * The body of B is represented as <code>OperEx(apply, NameEx("A"), NameEx("j"))</code>
-      *
-      *  </li>
-      *  <li>Consider a top-level definition:
-      *
-      *  <pre>
-      * A(f(_), i) == f(i)
-      *  </pre>
-      *
-      *      The body of A is represented as <code>OperEx(apply, NameEx("f"), NameEx("i"))</code>
-      *  </li>
-      * </ol>
-      * </p>
-      *
-      * @see TestSanyImporter.test("level-2 operators")
-      */
-    val apply: TlaOper = new TlaOper {
-      override def arity: OperArity = AnyPositiveArity()
-
-      override def interpretation: Interpretation.Value = Interpretation.Predefined
-      override val name: String = "_()"
-      override val precedence: (Int, Int) = (16, 16)
-    }
-
-    /**
-      * The CHOOSE operator: CHOOSE x \in S: p
-      */
-    val chooseBounded: TlaOper = new TlaOper {
-      // TODO: move this operator to TlaBoolOper? (Igor)
-      /* the number of arguments the operator has */
-      override val name: String = "CHOOSE3"
-
-      override def arity: OperArity = FixedArity(3)
-
-      override def interpretation: Interpretation.Value = Interpretation.Predefined
-
-      override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
-    }
-
-    /**
-      * The CHOOSE operator: CHOOSE x : p
-      */
-    val chooseUnbounded: TlaOper = new TlaOper {
-      // TODO: move this operator to TlaBoolOper? (Igor)
-      /* the number of arguments the operator has */
-      override val name: String = "CHOOSE2"
-
-      override def arity: OperArity = FixedArity(2)
-
-      override def interpretation: Interpretation.Value = Interpretation.Predefined
-
-      override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
-    }
-
-    /**
-      * The CHOOSE idiom: CHOOSE x : x \notin S.
-      *
-      * Igor (28.08.2020): having this operator in the IR is a hack. We should just remove it.
-      */
-    val chooseIdiom: TlaOper = new TlaOper {
-      // TODO: move this operator to TlaBoolOper? (Igor)
-      override val name: String = "CHOOSEI"
-
-      override def arity: OperArity = FixedArity(1)
-
-      override def interpretation: Interpretation.Value = Interpretation.Predefined
-
-      override val precedence: (Int, Int) = (0, 0) // Section 15.2.1
-    }
-
-    /**
-      * <p>An operator that decorates an expression with a label, e.g., l3(a, b) :: ex.
-      * The order of the arguments is as follows: (1) the decorated expression, e.g., ex,
-      * (2) the label, e.g., ValEx(TlaStr("l3")), and (3 to k) the label arguments,
-      * which must be strings, e.g., ValEx(TlaStr("a")) and ValEx(TlaStr("b")).</p>
-      *
-      * <p>To get more info about labels, see
-      * <a href="http://research.microsoft.com/en-us/um/people/lamport/tla/tla2-guide.pdf">TLA+2 Preliminary Guide</a>.</p>
-      *
-      * <p>Technically, a label is not an operator in TLA+, but a special form of an expression.
-      * As the labels are rarely used, we have decided to introduce a new operator instead of
-      * extending TlaEx with a new case class (it would have been annoying to take care of LabelEx
-      * in the pattern-matching code).</p>
-      */
-    val label: TlaOper = new TlaControlOper {
-      override val name: String = "LABEL"
-
-      override def arity: OperArity = MinimalArity(2)
-
-      override val interpretation: Interpretation.Value = Interpretation.Predefined
-
-      override val precedence: (Int, Int) = (16, 16) // similar to function application
-
-      /**
-        * Do the operator arguments satisfy the operator invariant?
-        * For instance, some operators only allow name expressions in certain positions.
-        *
-        * @param args operator arguments
-        * @return true, if the invariant is satisfied
-        */
-      override def permitsArgs(args: Seq[TlaEx]): Boolean = {
-        val isNameEx: PartialFunction[TlaEx, Boolean] = { case ValEx(TlaStr(_)) => true }
-        args.tail.forall(isNameEx.isDefinedAt)
-      }
-    }
-
-  }
-
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
@@ -16,7 +16,7 @@ package lir {
     *
     * TODO: rename to TlaDef.
     */
-  abstract class TlaDecl {
+  abstract class TlaDecl extends Serializable {
     def name: String
     def deepCopy(): TlaDecl
   }
@@ -29,7 +29,7 @@ package lir {
     * @param name the module name
     * @param declarations all kinds of declarations
     */
-  class TlaModule(val name: String, val declarations: Seq[TlaDecl]) {
+  class TlaModule(val name: String, val declarations: Seq[TlaDecl]) extends Serializable {
     def constDeclarations: Seq[TlaConstDecl] = {
       declarations.collect { case d: TlaConstDecl => d }
     }
@@ -48,12 +48,12 @@ package lir {
   }
 
   /** a constant as defined by CONSTANT */
-  case class TlaConstDecl(name: String) extends TlaDecl{
+  case class TlaConstDecl(name: String) extends TlaDecl with Serializable {
     override def deepCopy( ): TlaConstDecl =  TlaConstDecl( name )
   }
 
   /** a variable as defined by VARIABLE */
-  case class TlaVarDecl(name: String) extends TlaDecl{
+  case class TlaVarDecl(name: String) extends TlaDecl with Serializable {
     override def deepCopy( ): TlaVarDecl =  TlaVarDecl( name )
   }
 
@@ -61,7 +61,7 @@ package lir {
     * An assumption defined by ASSUME(...)
     * @param body the assumption body
     */
-  case class TlaAssumeDecl(body: TlaEx) extends TlaDecl {
+  case class TlaAssumeDecl(body: TlaEx) extends TlaDecl with Serializable {
     val name: String = "ASSUME" + body.ID
     override def deepCopy(): TlaAssumeDecl = TlaAssumeDecl(body.deepCopy())
   }
@@ -73,7 +73,7 @@ package lir {
     *
     * FIXME: a candidate for removal. Just use TlaModule?
     */
-  case class TlaSpec( name: String, declarations: List[TlaDecl] ){
+  case class TlaSpec( name: String, declarations: List[TlaDecl] ) extends Serializable {
     def deepCopy() : TlaSpec = TlaSpec( name, declarations.map( _.deepCopy() ) )
 
   }
@@ -84,7 +84,7 @@ package lir {
   /**
   A formal parameter of an operator.
     */
-  sealed abstract class FormalParam {
+  sealed abstract class FormalParam extends Serializable {
     def name: String
 
     def arity: Int
@@ -92,17 +92,16 @@ package lir {
   }
 
   /** An ordinary formal parameter, e.g., x used in A(x) == ... */
-  case class SimpleFormalParam(name: String) extends FormalParam {
+  case class SimpleFormalParam(name: String) extends FormalParam with Serializable {
     override def arity: Int = 0
   }
 
   /** A function signature, e.g., f(_, _) used in A(f(_, _), x, y) */
-  case class OperFormalParam(name: String, arity: Int) extends FormalParam {
+  case class OperFormalParam(name: String, arity: Int) extends FormalParam with Serializable {
   }
 
   /** An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values. */
-  sealed abstract class TlaEx extends Identifiable {
-
+  sealed abstract class TlaEx extends Identifiable with Serializable {
     // TODO: there must be a nice way of defining default printers in scala, so we do not have to make a choice here
     override def toString: String =  UTFPrinter( this )
 
@@ -117,31 +116,31 @@ package lir {
     * gibberish definitions by SANY.
     * We could use Option[TlaEx], but that would introduce unnecessary many pattern matches, as NoneEx will be rare.
     */
-  object NullEx extends TlaEx {
+  object NullEx extends TlaEx with Serializable {
     override def deepCopy() : TlaEx = NullEx
     override def toSimpleString: String = toString
   }
 
   /** just using a TLA+ value */
-  case class ValEx(value: TlaValue) extends TlaEx{
+  case class ValEx(value: TlaValue) extends TlaEx with Serializable {
     override def toSimpleString: String = value.toString
     override def deepCopy() : ValEx = ValEx( value )
   }
 
   /** referring to a variable, constant, operator, etc. by a name. */
-  case class NameEx(name: String) extends TlaEx{
+  case class NameEx(name: String) extends TlaEx with Serializable {
     override def toSimpleString: String = name
     override def deepCopy() : NameEx = NameEx(name)
   }
 
   // Introducing a LET-IN expression
-  case class LetInEx( body: TlaEx, decls: TlaOperDecl* ) extends TlaEx {
+  case class LetInEx( body: TlaEx, decls: TlaOperDecl* ) extends TlaEx with Serializable {
     override def deepCopy( ) = LetInEx( body.deepCopy(), decls map { _.deepCopy() } :_*)
     override def toSimpleString: String = s"LET ${decls.mkString(" ")} IN $body"
   }
 
   // applying an operator, including the one defined by OperFormalParam
-  case class OperEx(oper: TlaOper, args: TlaEx*) extends TlaEx {
+  case class OperEx(oper: TlaOper, args: TlaEx*) extends TlaEx with Serializable {
     require(oper.isCorrectArity(args.size),
       "unexpected arity %d in %s applied to %s".format(args.size, oper.name, args.map(_.toString) mkString ", "))
 
@@ -178,7 +177,8 @@ package lir {
     * @param formalParams formal parameters
     * @param body operator definition, that is a TLA+ expression that captures the operator definition
     */
-  case class TlaOperDecl( name: String, formalParams: List[FormalParam], var body: TlaEx ) extends TlaDecl {
+  case class TlaOperDecl( name: String, formalParams: List[FormalParam], var body: TlaEx )
+    extends TlaDecl with Serializable {
     // this is no longer required, as module instantiation uses null bodies
     //    require( !body.isNull )
 


### PR DESCRIPTION
This is a first changeset from `ik/multicore`. The operators and other basic classes in `lir` made `Serializable`.