### PR TITLE
closed #450 and #197: handling big integers and better preprocessing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ Changes for a given release should be split between the five sections:
 You must have release-me installed and configured with a token. See
 https://pypi.org/project/release-me/
 
-Assuming the current version recorded in the project's `.pom` files is
+Assuming the current version recorded in the project's `pom.xml` files is
 `l.m.n-SNAPSHOT`, the manual release process is as follows:
 
 ### Prepare the release

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,10 +13,12 @@
 ### Bug fixes
 
  * critical bugfix in unique renaming, #429
+ * handling big integers, #450
 
 ### Features
 
  * opt-in for statistics collection (shared with TLC and TLA+ Toolbox), see #288
+ * constant simplification over strings, #197
  
 ### Architecture
  

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,10 @@
          * Another change description, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+ * critical bugfix in unique renaming, #429
+
 ### Features
 
  * opt-in for statistics collection (shared with TLC and TLA+ Toolbox), see #288

--- a/test/tla/SafeMath.tla
+++ b/test/tla/SafeMath.tla
@@ -1,7 +1,7 @@
 ---------------------------- MODULE SafeMath -----------------------------------
 (*
  * Test that the operations over big integers go through.
- * This specification is expected to deadlock, but not violating the invariant.
+ * This specification is expected to deadlock, without violating the invariant.
  *
  * Here we are testing SafeMath:
  *

--- a/test/tla/SafeMath.tla
+++ b/test/tla/SafeMath.tla
@@ -1,0 +1,101 @@
+---------------------------- MODULE SafeMath -----------------------------------
+(*
+ * Test that the operations over big integers go through.
+ * This specification is expected to deadlock, but not violating the invariant.
+ *
+ * Here we are testing SafeMath:
+ *
+ * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/math/SafeMath.sol
+ *
+ * More on the topic:
+ *
+\* https://medium.com/coinmonks/math-in-solidity-part-2-overflow-3cd7283714b4
+\* https://medium.com/@soliditydeveloper.com/solidity-design-patterns-multiply-before-dividing-407980646f7
+ *
+ * Igor Konnov, 2021
+ *)
+EXTENDS Integers
+
+\* the width of the unsigned integers, like in Solidity
+BITWIDTH == 256
+MAX_UNSIGNED == (2^BITWIDTH) - 1
+
+VARIABLE opcode, arg1, arg2, res, is_error
+
+vars == <<opcode, arg1, arg2, res, is_error>>
+
+InRange(i) ==
+    i >= 0 /\ i <= MAX_UNSIGNED
+
+TryAdd(a, b) ==
+    LET c == (a + b) % MAX_UNSIGNED IN
+    IF c < a
+    THEN <<FALSE, 0>>
+    ELSE <<TRUE, c>>
+
+TrySub(a, b) ==
+    IF b > a
+    THEN <<FALSE, 0>>
+    ELSE <<TRUE, (a - b) % MAX_UNSIGNED>>
+
+TryMul(a, b) ==
+    IF a = 0
+    THEN <<TRUE, 0>>
+    ELSE LET c == (a * b) % MAX_UNSIGNED IN
+        IF c \div a /= b
+        THEN <<FALSE, 0>>
+        ELSE <<TRUE, c>>
+
+TryDiv(a, b) ==
+    IF b = 0
+    THEN <<FALSE, 0>>
+    ELSE <<TRUE, a \div b>>
+
+TryMod(a, b) ==
+    IF b = 0
+    THEN <<FALSE, 0>>
+    ELSE <<TRUE, a % b>>
+
+TestTry(code, Op(_, _)) ==
+    \* non-deterministically pick two non-negative integers
+    \E a, b \in Int:
+        /\ InRange(a)
+        /\ InRange(b)
+        /\ LET flag_c == Op(a, b) IN
+            /\ opcode' = code
+            /\ arg1' = a
+            /\ arg2' = b
+            /\ is_error' = flag_c[1]
+            /\ res' = flag_c[2]
+
+Init ==
+    /\ opcode = "NOP"
+    /\ arg1 = 0
+    /\ arg2 = 0
+    /\ res = 0
+    /\ is_error = FALSE
+
+Next ==
+    \/ /\ opcode = "NOP"
+       /\ \/ TestTry("ADD", TryAdd)
+          \/ TestTry("SUB", TrySub)
+          \/ TestTry("MUL", TryMul)
+          \/ TestTry("DIV", TryDiv)
+          \/ TestTry("MOD", TryMod)
+    \/ opcode /= "NOP" /\ UNCHANGED vars
+
+Inv ==
+    /\ opcode = "ADD"
+        => is_error <=> (arg1 + arg2 > MAX_UNSIGNED \/ res /= arg1 + arg2)
+    /\ opcode = "SUB"
+        => is_error <=> (arg1 - arg2 < 0 \/ res /= arg1 - arg2)
+    /\ opcode = "MUL"
+        => is_error <=> (arg1 * arg2 > MAX_UNSIGNED \/ res /= arg1 * arg2 )
+    /\ opcode = "DIV"
+        => is_error <=>
+            arg2 = 0 \/ arg1 \div arg2 > MAX_UNSIGNED \/ res /= arg1 \div arg2
+    /\ opcode = "MOD"
+        => is_error <=>
+            arg2 = 0 \/ arg1 % arg2 > MAX_UNSIGNED \/ res /= arg1 % arg2
+
+==============================================================================

--- a/test/tla/SafeMath.tla
+++ b/test/tla/SafeMath.tla
@@ -90,26 +90,31 @@ Next ==
     \/ opcode /= "NOP" /\ UNCHANGED vars
 
 InvAdd ==
+    LET perfectInt == arg1 + arg2 IN
     opcode = "ADD"
-        => is_error <=> (arg1 + arg2 > MAX_UNSIGNED /\ res /= arg1 + arg2)
+        => is_error <=> (perfectInt > MAX_UNSIGNED /\ res /= perfectInt)
 
 InvSub ==
+    LET perfectInt == arg1 - arg2 IN
     opcode = "SUB"
-        => is_error <=> (arg1 - arg2 < 0 /\ res /= arg1 - arg2)
+        => is_error <=> (perfectInt < 0 /\ res /= perfectInt)
 
 InvMul ==
+    LET perfectInt == arg1 * arg2 IN
     opcode = "MUL"
-        => is_error <=> (arg1 * arg2 > MAX_UNSIGNED /\ res /= arg1 * arg2 )
+        => is_error <=> (perfectInt > MAX_UNSIGNED /\ res /= perfectInt)
 
 InvDiv ==
+    LET perfectInt == arg1 \div arg2 IN
     opcode = "DIV"
         => is_error <=>
-            arg2 = 0 \/ (arg1 \div arg2 > MAX_UNSIGNED /\ res /= arg1 \div arg2)
+            arg2 = 0 \/ (perfectInt > MAX_UNSIGNED /\ res /= perfectInt)
 
 InvMod ==
+    LET perfectInt == arg1 % arg2 IN
     opcode = "MOD"
         => is_error <=>
-            arg2 = 0 \/ (arg1 % arg2 > MAX_UNSIGNED /\ res /= arg1 % arg2)
+            arg2 = 0 \/ (perfectInt > MAX_UNSIGNED /\ res /= perfectInt)
 
 
 \* check this to see an overflow

--- a/test/tla/SafeMath.tla
+++ b/test/tla/SafeMath.tla
@@ -98,4 +98,8 @@ Inv ==
         => is_error <=>
             arg2 = 0 \/ arg1 % arg2 > MAX_UNSIGNED \/ res /= arg1 % arg2
 
+
+\* check this to see an overflow
+FalseInv ==
+    arg1 + arg2 < MAX_UNSIGNED
 ==============================================================================

--- a/test/tla/SafeMath.tla
+++ b/test/tla/SafeMath.tla
@@ -18,6 +18,7 @@ EXTENDS Integers
 
 \* the width of the unsigned integers, like in Solidity
 BITWIDTH == 256
+POWER == 2^BITWIDTH
 MAX_UNSIGNED == (2^BITWIDTH) - 1
 
 VARIABLE opcode, arg1, arg2, res, is_error
@@ -28,7 +29,7 @@ InRange(i) ==
     i >= 0 /\ i <= MAX_UNSIGNED
 
 TryAdd(a, b) ==
-    LET c == (a + b) % MAX_UNSIGNED IN
+    LET c == (a + b) % POWER IN
     IF c < a
     THEN <<FALSE, 0>>
     ELSE <<TRUE, c>>
@@ -36,12 +37,12 @@ TryAdd(a, b) ==
 TrySub(a, b) ==
     IF b > a
     THEN <<FALSE, 0>>
-    ELSE <<TRUE, (a - b) % MAX_UNSIGNED>>
+    ELSE <<TRUE, (a - b) % POWER>>
 
 TryMul(a, b) ==
     IF a = 0
     THEN <<TRUE, 0>>
-    ELSE LET c == (a * b) % MAX_UNSIGNED IN
+    ELSE LET c == (a * b) % POWER IN
         IF c \div a /= b
         THEN <<FALSE, 0>>
         ELSE <<TRUE, c>>

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -113,7 +113,7 @@ EXITCODE: OK
 ### check SafeMath deadlocks (no error): regression for issue 450
 
 ```sh
-$ apalache-mc check --length=1 SafeMath.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --inv=Inv SafeMath.tla | sed 's/I@.*//'
 ...
 The outcome is: Deadlock
 ...

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -113,9 +113,18 @@ EXITCODE: OK
 ### check SafeMath deadlocks (no error): regression for issue 450
 
 ```sh
-$ apalache-mc check --length=1 --inv=Inv SafeMath.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --inv=InvSub SafeMath.tla | sed 's/I@.*//'
 ...
 The outcome is: Deadlock
+...
+```
+
+### check SafeMath reports an error: regression for issue 450
+
+```sh
+$ apalache-mc check --length=1 --inv=InvAdd SafeMath.tla | sed 's/I@.*//'
+...
+The outcome is: Error
 ...
 ```
 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -110,6 +110,15 @@ EXITCODE: OK
 ## running the check command
 
 
+### check SafeMath deadlocks (no error): regression for issue 450
+
+```sh
+$ apalache-mc check --length=1 SafeMath.tla | sed 's/I@.*//'
+...
+The outcome is: Deadlock
+...
+```
+
 ### check Fix365_ExistsSubset succeeds: regression for issue 365
 
 ```sh

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -110,16 +110,16 @@ EXITCODE: OK
 ## running the check command
 
 
-### check SafeMath deadlocks (no error): regression for issue 450
+### check InvSub for SafeMath reports no error: regression for issue 450
 
 ```sh
 $ apalache-mc check --length=1 --inv=InvSub SafeMath.tla | sed 's/I@.*//'
 ...
-The outcome is: Deadlock
+The outcome is: NoError
 ...
 ```
 
-### check SafeMath reports an error: regression for issue 450
+### check InvAdd for SafeMath reports an error: regression for issue 450
 
 ```sh
 $ apalache-mc check --length=1 --inv=InvAdd SafeMath.tla | sed 's/I@.*//'

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -119,12 +119,12 @@ The outcome is: NoError
 ...
 ```
 
-### check InvAdd for SafeMath reports an error: regression for issue 450
+### check InvAdd for SafeMath reports no error: regression for issue 450
 
 ```sh
 $ apalache-mc check --length=1 --inv=InvAdd SafeMath.tla | sed 's/I@.*//'
 ...
-The outcome is: Error
+The outcome is: NoError
 ...
 ```
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -460,7 +460,8 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
     * @return the snapshot
     */
   override def snapshot(): SymbStateRewriterSnapshot = {
-    new SymbStateRewriterSnapshot(typeFinder.asInstanceOf[TrivialTypeFinder].snapshot(), intValueCache.snapshot(),
+    new SymbStateRewriterSnapshot(typeFinder.asInstanceOf[TrivialTypeFinder].snapshot(),
+      intValueCache.snapshot(),
       intRangeCache.snapshot(), strValueCache.snapshot(), recordDomainCache.snapshot(), exprCache.snapshot())
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
@@ -12,9 +12,9 @@ import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
   *
   * @author Igor Konnov
   */
-class IntValueCache(solverContext: SolverContext) extends AbstractCache[Arena, Int, ArenaCell] with Serializable {
+class IntValueCache(solverContext: SolverContext) extends AbstractCache[Arena, BigInt, ArenaCell] with Serializable {
 
-  def create(arena: Arena, intValue: Int): (Arena, ArenaCell) = {
+  def create(arena: Arena, intValue: BigInt): (Arena, ArenaCell) = {
     // introduce a new constant
     val newArena = arena.appendCell(IntT())
     val intCell = newArena.topCell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
@@ -9,7 +9,7 @@ import at.forsyte.apalache.tla.lir.TlaEx
 import scala.collection.immutable.SortedSet
 
 class SymbStateRewriterSnapshot(val typeFinderSnapshot: TrivialTypeSnapshot,
-                                val intValueCacheSnapshot: AbstractCacheSnapshot[Arena, Int, ArenaCell],
+                                val intValueCacheSnapshot: AbstractCacheSnapshot[Arena, BigInt, ArenaCell],
                                 val intRangeCacheSnapshot: AbstractCacheSnapshot[Arena, (Int, Int), ArenaCell],
                                 val strValueCacheSnapshot: AbstractCacheSnapshot[Arena, String, ArenaCell],
                                 val recordDomainCache: AbstractCacheSnapshot[Arena, (SortedSet[String], SortedSet[String]), ArenaCell],

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunAppRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunAppRule.scala
@@ -74,8 +74,7 @@ class FunAppRule(rewriter: SymbStateRewriter) extends RewritingRule {
   }
 
   private def applyTuple(state: SymbState, tupleCell: ArenaCell, funEx: TlaEx, argEx: TlaEx): SymbState = {
-    val simpleArg = simplifier.simplifyDeep(argEx)
-    val index = simpleArg match {
+    val index = argEx match {
       case ValEx(TlaInt(i)) => i.toInt - 1
 
       case _ =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
@@ -33,15 +33,15 @@ class IntArithRule(rewriter: SymbStateRewriter) extends RewritingRule {
   }
 
   override def apply(state: SymbState): SymbState = state.ex match {
-    case OperEx(oper: TlaArithOper, left, right)
+    case OperEx(oper: TlaArithOper, _, _)
       if (oper == TlaArithOper.plus || oper == TlaArithOper.minus
         || oper == TlaArithOper.mult || oper == TlaArithOper.div
         || oper == TlaArithOper.mod || oper == TlaArithOper.exp)
     =>
-      rewriteGeneral(state, simplifier.simplifyDeep(state.ex))
+      rewriteGeneral(state, state.ex)
 
     case OperEx(TlaArithOper.uminus, _) =>
-      rewriteGeneral(state, simplifier.simplifyDeep(state.ex))
+      rewriteGeneral(state, state.ex)
 
     case _ =>
       throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -30,11 +30,11 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
   }
 
   override def apply(state: SymbState): SymbState = state.ex match {
-    case OperEx(oper: TlaArithOper, left, right)
+    case OperEx(oper: TlaArithOper, _, _)
       if (oper == TlaArithOper.lt || oper == TlaArithOper.le
         || oper == TlaArithOper.gt || oper == TlaArithOper.ge)
     =>
-      rewriteGeneral(state, simplifier.simplifyDeep(state.ex))
+      rewriteGeneral(state, state.ex)
 
     case _ =>
       throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntConstRule.scala
@@ -21,9 +21,6 @@ class IntConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def apply(state: SymbState): SymbState = {
     state.ex match {
       case ValEx(TlaInt(n)) =>
-        if (!n.isValidInt) {
-          throw new RewriterException(s"BigInt $n does not fit into integer range. Do not know how to translate in SMT.", state.ex)
-        }
         val (newArena: Arena, intCell: ArenaCell) = rewriter.intValueCache.getOrCreate(state.arena, n.toInt)
         state.setArena(newArena)
           .setRex(intCell.toNameEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntConstRule.scala
@@ -21,7 +21,7 @@ class IntConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def apply(state: SymbState): SymbState = {
     state.ex match {
       case ValEx(TlaInt(n)) =>
-        val (newArena: Arena, intCell: ArenaCell) = rewriter.intValueCache.getOrCreate(state.arena, n.toInt)
+        val (newArena: Arena, intCell: ArenaCell) = rewriter.intValueCache.getOrCreate(state.arena, n)
         state.setArena(newArena)
           .setRex(intCell.toNameEx)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntDotDotRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntDotDotRule.scala
@@ -39,7 +39,8 @@ class IntDotDotRule(rewriter: SymbStateRewriter,
   }
 
   private def getRange(ex: TlaEx, elems: Seq[TlaEx]): (Int, Int) = {
-    elems map (simplifier.simplifyDeep(_)) match {
+    // Do a shallow simplification. The expression optimizer pass should have done a deep one.
+    elems map (simplifier.simplifyShallow(_)) match {
       case Seq(ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
         if (!left.isValidInt || !right.isValidInt) {
           throw new RewriterException("Range bounds are too large to fit in scala.Int", ex)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/ImplRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/ImplRule.scala
@@ -27,7 +27,7 @@ class ImplRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def apply(state: SymbState): SymbState = {
     state.ex match {
       case OperEx(TlaBoolOper.implies, left, right) =>
-        state.setRex(simplifier.simplifyDeep(tla.or(tla.not(left), right)))
+        state.setRex(simplifier.simplifyShallow(tla.or(tla.not(left), right)))
 
       case _ =>
         throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
@@ -54,7 +54,7 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
     */
   override def assertGroundExpr(ex: TlaEx): Unit = {
     // there are plenty of top-level constraints like (= c1 c2) or tla.in(c1, c2)
-    val ppex = simplifier.simplifyDeep(preprocess(simplifier.simplifyDeep(ex)))
+    val ppex = simplifier.simplifyShallow(preprocess(simplifier.simplifyShallow(ex)))
     ppex match {
       case OperEx(TlaOper.eq, NameEx(left), NameEx(right)) =>
         // eq and not(ne), the latter is transformed by simplifier

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -435,7 +435,9 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
           val int = z3context.mkInt(num.toLong)
           (int, 1)
         } else {
-          flushAndThrow(new SmtEncodingException(s"SMT $id: A number constant is too large to fit in Long: $num", NullEx))
+          // support big integers, issue #450
+          val n = z3context.mkInt(num.toString())
+          (n, 1)
         }
 
       case OperEx(oper: TlaArithOper, lex, rex) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -565,7 +565,9 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
           val n = z3context.mkInt(num.toLong)
           (n, 1)
         } else {
-          flushAndThrow(new SmtEncodingException(s"SMT $id: A number constant is too large to fit in Long: " + num, ex))
+          // support big integers, issue #450
+          val n = z3context.mkInt(num.toString())
+          (n, 1)
         }
 
       case NameEx(name) =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
@@ -6,12 +6,14 @@ import at.forsyte.apalache.tla.lir.transformations.standard.FlatLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
 
+import scala.annotation.tailrec
+
 /**
   * A simplifier of constant TLA+ expressions, e.g., rewriting 1 + 2 to 3.
   *
   * @author Igor Konnov
   */
-class ConstSimplifier(tracker: TransformationTracker) extends TlaExTransformation {
+class ConstSimplifier(tracker: TransformationTracker) extends ConstSimplifierBase with TlaExTransformation {
   override def apply(expr: TlaEx): TlaEx = {
     LanguageWatchdog(FlatLanguagePred()).check(expr)
     simplify(expr)
@@ -38,167 +40,15 @@ class ConstSimplifier(tracker: TransformationTracker) extends TlaExTransformatio
     case ex => ex
   }
 
-  private def simplifyShallow(ex: TlaEx): TlaEx = ex match {
-    case ValEx(_) => ex
-
-    case NameEx(_) => ex
-
-    // integer operations
-    case OperEx(TlaArithOper.plus, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaInt(left + right))
-
-    case OperEx(TlaArithOper.minus, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaInt(left - right))
-
-    case OperEx(TlaArithOper.minus, NameEx(left), NameEx(right)) =>
-      if (left == right) ValEx(TlaInt(0)) else ex // this actually happens
-
-    case OperEx(TlaArithOper.mult, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaInt(left * right))
-
-    case OperEx(TlaArithOper.div, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaInt(left / right))
-
-    case OperEx(TlaArithOper.mod, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaInt(left % right))
-
-    case OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) =>
-      ValEx(TlaInt(Math.pow(base.toDouble, power.toDouble).toInt))
-
-    case OperEx(TlaArithOper.uminus, ValEx(TlaInt(value))) =>
-      ValEx(TlaInt(-value))
-
-    case OperEx(TlaArithOper.lt, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaBool(left < right))
-
-    case OperEx(TlaArithOper.le, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaBool(left <= right))
-
-    case OperEx(TlaArithOper.gt, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaBool(left > right))
-
-    case OperEx(TlaArithOper.ge, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaBool(left >= right))
-
-    case OperEx(TlaOper.eq, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaBool(left == right))
-
-    case OperEx(TlaOper.eq, NameEx(left), NameEx(right)) =>
-      if (left == right) ValEx(TlaBool(true)) else ex
-
-    case OperEx(TlaOper.ne, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
-      ValEx(TlaBool(left != right))
-
-    case OperEx(TlaOper.ne, NameEx(left), NameEx(right)) =>
-      if (left == right) ValEx(TlaBool(false)) else ex
-
+  override def simplifyShallow: TlaEx => TlaEx = {
     // boolean operations
-    case OperEx(TlaBoolOper.and, args @ _*) if args.contains(ValEx(TlaBool(false))) =>
-      ValEx(TlaBool(false))
-
-    case OperEx(TlaBoolOper.and, args @ _*) if args.forall (_.isInstanceOf[ValEx]) =>
-      val result = !args.contains(ValEx(TlaBool(false)))
-      ValEx(TlaBool(result))
-
-    case OperEx(TlaBoolOper.and, args @ _*)  =>
-      val simpEx = OperEx(TlaBoolOper.and, args.filterNot { _ == ValEx(TlaBool(true)) } :_*)
-      simpEx match {
-        case OperEx(TlaBoolOper.and) => ValEx(TlaBool(true)) // an empty disjunction is true
-        case e => e
-      }
-
-    case OperEx(TlaBoolOper.or, args @ _*) if args.contains(ValEx(TlaBool(true))) =>
-      ValEx(TlaBool(true))
-
-    case OperEx(TlaBoolOper.or, args @ _*) if args.forall (_.isInstanceOf[ValEx]) =>
-      val result = args.contains(ValEx(TlaBool(true)))
-      ValEx(TlaBool(result))
-
-    case OperEx(TlaBoolOper.or, args @ _*)  =>
-      val simpEx = OperEx(TlaBoolOper.or, args.filterNot { _ == ValEx(TlaBool(false)) } :_*)
-      simpEx match {
-        case OperEx(TlaBoolOper.or) => ValEx(TlaBool(false)) // an empty disjunction is false
-        case e => e
-      }
-
-    case OperEx(TlaBoolOper.not, ValEx(TlaBool(b))) =>
-      ValEx(TlaBool(!b))
-
-    case OperEx(TlaBoolOper.not, OperEx(TlaBoolOper.not, underDoubleNegation)) =>
-      underDoubleNegation
-
-    case OperEx(TlaBoolOper.not, OperEx(TlaOper.ne, lhs, rhs)) =>
-      OperEx(TlaOper.eq, lhs, rhs)
-
-//      Keep unmodified, as KerA+ does not allow for /=
-//    case OperEx(TlaBoolOper.not, OperEx(TlaOper.eq, lhs, rhs)) =>
-//      OperEx(TlaOper.ne, lhs, rhs)
-
-    //      Keep unmodified, as KerA+ does not allow for \notin
-//    case OperEx(TlaBoolOper.not, OperEx(TlaSetOper.in, lhs, rhs)) =>
-//      OperEx(TlaSetOper.notin, lhs, rhs)
 
     case OperEx(TlaBoolOper.not, OperEx(TlaSetOper.notin, lhs, rhs)) =>
       OperEx(TlaSetOper.in, lhs, rhs)
 
-    case OperEx(TlaBoolOper.implies, ValEx(TlaBool(left)), ValEx(TlaBool(right))) =>
-      ValEx(TlaBool(!left || right))
-
-    case OperEx(TlaBoolOper.implies, ValEx(TlaBool(false)), _) =>
-      ValEx(TlaBool(true))
-
-    case OperEx(TlaBoolOper.implies, ValEx(TlaBool(true)), right) =>
-      simplifyShallow(OperEx(TlaBoolOper.not, right))
-
-    case OperEx(TlaBoolOper.implies, lhs, ValEx(TlaBool(true))) =>
-      ValEx(TlaBool(true))
-
-    case OperEx(TlaBoolOper.implies, lhs, ValEx(TlaBool(false))) =>
-      simplifyShallow(OperEx(TlaBoolOper.not, lhs))
-
-    case OperEx(TlaBoolOper.equiv, ValEx(TlaBool(left)), ValEx(TlaBool(right))) =>
-      ValEx(TlaBool(left == right))
-
-    case OperEx(TlaBoolOper.equiv, ValEx(TlaBool(left)), right) =>
-      if (left) {
-        right
-      } else {
-        simplifyShallow(OperEx(TlaBoolOper.not, right))
-      }
-
-    case OperEx(TlaBoolOper.equiv, left, ValEx(TlaBool(right))) =>
-      if (right) {
-        left
-      } else {
-        simplifyShallow(OperEx(TlaBoolOper.not, left))
-      }
-
-      // many ite expressions can be simplified like this
-    case OperEx(TlaControlOper.ifThenElse, ValEx(TlaBool(true)), thenEx, _) =>
-      thenEx
-
-    case OperEx(TlaControlOper.ifThenElse, ValEx(TlaBool(false)), _, elseEx) =>
-      elseEx
-
-    case OperEx(TlaControlOper.ifThenElse, pred, ValEx(TlaBool(false)), elseEx) =>
-      simplifyShallow(OperEx(TlaBoolOper.and, OperEx(TlaBoolOper.not, pred), elseEx))
-
-    case OperEx(TlaControlOper.ifThenElse, pred, ValEx(TlaBool(true)), ValEx(TlaBool(false))) =>
-      simplifyShallow(pred)
-
-    case OperEx(TlaControlOper.ifThenElse, pred, ValEx(TlaBool(false)), ValEx(TlaBool(true))) =>
-      simplifyShallow(OperEx(TlaBoolOper.not, pred))
-
-    case ite @ OperEx(TlaControlOper.ifThenElse, _, thenEx, elseEx) =>
-      if (thenEx != elseEx) {
-        ite
-      } else {
-        thenEx
-      }
-
     // default
-    case _ =>
-      ex
+    case ex =>
+      super.simplifyShallow(ex)
   }
 }
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -1,0 +1,195 @@
+package at.forsyte.apalache.tla.pp
+
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.oper._
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+
+import scala.math.BigInt
+
+/**
+  * <p>A base class for constant simplification that is shared by more specialized simplifiers.</p>
+  *
+  * <p>Bugfix #450: make sure that the integers are simplified with BigInt.</p>
+  *
+  * @author Igor Konnov
+  */
+abstract class ConstSimplifierBase {
+  /**
+    * A shallow simplification that does not recurse into the expression structure.
+    */
+  def simplifyShallow: TlaEx => TlaEx = {
+    case OperEx(TlaSetOper.notin, lhs, rhs) =>
+      OperEx(TlaBoolOper.not, OperEx(TlaSetOper.in, lhs, rhs))
+
+    case OperEx(TlaBoolOper.not, OperEx(TlaSetOper.notin, lhs, rhs)) =>
+      OperEx(TlaSetOper.in, lhs, rhs)
+
+    // integer operations
+    case OperEx(TlaArithOper.plus, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      if (left == 0) {
+        ValEx(TlaInt(right))
+      } else if (right == 0) {
+        ValEx(TlaInt(left))
+      } else {
+        ValEx(TlaInt(left + right))
+      }
+
+    case OperEx(TlaArithOper.minus, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaInt(left - right))
+
+    case ex @ OperEx(TlaArithOper.minus, NameEx(left), NameEx(right)) =>
+      if (left == right) ValEx(TlaInt(0)) else ex // this actually happens
+
+    case OperEx(TlaArithOper.mult, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      if (left == 0 || right == 0) {
+        ValEx(TlaInt(BigInt(0)))
+      } else if (left == 1) {
+        ValEx(TlaInt(right))
+      } else if (right == 1) {
+        ValEx(TlaInt(left))
+      } else {
+        ValEx(TlaInt(left * right))
+      }
+
+    case OperEx(TlaArithOper.div, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaInt(left / right))
+
+    case OperEx(TlaArithOper.mod, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaInt(left % right))
+
+    case OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) =>
+      if (power.isValidInt) {
+        ValEx(TlaInt(base.pow(power.toInt)))
+      } else {
+        // the power does not fit into an integer. That is a lot. Use doubles.
+        val pow = Math.pow(base.toDouble, power.toDouble)
+        val powAsBigInt = BigDecimal(pow).setScale(0, BigDecimal.RoundingMode.DOWN).toBigInt()
+        ValEx(TlaInt(powAsBigInt))
+      }
+
+    case OperEx(TlaArithOper.uminus, ValEx(TlaInt(value))) =>
+      ValEx(TlaInt(-value))
+
+    case OperEx(TlaArithOper.lt, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaBool(left < right))
+
+    case OperEx(TlaArithOper.le, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaBool(left <= right))
+
+    case OperEx(TlaArithOper.gt, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaBool(left > right))
+
+    case OperEx(TlaArithOper.ge, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaBool(left >= right))
+
+    case OperEx(TlaOper.eq, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaBool(left == right))
+
+    case ex @ OperEx(TlaOper.eq, NameEx(left), NameEx(right)) =>
+      if (left == right) ValEx(TlaBool(true)) else ex
+
+    case ex @ OperEx(TlaOper.eq, ValEx(TlaStr(left)), ValEx(TlaStr(right))) =>
+      // bugfix #197
+      if (left == right) ValEx(TlaBool(true)) else ex
+
+    case OperEx(TlaOper.ne, ValEx(TlaInt(left)), ValEx(TlaInt(right))) =>
+      ValEx(TlaBool(left != right))
+
+    case ex @ OperEx(TlaOper.ne, NameEx(left), NameEx(right)) =>
+      if (left == right) ValEx(TlaBool(false)) else ex
+
+    case ex @ OperEx(TlaOper.eq, ValEx(TlaStr(left)), ValEx(TlaStr(right))) =>
+      // bugfix #197
+      if (left == right) ValEx(TlaBool(false)) else ex
+
+    // boolean operations
+    case OperEx(TlaBoolOper.and, args @ _*)  =>
+      val simpArgs = args.filterNot { _ == ValEx(TlaBool(true)) }
+      if (simpArgs.isEmpty) {
+        ValEx(TlaBool(true)) // an empty conjunction is true
+      } else if (simpArgs.contains(ValEx(TlaBool(false)))) {
+        ValEx(TlaBool(false)) // one false make conjunction false
+      } else {
+        OperEx(TlaBoolOper.and, simpArgs :_*)
+      }
+
+    case OperEx(TlaBoolOper.or, args @ _*)  =>
+      val simpArgs = args.filterNot { _ == ValEx(TlaBool(false)) }
+      if (simpArgs.isEmpty) {
+        ValEx(TlaBool(false)) // an empty disjunction is true
+      } else if (simpArgs.contains(ValEx(TlaBool(true)))) {
+        ValEx(TlaBool(true)) // one true make disjunction true
+      } else {
+        OperEx(TlaBoolOper.or, simpArgs :_*)
+      }
+
+    case OperEx(TlaBoolOper.not, ValEx(TlaBool(b))) =>
+      ValEx(TlaBool(!b))
+
+    case OperEx(TlaBoolOper.not, OperEx(TlaBoolOper.not, underDoubleNegation)) =>
+      underDoubleNegation
+
+    case OperEx(TlaBoolOper.not, OperEx(TlaOper.ne, lhs, rhs)) =>
+      OperEx(TlaOper.eq, lhs, rhs)
+
+    case OperEx(TlaBoolOper.implies, ValEx(TlaBool(left)), ValEx(TlaBool(right))) =>
+      ValEx(TlaBool(!left || right))
+
+    case OperEx(TlaBoolOper.implies, ValEx(TlaBool(false)), _) =>
+      ValEx(TlaBool(true))
+
+    case OperEx(TlaBoolOper.implies, ValEx(TlaBool(true)), right) =>
+      simplifyShallow(OperEx(TlaBoolOper.not, right))
+
+    case OperEx(TlaBoolOper.implies, _, ValEx(TlaBool(true))) =>
+      ValEx(TlaBool(true))
+
+    case OperEx(TlaBoolOper.implies, lhs, ValEx(TlaBool(false))) =>
+      simplifyShallow(OperEx(TlaBoolOper.not, lhs))
+
+    case OperEx(TlaBoolOper.equiv, ValEx(TlaBool(left)), ValEx(TlaBool(right))) =>
+      ValEx(TlaBool(left == right))
+
+    case OperEx(TlaBoolOper.equiv, ValEx(TlaBool(left)), right) =>
+      if (left) {
+        right
+      } else {
+        simplifyShallow(OperEx(TlaBoolOper.not, right))
+      }
+
+    case OperEx(TlaBoolOper.equiv, left, ValEx(TlaBool(right))) =>
+      if (right) {
+        left
+      } else {
+        simplifyShallow(OperEx(TlaBoolOper.not, left))
+      }
+
+    // many ite expressions can be simplified like this
+    case OperEx(TlaControlOper.ifThenElse, ValEx(TlaBool(true)), thenEx, _) =>
+      thenEx
+
+    case OperEx(TlaControlOper.ifThenElse, ValEx(TlaBool(false)), _, elseEx) =>
+      elseEx
+
+    case OperEx(TlaControlOper.ifThenElse, pred, ValEx(TlaBool(false)), elseEx) =>
+      OperEx(TlaBoolOper.and, OperEx(TlaBoolOper.not, pred), elseEx)
+
+    case OperEx(TlaControlOper.ifThenElse, pred, ValEx(TlaBool(true)), ValEx(TlaBool(false))) =>
+      pred
+
+    case OperEx(TlaControlOper.ifThenElse, pred, ValEx(TlaBool(false)), ValEx(TlaBool(true))) =>
+      OperEx(TlaBoolOper.not, pred)
+
+    case ite @ OperEx(TlaControlOper.ifThenElse, _, thenEx, elseEx) =>
+      if (thenEx != elseEx) {
+        ite
+      } else {
+        thenEx
+      }
+
+    // default
+    case ex =>
+      ex
+  }
+
+}


### PR DESCRIPTION
This PR reworks the constant preprocessor to:
  - fix operations on big integers: #450 
  - fix preprocessing of string comparisons: #197 

As a bonus, we can check Solidity's [SafeMath](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/math/SafeMath.sol), see [SafeMath.tla](https://github.com/informalsystems/apalache/blob/igor/bigint450/test/tla/SafeMath.tla). And the results are intriguing :-)

`ConstSimplifier` and `ConstSimplifierForSmt` need a massive set of unit tests. Postponed for #451 .

- [ ] ~Tests added for any new code~
- [ ] ~Documentation added for any new functionality~
- [X] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
