### PR TITLE
chunk 2 from ik/multicore: making caches Serializable and Recoverable

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/CoercionWithCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/CoercionWithCache.scala
@@ -22,6 +22,9 @@ class CoercionWithCache(val stateRewriter: SymbStateRewriter) extends StackableC
     */
   private var level: Int = 0
 
+  // a temporary fix for StackableContext. This class is planned for deletion.
+  override def contextLevel: Int = level
+
   // cache the integer constants that are introduced in SMT for integer literals
   private var cache: Map[SourceT, (TargetT, Int)] = Map()
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/PreproSolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/PreproSolverContext.scala
@@ -240,6 +240,13 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
   override def setSmtListener(listener: SmtListener): Unit = context.setSmtListener(listener)
 
   /**
+    * Get the current context level, that is the difference between the number of pushes and pops made so far.
+    *
+    * @return the current level, always non-negative.
+    */
+  override def contextLevel: Int = context.contextLevel
+
+  /**
     * Save the current context and push it on the stack for a later recovery with pop.
     */
   override def push(): Unit = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/StackableContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/StackableContext.scala
@@ -8,6 +8,13 @@ package at.forsyte.apalache.tla.bmcmt
   */
 trait StackableContext {
   /**
+    * Get the current context level, that is the difference between the number of pushes and pops made so far.
+    *
+    * @return the current level, always non-negative.
+    */
+  def contextLevel: Int
+
+  /**
     * Save the current context and push it on the stack for a later recovery with pop.
     */
   def push(): Unit
@@ -19,7 +26,7 @@ trait StackableContext {
   def pop(): Unit
 
   /**
-    * Pop the context as many times as needed to reach a given level.
+    * Pop the context n times.
     * @param n pop n times, if n > 0, otherwise, do nothing
     */
   def pop(n: Int)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Z3SolverContext.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import java.io.{File, PrintWriter}
+import java.util.concurrent.atomic.AtomicLong
 
 import at.forsyte.apalache.tla.bmcmt.profiler.{IdleSmtListener, SmtListener}
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
@@ -20,13 +21,15 @@ import scala.collection.mutable
   * @author Igor Konnov
   */
 class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends SolverContext {
+  private val id: Long = Z3SolverContext.createId()
+
   /**
     * A log writer, for debugging purposes.
     */
   private val logWriter: PrintWriter = initLog()
 
   var level: Int = 0
-  var nBoolConsts: Int = 0 // the first three cells are reserved for: false and true
+  var nBoolConsts: Int = 0 // the solver introduces Boolean constants internally
   var nIntConsts: Int = 0
   private val z3context: Context = new Context()
   private val z3solver = z3context.mkSolver()
@@ -91,8 +94,8 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
       // Checking consistency. When the user accidentally replaces a fresh arena with an older one,
       // we report it immediately. Otherwise, it is very hard to find the cause.
       logWriter.flush() // flush the SMT log
-      throw new InternalCheckerError("Declaring cell %d, while cell %d has been already declared. Damaged arena?"
-        .format(cell.id, maxCellIdPerContext.head), NullEx)
+      throw new InternalCheckerError("SMT %d: Declaring cell %d, while cell %d has been already declared. Damaged arena?"
+        .format(id, cell.id, maxCellIdPerContext.head), NullEx)
     } else {
       maxCellIdPerContext = cell.id +: maxCellIdPerContext.tail
     }
@@ -139,7 +142,7 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
       // Checking consistency. When the user accidentally replaces a fresh arena with an older one,
       // we report it immediately. Otherwise, it is very hard to find the cause.
       logWriter.flush() // flush the SMT log
-      throw new InternalCheckerError(s"Current arena has cell id = $topId, while SMT has ${maxCellIdPerContext.head}. Damaged arena?", NullEx)
+      throw new InternalCheckerError(s"SMT $id: Current arena has cell id = $topId, while SMT has ${maxCellIdPerContext.head}. Damaged arena?", NullEx)
     }
   }
 
