### PR TITLE
Fixing 285: step 1

### DIFF
--- a/test/tla/ConfigUnsorted.tla
+++ b/test/tla/ConfigUnsorted.tla
@@ -1,0 +1,16 @@
+-------------------------- MODULE ConfigUnsorted ----------------------------------------
+(* A specification that introduces preprocessing issues *)
+VARIABLES x
+
+A == 1
+B == 2
+C == 3
+
+\* the following annotations introduce a circular dependency
+OVERRIDE_A == B
+OVERRIDE_B == C
+OVERRIDE_C == A
+
+Init == x = 0
+Next == UNCHANGED x
+========================================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -521,3 +521,14 @@ $ apalache-mc check --config=Config2.cfg Config.tla | sed 's/[IEW]@.*//'
 The outcome is: NoError
 ...
 ```
+
+### configure complains about circular dependencies
+
+```sh
+$ apalache-mc check ConfigUnsorted.tla | sed 's/[IEW]@.*//'
+...
+Configuration error (see the manual): Circular definition dependency detected
+...
+EXITCODE: ERROR (99)
+```
+

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -126,7 +126,7 @@ class ExprOrOpArgNodeTranslator(sourceStore: SourceStore,
       case defNode: OpDefNode if name == "LAMBDA" =>
         val decl = OpDefTranslator(sourceStore, context).translate(defNode)
         // e.g., LET Foo(x) == e1 in Foo
-        LetInEx(name, decl)
+        LetInEx(NameEx(name), decl)
 
       // an operator that is passed as an argument to another operator
       case _: OpDefNode =>

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -126,7 +126,7 @@ class ExprOrOpArgNodeTranslator(sourceStore: SourceStore,
       case defNode: OpDefNode if name == "LAMBDA" =>
         val decl = OpDefTranslator(sourceStore, context).translate(defNode)
         // e.g., LET Foo(x) == e1 in Foo
-        LetInEx(NameEx(opArgNode.getName.toString), decl)
+        LetInEx(name, decl)
 
       // an operator that is passed as an argument to another operator
       case _: OpDefNode =>

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -21,31 +21,43 @@ class ExprOrOpArgNodeTranslator(sourceStore: SourceStore,
       node match {
         // as tlatools do not provide us with a visitor pattern, we have to enumerate classes here
         case num: NumeralNode =>
+          // an integer literal, e.g., 123
           translateNumeral(num)
 
         case str: StringNode =>
+          // a string literal
           translateString(str)
 
         case dec: DecimalNode =>
+          // a decimal literal, e.g., 123.456 (not a floating point!)
           translateDecimal(dec)
 
         case opApp: OpApplNode =>
+          // application of an operator, e.g., F(x)
           OpApplTranslator(sourceStore, context, recStatus).translate(opApp)
 
-        case arg: OpArgNode =>
-          // we just pass the name of the argument without any extra information
-          NameEx(arg.getName.toString.intern())
+        case opArg: OpArgNode =>
+          // An operator definition that is used as an expression, e.g., LAMBDA x: x = 1.
+          // There are at least two cases:
+          //   1. An operator that is passed as an argument to another operator, e.g., B in A(B)
+          //   2. A lambda-expression that is passed as an argument ao another operator, e.g., A(LAMBDA x: x)
+          translateLambdaOrOperatorAsArgument(opArg)
 
         case letIn: LetInNode =>
+          // Example: LET Foo(a, b) == e1 IN e2
           translateLetIn(letIn)
 
         case substIn: SubstInNode =>
+          // A substitution that originates from INSTANCE Foo WITH x <- a, y <- b.
+          // The substitution contains the bindings x <- a, y <- b.
           translateSubstIn(substIn)
 
         case at: AtNode =>
+          // the shortcut "@" that is used in EXCEPT
           translateAt(at)
 
         case label: LabelNode =>
+          // a node label, e.g., lab(x) :: e
           translateLabel(label)
 
         case n =>
@@ -101,6 +113,29 @@ class ExprOrOpArgNodeTranslator(sourceStore: SourceStore,
     val body = ExprOrOpArgNodeTranslator(sourceStore, letInContext, recStatus)
       .translate(letIn.getBody)
     LetInEx( body, letInDeclarations : _* )
+  }
+
+  // translate an operator definition that is used as an expression, that is, LAMBDA
+  private def translateLambdaOrOperatorAsArgument(opArgNode: OpArgNode): TlaEx = {
+    // Instead of extending the IR with a new expression type, we simply introduce a local LET-IN definition.
+    // Although this is a well-defined expression in the IR, it does not correspond to a well-defined TLA+ expression.
+    // Hence, one has to take care of this, when printing the output to the user.
+    val name = opArgNode.getName.toString
+    opArgNode.getOp match {
+      // a lambda-definition is passed as an argument
+      case defNode: OpDefNode if name == "LAMBDA" =>
+        val decl = OpDefTranslator(sourceStore, context).translate(defNode)
+        // e.g., LET Foo(x) == e1 in Foo
+        LetInEx(NameEx(opArgNode.getName.toString), decl)
+
+      // an operator that is passed as an argument to another operator
+      case _: OpDefNode =>
+        // simply return a reference to the operator by name
+        NameEx(name)
+
+      case e =>
+        throw new SanyImporterException("Expected an operator definition as an argument, found: " + e)
+    }
   }
 
   // substitute an expression with the declarations that come from INSTANCE M WITH ...

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
@@ -110,10 +110,19 @@ class ConstAndDefRewriter(tracker: TransformationTracker) extends TlaModuleTrans
     }
     while(defsWithDeps.nonEmpty && newAdded)
     if(defsWithDeps.nonEmpty) {
-      logger.error(s"  > topological sort: can't order these definitions: ${defsWithDeps.toString}")
-      throw new Exception("Circular definition dependency detected" )
+      val msg = "  > topological sort: can't order these definitions: " + defsWithDepsAsHumanReadable(defsWithDeps)
+      logger.error(msg)
+      throw new ConfigurationError("Circular definition dependency detected" )
     }
     sorted
+  }
+
+  // convert the dependencies into a readable form
+  private def defsWithDepsAsHumanReadable(dds: List[(TlaDecl, Set[String])]): String = {
+    def depToString(decl: TlaDecl, uses: Set[String]): String = {
+      "Operator %s uses %s".format(decl.name, uses.toSeq.sorted.mkString(", "))
+    }
+    dds.map(p => depToString(p._1, p._2)).mkString("; ")
   }
 
   private def findDeps(decl: TlaDecl): mutable.Set[String] = {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
@@ -755,6 +755,17 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
     assert(expected == stringWriter.toString)
   }
 
+  test("a LAMBDA as LET-IN") {
+    val writer = new PrettyWriter(printWriter, 40)
+    val aDecl = TlaOperDecl("LAMBDA", List(SimpleFormalParam("x")), NameEx("x"))
+    val expr = letIn(NameEx("LAMBDA"), aDecl)
+    writer.write(expr)
+    printWriter.flush()
+    val expected =
+      """LAMBDA x: x""".stripMargin
+    assert(expected == stringWriter.toString)
+  }
+
   test("a one-line operator declaration") {
     val writer = new PrettyWriter(printWriter, 40)
     val body =


### PR DESCRIPTION
This PR does not completely fix the problem discovered by Markus in #285, as the spec uncovers multiple layers of issues with parsing advanced specs. This commit fixes the long-known issue with LAMBDAs. 

@Kukovec can you have a look at the changes and tell us if this solution potentially breaks your code. I can imagine that having a LET-definition in the operator parameters may come a bit unexpected.