### PR TITLE
Automate release preparation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,11 +6,17 @@
 # - RELEASEME_TOKEN: a github token used in ./script/release
 [[ -f "./.local-envrc" ]] && source "./.local-envrc"
 
-# The directory of this file
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# This function is to protect local variables from polluting downstream scripts
+# that source this one.
+exports () {
+    # The directory of this file
+    local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Provide reference to the target directory
-export TARGET_DIR=$DIR/target
+    # Provide reference to the target directory
+    export TARGET_DIR=$DIR/target
 
-# Add executables to path
-export PATH=$DIR/bin:$PATH
+    # Add executables to path
+    export PATH=$DIR/bin:$PATH
+}
+
+exports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,13 +246,13 @@ Assuming the current version recorded in the project's `.pom` files is
 - [ ] `git checkout unstable && git pull`
 - [ ] Run `./script/release-prepare.sh` to
   - create and checkout a branch `release/l.m.n`.
-  - prepare an commit a release commit `[release] l.m.n`
+  - prepare and add a release commit `[release] l.m.n`
 - [ ] Run `./script/version-bump.sh` to
   - update the changelog
   - bump the version number
   - commit the changes
 - [ ] Open a PR merging the newly created branch into `unstable`, with the title
-      `Release l.m.n`.
+      `[release] l.m.n`.
 - [ ] Get the PR reviewed and merged and **DO NOT SQUASH THE CHANGES** on merge.
 
 If you need to set a specific version (e.g., to increment to a major version),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ Apalache:
             - [Running the tests](#running-the-tests)
         - [Continuous Integration](#continuous-integration)
     - [Changelog](#changelog)
+        - [Structure](#structure)
+        - [Recording changes](#recording-changes)
     - [Releases](#releases)
         - [Prepare the release](#prepare-the-release)
         - [Cut the release](#cut-the-release)
@@ -228,7 +230,7 @@ Every non-trivial PR must update the [unreleased changes log](./UNRELEASED.md).
 Changes for a given release should be split between the five sections:
 
 1. Breaking Changes
-2. Features 
+2. Features
 3. Improvements
 4. Bug Fixes
 5. Documentation
@@ -238,18 +240,23 @@ Changes for a given release should be split between the five sections:
 You must have release-me installed and configured with a token. See
 https://pypi.org/project/release-me/
 
-Assuming the version to be released is `l.m.n`, as per semantic versioning, the
-current release process is as follows:
+Assuming the current version recorded in the project's `.pom` files is
+`l.m.n-SNAPSHOT`, the manual release process is as follows:
 
 ### Prepare the release
 
-- [ ] Create a new feature branch, `release-l.m.n` and check it out
-- [ ] Generate the release notes by running `./script/release-notes.sh`, this
-      will create a file `RELEASE-NOTES.md`.
-- [ ] Mark the version as RELEASE via `mvn versions:set -DnewVersion=l.m.n-RELEASE`
-- [ ] Commit the changes: `git add . && git commit -m "Prepare for release l.m.n"`
-- [ ] Open a PR merging the feature branch into `develop`. Get it merged.
-- [ ] Open a PR to merge `unstable` into `master`, titling it `Release l.m.n`
+- [ ] `git checkout unstable && git pull`
+- [ ] Run `./script/release-prepare.sh`, which will prepare the release on a
+      branch `release/l.m.n`.
+- [ ] Open a PR merging the newly created branch into `unstable`, with the title
+      `Release l.m.n`. Get it merged.
+
+If you need to set a specific version (e.g., to increment to a major version),
+override the `RELEASE_VERSION`:
+
+```sh
+RELEASE_VERSION=l.m.n ./script/release-prepare.sh
+```
 
 ### Cut the release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,6 @@ Apalache:
     - [Releases](#releases)
         - [Prepare the release](#prepare-the-release)
         - [Cut the release](#cut-the-release)
-        - [Advance the version on unstable](#advance-the-version-on-unstable)
-        - [Announce the relesae](#announce-the-relesae)
 
 <!-- markdown-toc end -->
 
@@ -246,13 +244,19 @@ Assuming the current version recorded in the project's `.pom` files is
 ### Prepare the release
 
 - [ ] `git checkout unstable && git pull`
-- [ ] Run `./script/release-prepare.sh`, which will prepare the release on a
-      branch `release/l.m.n`.
+- [ ] Run `./script/release-prepare.sh` to
+  - create and checkout a branch `release/l.m.n`.
+  - prepare an commit a release commit `[release] l.m.n`
+- [ ] Run `./script/version-bump.sh` to
+  - update the changelog
+  - bump the version number
+  - commit the changes
 - [ ] Open a PR merging the newly created branch into `unstable`, with the title
-      `Release l.m.n`. Get it merged.
+      `Release l.m.n`.
+- [ ] Get the PR reviewed and merged and **DO NOT SQUASH THE CHANGES** on merge.
 
 If you need to set a specific version (e.g., to increment to a major version),
-override the `RELEASE_VERSION`:
+override the `RELEASE_VERSION` when preparing the release:
 
 ```sh
 RELEASE_VERSION=l.m.n ./script/release-prepare.sh
@@ -260,24 +264,12 @@ RELEASE_VERSION=l.m.n ./script/release-prepare.sh
 
 ### Cut the release
 
-When the PR is merged into `master`:
+When the PR is merged into `unstable`:
 
-- [ ] Checkout `master`
-- [ ] Sync with upstream via`git pull origin master`
+- [ ] Checkout the `[release] l.m.n` commit from the latest `unstable`
 - [ ] Build the artifact with `make`
 - [ ] Post the release with `./script/release vl.m.n ./scripts/release-l.m.n.txt`
 - [ ] Update the download links at https://github.com/informalsystems/apalache/blob/gh-pages/_config.yml#L7
-
-### Advance the version on unstable
-
-- [ ] Checkout `unstable`
-- [ ] Update the `CHANGES.md` and refresh the `UNRELEASED.md` by running `./scripts/update-changes.sh`.
-- [ ] Run `mvn --batch-mode release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=l.m.(n+1)-SNAPSHOT`
-- [ ] Commit the changes `git add . && git commit -m "Bump version to l.m.(n+1)-SNAPSHOT" && git push`
-
-### Announce the relesae
-
-- [ ] Post a notification to the (internal) `#releases` slack channel.
 
 [Github Issue]: https://github.com/informalsystems/apalache/issues
 [rfc]: https://en.wikipedia.org/wiki/Request_for_Comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ Changes for a given release should be split between the five sections:
 You must have release-me installed and configured with a token. See
 https://pypi.org/project/release-me/
 
-Assuming the current version recorded in the project's `.pom` files is
+Assuming the current version recorded in the project's `pom.xml` files is
 `l.m.n-SNAPSHOT`, the manual release process is as follows:
 
 ### Prepare the release

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,3 @@
-
 <!-- NOTE:
      Release notes for unreleased changes go here, following this format:
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,10 @@
          * Another change description, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+ * critical bugfix in unique renaming, #429
+
 ### Features
 
  * opt-in for statistics collection (shared with TLC and TLA+ Toolbox), see #288

--- a/script/get-version.sh
+++ b/script/get-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the version of the project from mvn
+
+# The directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=./shared.sh
+source "$DIR"/shared.sh
+
+# We need to be in the root dir to get the project version from mvn
+cd "$PROJ_ROOT"
+
+# See https://stackoverflow.com/a/26514030/1187277
+mvn -q \
+    -Dexec.executable=echo \
+    -Dexec.args='${project.version}' \
+    --non-recursive \
+    exec:exec

--- a/script/release-notes.sh
+++ b/script/release-notes.sh
@@ -28,14 +28,17 @@ PREAMBLE="<!-- NOTE:
 
 PREAMBLE_LINES=$(( $(echo "$PREAMBLE" | wc -l | cut -d' ' -f 1) + 1))
 
-# See https://stackoverflow.com/a/26514030/1187277
-MVN_VERSION=$(mvn -q \
-    -Dexec.executable=echo \
-    -Dexec.args='${project.version}' \
-    --non-recursive \
-    exec:exec)
+if [ -z "$RELEASE_VERSION" ]
+then
+    # See https://stackoverflow.com/a/26514030/1187277
+    RELEASE_VERSION=$(mvn -q \
+        -Dexec.executable=echo \
+        -Dexec.args='${project.version}' \
+        --non-recursive \
+        exec:exec)
+fi
 
-echo "## $MVN_VERSION" > "$RELEASE_NOTES"
+echo "## $RELEASE_VERSION" > "$RELEASE_NOTES"
 echo "" >> "$RELEASE_NOTES"
 tail -n +"$PREAMBLE_LINES" "$UNRELEASED" >> "$RELEASE_NOTES"
 

--- a/script/release-notes.sh
+++ b/script/release-notes.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # The directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./shared.sh
-source "$DIR"/shared.sh
+. "$DIR"/shared.sh
 
 RELEASE_VERSION=${RELEASE_VERSION:-''}
 

--- a/script/release-notes.sh
+++ b/script/release-notes.sh
@@ -26,7 +26,7 @@ PREAMBLE="<!-- NOTE:
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->"
 
-PREAMBLE_LINES=$(( $(echo "$PREAMBLE" | wc -l | cut -d' ' -f 1) + 1))
+PREAMBLE_LINES=$(( $(echo "$PREAMBLE" | wc -l | cut -d' ' -f 1) + 1 ))
 
 if [ -z "$RELEASE_VERSION" ]
 then

--- a/script/release-notes.sh
+++ b/script/release-notes.sh
@@ -30,12 +30,7 @@ PREAMBLE_LINES=$(( $(echo "$PREAMBLE" | wc -l | cut -d' ' -f 1) + 1))
 
 if [ -z "$RELEASE_VERSION" ]
 then
-    # See https://stackoverflow.com/a/26514030/1187277
-    RELEASE_VERSION=$(mvn -q \
-        -Dexec.executable=echo \
-        -Dexec.args='${project.version}' \
-        --non-recursive \
-        exec:exec)
+    RELEASE_VERSION=$("$DIR"/get-version.sh)
 fi
 
 echo "## $RELEASE_VERSION" > "$RELEASE_NOTES"

--- a/script/release-notes.sh
+++ b/script/release-notes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Run this script to create release notes for based on the changes recorded in the
+# Run this script to create release notes based on the changes recorded in the
 # UNRELEASED.md file. The version for the release notes is determined by the
 # version of the software specified in the pom.xml.
 

--- a/script/release-notes.sh
+++ b/script/release-notes.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 
 # The directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-PROJ_ROOT=$DIR"/.."
+# shellcheck source=./shared.sh
+source "$DIR"/shared.sh
 
-UNRELEASED=$PROJ_ROOT"/UNRELEASED.md"
-RELEASE_NOTES=$PROJ_ROOT"/RELEASE-NOTES.md"
+RELEASE_VERSION=${RELEASE_VERSION:-''}
 
 PREAMBLE="<!-- NOTE:
      Release notes for unreleased changes go here, following this format:

--- a/script/release-prepare.sh
+++ b/script/release-prepare.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+set -o xtrace
+
+# Perpare a release on the current branch
+
+# The directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=./shared.sh
+. "$DIR"/shared.sh
+
+# make sure that we do not release uncommited files
+if ! (git diff --exit-code && git diff --cached --exit-code) >/dev/null
+then
+    echo "error: Git directory is not clean. Remove changes to tracked files."
+    exit 255
+fi
+
+RELEASE_VERSION=${RELEASE_VERSION:-''}
+
+if [ -n "$RELEASE_VERSION" ]
+then
+    # Explicitly set the release version
+    mvn versions:set -DnewVersion="${RELEASE_VERSION}"
+else
+    # Derive the relesae version by removing the -SNAPSHOT suffix
+    mvn versions:set -DremoveSnapshot
+    RELEASE_VERSION=$("$DIR"/get-version.sh)
+fi
+
+git checkout -b "release/${RELEASE_VERSION}"
+RELEASE_VERSION=$RELEASE_VERSION "$DIR"/release-notes.sh
+
+git add --update
+git add "$RELEASE_NOTES"
+git commit -m "[release] ${RELEASE_VERSION}"

--- a/script/shared.sh
+++ b/script/shared.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared variables used in other scripts
+
+exports () {
+    # tell shellcheck we can use `local`
+    # The directory of this file
+    local DIR
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+    export PROJ_ROOT=$DIR"/.."
+    export UNRELEASED=$PROJ_ROOT"/UNRELEASED.md"
+    export CHANGES=$PROJ_ROOT"/CHANGES.md"
+    export RELEASE_NOTES=$PROJ_ROOT"/RELEASE-NOTES.md"
+}
+exports

--- a/script/shared.sh
+++ b/script/shared.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # Shared variables used in other scripts
 
 exports () {
-    # tell shellcheck we can use `local`
     # The directory of this file
     local DIR
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/script/update-changes.sh
+++ b/script/update-changes.sh
@@ -7,10 +7,8 @@ set -euo pipefail
 
 # The directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-PROJ_ROOT=$DIR"/.."
-
-CHANGES=$PROJ_ROOT"/TEST-CHANGES.md"
-RELEASE_NOTES=$PROJ_ROOT"/RELEASE-NOTES.md"
+# shellcheck source=./shared.sh
+source "$DIR"/shared.sh
 
 PREAMBLE="<!-- NOTE:
      This file is generated. Do not write release notes here.

--- a/script/update-changes.sh
+++ b/script/update-changes.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./shared.sh
-source "$DIR"/shared.sh
+. "$DIR"/shared.sh
 
 if ! [ -f "$RELEASE_NOTES" ]
 then

--- a/script/update-changes.sh
+++ b/script/update-changes.sh
@@ -5,10 +5,18 @@
 
 set -euo pipefail
 
-# The directory of this file
+# the directory of this file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./shared.sh
 source "$DIR"/shared.sh
+
+if ! [ -f "$RELEASE_NOTES" ]
+then
+    echo "error: RELEASE-NOTES.md is missing."
+    echo "Did you run script/release-notes.sh first?"
+    exit 1
+fi
+
 
 PREAMBLE="<!-- NOTE:
      This file is generated. Do not write release notes here.

--- a/script/version-bump.sh
+++ b/script/version-bump.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# set -o xtrace
+
+# Increment the version to a SNAPSHOT and update the changelog
+
+# The directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=./shared.sh
+. "$DIR"/shared.sh
+
+VERSION=$("$DIR"/get-version.sh)
+"$DIR"/update-changes.sh
+git add --update
+git commit -m "Update changelog for version ${VERSION}"
+
+mvn --batch-mode release:update-versions -DautoVersionSubmodules=true
+
+DEV_VERSION=$("$DIR"/get-version.sh)
+git add --update
+git commit -m "Bump version to ${DEV_VERSION}"

--- a/test/.envrc
+++ b/test/.envrc
@@ -13,17 +13,19 @@
 #     [username@comp test]$ which apalache-mc
 #     /home/username/Sync/informal-systems/apalache/apalache-core/test/docker-bin/apalache-mc
 
-# The directory of this file
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# This function is to protect local variables from polluting downstream scripts
+# that source this one.
+exports () {
+    # The directory of this file
+    local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Inherit the environment of the root .envrc if it's not already sourced
-source "$DIR"/../.envrc
+    # Inherit the environment of the root .envrc if it's not already sourced
+    source "$DIR"/../.envrc
 
-# Shadow potential DIR in sourced .envrc
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-if [[ "$USE_DOCKER" == "true" ]]
-then
-    echo "WARNING: Shadowing ../bin/apalache-mc with dockerized executable"
-    export PATH=$DIR/docker-bin:$PATH
-fi
+    if [[ "$USE_DOCKER" == "true" ]]
+    then
+        echo "WARNING: Shadowing ../bin/apalache-mc with dockerized executable"
+        export PATH=$DIR/docker-bin:$PATH
+    fi
+}
+exports

--- a/test/run-integration
+++ b/test/run-integration
@@ -9,13 +9,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Ensure the environment is set
+# shellcheck source=./.envrc
 source "$DIR"/.envrc
 
-# Shadow potential DIR in sourced .envrc
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 # Ensure the mdx executable is on the path
-eval $(opam env)
+eval "$(opam env)"
 
 # Execute the wrapper script
 "$DIR"/mdx-test.py


### PR DESCRIPTION
Closes #441
Towards #388

This adds scripts to automate preparing a release and incrementing to the next development version.

This also includes a few cleanups to existing bash scripts, relevant just because of their bashist affiliation.

Once these are in place, almost all of the remaining work for #442 will be in the yaml config for our CI pipeline.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [X] Documentation added for any new functionality
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
