### PR TITLE
Strategy element duplication fix

### DIFF
--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SmtFreeSymbolicTransitionExtractor.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SmtFreeSymbolicTransitionExtractor.scala
@@ -70,7 +70,9 @@ class SmtFreeSymbolicTransitionExtractor(
       throw new AssignmentException( problems.mkString("\n") )
     }
     // Assuming all branches assign the same variables, works correctly if args.isEmpty (for whatever reason)
-    val unifiedStrat = (childStates map { _.partialStrat }).foldLeft( s.partialStrat ) { _ ++ _ }
+    val unifiedStrat = (childStates map { _.partialStrat }).foldLeft( s.partialStrat ) {
+      case (a,b) => a ++ b.filterNot( a.contains )
+    }
     PartialState( unassignedEverywhere, unifiedStrat )
   }
 


### PR DESCRIPTION
Fixed a bug where assignment strategies contained duplicate elements, causing noticeable slowdowns in `TransitionFinderPass` on formulas with many disjunctions.
