### PR TITLE
Accept expressions as the first arguments of EXCEPT

### DIFF
--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
@@ -418,13 +418,14 @@ class OpApplTranslator(sourceStore: SourceStore, val context: Context, val recSt
     val exTran = ExprOrOpArgNodeTranslator(sourceStore, context, recStatus)
     node.getArgs.toList match {
       case (fnode: OpApplNode) :: pairNodes =>
+        // ![e1] = e2
         val fun = exTran.translate(fnode)
         // Note that -- as in TLA tools -- the updated indices are represented with sequences (i.e., tuples),
         // in order to support multidimensional arrays
         OperEx(TlaFunOper.except, fun +: unpackPairs(exTran)(pairNodes): _*)
 
       case _ =>
-        throw new SanyImporterException("Unexpected structure of EXCEPT")
+        throw new SanyImporterException("Unexpected structure of EXCEPT: " + node)
     }
   }
 }

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
@@ -417,11 +417,13 @@ class OpApplTranslator(sourceStore: SourceStore, val context: Context, val recSt
   private def mkExceptBuiltin(node: OpApplNode): TlaEx = {
     val exTran = ExprOrOpArgNodeTranslator(sourceStore, context, recStatus)
     node.getArgs.toList match {
-      case (fnode: OpApplNode) :: pairNodes =>
-        // ![e1] = e2
+      case (fnode: ExprNode) :: pairNodes =>
+        // For instance, [f EXCEPT ![e1] = e2, ![e3] = e4] or [@ EXCEPT ![e1] = e2, ![e3] = e4]
+        // First, translate the expression that encodes the function to be updated.
         val fun = exTran.translate(fnode)
+        // Second, translate the expressions that encode the update pairs (e1, e2), (e3, e4), etc.
         // Note that -- as in TLA tools -- the updated indices are represented with sequences (i.e., tuples),
-        // in order to support multidimensional arrays
+        // in order to support multidimensional arrays.
         OperEx(TlaFunOper.except, fun +: unpackPairs(exTran)(pairNodes): _*)
 
       case _ =>

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -908,8 +908,8 @@ class TestSanyImporter extends FunSuite {
         NameEx("f"),
         TlaFunOper.mkTuple(ValEx(TlaInt(0))),
         OperEx(TlaFunOper.except,
-          TlaFunOper.mkTuple(ValEx(TlaInt(0))), // that is what @ gives us
-          ValEx(TlaStr("state")),
+          OperEx(TlaFunOper.app, NameEx("f"), ValEx(TlaInt(0))), // this is the equivalent of @
+          TlaFunOper.mkTuple(ValEx(TlaStr("state"))),
           ValEx(TlaInt(4)))
       ))(mod.declarations(4))
   }

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -865,6 +865,7 @@ class TestSanyImporter extends FunSuite {
         |E1 == [ f EXCEPT ![0] = 1, ![2] = 3 ]
         |E2 == [ f EXCEPT ![0][1][2] = 3 ]
         |E3 == [ f EXCEPT ![0,1,2] = 3 ]
+        |E4 == [ f EXCEPT ![0] = [@ EXCEPT !.state = 4] ]
         |================================
         |""".stripMargin
 
@@ -894,28 +895,23 @@ class TestSanyImporter extends FunSuite {
       )
     ) (mod.declarations(2))
 
-    /* // the old test when Desugarer was part of SanyImporter
-    expectDecl("E2",
-      OperEx(TlaFunOper.except,
-        NameEx("f"),
-        TlaFunOper.mkTuple(ValEx(TlaInt(0))),
-        OperEx(TlaFunOper.except,
-          OperEx(TlaFunOper.app, NameEx("f"), ValEx(TlaInt(0))),
-          TlaFunOper.mkTuple(ValEx(TlaInt(1))),
-          OperEx(TlaFunOper.except,
-            OperEx(TlaFunOper.app, OperEx(TlaFunOper.app, NameEx("f"), ValEx(TlaInt(0))), ValEx(TlaInt(1))),
-            TlaFunOper.mkTuple(ValEx(TlaInt(2))),
-            ValEx(TlaInt(3)))
-        )//
-      ))(mod.declarations(2))
-      */
-
     expectDecl("E3",
       OperEx(TlaFunOper.except,
         NameEx("f"),
         TlaFunOper.mkTuple(TlaFunOper.mkTuple(ValEx(TlaInt(0)), ValEx(TlaInt(1)), ValEx(TlaInt(2)))),
         ValEx(TlaInt(3))
       ))(mod.declarations(3))
+
+    // using @ in EXCEPT: https://github.com/informalsystems/apalache/issues/286
+    expectDecl("E4",
+      OperEx(TlaFunOper.except,
+        NameEx("f"),
+        TlaFunOper.mkTuple(ValEx(TlaInt(0))),
+        OperEx(TlaFunOper.except,
+          TlaFunOper.mkTuple(ValEx(TlaInt(0))), // that is what @ gives us
+          ValEx(TlaStr("state")),
+          ValEx(TlaInt(4)))
+      ))(mod.declarations(4))
   }
 
   test("complex record selects") {


### PR DESCRIPTION
This PR fixes issue #286. The importer expected an operator application as the first argument of `EXCEPT`, but actually other kinds of expression may also occur there, e.g., the reference `@`. The solution is simply a one-liner. The job of checking expression compatibility for `EXCEPT` has been done by SANY already.