### PR TITLE
Replace double with single quotes in alias command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: build
 
@@ -11,7 +11,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.5'
+          mdbook-version: "0.4.5"
 
       - name: Compile mdBook
         run: |

--- a/docs/src/apalache/installation/docker.md
+++ b/docs/src/apalache/installation/docker.md
@@ -58,11 +58,11 @@ Apalache in docker while sharing the working directory:
 
 ###### using the latest stable
 
-$ alias apalache="docker run --rm -v $(pwd):/var/apalache apalache/mc"
+$ alias apalache='docker run --rm -v $(pwd):/var/apalache apalache/mc'
 
 ###### using the latest unstable
 
-$ alias apalache="docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable"
+$ alias apalache='docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable'
 ```
 
 ## Using the unstable version of Apalache
@@ -93,7 +93,7 @@ $ docker run --rm -v <your-spec-directory>:/var/apalache apalache/mc:unstable <a
 To create an alias pointing to the `unstable` version:
 
 ```bash
-$ alias apalache="docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable"
+$ alias apalache='docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable'
 ```
 
 ## Building an image


### PR DESCRIPTION
The alias does not work with double quotes since it means `$(pwd)` gets
expanded at the time the alias is created and so the mounted volume
stays the same wherever the command is run.
