### PR TITLE
Fix CI formatting check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ test/tla/%.md: target/test/tla/%.md.corrected
 	cp -f $< $@
 
 fmt-check:
+	git fetch origin
 	mvn --batch-mode spotless:check || \
 		( echo "TO FIX: run 'make fmt-fix' and commit the changes" ; \
 		  exit 1 )


### PR DESCRIPTION
We "ratchet" our formatting checks, which means we only check files that
have changed relative to `origin/unstable`. This makes sure we have
fetched the latest changes before running those checks, so we're getting
an accurate report.

Apparently the checkout action doesn't fetch our remote branches, but we need
unstable for our ratcheted format checking.

This is causing the formatting check to fail on on #503  and #467 

