### PR TITLE
Only run main.yml workflow on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 name: build
 


### PR DESCRIPTION
Follow up to 8511b49f11fdbb582e107147c735ce5fce5a149b which added
`pull_request` in addition to `push`.

If we only have `push` then we don't get CI running for PRs opened by
external contributors.

If we have both `push` and `pull_request`, then we get CI running
duplicate jobs for PRs from internal contributors.

So we must only enable `pull_request`. An added advantage of this change
is that the CI will now run on the result of merging the feature branch
into our trunk, which is what we want to be testing any how :)