@@ -151,23 +154,9 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
   def assertGroundExpr(ex: TlaEx): Unit = {
     smtListener.onSmtAssert(ex)
     log(s";; assert ${UTFPrinter.apply(ex)}")
-    if (!debug) {
-      simplifier.simplify(ex) match {
-        case OperEx(TlaBoolOper.and, args@_*) =>
-          // this optimization slows down model checking
-          args foreach assertGroundExpr // break down into clauses
-
-        case simple@_ =>
-          val z3expr = toExpr(simple)
-          log(s"(assert ${z3expr.toString})")
-          z3solver.add(z3expr.asInstanceOf[BoolExpr])
-      }
-    } else {
-      // preprocessing makes bugs disappear, turn it off in the debugging
-      val z3expr = toExpr(ex)
-      log(s"(assert ${z3expr.toString})")
-      z3solver.add(z3expr.asInstanceOf[BoolExpr])
-    }
+    val z3expr = toExpr(ex)
+    log(s"(assert ${z3expr.toString})")
+    z3solver.add(z3expr.asInstanceOf[BoolExpr])
 
     if (profile) {
       val timeBefore = System.nanoTime()
@@ -188,7 +177,7 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
     * @return a TLA+ value
     */
   def evalGroundExpr(ex: TlaEx): TlaEx = {
-    val z3expr = z3solver.getModel.eval(toExpr(simplifier.simplify(ex)), true)
+    val z3expr = z3solver.getModel.eval(toExpr(ex), true)
     z3expr match {
       case b: BoolExpr =>
         val isTrue = b.getBoolValue.equals(Z3_lbool.Z3_L_TRUE)
@@ -201,13 +190,14 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
         if (z3expr.isConst && z3expr.getSort.getName.toString.startsWith("Cell_")) {
           NameEx(z3expr.toString)
         } else {
-          throw new SmtEncodingException("Expected an integer or Boolean, found: " + z3expr, ex)
+          logWriter.flush() // flush the SMT log
+          throw new SmtEncodingException(s"SMT $id: Expected an integer or Boolean, found: $z3expr", ex)
         }
     }
   }
 
   private def initLog(): PrintWriter = {
-    val writer = new PrintWriter(new File("log.smt"))
+    val writer = new PrintWriter(new File(s"log$id.smt"))
     if (!debug) {
       writer.println("Logging is disabled (Z3SolverContext.debug = false). Activate with --debug.")
       writer.flush()
@@ -292,7 +282,8 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
     val resSig = resultType.signature
     val funName = s"fun$cellName"
     if (funDecls.contains(funName)) {
-      throw new SmtEncodingException(s"Declaring twice the function associated with cell $cellName", NullEx)
+      logWriter.flush() // flush the SMT log
+      throw new SmtEncodingException(s"SMT $id: Declaring twice the function associated with cell $cellName", NullEx)
     } else {
       val domSort = getOrMkCellSort(argType)
       val cdmSort = getOrMkCellSort(resultType)
@@ -303,15 +294,12 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
     }
   }
 
-  private def getCellFun(cellName: String): FuncDecl = {
-    val funName = s"fun$cellName"
-    val funDecl = funDecls.get(funName)
-    if (funDecl.isDefined) {
-      funDecl.get._1
-    } else {
-      throw new SmtEncodingException(s"A function associated with cell $cellName is not declared", NullEx)
-    }
-  }
+  /**
+    * Get the current context level, that is the difference between the number of pushes and pops made so far.
+    *
+    * @return the current level, always non-negative.
+    */
+  override def contextLevel: Int = level
 
   /**
     * Push SMT context
@@ -362,7 +350,8 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
     logWriter.flush() // good time to flush
     if (status == Status.UNKNOWN) {
       // that seems to be the only reasonable behavior
-      throw new SmtEncodingException("SMT solver reports UNKNOWN. Perhaps, your specification is outside the supported logic.", NullEx)
+      logWriter.flush() // flush the SMT log
+      throw new SmtEncodingException(s"SMT $id: z3 reports UNKNOWN. Maybe, your specification is outside the supported logic.", NullEx)
     }
     status == Status.SATISFIABLE
   }
@@ -388,22 +377,6 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
         case Status.UNSATISFIABLE => Some(false)
         case Status.UNKNOWN => None
       }
-
-      /*
-      // XXX: this produces a segfault sometimes...
-      val satFuture: Future[Boolean] = Future {
-        sat()
-      }(ExecutionContext.global)
-
-      try {
-        Some(Await.result(satFuture, Duration(timeoutSec, TimeUnit.SECONDS)))
-      } catch {
-        case _: TimeoutException | _: InterruptedException =>
-          z3context.interrupt()
-          log(s";; timeout")
-          None
-      }
-      */
     }
   }
 
@@ -447,25 +420,6 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
     }
   }
 
