### PR TITLE
Fix release cron schedule

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,7 +12,8 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Automatically prepare a minor version release every Monday
-    - cron: "* * * * 1"
+    # See https://crontab.guru/#0_0_*_*_1
+    - cron: "0 0 * * 1"
 
 jobs:
   prepare-release:


### PR DESCRIPTION
The release preparation job has been trying to run continuously since it became Monday wherever the server is located.

I apparently forgot my cron syntax. 

With this fix, it should only run once per week, instead of trying to run constantly on Monday.

Followup to #470 