### PR TITLE
add alias for the unstable docker image

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -136,7 +136,10 @@ If you are running Apalache on Linux :penguin: or MacOS
 Apalache in docker while sharing the working directory:
 
 ```bash
+# using the latest stable
 $ alias apalache="docker run --rm -v $(pwd):/var/apalache apalache/mc"
+# using the latest unstable
+$ alias apalache="docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable"
 ```
 
 ### Using the unstable version of Apalache


### PR DESCRIPTION
This is a tiny update to the manual. The current version defines an alias for the latest stable build. Added an alias f or the unstable docker image too.