### PR TITLE
Passes reordered + keep (C)initPrime after InlinePass

### DIFF
--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/CoverAnalysisPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/CoverAnalysisPassImpl.scala
@@ -20,7 +20,11 @@ class CoverAnalysisPassImpl @Inject()(options: PassOptions,
 
   override def name: String = "CoverAnalysisPass"
 
-  override def execute(): Boolean = {
+
+  // TODO: disabled for the purposes of pass reordering, re-introduced in #308
+  override def execute( ) : Boolean = true
+
+  def execute2(): Boolean = {
     val inModule = tlaModule.get
 
     val operDecls = inModule.operDeclarations

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerModule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerModule.scala
@@ -64,23 +64,29 @@ class CheckerModule extends AbstractModule {
     bind(classOf[Pass])
       .annotatedWith(Names.named("AfterConfiguration"))
       .to(classOf[UnrollPass])
-    // the next pass is InlinePass
-    bind(classOf[InlinePass])
-      .to(classOf[InlinePassImpl])
-    bind(classOf[Pass])
-      .annotatedWith(Names.named("AfterUnroll"))
-      .to(classOf[InlinePass])
     // the next pass is PrimingPass
     bind(classOf[PrimingPass])
       .to(classOf[PrimingPassImpl])
     bind(classOf[Pass])
-      .annotatedWith(Names.named("AfterInline"))
+      .annotatedWith(Names.named("AfterUnroll"))
       .to(classOf[PrimingPass])
+    // the next pass is CoverAnalysisPass
+    bind(classOf[CoverAnalysisPass])
+      .to(classOf[CoverAnalysisPassImpl])
+    bind(classOf[Pass])
+      .annotatedWith(Names.named("AfterPriming"))
+      .to(classOf[CoverAnalysisPass])
+    // the next pass is InlinePass
+    bind(classOf[InlinePass])
+      .to(classOf[InlinePassImpl])
+    bind(classOf[Pass])
+      .annotatedWith(Names.named("AfterCoverAnalysis"))
+      .to(classOf[InlinePass])
     // the next pass is VCGenPass
     bind(classOf[VCGenPass])
       .to(classOf[VCGenPassImpl])
     bind(classOf[Pass])
-      .annotatedWith(Names.named("AfterPriming"))
+      .annotatedWith(Names.named("AfterInline"))
       .to(classOf[VCGenPass])
     // the next pass after SanyParserPass is PreproPass
     bind(classOf[PreproPass])
@@ -88,17 +94,11 @@ class CheckerModule extends AbstractModule {
     bind(classOf[Pass])
       .annotatedWith(Names.named("AfterVCGen"))
       .to(classOf[PreproPass])
-    // the next pass after PreproPass is CoverAnalysisPass
-    bind(classOf[CoverAnalysisPass])
-      .to(classOf[CoverAnalysisPassImpl])
-    bind(classOf[Pass])
-      .annotatedWith(Names.named("AfterPrepro"))
-      .to(classOf[CoverAnalysisPass])
-    // the next pass after CoverAnalysisPass is AssignmentPass
+    // the next pass after PreproPass is AssignmentPass
     bind(classOf[TransitionPass])
       .to(classOf[TransitionPassImpl])
     bind(classOf[Pass])
-      .annotatedWith(Names.named("AfterCoverAnalysis"))
+      .annotatedWith(Names.named("AfterPrepro"))
       .to(classOf[TransitionPass])
     // the next pass after AssignmentPass is AnalysisPass
     bind(classOf[OptPass])

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -65,10 +65,17 @@ class InlinePassImpl @Inject()(val options: PassOptions,
     // Remove the operators that are not needed,
     // as some of them may contain higher-order operators that cannot be substituted
     val relevantOperators = NormalizedNames.userOperatorNamesFromOptions(options).toSet
-    logger.info("Leaving only relevant operators: " + relevantOperators.toList.sorted.mkString(", "))
+
+    // Since PrimingPass now happens before inlining, we have to add InitPrime and CInitPrime as well
+    val initName = options.getOrElse("checker", "init", "Init")
+    val cinitName = options.getOrElse("checker", "cinit", "CInit")
+    val initPrimedName = initName + "Primed"
+    val cinitPrimedName = cinitName + "Primed"
+    val relevantOperatorsAndInitCInitPrimed = relevantOperators + initPrimedName + cinitPrimedName
+    logger.info("Leaving only relevant operators: " + relevantOperatorsAndInitCInitPrimed.toList.sorted.mkString(", "))
     val filteredDefs = inlined.declarations.filter {
       case TlaOperDecl(name, _, _) =>
-        relevantOperators.contains(name)
+        relevantOperatorsAndInitCInitPrimed.contains(name)
       case _ => true // accept all other declarations
     }
 


### PR DESCRIPTION
Changes the order of passes, so `CoverAnalysisPass` comes before inlining.