### PR TITLE
ETC7: Add Type1 parser and lexer changes

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/TlaType1.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/TlaType1.scala
@@ -34,6 +34,7 @@ case class RealT1() extends TlaType1 {
 
 }
 
+
 /**
   * A Boolean type.
   */
@@ -172,7 +173,6 @@ case class TupT1(elems: TlaType1*) extends TlaType1 {
   }
 
   override def usedNames: Set[Int] = elems.foldLeft(Set[Int]()) { (s, t) => s ++ t.usedNames }
-
 }
 
 /**

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/parser/Type1Lexer.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/parser/Type1Lexer.scala
@@ -32,9 +32,9 @@ object Type1Lexer extends RegexParsers {
 
   def token: Parser[Type1Token] =
     positioned(
-      int | bool | str | set | seq | capsIdentifier | letterIdentifier | fieldIdentifier |
+      int | real | bool | str | set | seq | capsIdentifier | fieldIdentifier | fieldNumber |
         rightArrow | doubleRightArrow | leftParen | rightParen | leftBracket | rightBracket |
-        doubleLeftAngle | doubleRightAngle | comma | colon
+        leftCurly | rightCurly | doubleLeftAngle | doubleRightAngle | comma | colon
     ) ///
 
   // a linefeed is not a white-space
@@ -44,16 +44,20 @@ object Type1Lexer extends RegexParsers {
     "[A-Z_][A-Z0-9_]*".r ^^ { name => CAPS_IDENT(name) }
   }
 
-  private def letterIdentifier: Parser[LETTER_IDENT] = {
-    "[a-z]".r ^^ { name => LETTER_IDENT(name) }
-  }
-
   private def fieldIdentifier: Parser[FIELD_IDENT] = {
     "[A-Za-z_][A-Za-z0-9_]*".r ^^ { name => FIELD_IDENT(name) }
   }
 
+  private def fieldNumber: Parser[FIELD_NO] = {
+    "[0-9]+".r ^^ { str => FIELD_NO(Integer.parseInt(str)) }
+  }
+
   private def int: Parser[INT] = {
     "Int".r ^^ { _ => INT() }
+  }
+
+  private def real: Parser[REAL] = {
+    "Real".r ^^ { _ => REAL() }
   }
 
   private def bool: Parser[BOOL] = {
@@ -94,6 +98,14 @@ object Type1Lexer extends RegexParsers {
 
   private def rightBracket: Parser[RBRACKET] = {
     "]" ^^ { _ => RBRACKET() }
+  }
+
+  private def leftCurly: Parser[LCURLY] = {
+    "{" ^^ { _ => LCURLY() }
+  }
+
+  private def rightCurly: Parser[RCURLY] = {
+    "}" ^^ { _ => RCURLY() }
   }
 
   private def doubleLeftAngle: Parser[DOUBLE_LEFT_ANGLE] = {

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/parser/tokens.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/parser/tokens.scala
@@ -16,17 +16,6 @@ private[parser] case class CAPS_IDENT(name: String) extends Type1Token {
 }
 
 /**
-  * A single-letter identifier. For consistency with CAPS_INDENT, we assign a String to name, not Char.
-  *
-  * @param name the name associated with the identifier
-  */
-private[parser] case class LETTER_IDENT(name: String) extends Type1Token {
-  require(name.length == 1)
-
-  override def toString: String = "letter ident '%s'".format(name)
-}
-
-/**
   * A field identifier. Since it syntactically includes CAPS_IDENT and LETTER_IDENT, one has to expect
   * CAPS_IDENT, LETTER_INDENT, and FIELD_INDENT, whenever a record field is expected.
   *
@@ -41,6 +30,13 @@ private[parser] case class FIELD_IDENT(name: String) extends Type1Token {
   */
 private[parser] case class INT() extends Type1Token {
   override def toString: String = "Int"
+}
+
+/**
+  * A real identifier: Real
+  */
+private[parser] case class REAL() extends Type1Token {
+  override def toString: String = "Real"
 }
 
 /**
@@ -125,6 +121,28 @@ private[parser] case class LBRACKET() extends Type1Token {
   */
 private[parser] case class RBRACKET() extends Type1Token {
   override def toString: String = "]"
+}
+
+/**
+  * Left curly bracket "{".
+  */
+private[parser] case class LCURLY() extends Type1Token {
+  override def toString: String = "{"
+}
+
+/**
+  * Right curly bracket "}".
+  */
+private[parser] case class RCURLY() extends Type1Token {
+  override def toString: String = "}"
+}
+
+/**
+  * A field number, e.g., 3
+  * @param no the number
+  */
+private[parser] case class FIELD_NO(no: Int) extends Type1Token {
+  override def toString: String = no.toString
 }
 
 /**

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
@@ -18,6 +18,11 @@ class TestDefaultType1Parser  extends FunSuite {
     assert(IntT1() == result)
   }
 
+  test("Real") {
+    val result = DefaultType1Parser("Real")
+    assert(RealT1() == result)
+  }
+
   test("Bool") {
     val result = DefaultType1Parser("Bool")
     assert(BoolT1() == result)
@@ -62,8 +67,14 @@ class TestDefaultType1Parser  extends FunSuite {
     assert(TupT1(BoolT1(), IntT1()) == result)
   }
 
-  test("[] is rejected") {
-    assertThrows[Type1ParseError](DefaultType1Parser("[]"))
+  test("{ 3: Bool, 5: Int }") {
+    val result = DefaultType1Parser("{ 3: Bool, 5: Int }")
+    assert(SparseTupT1(SortedMap(3 -> BoolT1(), 5 -> IntT1())) == result)
+  }
+
+  test("[] is ok") {
+    val result = DefaultType1Parser("[]")
+    assert(RecT1() == result)
   }
 
   test("[a: Int]") {
@@ -74,6 +85,11 @@ class TestDefaultType1Parser  extends FunSuite {
   test("[a: Int, b: Bool]") {
     val result = DefaultType1Parser("[a: Int, b: Bool]")
     assert(RecT1(SortedMap("a" -> IntT1(), "b" -> BoolT1())) == result)
+  }
+
+  test("[f1: Int, f2: Bool]") {
+    val result = DefaultType1Parser("[f1: Int, f2: Bool]")
+    assert(RecT1(SortedMap("f1" -> IntT1(), "f2" -> BoolT1())) == result)
   }
 
   test("Set(Int) -> Bool") {


### PR DESCRIPTION
Broken out of #259

Originally authored by Igor Konnov <konnov@forsyte.at>

Also includes a white space change to `TlaType1.scala` that I'd not picked up before.