### PR TITLE
Update readme to reflect new release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ manual][user-manual-installation].
 
 ## Website
 
-[apalache.informal.systems][] is the main website of the project.
+Our current website is served at https://apalache.informal.systems .
+
+The site is hosted by github, and changes can be made through PRs into the
+[gh-pages](https://github.com/informalsystems/apalache/tree/gh-pages) branch of
+this repository. See the README.md on that branch for more information.
+
+The user documentation is automatically deployed to the website branch as per
+the [CI configuration](./.github/workflows/deploy.yml).
+
+Our old website is still available at https://forsyte.at/research/apalache/ .
 
 ## Community
 
@@ -96,19 +105,6 @@ To read an academic paper about the theory behind Apalache,
 check our [paper at OOPSLA19](https://dl.acm.org/doi/10.1145/3360549).
 Related reports and publications can be found at the
 [Apalache page at TU Wien](http://forsyte.at/research/apalache/).
-
-## Website
-
-Our current website is served at https://apalache.informal.systems .
-
-The site is hosted by github, and changes can be made through PRs into the
-[gh-pages](https://github.com/informalsystems/apalache/tree/gh-pages) branch of
-this repository. See the README.md on that branch for more information.
-
-The user documentation is automatically deployed to the website branch as per
-the [CI configuration](./.github/workflows/deploy.yml).
-
-Our old website is still available at https://forsyte.at/research/apalache/ .
 
 [tla+]: http://lamport.azurewebsites.net/tla/tla.html
 [microsoft z3]: https://github.com/Z3Prover/z3

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ course].
 
 ## Releases
 
-Check the [releases page].
+Check the [releases page][].
 
-We recommend that you run the latest stable docker image `apalache/mc:latest`,
-or checkout the source code from [master], which accumulates bugfixes over the
-latest release. For more information, see [the manual][manual-docker].
-To try the latest cool features, check out the [unstable branch].
+For a stable release, we recommend that you run the latest docker image
+`apalache/mc:latest` or checkout the source code from our latest release tag.
+
+To try the latest cool features, check out the [unstable branch][].
+
+For more information on installation options, see [the
+manual][user-manual-installation].
 
 ## Getting started
 
@@ -60,7 +63,7 @@ To try the latest cool features, check out the [unstable branch].
 ## Talks
 
 - [How TLA+ and Apalache Helped Us to Design the Tendermint Light Client](https://www.crowdcast.io/e/interchain-conversations-II/38).
-    Interchain Conversations 2020 (December 2020).
+  Interchain Conversations 2020 (December 2020).
 
 - [Model-based testing with TLA+ and Apalache](https://youtu.be/aveoIMphzW8).
   TLA+ Community Event 2020 (October 2020).
@@ -82,7 +85,7 @@ To try the latest cool features, check out the [unstable branch].
 
 ## Performance
 
-We are collecting [apalache benchmarks].  See the Apalache performance when
+We are collecting [apalache benchmarks]. See the Apalache performance when
 [checking inductive invariants] and running [bounded model checking]. Versions
 0.6.0 and 0.7.2 are a major improvement over version 0.5.2 (the version
 [reported at OOPSLA19](https://dl.acm.org/doi/10.1145/3360549)).
@@ -107,26 +110,27 @@ the [CI configuration](./.github/workflows/deploy.yml).
 
 Our old website is still available at https://forsyte.at/research/apalache/ .
 
-[TLA+]: http://lamport.azurewebsites.net/tla/tla.html
-[Microsoft Z3]: https://github.com/Z3Prover/z3
+[tla+]: http://lamport.azurewebsites.net/tla/tla.html
+[microsoft z3]: https://github.com/Z3Prover/z3
 [supported features]: ./docs/features.md
-[TLC]: http://lamport.azurewebsites.net/tla/tools.html
-[Leslie Lamport's page on TLA+]: http://lamport.azurewebsites.net/tla/tla.html
-[Video course]: http://lamport.azurewebsites.net/video/videos.html
+[tlc]: http://lamport.azurewebsites.net/tla/tools.html
+[leslie lamport's page on tla+]: http://lamport.azurewebsites.net/tla/tla.html
+[video course]: http://lamport.azurewebsites.net/video/videos.html
 [releases page]: https://github.com/informalsystems/apalache/releases
 [master]: https://github.com/informalsystems/apalache/tree/master
 [unstable branch]: https://github.com/informalsystems/apalache/tree/unstable
-[Apalache zulip stream]: https://informal-systems.zulipchat.com/#narrow/stream/265309-apalache
-[Tendermint specs]: https://github.com/tendermint/spec/tree/master/rust-spec
-[Tendermint blockchain]: https://github.com/tendermint
-[standard repository of TLA+ examples]: https://github.com/tlaplus/Examples
+[apalache zulip stream]: https://informal-systems.zulipchat.com/#narrow/stream/265309-apalache
+[tendermint specs]: https://github.com/tendermint/spec/tree/master/rust-spec
+[tendermint blockchain]: https://github.com/tendermint
+[standard repository of tla+ examples]: https://github.com/tlaplus/Examples
 [apalache benchmarks]: https://github.com/informalsystems/apalache-tests
 [checking inductive invariants]: https://github.com/informalsystems/apalache-tests/blob/master/results/001indinv-report.md
 [bounded model checking]: https://github.com/informalsystems/apalache-tests/blob/master/results/002bmc-report.md
 [user-manual]: http://informalsystems.github.io/apalache/docs/index.html
 [user-manual-docker]: https://apalache.informal.systems/docs/apalache/installation/docker.html
+[user-manual-installation]: https://apalache.informal.systems/docs/apalache/installation/index.html
 [language-manual]: https://apalache.informal.systems/docs/lang/index.html
 [idioms]: https://apalache.informal.systems//docs/idiomatic/index.html
-[Light client specs]: https://github.com/tendermint/spec/tree/master/rust-spec/lightclient/verification
-[Model-based testing]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client/tests/support/model_based#light-client-model-based-testing-guide
+[light client specs]: https://github.com/tendermint/spec/tree/master/rust-spec/lightclient/verification
+[model-based testing]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client/tests/support/model_based#light-client-model-based-testing-guide
 [apalache.informal.systems]: https://apalache.informal.systems

--- a/README.md
+++ b/README.md
@@ -7,18 +7,12 @@ alt="Apalache Logo">
 
 <p>A symbolic model checker for TLA+<p>
 
-|             master             |              unstable              |
-| :----------------------------: | :--------------------------------: |
-| [![master badge][]][master-ci] | [![unstable badge][]][unstable-ci] |
-
-[master badge]: https://github.com/informalsystems/apalache/workflows/build/badge.svg?branch=master
-[master-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Amaster+workflow%3Abuild
-[unstable badge]: https://github.com/informalsystems/apalache/workflows/build/badge.svg?branch=unstable
-[unstable-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Aunstable+workflow%3Abuild
-
 </div>
 
----
+[![unstable badge][]][unstable-ci]
+
+[unstable badge]: https://github.com/informalsystems/apalache/workflows/build/badge.svg?branch=unstable
+[unstable-ci]: https://github.com/informalsystems/apalache/actions?query=branch%3Aunstable+workflow%3Abuild
 
 Apalache translates [TLA+] into the logic supported by SMT solvers such as
 [Microsoft Z3]. Apalache can check inductive invariants (for fixed or bounded


### PR DESCRIPTION
We don't need the master CI badge any more, since we're not releasing from master.

Also updated the section on releases and removed a duplicate link to the website added in #489 