### PR TITLE
Fix path of jar in zip artifact

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Another change description, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+## Bug fixes
+
+ * Fixed path of jar in ZIP distribution, reported in #500, see #506

--- a/script/release-publish.sh
+++ b/script/release-publish.sh
@@ -42,8 +42,9 @@ cd "$PROJ_ROOT"
 make clean
 make apalache
 
-# Location of the jar that get's published in releases
-RELEASE_JAR="${PROJ_ROOT}/mod-distribution/target/apalache-pkg-${VERSION}-full.jar"
+# Relative location of the jar that gets published in releases
+# This must be a relative path. Aboslute paths break the zip archive.
+RELEASE_JAR="mod-distribution/target/apalache-pkg-${VERSION}-full.jar"
 
 # Confirm the jar was produced
 if [ ! -f "$RELEASE_JAR" ]; then


### PR DESCRIPTION
Closes  #500

The tar operation was automatically relativizing the path, but not the
zip. So I went back to just using a relative path for the jar.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
