### PR TITLE
Added minimal breaking retorderTest, disabled APABcastByz test

### DIFF
--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -457,13 +457,23 @@ The outcome is: NoError
 ...
 ```
 
-### check APAbcastByz.tla succeeds: regression for issue 157
+### check reorderTest.tla MayFail succeeds: fixed SMT fails under SMT-based assignment finding
 
 ```sh
-$ apalache-mc check --length=1 --init=IndInv_Unforg_NoBcast --inv=IndInv_Unforg_NoBcast --cinit=ConstInit4 APAbcastByz.tla | sed 's/I@.*//'
+$ apalache-mc check --next=MayFail --tuning=reorderTest.properties reorderTest.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
+```
+
+### check reorderTest.tla MustFail fails
+
+```sh
+$ apalache-mc check --next=MustFail reorderTest.tla | sed 's/[IEW]@.*//'
+...
+The outcome is: Error
+...
+EXITCODE: OK
 ```
 
 

--- a/test/tla/reorderTest.properties
+++ b/test/tla/reorderTest.properties
@@ -1,0 +1,1 @@
+smt.randomSeed=0

--- a/test/tla/reorderTest.tla
+++ b/test/tla/reorderTest.tla
@@ -28,7 +28,7 @@ MayFail == /\ v1' = 1     \* (1)
            
 
 \* MustFail cannot be reordered, because (2) has a use-case dependency
-\* on (4) (and (3) on (1)), but the \E blocks are reordered as a single unit
+\* on (3) (and (4) on (1)), but the \E blocks are reordered as a single unit
 
 \* In left-to-right processing, assignments do not exist, due to the 
 \* assignment-before-use paradigm

--- a/test/tla/reorderTest.tla
+++ b/test/tla/reorderTest.tla
@@ -1,0 +1,44 @@
+------------------------------ MODULE reorderTest ------------------------------
+
+EXTENDS Integers 
+
+VARIABLE v1, v2
+
+Init == v1 = 1 /\ v2 = 1
+
+S == {1}
+
+\* As the use-case constraint produced by (3) is not an assignment SMT constraint,
+\* the SMT-based assignment solver has 3 solutions:
+\*  - pick (2) and (4) as assignments, forced (2) < (4)
+\*  - pick (2) and (1) as assignments, arbitrary (2) < (1)
+\*  - pick (2) and (1) as assignments, arbitrary (1) < (2)
+
+\* MayFail can only be reordered in the last case, i.e., if
+\* a) the SMT solver arbitrarily picks (1) as the v1 assignment and
+\* b) the SMT solver arbitrarily picks the assignment order (1) < (2)
+
+\* In left-to-right processing, (1) is always chosen and the formula order
+\* is already correct
+MayFail == /\ v1' = 1     \* (1)
+           /\ \E x \in S: 
+             /\ v2' = x   \* (2)
+             /\ v1' > 0   \* (3)
+           /\ v1' = v2'   \* (4)
+           
+
+\* MustFail cannot be reordered, because (2) has a use-case dependency
+\* on (4) (and (3) on (1)), but the \E blocks are reordered as a single unit
+
+\* In left-to-right processing, assignments do not exist, due to the 
+\* assignment-before-use paradigm
+MustFail == /\ \E x \in S: 
+              /\ v1' = x   \* (1)
+              /\ v2' > 0   \* (2)
+            /\ \E y \in S: 
+              /\ v2' = y   \* (3)
+              /\ v1' > 0   \* (4)
+
+=============================================================================
+
+


### PR DESCRIPTION
Replaces the monolithic `APABcastByz.tla` test with a minimal problem-isolating spec.

This PR is expected to fail the integration tests, as it does not fix the problems with SMT-based assignment finding and reordering, but merely improves the tests themselves. 

Tests are expected to pass after #348.