### PR TITLE
Reworked assignment search

### DIFF
--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SmtFreeSymbolicTransitionExtractor.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SmtFreeSymbolicTransitionExtractor.scala
@@ -1,0 +1,174 @@
+package at.forsyte.apalache.tla.assignments
+
+import at.forsyte.apalache.tla.lir.oper._
+import at.forsyte.apalache.tla.lir.storage.{BodyMap, BodyMapFactory, SourceLocator}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
+
+
+/**
+  * Performs the complete procedure of finding symbolic transitions from the TLA+ implementation.
+  *
+  * Assignment candidates follow the assignment-before-use paradigm.
+  *
+  * @see [[SymbTransGenerator]]
+  *
+  */
+class SmtFreeSymbolicTransitionExtractor(
+                                          tracker: TransformationTracker,
+                                          sourceLoc: SourceLocator
+                                        ) {
+
+  private def getLocString( ex: TlaEx ) = sourceLoc.sourceOf( ex ).getOrElse( "<[UNKNOWN]>" )
+
+  /** Checks whether expressions, which cannot contain assignments, use unassigned variables */
+  private def throwOnUseBeforeAssignment( unassignedVars: Set[String] ) : TlaEx => Unit = {
+    case ex@OperEx( TlaActionOper.prime, NameEx( name ) ) if unassignedVars.contains( name ) =>
+      val locString = getLocString( ex )
+      throw new AssignmentException( s"$locString: $name' is used before it is assigned." )
+    case OperEx( _, args@_* ) =>
+      args foreach throwOnUseBeforeAssignment( unassignedVars )
+    case LetInEx( body, defs@_* ) =>
+      defs foreach { d => throwOnUseBeforeAssignment( unassignedVars )( d.body ) }
+      throwOnUseBeforeAssignment( unassignedVars )( body )
+    case _ =>
+  }
+
+  // Partial state in the computation, with some subset of all variables already assigned and a partial strategy found
+  private case class PartialState( unassignedVars: Set[String], partialStrat: StrategyType )
+
+  // Since disjunction and ITE behave exactly the same w.r.t. assignments, we write a unified routine
+  private def handleDisjunctionOrITE( s: PartialState, letInOperMap: BodyMap , args: Seq[TlaEx] ): PartialState = {
+    // We independently process each disjunct
+    val childStates = args map { getStrategyOptInternal(s, letInOperMap)(_) }
+    val unassignedVarsSeq = childStates map { _.unassignedVars }
+    // We need to see whether all branches assign exactly the same variables
+    val unassignedEverywhere = unassignedVarsSeq.foldLeft( s.unassignedVars ){ _.intersect( _ ) }
+    val unassignedSomewhere = unassignedVarsSeq.foldLeft( Set.empty[String] ) { _.union( _ ) }
+    // Variables that are unassigned on at least one branch and assigned on all others
+    val imbalancedAssignments = unassignedSomewhere -- unassignedEverywhere
+    if (imbalancedAssignments.nonEmpty) {
+      // Report problms for each disjunct, if any
+      val problems : Seq[String] = args.zip( childStates ) flatMap {
+        case (childEx, PartialState( childUnassignedVars, _ )) =>
+          val s = childUnassignedVars.intersect( imbalancedAssignments )
+          if ( s.isEmpty ) None
+          else {
+            val locString = getLocString( childEx )
+            Some( s"$locString - Missing assignments to: ${s.mkString( "," )}" )
+          }
+      }
+
+      throw new AssignmentException( problems.mkString("\n") )
+    }
+    // Assuming all branches assign the same variables, works correctly if args.isEmpty (for whatever reason)
+    val unifiedStrat = (childStates map { _.partialStrat }).foldLeft( s.partialStrat ) { _ ++ _ }
+    PartialState( unassignedEverywhere, unifiedStrat )
+  }
+
+  // Transition method between partial states
+  private def getStrategyOptInternal( s: PartialState, letInOperMap: BodyMap ): TlaEx => PartialState = {
+    /** Base case, assignment candidates  */
+    case ex@OperEx( TlaOper.eq, OperEx( TlaActionOper.prime, NameEx( name ) ), star ) =>
+      // First, check if star contains unassigned varaible access
+      throwOnUseBeforeAssignment( s.unassignedVars )( star )
+      // if `name` is not yet assigned, this spot becomes an assignment
+      if ( s.unassignedVars.contains( name )) PartialState( s.unassignedVars - name, s.partialStrat :+ ex.ID )
+      else s
+
+    /** Base case, manual assignments */
+    case ex@OperEx( BmcOper.assign, OperEx( TlaActionOper.prime, NameEx( name ) ), star ) =>
+      // Similar to above, except manual assignments throw if spurious
+      throwOnUseBeforeAssignment( s.unassignedVars )( star )
+      if ( s.unassignedVars.contains( name )) PartialState( s.unassignedVars - name, s.partialStrat :+ ex.ID )
+      else {
+        val locString = getLocString( ex )
+        throw new AssignmentException( s"Manual assignment at $locString is spurious: $name is already assigned!" )
+      }
+
+    /** Conjunction */
+    case OperEx( TlaBoolOper.and, args@_* ) =>
+      // We sequentially update the partial state
+      args.foldLeft( s ) { getStrategyOptInternal(_, letInOperMap)(_) }
+    /** Disjunction */
+    case ex@OperEx( TlaBoolOper.or, args@_* ) =>
+      handleDisjunctionOrITE( s, letInOperMap,  args)
+
+    /** \E quantifier */
+    case OperEx( TlaBoolOper.exists, NameEx( _ ), star, subEx ) =>
+      // We need to check that star does not contain unassigned primes.
+      throwOnUseBeforeAssignment( s.unassignedVars )( star )
+      // if no exception is thrown, continue in setEx
+      getStrategyOptInternal( s, letInOperMap )( subEx )
+
+
+    /** ITE */
+    case OperEx( TlaControlOper.ifThenElse, star, thenAndElse@_* ) =>
+      // We need to check that star does not contain unassigned primes.
+      throwOnUseBeforeAssignment( s.unassignedVars )( star )
+      // The rest is equivalent to the disjunction case
+      handleDisjunctionOrITE( s, letInOperMap, thenAndElse)
+
+    /** Nullary LetIn */
+    case LetInEx( body, defs@_* ) =>
+      // Sanity check, all operators must be nullary and non-recursive
+      assert( defs.forall { d => d.formalParams.isEmpty && !d.isRecursive } )
+      // We memorize the let-in operators, to recall when we see an apply
+      val newMap = BodyMapFactory.makeFromDecls( defs, letInOperMap)
+      // finally, we check the let-in body as well
+      getStrategyOptInternal( s, newMap )( body )
+
+    /** Nullary apply */
+    case OperEx( TlaOper.apply, NameEx(operName) ) =>
+      // Apply may appear in higher order operators, so it might not be possible to pre-analyze
+      val knownBodyOpt = letInOperMap.get( operName ) map { _.body }
+      val newStateOpt = knownBodyOpt map { getStrategyOptInternal(s, letInOperMap)(_) }
+
+      newStateOpt.getOrElse( s )
+
+    /** Misc. operator */
+    case OperEx( _, args@_* ) =>
+      // For other operators, make sure they don't use unassigned variables ...
+      args foreach throwOnUseBeforeAssignment( s.unassignedVars )
+      // ... but don't update assignments
+      s
+    /** In the other cases, return the default args */
+    case _ => s
+  }
+
+  def getStrategy(vars: Set[String], actionEx: TlaEx): StrategyType = {
+    // The strategy can be extracted from the state obtained by starting from the initial state, where
+    //   - all variables in `vars` are unassigned
+    //   - no partial strategy has been found
+    //   - no let-in defined operators are known
+    val finalState = getStrategyOptInternal( PartialState( vars, Seq.empty ), Map.empty )( actionEx )
+    // There is a possibility that some variables never get assigned at all
+    val missingVars = finalState.unassignedVars
+    // If any are missing, throw, otherwise the final partial strategy is the solution
+    if (missingVars.nonEmpty) throw new AssignmentException(s"No assignments found for: ${missingVars.mkString(", ")}")
+    else finalState.partialStrat
+  }
+
+  /**
+    * Find assignments in an action expression and produce symbolic transitions, if possible.
+    *
+    * @param vars names of the variables on which actionExpr is operating, e.g, the variables defined with VARIABLES
+    * @param actionExpr an expression over primed and unprimed variables, e.g., Next or Init
+    * @return A collection of symbolic transitions, if they can be extracted
+    *
+    */
+  def apply(vars: Set[String], actionExpr: TlaEx) : Seq[SymbTrans] = {
+    /** Get strategy from the actionExpr */
+    val assignmentStrategy = getStrategy( vars, actionExpr )
+    val stg = new SymbTransGenerator( tracker )
+    stg( actionExpr, assignmentStrategy )
+  }
+
+}
+
+object SmtFreeSymbolicTransitionExtractor {
+  def apply(tracker: TransformationTracker, sourceLoc: SourceLocator): SmtFreeSymbolicTransitionExtractor = {
+    new SmtFreeSymbolicTransitionExtractor(tracker, sourceLoc)
+  }
+}
+

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SymbTransGenerator.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SymbTransGenerator.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.assignments
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.transformations.standard.Flatten
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.TlaBool
 
