### PR TITLE
Deploy manual from unstable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      # TODO Remove once deploying unstable versions separately
+      - unstable
 
 jobs:
   deploy:
@@ -14,7 +16,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.5'
+          mdbook-version: "0.4.5"
           # mdbook-version: 'latest'
 
       - run: |
@@ -32,4 +34,3 @@ jobs:
           destination_dir: docs
           # We use GitHub's builtin jekyll for rendering the main landing page
           enable_jekyll: true
-


### PR DESCRIPTION
While we are working rapidly on the manual, catching up on the current
state of things, we want to deploy manual updates to unstable
immediately without having to wait for a release to master.

As discussed in our meeting on monday.