-  /*
-  // this is the old implementation that used uninterpreted functions
-  private def getOrMkInPred(setType: CellT, elemType: CellT): FuncDecl = {
-    val name = s"in_${elemType.signature}_${setType.signature}"
-    val funDecl = funDecls.get(name)
-    if (funDecl.isDefined) {
-      funDecl.get._1
-    } else {
-      val elemSort = getOrMkCellSort(elemType)
-      val setSort = getOrMkCellSort(setType)
-      val newDecl = z3context.mkFuncDecl(name,
-        Array[Sort](elemSort, setSort), z3context.getBoolSort)
-      funDecls += (name -> (newDecl, level))
-      log(s"(declare-fun $name ($elemSort $setSort) Bool)") // log declaration
-      newDecl
-    }
-  }
-  */
-
   private def getInPred(setName: String, setT: CellT, elemName: String, elemT: CellT): Expr = {
     val name = s"in_${elemT.signature}${elemName}_${setT.signature}$setName"
 
@@ -493,7 +447,8 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
         if (num.isValidLong) {
           z3context.mkInt(num.toLong)
         } else {
-          throw new SmtEncodingException("A number constant is too large to fit in Long: " + num, NullEx)
+          logWriter.flush() // flush the SMT log
+          throw new SmtEncodingException(s"SMT $id: A number constant is too large to fit in Long: $num", NullEx)
         }
 
       case OperEx(oper: TlaArithOper, lex, rex) =>
@@ -523,25 +478,15 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
         z3context.mkDistinct(args map toExpr :_*)
 
       case OperEx(TlaBoolOper.and, es@_*) =>
-        if (es.size < 1000) {
-          val newEs = es.map(e => toExpr(e).asInstanceOf[BoolExpr])
-          z3context.mkAnd(newEs: _*)
-        } else {
-          // use Tseitin to produce many short clauses, as our clauses sometimes contain thousands of literals
-          tseitinAnd(es)
-        }
+        val newEs = es.map(e => toExpr(e).asInstanceOf[BoolExpr])
+        z3context.mkAnd(newEs: _*)
 
       case OperEx(TlaBoolOper.or, es@_*) =>
-        if (es.size < 1000) {
-          val mapped_es = es map toExpr
-          // check the assertion before casting, to make debugging easier
-          assert(mapped_es.forall(e => e.isInstanceOf[BoolExpr]))
-          val cast_es = mapped_es.map(_.asInstanceOf[BoolExpr])
-          z3context.mkOr(cast_es: _*)
-        } else {
-          // use Tseitin to produce many short clauses, as our clauses sometimes contain thousands of literals
-          tseitinOr(es)
-        }
+        val mapped_es = es map toExpr
+        // check the assertion before casting, to make debugging easier
+        assert(mapped_es.forall(e => e.isInstanceOf[BoolExpr]))
+        val cast_es = mapped_es.map(_.asInstanceOf[BoolExpr])
+        z3context.mkOr(cast_es: _*)
 
       case OperEx(TlaBoolOper.implies, lhs, rhs) =>
         val lhsZ3 = toExpr(lhs).asInstanceOf[BoolExpr]
@@ -574,10 +519,12 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
       // the old implementation allowed us to do that, but the new one is encoding edges directly
     case OperEx(TlaSetOper.in, ValEx(TlaInt(_)), NameEx(_))
         | OperEx(TlaSetOper.in, ValEx(TlaBool(_)), NameEx(_)) =>
-        throw new InvalidTlaExException("Preprocessing introduced a literal inside tla.in: " + ex, ex)
+        logWriter.flush() // flush the SMT log
+        throw new InvalidTlaExException(s"SMT $id: Preprocessing introduced a literal inside tla.in: $ex", ex)
 
       case _ =>
-        throw new InvalidTlaExException("Unexpected TLA+ expression: " + ex, ex)
+        logWriter.flush() // flush the SMT log
+        throw new InvalidTlaExException(s"SMT $id: Unexpected TLA+ expression: $ex", ex)
     }
   }
 
