### PR TITLE
fix 292: better diagnostics for type annotations in type annotations

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -91,6 +91,10 @@ class ExpansionMarker @Inject()(tracker: TransformationTracker) extends TlaExTra
 
       LetInEx(transform(shallExpand)(body), defs map mapDef: _*)
 
+    case OperEx(BmcOper.withType, expr, annot) =>
+      // transform the expression, but not the annotation! See #292
+      OperEx(BmcOper.withType, transform(shallExpand)(expr), annot)
+
     case OperEx(oper, args@_*) =>
       // try to descend in the children, which may contain Boolean operations, e.g., { \E x \in S: P }
       OperEx(oper, args map transform(shallExpand): _*)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -92,7 +92,7 @@ class ExpansionMarker @Inject()(tracker: TransformationTracker) extends TlaExTra
       LetInEx(transform(shallExpand)(body), defs map mapDef: _*)
 
     case OperEx(BmcOper.withType, expr, annot) =>
-      // transform the expression, but not the annotation! See #292
+      // transform the expression, but not the annotation! See https://github.com/informalsystems/apalache/issues/292
       OperEx(BmcOper.withType, transform(shallExpand)(expr), annot)
 
     case OperEx(oper, args@_*) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/AnnotationParser.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/AnnotationParser.scala
@@ -1,8 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt.types
 
-import at.forsyte.apalache.tla.bmcmt.RewriterException
+import at.forsyte.apalache.tla.bmcmt.{RewriterException, TypeException}
 import at.forsyte.apalache.tla.lir.convenience.tla
-import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaSetOper}
+import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaFunOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import at.forsyte.apalache.tla.lir.{NullEx, OperEx, TlaEx, ValEx}
@@ -45,7 +45,7 @@ object AnnotationParser {
         val keys = kv.zipWithIndex.filter(_._2 % 2 == 0).map(_._1) // pick the even indices (starting with 0)
       def toStr(key: TlaEx) = key match {
         case ValEx(TlaStr(s)) => s
-        case _ => throw new RewriterException("Expected a string, found: %s".format(key), annot)
+        case _ => throw new TypeException("Expected a string, found: %s".format(key), annot)
       }
 
         val vals = kv.zipWithIndex.filter(_._2 % 2 == 1).map(_._1) // pick the odd indices (starting with 0)
@@ -70,12 +70,15 @@ object AnnotationParser {
         val argPairs = args.grouped( 2 ).toSeq map {
           case Seq( ValEx( TlaStr( s ) ), value ) =>
             (s, fromTla( value ))
-          case e => throw new RewriterException("Expected a Seq(string, _) found: %s".format(e), annot)
+          case e => throw new TypeException("Expected a Seq(string, _) found: %s".format(e), annot)
         }
         RecordT( SortedMap( argPairs : _* ) )
 
+      case OperEx(BmcOper.withType, _, otherAnnot) =>
+        throw new TypeException(s"Found another annotation ${otherAnnot} inside the annotation: $annot", annot)
+
       case e =>
-        throw new RewriterException("Unexpected type annotation: %s".format(annot), annot)
+        throw new TypeException("Unexpected type annotation: %s".format(annot), annot)
     }
   }
 
@@ -105,7 +108,7 @@ object AnnotationParser {
         OperEx(TlaFunOper.enum, args :_*)
 
       case _ =>
-        throw new RewriterException("No translation of type %s to a TLA+ expression".format(tp), NullEx)
+        throw new TypeException("No translation of type %s to a TLA+ expression".format(tp), NullEx)
     }
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestTrivialTypeFinder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestTrivialTypeFinder.scala
@@ -802,6 +802,14 @@ class TestTrivialTypeFinder extends RewriterBase {
     assert(FinSetT(IntT()) == typeFinder.compute(ex))
   }
 
+  // regression, see issue #292
+  test("error on type annotation inside type annotation") {
+    val typeFinder = new TrivialTypeFinder()
+    val ex = tla.enumSet()
+    val annotatedEx = tla.withType(ex, tla.withType(tla.enumSet(), tla.enumSet(ValEx(TlaIntSet))))
+    assertThrows[TypeException] { typeFinder.inferAndSave(annotatedEx) }
+  }
+
   // Since the introduction of BmcOper.assign, the old assignments need to be transformed
   // into the form \E t \in S: x' = t
   test( "inferAndSave from the wild" ){

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
@@ -103,6 +103,22 @@ class TestExpansionMarker extends FunSuite with BeforeAndAfterEach {
     assert(input == output)
   }
 
+  test("""not marked: x \in {} <: {[Int -> Int]}""") {
+    val input =
+      tla.exists(
+        tla.name("x"),
+        OperEx(BmcOper.withType,
+          tla.enumSet(),
+          tla.enumSet(tla.funSet(tla.intSet(), tla.intSet()))
+        ),
+        tla.bool(true)
+      ) //
+
+    val output = marker.apply(input)
+
+    assert(input == output)
+  }
+
   test("""not marked: \CHOOSE x \in SUBSET S: P""") {
     val input =
         tla.choose(


### PR DESCRIPTION
Better diagnostics for unexpected type annotations inside type annotations #292 , discovered by @istoilkovska and @andrey-kuprianov 