@@ -10,13 +9,6 @@ import at.forsyte.apalache.tla.lir.values.TlaBool
   * Constructs symbolic transitions from an assignment strategy.
   */
 class SymbTransGenerator( tracker : TransformationTracker ) {
-
-
-  private def mkReordering( fn: TlaEx => Option[Int]) : Reordering[Option[Int]] = new Reordering[Option[Int]](
-    Reordering.IntOptOrdering,
-    fn,
-    tracker
-  )
 
   private[assignments] object helperFunctions {
     type LabelMapType = Map[UID, Set[UID]]
@@ -243,42 +235,6 @@ class SymbTransGenerator( tracker : TransformationTracker ) {
     }
 
     /**
-      * Constructs a ranking function which assigns
-      * to each `tlaEx` the following value:
-      *   - Some( min S ), if the set filtered = { e.ID | e is a subexpression of tlaEx and s.contains( e.ID ) } of
-      *     assignment subexpression IDs is nonempty and the set S = { j | orderedAssignments[j] \in filtered }
-      *     of positions those assignments hold w.r.t. orderedAssignments is nonempty
-      *   - None otherwise
-      *
-      * Example:
-      *   s = { 1, 3, 42},
-      *   orderedAssignments = [ 3, 42, 1 ]
-      *   tlaEx = /\ x' = 1 (uid 1)
-      *           /\ x' = 2 (uid 2)
-      *           /\ y' = 3 (uid 3)
-      *
-      *   Then, filtered = { 1, 3 }, S = { 0, 2 } and the ranking function for tlaEx returns Some( 0 )
-      *   (i.e. in reordering, tlaEx has the same rank as its lowest-ranking assingment subexpression `y' = 3`)
-      */
-    private def mkRankingFun( s: Set[UID],
-                              selections : SelMapType,
-                              orderedAssignments: StrategyType
-                            ) : TlaEx => Option[Int] = { tlaEx =>
-      // the union of all sets in selections( tlaEx.ID ) lists all the assignments in the subexpressions of TlaEx
-      val assignmentsBelow = selections.getOrElse( tlaEx.ID, Set.empty[Set[UID]] ).foldLeft( Set.empty[UID] ){ _ ++ _ }
-      // We filter them via the current selection (to ignore assignments on a branch we're not currently on)
-      val filtered = assignmentsBelow.intersect( s )
-      // Of all the assignment candidates, the one with the lowest position in `orderedAssignments` determines the rank
-      filtered.foldLeft( None : Option[Int] ) {
-        case (rankCand, uid) =>
-          val uidRank = orderedAssignments.find( _ == uid ) map {
-            orderedAssignments.indexOf
-          }
-          Reordering.IntOptOrdering.min( rankCand, uidRank )
-      }
-    }
-
-    /**
       * Gathers the orderedAssignments selections and their corresponding restricted formulas.
       *
       * @param ex         Input formula.
@@ -292,19 +248,7 @@ class SymbTransGenerator( tracker : TransformationTracker ) {
                         selections : SelMapType
                       ) : Seq[SymbTrans] =
       selections( ex.ID ).map { s =>
-        val sliced = sliceWith( s, selections )( ex )
-        // Flatten /\, so we can reorder properly
-        val flattened = Flatten(tracker)( sliced )
-
-        // To proceed, we need to have elements of `s` in the order defined by `strategy`
-        val orderedAssignments = mkOrdered( s, strategy )
-        // `orderedAssignments` helps define a ranking function ...
-        val rankingFn = mkRankingFun(s, selections, orderedAssignments)
-        // ... which we can use to reorder the flattened expression
-        val reordering = mkReordering( rankingFn )
-        val reorderedEx = reordering.reorder( flattened )
-
-        (orderedAssignments, reorderedEx)
+        (mkOrdered( s, strategy ), sliceWith( s, selections )( ex ))
       }.toSeq
     }
 

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
@@ -92,7 +92,7 @@ class TransitionPassImpl @Inject()(options: PassOptions,
 
     val sourceLoc = SourceLocator(sourceStore.makeSourceMap, changeListener)
 
-    val transitionPairs = SymbolicTransitionExtractor(tracker)(vars, primedName)
+    val transitionPairs = SmtFreeSymbolicTransitionExtractor(tracker, sourceLoc)(vars.toSet, primedName)
     // sort the transitions by their occurrence in the source code
     val sorter = new TransitionOrder( sourceLoc )
     val sortedPairs = sorter.sortBySource(transitionPairs)

--- a/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSmtFreeSTE.scala
+++ b/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSmtFreeSTE.scala
@@ -1,0 +1,95 @@
+package at.forsyte.apalache.tla.assignments
+
+import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.TestingPredefs
+import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
+import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith( classOf[JUnitRunner] )
+class TestSmtFreeSTE extends FunSuite with TestingPredefs {
+
+  val sourceLoc = new SourceLocator( Map.empty, new ChangeListener )
+
+  val ste = new SmtFreeSymbolicTransitionExtractor( TrackerWithListeners(), sourceLoc )
+
+  test( "Single ex: candidate" ) {
+    val ex = tla.primeEq( n_x, 1 )
+    val vars = Set( "x" )
+    val strat = ste.getStrategy( vars, ex )
+
+    assert( strat == Seq( ex.ID ) )
+  }
+
+  test( "Single ex: manual asgn" ) {
+    val ex = tla.assignPrime( n_x, 1 )
+    val vars = Set( "x" )
+    val strat = ste.getStrategy( vars, ex )
+
+    assert( strat == Seq( ex.ID ) )
+  }
+
+  test( "2 candidates: Manual / natural" ) {
+    val manual = tla.assignPrime( n_x, 1 )
+    val natural = tla.primeEq( n_x, 1 )
+    val vars = Set( "x" )
+
+    val ex1 = tla.and( manual, natural )
+    val strat1 = ste.getStrategy( vars, ex1 )
+
+    assert( strat1 == Seq( manual.ID ) )
+
+    val ex2 = tla.and( natural, manual )
+    assertThrows[AssignmentException] {
+      ste.getStrategy( vars, ex2 )
+    }
+
+  }
+
+  test( "Missing var" ) {
+    val ex = tla.primeEq( n_x, 1 )
+    val vars = Set( "x", "y" )
+
+    assertThrows[AssignmentException] {
+      ste.getStrategy( vars, ex )
+    }
+  }
+
+  test( "Assignment in LET-IN" ) {
+    val asgn = tla.primeEq( n_x, 1 )
+    val declA = tla.declOp( "A", asgn )
+    val ex = tla.letIn( tla.appDecl( declA ), declA )
+
+    val vars = Set( "x" )
+
+    val strat = ste.getStrategy( vars, ex )
+
+    val x = 1
+    assert( x == 1 && strat == Seq( asgn.ID ) )
+  }
+
+  test( "Disjunction" ) {
+    val asgn1 = tla.primeEq( n_x, 1 )
+    val asgn2 = tla.primeEq( n_x, 2 )
+    val ex = tla.or( asgn1, asgn2 )
+    val vars = Set( "x" )
+    val strat = ste.getStrategy( vars, ex )
+
+    assert( strat == Seq( asgn1.ID, asgn2.ID ) )
+  }
+
+  test( "Use before assignment" ) {
+    val asgn = tla.primeEq( n_x, 1 )
+    val cmp = tla.gt( tla.prime( n_x ), 0 )
+    val ex = tla.and( cmp, asgn )
+    val vars = Set( "x" )
+
+    assertThrows[AssignmentException] {
+      ste.getStrategy( vars, ex )
+    }
+  }
+
+
+}

--- a/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSymbTransGenerator.scala
+++ b/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSymbTransGenerator.scala
@@ -209,12 +209,6 @@ class TestSymbTransGenerator extends FunSuite with TestingPredefs {
       and(n_B, appDecl( xDecl ) )
     )
 
-    // Reordering pushes assignment to the front
-    val disjOrdered = or(
-      and(appDecl( xDecl ), n_A ),
-      and(appDecl( xDecl ), n_B )
-    )
-
     val next = letIn(
       disj,
       xDecl
@@ -224,7 +218,7 @@ class TestSymbTransGenerator extends FunSuite with TestingPredefs {
 
     val ret = stg( next, strat ) map { _._2 }
     assert( ret == Seq(
-      letIn( disjOrdered, declOp( "X", assignPrime( n_x, int( 1 ) ) ) )
+      letIn( disj, declOp( "X", assignPrime( n_x, int( 1 ) ) ) )
     ) )
   }
 


### PR DESCRIPTION
closes #348
closes #354 (together with #364)

As this approach to assignments makes cover analysis irrelevant, this PR implicitly closes/invalidates the following:
issues: #279, #298, #353, #111
open pr: #308

Potentially resolves issue #346: Under this build, the solver returns to expected behavior (EXITCODE: OK), but finds a deadlock in the listed specification. Author clarification required to close.

See also:  #62