@@ -600,7 +547,8 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
         z3context.mkEq(le, re)
 
       case _ =>
-        throw new CheckerException("Incomparable expressions", NullEx)
+        logWriter.flush() // flush the SMT log
+        throw new CheckerException(s"SMT $id: Incomparable expressions", NullEx)
     }
   }
 
@@ -610,7 +558,8 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
         if (num.isValidLong) {
           z3context.mkInt(num.toLong)
         } else {
-          throw new SmtEncodingException("A number constant is too large to fit in Long: " + num, ex)
+          logWriter.flush() // flush the SMT log
+          throw new SmtEncodingException(s"SMT $id: A number constant is too large to fit in Long: " + num, ex)
         }
 
       case NameEx(name) =>
@@ -663,78 +612,17 @@ class Z3SolverContext(debug: Boolean = false, profile: Boolean = false) extends 
 
 
       case _ =>
-        throw new InvalidTlaExException("Unexpected arithmetic expression: " + ex, ex)
+        logWriter.flush() // flush the SMT log
+        throw new InvalidTlaExException(s"SMT $id: Unexpected arithmetic expression: $ex", ex)
     }
 
   }
+}
 
-  private def tseitinOr(es: Seq[TlaEx]): BoolExpr = {
-    def processOr(in: BoolExpr, form: BoolExpr, out: BoolExpr): BoolExpr = {
-      log(s";; Tseitin of OR for $form")
-      z3solver.add(z3context.mkOr(in, form, z3context.mkNot(out)))
-      z3solver.add(z3context.mkOr(z3context.mkNot(in), out))
-      z3solver.add(z3context.mkOr(z3context.mkNot(form), out))
-      out
-    }
+object Z3SolverContext {
+  private var nextId: AtomicLong = new AtomicLong(0)
 
-    def each(past: BoolExpr, oneEx: TlaEx): BoolExpr = {
-      oneEx match {
-        case ValEx(TlaBool(false)) =>
-          past
-
-        case ValEx(TlaBool(true)) =>
-          z3context.mkTrue()
-
-        case NameEx(_) =>
-          // just a Boolean constant
-          val out = constCache(introBoolConst())._1.asInstanceOf[BoolExpr]
-          processOr(past, toExpr(oneEx).asInstanceOf[BoolExpr], out)
-
-        case _ =>
-          // a complex expression, introduce a Boolean constant
-          val pred = constCache(introBoolConst())._1.asInstanceOf[BoolExpr]
-          z3solver.add(z3context.mkIff(pred, toExpr(oneEx).asInstanceOf[BoolExpr]))
-          val out = constCache(introBoolConst())._1.asInstanceOf[BoolExpr]
-          processOr(past, pred, out)
-      }
-    }
-
-    es.foldLeft(z3context.mkFalse())(each)
-  }
-
-  private def tseitinAnd(es: Seq[TlaEx]): BoolExpr = {
-    def not = z3context.mkNot _
-
-    def processAnd(in: BoolExpr, form: BoolExpr, out: BoolExpr): BoolExpr = {
-      log(s";; Tseitin of AND for $form")
-      z3solver.add(z3context.mkOr(not(in), not(form), out))
-      z3solver.add(z3context.mkOr(in, not(out)))
-      z3solver.add(z3context.mkOr(form, not(out)))
-      out
-    }
-
-    def each(past: BoolExpr, oneEx: TlaEx): BoolExpr = {
-      oneEx match {
-        case ValEx(TlaBool(true)) =>
-          past
-
-        case ValEx(TlaBool(false)) =>
-          z3context.mkFalse()
-
-        case NameEx(_) =>
-          // just a Boolean constant
-          val out = constCache(introBoolConst())._1.asInstanceOf[BoolExpr]
-          processAnd(past, toExpr(oneEx).asInstanceOf[BoolExpr], out)
-
-        case _ =>
-          // a complex expression, introduce a Boolean constant
-          val pred = constCache(introBoolConst())._1.asInstanceOf[BoolExpr]
-          z3solver.add(z3context.mkIff(pred, toExpr(oneEx).asInstanceOf[BoolExpr]))
-          val out = constCache(introBoolConst())._1.asInstanceOf[BoolExpr]
-          processAnd(past, pred, out)
-      }
-    }
-
-    es.foldLeft(z3context.mkTrue())(each)
+  private def createId(): Long = {
+    nextId.getAndIncrement()
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeStoreImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeStoreImpl.scala
@@ -6,7 +6,7 @@ import com.google.inject.Singleton
 import scala.collection.mutable
 
 @Singleton
-class ExprGradeStoreImpl extends ExprGradeStore {
+class ExprGradeStoreImpl extends ExprGradeStore with Serializable {
   var store: mutable.Map[UID, ExprGrade.Value] = mutable.HashMap[UID, ExprGrade.Value]()
 
   override def get(uid: UID): Option[ExprGrade.Value] = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/FormulaHintsStoreImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/FormulaHintsStoreImpl.scala
@@ -7,7 +7,7 @@ import com.google.inject.Singleton
 import scala.collection.mutable
 
 @Singleton
-class FormulaHintsStoreImpl extends FormulaHintsStore {
+class FormulaHintsStoreImpl extends FormulaHintsStore with Serializable {
   var store: mutable.Map[UID, FormulaHint] = mutable.HashMap[UID, FormulaHint]()
 
   override def getHint(uid: UID): Option[FormulaHint] = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/AbstractCacheSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/AbstractCacheSnapshot.scala
@@ -1,0 +1,14 @@
+package at.forsyte.apalache.tla.bmcmt.caches
+
+import scala.collection.immutable.HashMap
+
+/**
+  * A snapshot of AbstractCache that can be recovered into a new AbstractCache.
+  * All intermediate context are squashed into a single context.
+  *
+  * @author Igor Konnov
+  */
+class AbstractCacheSnapshot[ContextT, SourceT, TargetT](val cache: Map[SourceT, (TargetT, Int)] = HashMap(),
+                                                        val reverseCache: Map[TargetT, (SourceT, Int)]) {
+
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/EqCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/EqCache.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.caches
 
 import at.forsyte.apalache.tla.bmcmt.caches.EqCache._
+import at.forsyte.apalache.tla.bmcmt.rewriter.Recoverable
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, StackableContext}
 import at.forsyte.apalache.tla.lir.TlaEx
 import at.forsyte.apalache.tla.lir.convenience.tla
@@ -24,7 +25,7 @@ object EqCache {
   *
   * @author Igor Konnov
   */
-class EqCache(val falseConst: TlaEx, val trueConst: TlaEx) extends StackableContext {
+class EqCache() extends StackableContext with Serializable with Recoverable[EqCacheSnapshot] {
   /**
     * The current context level, see StackableContext.
     */
@@ -61,10 +62,10 @@ class EqCache(val falseConst: TlaEx, val trueConst: TlaEx) extends StackableCont
   def toTla(left: ArenaCell, right: ArenaCell, cacheResult: CacheEntry): TlaEx =
     cacheResult match {
       case FalseEntry() =>
-        falseConst
+        tla.bool(false)
 
       case TrueEntry() =>
-        trueConst
+        tla.bool(true)
 
       case EqEntry() =>
         tla.eql(left.toNameEx, right.toNameEx)
@@ -78,6 +79,32 @@ class EqCache(val falseConst: TlaEx, val trueConst: TlaEx) extends StackableCont
     * @return the immutable copy of the cache entries
     */
   def getMap: Map[(ArenaCell, ArenaCell), (CacheEntry, Int)] = eqCache.toMap
+
+  /**
+    * Take a snapshot and return it
+    *
+    * @return the snapshot
+    */
+  override def snapshot(): EqCacheSnapshot = {
+    val squashedCache = eqCache.map { case (key, (value, _)) => (key, (value, 0)) }
+    new EqCacheSnapshot(squashedCache)
+  }
+
+  /**
+    * Recover a previously saved snapshot (not necessarily saved by this object).
+    *
+    * @param shot a snapshot
+    */
+  override def recover(shot: EqCacheSnapshot): Unit = {
+    eqCache = shot.cache
+  }
+
+  /**
+    * Get the current context level, that is the difference between the number of pushes and pops made so far.
+    *
+    * @return the current level, always non-negative.
+    */
+  override def contextLevel: Int = level
 
   /**
     * Save the current context and push it on the stack for a later recovery with pop.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/EqCacheSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/EqCacheSnapshot.scala
@@ -1,0 +1,15 @@
+package at.forsyte.apalache.tla.bmcmt.caches
+
+import at.forsyte.apalache.tla.bmcmt.ArenaCell
+import at.forsyte.apalache.tla.bmcmt.caches.EqCache.CacheEntry
+
+import scala.collection.mutable
+
+/**
+  * A snapshot of EqCache that can be recovered into a new EqCache.
+  * All intermediate context are squashed into a single context.
+  *
+  * @author Igor Konnov
+  */
+class EqCacheSnapshot(val cache: mutable.Map[(ArenaCell, ArenaCell), (CacheEntry, Int)]) {
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/ExprCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/ExprCache.scala
@@ -8,7 +8,7 @@ import at.forsyte.apalache.tla.lir.TlaEx
   *
   * @author Igor Konnov
   */
-class ExprCache(val store: ExprGradeStore) extends SimpleCache[TlaEx, (TlaEx, ExprGrade.Value)] {
+class ExprCache(val store: ExprGradeStore) extends SimpleCache[TlaEx, (TlaEx, ExprGrade.Value)] with Serializable {
   def put(key: TlaEx, value: TlaEx): Unit = {
     store.get(key.ID) match {
       case Some(g) => put(key, (value, g))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntRangeCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntRangeCache.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.caches
 
 import at.forsyte.apalache.tla.bmcmt.implicitConversions._
-import at.forsyte.apalache.tla.bmcmt.types.{ConstT, FinSetT, IntT}
+import at.forsyte.apalache.tla.bmcmt.types.{FinSetT, IntT}
 import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell, SolverContext}
 import at.forsyte.apalache.tla.lir.convenience.tla
 
@@ -11,7 +11,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
   * @author Igor Konnov
   */
 class IntRangeCache(solverContext: SolverContext, intValueCache: IntValueCache)
-  extends AbstractCache[Arena, (Int, Int), ArenaCell] {
+  extends AbstractCache[Arena, (Int, Int), ArenaCell] with Serializable {
 
   /**
     * Create a set a..b.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
@@ -11,7 +11,7 @@ import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
   *
   * @author Igor Konnov
   */
-class IntValueCache(solverContext: SolverContext) extends AbstractCache[Arena, Int, ArenaCell] {
+class IntValueCache(solverContext: SolverContext) extends AbstractCache[Arena, Int, ArenaCell] with Serializable {
 
   def create(arena: Arena, intValue: Int): (Arena, ArenaCell) = {
     // introduce a new constant

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/RecordDomainCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/RecordDomainCache.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable.SortedSet
   * @author Igor Konnov
   */
 class RecordDomainCache(solverContext: SolverContext, strValueCache: StrValueCache)
-  extends AbstractCache[Arena, (SortedSet[String], SortedSet[String]), ArenaCell] {
+  extends AbstractCache[Arena, (SortedSet[String], SortedSet[String]), ArenaCell] with Serializable {
 
   /**
     * Create a set for a sorted set of record keys.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/SimpleCacheSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/SimpleCacheSnapshot.scala
@@ -1,0 +1,13 @@
+package at.forsyte.apalache.tla.bmcmt.caches
+
+import scala.collection.immutable.HashMap
+
+/**
+  * A snapshot of SimpleCache that can be recovered into a new SimpleCache.
+  * All intermediate context are squashed into a single context.
+  *
+  * @author Igor Konnov
+  */
+class SimpleCacheSnapshot[KeyT, ValueT](val cache: Map[KeyT, (ValueT, Int)] = HashMap()) {
+
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/StrValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/StrValueCache.scala
@@ -11,7 +11,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
   *
   * @author Igor Konnov
   */
-class StrValueCache(solverContext: SolverContext) extends AbstractCache[Arena, String, ArenaCell] {
+class StrValueCache(solverContext: SolverContext) extends AbstractCache[Arena, String, ArenaCell] with Serializable {
 
   override protected def create(arena: Arena, strValue: String): (Arena, ArenaCell) = {
     // introduce a new cell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/Recoverable.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/Recoverable.scala
@@ -1,0 +1,19 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter
+
+/**
+  * An object implementing Recoverable implements two methods: snapshot and recover. The method 'snapshot' takes
+  * a snapshot of the object state. This snapshot can be restored with the method 'recover'.
+  */
+trait Recoverable[T] {
+  /**
+    * Take a snapshot and return it
+    * @return the snapshot
+    */
+  def snapshot(): T
+
+  /**
+    * Recover a previously saved snapshot (not necessarily saved by this object).
+    * @param shot a snapshot
+    */
+  def recover(shot: T): Unit
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
@@ -1,0 +1,17 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter
+
+import at.forsyte.apalache.tla.bmcmt.analyses.ExprGrade
+import at.forsyte.apalache.tla.bmcmt.caches.{AbstractCacheSnapshot, SimpleCacheSnapshot}
+import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeSnapshot
+import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
+import at.forsyte.apalache.tla.lir.TlaEx
+
+import scala.collection.immutable.SortedSet
+
+class SymbStateRewriterSnapshot(val typeFinderSnapshot: TrivialTypeSnapshot,
+                                val intValueCacheSnapshot: AbstractCacheSnapshot[Arena, Int, ArenaCell],
+                                val intRangeCacheSnapshot: AbstractCacheSnapshot[Arena, (Int, Int), ArenaCell],
+                                val strValueCacheSnapshot: AbstractCacheSnapshot[Arena, String, ArenaCell],
+                                val recordDomainCache: AbstractCacheSnapshot[Arena, (SortedSet[String], SortedSet[String]), ArenaCell],
+                                val exprCacheSnapshot: SimpleCacheSnapshot[TlaEx, (TlaEx, ExprGrade.Value)]) {
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/eager/TrivialTypeSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/eager/TrivialTypeSnapshot.scala
@@ -1,0 +1,16 @@
+package at.forsyte.apalache.tla.bmcmt.types.eager
+
+import at.forsyte.apalache.tla.bmcmt.types.CellT
+import at.forsyte.apalache.tla.lir.UID
+
+import scala.collection.immutable.{Map, SortedMap}
+
+/**
+  * A snapshot of TrivialTypeFinder that can be recovered into a new TrivialTypeFinder.
+  * All intermediate context are squashed into a single context.
+  *
+  * @author Igor Konnov
+  */
+class TrivialTypeSnapshot(val typeAnnotations: Map[UID, CellT], val varTypes: SortedMap[String, CellT]) {
+
+}


### PR DESCRIPTION
This is a second PR that is extracted from ik/multicore. Most of the code involves mechanical updates that declare caches `Serializable`. It also defines the trait `Recoverable` that is meant for objects to be saved and restored in different threads. This trait is used by the parallel model checker, which will be extracted in the end of this story. It also cleans up `Z3SolverContext` a bit.