### PR TITLE
Add zulip link and give readme a facelift

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ branch](https://github.com/informalsystems/apalache/tree/unstable).
 
 ## Getting started
 
-Read the [Apalache user manual](./docs/manual.md).
+- Read the [Apalache user manual](./docs/manual.md).
+- Consult the (WIP) [Idioms for writing better TLA+](./docs/idiomatic)
 
-WIP: [Idioms for writing better TLA+](./docs/idiomatic)
+## Community
+
+- Join the chat in the [Apalache zulip stream](https://informal-systems.zulipchat.com/#narrow/stream/265309-apalache).
+- [Contribute](./CONTRIBUTING.md) to the development of Apalache.
 
 ## Talks
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,24 @@ alt="Apalache Logo">
 </div>
 
 ---
+
+Apalache translates TLA+ into the logic supported by SMT solvers such as
+[Microsoft Z3](https://github.com/Z3Prover/z3). Apalache can check inductive
+invariants (for fixed or bounded parameters) and check safety of bounded
+executions (bounded model checking). To see the list of supported TLA+
+constructs, check the [supported features](docs/features.md). In general,
 Apalache runs under the same assumptions as TLC.
 
 ## Releases
 
 Check the [releases page](https://github.com/informalsystems/apalache/releases).
 
-We recommend you to run the latest docker image `apalache/mc:latest` and
-checkout the source code from
-[master](https://github.com/informalsystems/apalache/tree/master), which accumulate
-bugfixes over the latest release, see the [manual](docs/manual.md#useDocker).
-To try the latest cool features, check the [unstable
+We recommend that you run the latest stable docker image `apalache/mc:latest`,
+or checkout the source code from
+[master](https://github.com/informalsystems/apalache/tree/master), which
+accumulates bugfixes over the latest release. For more information, see [the
+manual](docs/manual.md#useDocker). To try the latest cool features, check out
+the [unstable
 branch](https://github.com/informalsystems/apalache/tree/unstable).
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -40,23 +40,23 @@ branch](https://github.com/informalsystems/apalache/tree/unstable).
 
 ## Talks
 
- * [Model-based testing with TLA+ and Apalache](https://youtu.be/aveoIMphzW8).
-    TLA+ Community Event 2020 (October 2020).
+- [Model-based testing with TLA+ and Apalache](https://youtu.be/aveoIMphzW8).
+  TLA+ Community Event 2020 (October 2020).
 
- * [Type inference for TLA+ in Apalache](https://youtu.be/hnp25hmCMN8).
-    TLA+ Community Event 2020 (October 2020).
+- [Type inference for TLA+ in Apalache](https://youtu.be/hnp25hmCMN8).
+  TLA+ Community Event 2020 (October 2020).
 
- * [Formal Spec and Model Checking of the Tendermint Blockchain Synchronization Protocol](https://youtu.be/h2Ovc1KWlXM)
-    2nd Workshop on Formal Methods for Blockchains (July 2020).
+- [Formal Spec and Model Checking of the Tendermint Blockchain Synchronization Protocol](https://youtu.be/h2Ovc1KWlXM)
+  2nd Workshop on Formal Methods for Blockchains (July 2020).
 
- * [Showing safety of Tendermint Consensus with TLA+ and Apalache](https://www.youtube.com/watch?v=aF20-28sMII).
-    Dev session at Informal Systems (May 2020).
+- [Showing safety of Tendermint Consensus with TLA+ and Apalache](https://www.youtube.com/watch?v=aF20-28sMII).
+  Dev session at Informal Systems (May 2020).
 
- * [TLA+ model checking made symbolic](https://www.youtube.com/watch?v=e66FGgRzaqw)
-    OOPSLA 2019 (October 2019).
+- [TLA+ model checking made symbolic](https://www.youtube.com/watch?v=e66FGgRzaqw)
+  OOPSLA 2019 (October 2019).
 
- * [Bounded model checking of TLA+ specifications with SMT](https://www.youtube.com/watch?v=Xl1--arESl8)
-   TLA+ Community Event 2018 (July 2018).
+- [Bounded model checking of TLA+ specifications with SMT](https://www.youtube.com/watch?v=Xl1--arESl8)
+  TLA+ Community Event 2018 (July 2018).
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-![Apalache Logo](./logo-apalache.svg)
+<div align="center">
+<img
+src="https://raw.githubusercontent.com/informalsystems/apalache/99e58d6f5eebcc41f432a126a13a5f8d2ae7afe6/logo-apalache.svg"
+alt="Apalache Logo">
 
-# APALACHE
+<h1>APALACHE</h1>
 
-A symbolic model checker for TLA+
+<p>A symbolic model checker for TLA+<p>
 
 |             master             |              unstable              |
 | :----------------------------: | :--------------------------------: |
@@ -13,8 +16,9 @@ A symbolic model checker for TLA+
 [unstable badge]: https://github.com/informalsystems/apalache/workflows/build/badge.svg
 [unstable-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Aunstable+workflow%3Abuild
 
-Apalache translates TLA+ in the logic supported by the SMT solvers, for instance, [Microsoft Z3](https://github.com/Z3Prover/z3). Apalache can check inductive invariants (for fixed or bounded parameters) and check safety of bounded executions (bounded model checking). To see the list of supported
-TLA+ constructs, check the [supported features](docs/features.md). In general,
+</div>
+
+---
 Apalache runs under the same assumptions as TLC.
 
 ## Releases


### PR DESCRIPTION
This adds the link to our zulip stream on the public informal-systems zulip instance.

Since I was touching the README, I also added some styling to center the header section, and to suggest some tweaks to wording in a few passages.

Rendered, the changes look like this:

![2020-11-19-121014_2394x1749_scrot](https://user-images.githubusercontent.com/19820422/99699670-3509e500-2a60-11eb-958f-ba32ee977d7a.png)
