### PR TITLE
Added renaming before the first Unroller call.

### DIFF
--- a/test/tla/Rec13.tla
+++ b/test/tla/Rec13.tla
@@ -1,0 +1,16 @@
+----------------- MODULE Rec13 ----------------------                           
+EXTENDS Integers
+
+VARIABLE y
+
+LOCAL Send[x \in { 1, 2}] ==
+    x \* at this point, we expect x = 2, not x = 1
+
+SendAll(x) == Send[x + 1]
+
+Init == y = SendAll(1)
+
+Next == UNCHANGED y
+
+Inv == y = 2
+=====================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -438,6 +438,15 @@ The outcome is: Error
 EXITCODE: OK
 ```
 
+### check Rec13.tla succeeds
+
+```sh
+$ apalache-mc check --inv=Inv Rec13.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+```
+
 
 ### check ExistsAsValue.tla succeeds
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
@@ -45,11 +45,23 @@ class UnrollPassImpl @Inject()( val options : PassOptions,
   override def execute(): Boolean = {
     val module = tlaModule.get
 
+    // We have to rename the input, as LOCAL-toplevel TLA+ functions get
+    // introduced as LET-IN operators (copying the definition). The problem is,
+    // the operator bodies may introduce namespace collisions, e.g. with
+    //
+    // LOCAL f[x \in S] = x
+    // Op(x) == f[x + 1]
+    //   |
+    //   V
+    // Op(x) == LET f == [x \in S] In f[(x + 1)] <- namespace collision on x
+    //
+    val renamedModule = renaming.renameInModule(module)
+
     val unroller = Unroller( nameGenerator, tracker, renaming )
     logger.info("  > %s".format(unroller.getClass.getSimpleName))
 
     // TODO: re-enable cacher once caching is reworked (see #276 for context)
-    val newModule = unroller( module )
+    val newModule = unroller( renamedModule )
 
     // dump the result of preprocessing
     val outdir = options.getOrError("io", "outdir").asInstanceOf[Path]

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
@@ -187,6 +187,17 @@ package lir {
       */
     var isRecursive: Boolean = false
 
+    // Temporary solution, until #345 is resolved
+    def copy(
+              name : String = this.name,
+              formalParams : List[FormalParam] = this.formalParams,
+              body : TlaEx = this.body
+            ) : TlaOperDecl = {
+      val ret = TlaOperDecl( name, formalParams, body )
+      ret.isRecursive = this.isRecursive
+      ret
+    }
+
     override def deepCopy( ): TlaOperDecl =  TlaOperDecl( name, formalParams, body.deepCopy() )
   }
 


### PR DESCRIPTION
closes #313 

Adds a temporary workaround, to address the problems described in #345 (unexpected behavior of `TlaOperDecl.copy` when the declaration is recursive)