### PR TITLE
ETC-6: Add the EtcExpr module

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcExpr.scala
@@ -32,7 +32,8 @@ case class EtcConst(polytype: TlaType1)(val sourceRef: EtcRef) extends EtcExpr {
 
 /**
   * A reference to a name, which can be introduced in the initial type context, or with EtcAbs.
-  * Note that name is not a type variable, but rather a TLA+ name that carries a type.
+  * Note that name is not a type variable, but rather a TLA+ name. The type can be retrieved
+  * by looking up the name in the type context.
   *
   * @param name  a name
   * @param sourceRef the identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcExpr.scala
@@ -1,0 +1,117 @@
+package at.forsyte.apalache.tla.typecheck.etc
+
+import at.forsyte.apalache.tla.typecheck.TlaType1
+
+/**
+  * An expression in a simple typed lambda calculus. Here we do not care about the concrete values,
+  * but only care about the types that the expressions carry. Since we introduce type variables and quantifiers
+  * in the principal types, this calculus is probably not that simple. If you have an idea, whether it is in
+  * System F, or System F_\omega, or whatever, let us know.
+  *
+  * @author Igor Konnov
+  */
+sealed trait EtcExpr {
+  /**
+    * The reference to the source.
+    * This identifier is not taken into account in equals and hash.
+    */
+  val sourceRef: EtcRef
+}
+
+/**
+  * A constant expression, i.e., just a type (may be polymorphic).
+  *
+  * @param polytype a type constant that may have free variables (polytype).
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  */
+case class EtcConst(polytype: TlaType1)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = {
+    s"$sourceRef@$polytype"
+  }
+}
+
+/**
+  * A reference to a name, which can be introduced in the initial type context, or with STCAbs.
+  * Note that name is not a type variable, but rather a TLA+ name that carries a type.
+  *
+  * @param name  a name
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  */
+case class EtcName(name: String)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = s"$sourceRef@$name"
+}
+
+/**
+  * Lambda abstraction that introduces an operator type
+  * of multiple arguments that range over their respective types Set(*).
+  *
+  * @param body          the function body
+  * @param paramsAndDoms parameter names and type expressions that encode sets of values
+  * @param sourceRef     the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  */
+case class EtcAbs(body: EtcExpr, paramsAndDoms: (String, EtcExpr)*)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = {
+    val bindings = paramsAndDoms.map(p => "%s ∈ %s".format(p._1, p._2))
+    "%s@λ %s. %s".format(sourceRef, String.join(", ", bindings: _*), body)
+  }
+}
+
+/**
+  * Application of an operator whose signature is known. An operator may have several overloaded polytypes, e.g., f[e].
+  *
+  * @param operTypes  an STC expression that represents an operator type
+  * @param args  operator arguments
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  */
+case class EtcApp(operTypes: Seq[TlaType1], args: EtcExpr*)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = {
+    "%s@((%s) %s)".format(sourceRef, String.join(" | ", operTypes.map(_.toString): _*),
+      String.join(" ", args.map(_.toString): _*))
+  }
+}
+
+/**
+  * Application of an operator by its name. The operator type should be resolved with a type signature that is
+  * encoded in a type context.
+  *
+  * @param name operator name
+  * @param args operator arguments
+  * @param sourceRef identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  */
+case class EtcAppByName(name: String, args: EtcExpr*)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = {
+    "%s@(%s %s)".format(sourceRef, name, String.join(" ", args.map(_.toString): _*))
+  }
+}
+
+/**
+  * Bind an expression to a name. To bind an operator of multiple arguments, use STCAbs.
+  * The operator type should be resolved with a type signature that is encoded in a type context.
+  *
+  * @param name  an expression name in the let-in binding
+  * @param bound the expression to bind
+  * @param body  the expression the binding applies to
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  */
+case class EtcLet(name: String, bound: EtcExpr, body: EtcExpr)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = {
+    "%s@let %s = %s in %s".format(sourceRef, name, bound, body)
+  }
+}
+
+/**
+  * A built-in type annotation for a name. In a programming language, like Scala, a type annotation is usually
+  * given right in the declaration. In the TLA+ case, type declarations are not part of the language.
+  * That is why we separate EtcTypeDecl from EtcLet. In a TLA+ specification, a type annotation may be placed
+  * far away from the variable declaration.
+  *
+  * @param name a name, with which the type is associated
+  * @param declaredType the type to be associated with the name
+  * @param scopedEx the expression in the scope of the type declaration
+  * @param sourceRef a reference to the original expression
+  */
+case class EtcTypeDecl(name: String, declaredType: TlaType1, scopedEx: EtcExpr)(val sourceRef: EtcRef) extends EtcExpr {
+  override def toString: String = {
+    "%s@%s: %s in %s".format(sourceRef, name, declaredType, scopedEx)
+  }
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcExpr.scala
@@ -22,7 +22,7 @@ sealed trait EtcExpr {
   * A constant expression, i.e., just a type (may be polymorphic).
   *
   * @param polytype a type constant that may have free variables (polytype).
-  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).
   */
 case class EtcConst(polytype: TlaType1)(val sourceRef: EtcRef) extends EtcExpr {
   override def toString: String = {
@@ -31,11 +31,11 @@ case class EtcConst(polytype: TlaType1)(val sourceRef: EtcRef) extends EtcExpr {
 }
 
 /**
-  * A reference to a name, which can be introduced in the initial type context, or with STCAbs.
+  * A reference to a name, which can be introduced in the initial type context, or with EtcAbs.
   * Note that name is not a type variable, but rather a TLA+ name that carries a type.
   *
   * @param name  a name
-  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).
   */
 case class EtcName(name: String)(val sourceRef: EtcRef) extends EtcExpr {
   override def toString: String = s"$sourceRef@$name"
@@ -47,7 +47,7 @@ case class EtcName(name: String)(val sourceRef: EtcRef) extends EtcExpr {
   *
   * @param body          the function body
   * @param paramsAndDoms parameter names and type expressions that encode sets of values
-  * @param sourceRef     the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  * @param sourceRef     the identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).
   */
 case class EtcAbs(body: EtcExpr, paramsAndDoms: (String, EtcExpr)*)(val sourceRef: EtcRef) extends EtcExpr {
   override def toString: String = {
@@ -59,9 +59,9 @@ case class EtcAbs(body: EtcExpr, paramsAndDoms: (String, EtcExpr)*)(val sourceRe
 /**
   * Application of an operator whose signature is known. An operator may have several overloaded polytypes, e.g., f[e].
   *
-  * @param operTypes  an STC expression that represents an operator type
+  * @param operTypes  an Etc expression that represents an operator type
   * @param args  operator arguments
-  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).
   */
 case class EtcApp(operTypes: Seq[TlaType1], args: EtcExpr*)(val sourceRef: EtcRef) extends EtcExpr {
   override def toString: String = {
@@ -76,7 +76,7 @@ case class EtcApp(operTypes: Seq[TlaType1], args: EtcExpr*)(val sourceRef: EtcRe
   *
   * @param name operator name
   * @param args operator arguments
-  * @param sourceRef identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  * @param sourceRef identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).
   */
 case class EtcAppByName(name: String, args: EtcExpr*)(val sourceRef: EtcRef) extends EtcExpr {
   override def toString: String = {
@@ -85,13 +85,13 @@ case class EtcAppByName(name: String, args: EtcExpr*)(val sourceRef: EtcRef) ext
 }
 
 /**
-  * Bind an expression to a name. To bind an operator of multiple arguments, use STCAbs.
+  * Bind an expression to a name. To bind an operator of multiple arguments, use EtcAbs.
   * The operator type should be resolved with a type signature that is encoded in a type context.
   *
   * @param name  an expression name in the let-in binding
   * @param bound the expression to bind
   * @param body  the expression the binding applies to
-  * @param sourceRef the identifier of the TLA+ expression that resulted in this STCExpr (ignored in equals).
+  * @param sourceRef the identifier of the TLA+ expression that resulted in this EtcExpr (ignored in equals).
   */
 case class EtcLet(name: String, bound: EtcExpr, body: EtcExpr)(val sourceRef: EtcRef) extends EtcExpr {
   override def toString: String = {

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcId.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcId.scala
@@ -1,0 +1,36 @@
+package at.forsyte.apalache.tla.typecheck.etc
+
+import at.forsyte.apalache.tla.lir.UID
+
+/**
+  * A reference to the source expression. Some expressions have the exact source, so their type coincides with
+  * the type of the source expression. For those expressions, we use ExactRef.
+  * Other expressions are auxillary expressions, so they only point to the source
+  * expression, in order to understand type errors, but they should not be used to collect types.
+  * For those expressions, we use BlameRef.
+  *
+  * @author Igor Konnov
+  */
+sealed trait EtcRef {
+  def tlaId: UID
+}
+
+/**
+  * An exact reference to the source TLA+ expression. Once the type of an expression with ExactRef has been found,
+  * we can draw conclusions about the types of the source TLA+ expression.
+  *
+  * @param tlaId the id of the original TLA+ expression
+  */
+case class ExactRef(tlaId: UID) extends EtcRef {
+  override def toString: String = "E" + tlaId
+}
+
+/**
+  * A blame reference to the source TLA+ expression. This reference should be used to report type errors,
+  * but it should not be used for drawing conclusions about the type of the original expression.
+  *
+  * @param tlaId the id of the original TLA+ expression
+  */
+case class BlameRef(tlaId: UID) extends EtcRef {
+  override def toString: String = "B" + tlaId
+}


### PR DESCRIPTION
This encodes the AST of the labda-calculus like language used as the basis of type checking in the Etc.

Authored by @konnov and broken out of #259 