### PR TITLE
ETC-5: Update Typing's Operator typing operator from :> to ##

### DIFF
--- a/src/tla/Typing.tla
+++ b/src/tla/Typing.tla
@@ -36,7 +36,7 @@ AssumeType(name, tp) == TRUE
 (* @see ADR-002.                                                            *)
 (*                                                                          *)
 (* Example:                                                                 *)
-(* Plus(x, y) == "(Int, Int) => Int" :>                                     *)
+(* Plus(x, y) == "(Int, Int) => Int" ##                                     *)
 (*               x + y                                                      *)
 (*                                                                          *)
 (* @param type_str is a string that represents a type in Type System 1      *)
@@ -44,7 +44,7 @@ AssumeType(name, tp) == TRUE
 (* @param ex the operator body to be wrapped with a type                    *)
 (* @return ex, that is, erase type information                              *)
 (****************************************************************************)
-type_str :> ex == ex
+type_str ## ex == ex
 
 (****************************************************************************)
 (* Produce an empty set, whose elements have the type tp.                   *)

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -73,7 +73,7 @@ object StandardLibrary {
       ("Apalache", "Expand") -> BmcOper.expand,
       ("Apalache", "ConstCardinality") -> BmcOper.constCard,
       ("Typing", "AssumeType") -> TypingOper.assumeType,
-      ("Typing", ":>") -> TypingOper.withType,
+      ("Typing", "##") -> TypingOper.withType,
       ("Typing", "EmptySet") -> TypingOper.emptySet,
       ("Typing", "EmptySeq") -> TypingOper.emptySeq
     )////

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -2018,7 +2018,7 @@ class TestSanyImporter extends FunSuite {
         |  /\ AssumeType(x, "Int")
         |  /\ AssumeType(S, "Set(Int)")
         |
-        |Foo(y) == "(Int) -> Set(Int)" :> {y}
+        |Foo(y) == "(Int) -> Set(Int)" ## {y}
         |================================
       """.stripMargin
 


### PR DESCRIPTION
I'd missed this update in my previous port of these changes in #260