### PR TITLE
closes #512: parsing Boolean values in TLC config files

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,23 +12,23 @@
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Feature Model Checker
 
- * new sequential model checker that is using TransitionExecutor, see #467
- * new command-line options, see #467 and the manual for details:
-   - choose the algorithm: `--algo=(offline|incremental)`
-   - pre-check, whether a transition disabled, discard the disabled transitions: `--discard-disabled`
-   - do not check for deadlocks: `--no-deadlock`
-   - pass tuning parameters in CLI: `--tune-here`
+* new sequential model checker that is using TransitionExecutor, see #467
+* new command-line options, see #467 and the manual for details:
+  - choose the algorithm: `--algo=(offline|incremental)`
+  - pre-check, whether a transition disabled, discard the disabled transitions: `--discard-disabled`
+  - do not check for deadlocks: `--no-deadlock`
+  - pass tuning parameters in CLI: `--tune-here`
 
 ### Feature TLA+ Parser (SANY importer)
 
-  * parsing in-comment Java-like annotations, see #226
-  * tracking the source of variable/constant declarations and operator definitions, see #262
+* parsing in-comment Java-like annotations, see #226
+* tracking the source of variable/constant declarations and operator definitions, see #262
 
 ### Bugfixes
 
- * the new sequential model checker has uncovered a bug that was not found
-   by the old model checker, see #467
+* the new sequential model checker has uncovered a bug that was not found by the old model checker, see #467
+* Boolean values are now supported in TLC config files, see #512
 
 ### Documentation
 
-  * ADR004: In-comment annotations for declarations (of constants, variables, operators)
+* ADR004: In-comment annotations for declarations (of constants, variables, operators)

--- a/docs/src/apalache/tlc-config.md
+++ b/docs/src/apalache/tlc-config.md
@@ -72,6 +72,7 @@ constExpr ::=
     modelValue
   | integer
   | string
+  | boolean
   | "{" "}"
   | "{" constExpr ("," constExpr)* "}"
 
@@ -92,6 +93,9 @@ integer ::=
 // a restricted set of characters is allowed (pre-UTF8 era, Paxon scripts?)
 string ::=
     '"' <string matching regex [a-zA-Z0-9_~!@#\$%^&*-+=|(){}[\],:;`'<>.?/ ]*> '"'
+
+// A Boolean literal
+boolean ::= "FALSE" | "TRUE"
 
 // Set an invariant (over unprimed variables) to be checked against
 // every reachable state.

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/TlcConfigParserApalache.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/TlcConfigParserApalache.scala
@@ -8,15 +8,14 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.NoPosition
 
-
 /**
-  * <p>A parser for the TLC configuration files. For the syntax, see ./docs/tlc-config.md.
-  *
-  * <p>This parser is built with
-  * <a href="https://github.com/scala/scala-parser-combinators">Scala parser combinators</a>.</p>
-  *
-  * @author Igor Konnov
-  */
+ * <p>A parser for the TLC configuration files. For the syntax, see ./docs/tlc-config.md.
+ *
+ * <p>This parser is built with
+ * <a href="https://github.com/scala/scala-parser-combinators">Scala parser combinators</a>.</p>
+ *
+ * @author Igor Konnov
+ */
 object TlcConfigParserApalache extends Parsers with TlcConfigParser with LazyLogging {
   override type Elem = TlcConfigToken
 
@@ -25,31 +24,35 @@ object TlcConfigParserApalache extends Parsers with TlcConfigParser with LazyLog
   private case class ConstReplacement(name: String, replacement: String) extends ConstBinding
 
   /**
-    * Parse a configuration file from a reader.
-    * @param reader a reader
-    * @return a config on success; throws TlcConfigParseError on failure
-    */
+   * Parse a configuration file from a reader.
+   *
+   * @param reader a reader
+   * @return a config on success; throws TlcConfigParseError on failure
+   */
   def apply(reader: Reader): TlcConfig = {
     config(new TlcConfigTokenReader(TlcConfigLexer(reader))) match {
       case Success(config: TlcConfig, _) => config
-      case Success(_, _) => throw new TlcConfigParseError("Unexpected parse result", NoPosition)
-      case Failure(msg, next) => throw new TlcConfigParseError(msg, next.pos)
-      case Error(msg, next) => throw new TlcConfigParseError(msg, next.pos)
+      case Success(_, _)                 => throw new TlcConfigParseError("Unexpected parse result", NoPosition)
+      case Failure(msg, next)            => throw new TlcConfigParseError(msg, next.pos)
+      case Error(msg, next)              => throw new TlcConfigParseError(msg, next.pos)
     }
   }
 
   /**
-    * Parse a configuration file from a string.
-    * @param text a string
-    * @return a config on success; throws TlcConfigParseError on failure
-    */
+   * Parse a configuration file from a string.
+   *
+   * @param text a string
+   * @return a config on success; throws TlcConfigParseError on failure
+   */
   def apply(text: String): TlcConfig = {
     apply(new StringReader(text))
   }
 
   private def config: Parser[TlcConfig] = {
-    phrase(rep1(option)) ^^ {
-      cfgs => cfgs.foldLeft(TlcConfig.empty) { (other, cfg) => other.join(cfg) }
+    phrase(rep1(option)) ^^ { cfgs =>
+      cfgs.foldLeft(TlcConfig.empty) { (other, cfg) =>
+        other.join(cfg)
+      }
     }
   }
 
@@ -60,75 +63,70 @@ object TlcConfigParserApalache extends Parsers with TlcConfigParser with LazyLog
   }
 
   private def constList: Parser[TlcConfig] = {
-    CONST() ~ rep1(assign | replace) ^^ {
-      case _ ~ bindingList =>
-        val assignments = bindingList.collect { case ConstAssignment(nm, asgn) => nm -> asgn }
-        val replacements = bindingList.collect { case ConstReplacement(nm, repl) => nm -> repl }
-        TlcConfig.empty
-          .addConstAssignments(Map(assignments :_*))
-          .addConstReplacements(Map(replacements: _*))
+    CONST() ~ rep1(assign | replace) ^^ { case _ ~ bindingList =>
+      val assignments = bindingList.collect { case ConstAssignment(nm, asgn) => nm -> asgn }
+      val replacements = bindingList.collect { case ConstReplacement(nm, repl) => nm -> repl }
+      TlcConfig.empty
+        .addConstAssignments(Map(assignments: _*))
+        .addConstReplacements(Map(replacements: _*))
     }
   }
 
   // SYMMETRY constraints. Ignore.
   private def symmetry: Parser[TlcConfig] = {
-    SYMMETRY() ~ ident ^^ {
-      case _ ~ name =>
-        logger.warn("TLC config option SYMMETRY %s will be ignored".format(name))
-        TlcConfig.empty
+    SYMMETRY() ~ ident ^^ { case _ ~ name =>
+      logger.warn("TLC config option SYMMETRY %s will be ignored".format(name))
+      TlcConfig.empty
     }
   }
 
   // VIEW definition. Ignore.
   private def view: Parser[TlcConfig] = {
-    VIEW() ~ ident ^^ {
-      case _ ~ name =>
-        logger.warn("TLC config option VIEW %s will be ignored".format(name))
-        TlcConfig.empty
+    VIEW() ~ ident ^^ { case _ ~ name =>
+      logger.warn("TLC config option VIEW %s will be ignored".format(name))
+      TlcConfig.empty
     }
   }
 
   // ALIAS definition. Ignore.
   private def alias: Parser[TlcConfig] = {
-    ALIAS() ~ ident ^^ {
-      case _ ~ name =>
-        logger.warn("TLC config option ALIAS %s will be ignored".format(name))
-        TlcConfig.empty
+    ALIAS() ~ ident ^^ { case _ ~ name =>
+      logger.warn("TLC config option ALIAS %s will be ignored".format(name))
+      TlcConfig.empty
     }
   }
 
   // POSTCONDITION definition. Ignore.
   private def postcondition: Parser[TlcConfig] = {
-    POSTCONDITION() ~ ident ^^ {
-      case _ ~ name =>
-        logger.warn("TLC config option POSTCONDITION %s will be ignored".format(name))
-        TlcConfig.empty
+    POSTCONDITION() ~ ident ^^ { case _ ~ name =>
+      logger.warn("TLC config option POSTCONDITION %s will be ignored".format(name))
+      TlcConfig.empty
     }
   }
 
   // CHECK_DEADLOCK definition. Ignore.
   private def checkDeadlock: Parser[TlcConfig] = {
-    CHECK_DEADLOCK() ~ boolean ^^ {
-      case _ ~ flag =>
-        logger.warn("TLC config option CHECK_DEADLOCK %b will be ignored".format(flag))
-        TlcConfig.empty
+    CHECK_DEADLOCK() ~ boolean ^^ { case _ ~ flag =>
+      logger.warn("TLC config option CHECK_DEADLOCK %b will be ignored".format(flag))
+      TlcConfig.empty
     }
   }
 
   private def assign: Parser[ConstBinding] = {
-    ident ~ EQ() ~ constExpr ^^ {
-      case IDENT(lhs) ~ _ ~ expr => ConstAssignment(lhs, expr)
+    ident ~ EQ() ~ constExpr ^^ { case IDENT(lhs) ~ _ ~ expr =>
+      ConstAssignment(lhs, expr)
     }
   }
 
   // constant expressions
   private def constExpr: Parser[ConfigConstExpr] = {
-    (ident | number | string | (LEFT_BRACE() ~ constExprList ~ RIGHT_BRACE())) ^^ {
-      case IDENT(name) => ConfigModelValue(name)
-      case NUMBER(text) => ConfigIntValue(BigInt(text))
-      case STRING(text) => ConfigStrValue(text)
+    (ident | number | string | boolean | (LEFT_BRACE() ~ constExprList ~ RIGHT_BRACE())) ^^ {
+      case IDENT(name)   => ConfigModelValue(name)
+      case NUMBER(text)  => ConfigIntValue(BigInt(text))
+      case STRING(text)  => ConfigStrValue(text)
+      case BOOLEAN(text) => ConfigBoolValue(text.toBoolean)
       case _ ~ list ~ _ =>
-        ConfigSetValue(list.asInstanceOf[List[ConfigConstExpr]] :_*)
+        ConfigSetValue(list.asInstanceOf[List[ConfigConstExpr]]: _*)
     }
   }
 
@@ -138,29 +136,27 @@ object TlcConfigParserApalache extends Parsers with TlcConfigParser with LazyLog
   }
 
   private def replace: Parser[ConstBinding] = {
-    ident ~ LEFT_ARROW() ~ ident ^^ {
-      case IDENT(lhs) ~ LEFT_ARROW() ~ IDENT(rhs) => ConstReplacement(lhs, rhs)
+    ident ~ LEFT_ARROW() ~ ident ^^ { case IDENT(lhs) ~ LEFT_ARROW() ~ IDENT(rhs) =>
+      ConstReplacement(lhs, rhs)
     }
   }
 
   private def constraintList: Parser[TlcConfig] = {
-    CONSTRAINT() ~ rep1(ident) ^^ {
-      case _ ~ list =>
-        val cons = list.collect { case IDENT(name) => name }
-        TlcConfig.empty.addStateConstraints(cons)
+    CONSTRAINT() ~ rep1(ident) ^^ { case _ ~ list =>
+      val cons = list.collect { case IDENT(name) => name }
+      TlcConfig.empty.addStateConstraints(cons)
     }
   }
 
   private def actionConstraintList: Parser[TlcConfig] = {
-    ACTION_CONSTRAINT() ~ rep1(ident) ^^ {
-      case _ ~ list =>
-        val cons = list.collect { case IDENT(name) => name }
-        TlcConfig.empty.addActionConstraints(cons)
+    ACTION_CONSTRAINT() ~ rep1(ident) ^^ { case _ ~ list =>
+      val cons = list.collect { case IDENT(name) => name }
+      TlcConfig.empty.addActionConstraints(cons)
     }
   }
 
   private def initNextSection: Parser[TlcConfig] = {
-    (INIT() ~ ident ~ NEXT() ~ ident | NEXT() ~ ident ~ INIT() ~ ident)  ^^ {
+    (INIT() ~ ident ~ NEXT() ~ ident | NEXT() ~ ident ~ INIT() ~ ident) ^^ {
       case INIT() ~ IDENT(initName) ~ _ ~ IDENT(nextName) =>
         TlcConfig.empty.setBehaviorSpecUnlessNull(InitNextSpec(initName, nextName))
 
@@ -170,25 +166,22 @@ object TlcConfigParserApalache extends Parsers with TlcConfigParser with LazyLog
   }
 
   private def specSection: Parser[TlcConfig] = {
-    SPECIFICATION() ~ ident ^^ {
-      case _ ~ IDENT(specName) =>
-        TlcConfig.empty.setBehaviorSpecUnlessNull(TemporalSpec(specName))
+    SPECIFICATION() ~ ident ^^ { case _ ~ IDENT(specName) =>
+      TlcConfig.empty.setBehaviorSpecUnlessNull(TemporalSpec(specName))
     }
   }
 
   private def invariantList: Parser[TlcConfig] = {
-    INVARIANT() ~ rep1(ident) ^^ {
-      case _ ~ list =>
-        val invs = list.collect { case IDENT(name) => name }
-        TlcConfig.empty.addInvariants(invs)
+    INVARIANT() ~ rep1(ident) ^^ { case _ ~ list =>
+      val invs = list.collect { case IDENT(name) => name }
+      TlcConfig.empty.addInvariants(invs)
     }
   }
 
   private def propertyList: Parser[TlcConfig] = {
-    PROPERTY() ~ rep1(ident) ^^ {
-      case _ ~ list =>
-        val props = list.collect { case IDENT(name) => name }
-        TlcConfig.empty.addTemporalProps(props)
+    PROPERTY() ~ rep1(ident) ^^ { case _ ~ list =>
+      val props = list.collect { case IDENT(name) => name }
+      TlcConfig.empty.addTemporalProps(props)
     }
   }
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfig.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfig.scala
@@ -3,111 +3,118 @@ package at.forsyte.apalache.io.tlc.config
 import at.forsyte.apalache.io.tlc.config.ConfigModelValue.STR_PREFIX
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
-import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
 
 import scala.util.parsing.input.NoPosition
 
 /**
-  * A behavior spec is either Init-Next, or a temporal specification Init /\ [] [Next]_vars /\ Temporal.
-  */
+ * A behavior spec is either Init-Next, or a temporal specification Init /\ [] [Next]_vars /\ Temporal.
+ */
 abstract sealed class BehaviorSpec
 
 /**
-  * The behavior is given by INIT and NEXT.
-  *
-  * @param init name of the Init predicate
-  * @param next name of the Next predicate
-  */
+ * The behavior is given by INIT and NEXT.
+ *
+ * @param init name of the Init predicate
+ * @param next name of the Next predicate
+ */
 case class InitNextSpec(init: String, next: String) extends BehaviorSpec
 
 /**
-  * The behavior is given by SPECIFICATION, that is, a definition of the form Init /\ [] [Next]_vars /\ Temporal.
-  *
-  * @param name the name of the specification definition
-  */
+ * The behavior is given by SPECIFICATION, that is, a definition of the form Init /\ [] [Next]_vars /\ Temporal.
+ *
+ * @param name the name of the specification definition
+ */
 case class TemporalSpec(name: String) extends BehaviorSpec
 
 /**
-  * An unspecified behavior spec.
-  */
+ * An unspecified behavior spec.
+ */
 case class NullSpec() extends BehaviorSpec
 
 /**
-  * A constant expression that can be written in the right-hand side of an assignment.
-  */
+ * A constant expression that can be written in the right-hand side of an assignment.
+ */
 abstract sealed class ConfigConstExpr {
+
   /**
-    * Convert the expression to the intermediate representation.
-    * @return the TLA IR expression that represents the parsed constant expression
-    */
+   * Convert the expression to the intermediate representation.
+   *
+   * @return the TLA IR expression that represents the parsed constant expression
+   */
   def toTlaEx: TlaEx
 }
 
 object ConfigModelValue {
+
   /**
-    * Every model value is prefixed with this string when converted to a string.
-    */
+   * Every model value is prefixed with this string when converted to a string.
+   */
   val STR_PREFIX = "ModelValue_"
 }
 
 /**
-  * A TLC model value, that is, a unique identifier that is treated as an uninterpreted constant.
-  * @param name the name of a model value
-  */
+ * A TLC model value, that is, a unique identifier that is treated as an uninterpreted constant.
+ *
+ * @param name the name of a model value
+ */
 case class ConfigModelValue(name: String) extends ConfigConstExpr {
   override def toTlaEx: TlaEx = ValEx(TlaStr(STR_PREFIX + name))
 }
 
 /**
-  * An unbounded integer literal.
-  * @param num an integer as BigInt
-  */
+ * An unbounded integer literal.
+ *
+ * @param num an integer as BigInt
+ */
 case class ConfigIntValue(num: BigInt) extends ConfigConstExpr {
   override def toTlaEx: TlaEx = ValEx(TlaInt(num))
 }
 
 /**
-  * A string literal.
-  * @param str a string
-  */
+ * A Boolean literal.
+ *
+ * @param b a boolean
+ */
+case class ConfigBoolValue(b: Boolean) extends ConfigConstExpr {
+  override def toTlaEx: TlaEx = ValEx(TlaBool(b))
+}
+
+/**
+ * A string literal.
+ *
+ * @param str a string
+ */
 case class ConfigStrValue(str: String) extends ConfigConstExpr {
   override def toTlaEx: TlaEx = ValEx(TlaStr(str))
 }
 
 /**
-  * A set literal.
-  *
-  * @param elems the set elements, which are constant expression themselves.
-  */
+ * A set literal.
+ *
+ * @param elems the set elements, which are constant expression themselves.
+ */
 case class ConfigSetValue(elems: ConfigConstExpr*) extends ConfigConstExpr {
-  override def toTlaEx: TlaEx = OperEx(TlaSetOper.enumSet, elems.map(_.toTlaEx) :_*)
+  override def toTlaEx: TlaEx = OperEx(TlaSetOper.enumSet, elems.map(_.toTlaEx): _*)
 }
 
 /**
-  * A parsed TLC configuration file. The case class is used here to make copying easier.
-  *
-  * @param constAssignments  Assignments of the form MyParam = ConstExpr, which makes TLC to replace MyParam with
-  *                          the expression.
-  * @param constReplacements Replacements of the form MyParam <- AnotherDef. In this case,
-  *                          AnotherDef has to be defined in the respective TLA+ module.
-  *
-  * @param stateConstraints state constraints
-  * @param actionConstraints action constraints
-  * @param invariants A list of invariants to check.
-  *
-  * @param temporalProps A list of temporal properties to check.
-  *
-  * @param behaviorSpec A behavior specification. A well-formed config should have one.
-  *
-  * @author Igor Konnov
-  */
-case class TlcConfig(constAssignments: Map[String, ConfigConstExpr],
-                     constReplacements: Map[String, String],
-                     stateConstraints: List[String],
-                     actionConstraints: List[String],
-                     invariants: List[String],
-                     temporalProps: List[String],
-                     behaviorSpec: BehaviorSpec) {
+ * A parsed TLC configuration file. The case class is used here to make copying easier.
+ *
+ * @param constAssignments  Assignments of the form MyParam = ConstExpr, which makes TLC to replace MyParam with
+ *                          the expression.
+ * @param constReplacements Replacements of the form MyParam <- AnotherDef. In this case,
+ *                          AnotherDef has to be defined in the respective TLA+ module.
+ * @param stateConstraints  state constraints
+ * @param actionConstraints action constraints
+ * @param invariants        A list of invariants to check.
+ * @param temporalProps     A list of temporal properties to check.
+ * @param behaviorSpec      A behavior specification. A well-formed config should have one.
+ * @author Igor Konnov
+ */
+case class TlcConfig(constAssignments: Map[String, ConfigConstExpr], constReplacements: Map[String, String],
+    stateConstraints: List[String], actionConstraints: List[String], invariants: List[String],
+    temporalProps: List[String], behaviorSpec: BehaviorSpec) {
 
   def addConstAssignments(moreConstAssignments: Map[String, ConfigConstExpr]): TlcConfig = {
     this.copy(constAssignments = constAssignments ++ moreConstAssignments)
@@ -135,8 +142,9 @@ case class TlcConfig(constAssignments: Map[String, ConfigConstExpr],
 
   def setBehaviorSpecUnlessNull(newSpec: BehaviorSpec): TlcConfig = {
     if (behaviorSpec != NullSpec() && newSpec != NullSpec()) {
-      throw new TlcConfigParseError("Found several behavior specifications: %s and %s"
-        .format(behaviorSpec, newSpec), NoPosition)
+      throw new TlcConfigParseError(
+          "Found several behavior specifications: %s and %s"
+            .format(behaviorSpec, newSpec), NoPosition)
     }
 
     if (newSpec != NullSpec()) {
@@ -160,11 +168,6 @@ case class TlcConfig(constAssignments: Map[String, ConfigConstExpr],
 
 object TlcConfig {
   val empty: TlcConfig =
-    TlcConfig(constAssignments = Map(),
-              constReplacements = Map(),
-              stateConstraints = List.empty,
-              actionConstraints = List.empty,
-              invariants = List.empty,
-              temporalProps = List.empty,
-              behaviorSpec = NullSpec())
+    TlcConfig(constAssignments = Map(), constReplacements = Map(), stateConstraints = List.empty,
+        actionConstraints = List.empty, invariants = List.empty, temporalProps = List.empty, behaviorSpec = NullSpec())
 }

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
@@ -6,27 +6,27 @@ import scala.util.matching.Regex
 import scala.util.parsing.combinator.RegexParsers
 
 /**
-  * <p>A lexer for the TLC configuration files.</p>
-  *
-  * <p>This code follows the
-  * <a href="http://nielssp.dk/2015/07/creating-a-scanner-using-parser-combinators-in-scala">tutorial on scanners</a>.</p>
-  *
-  * @author Igor Konnov
+ * <p>A lexer for the TLC configuration files.</p>
+ *
+ * <p>This code follows the
+ * <a href="http://nielssp.dk/2015/07/creating-a-scanner-using-parser-combinators-in-scala">tutorial on scanners</a>.</p>
+ *
+ * @author Igor Konnov
  */
 object TlcConfigLexer extends RegexParsers {
   override def skipWhitespace: Boolean = true
   override val whiteSpace: Regex = "[ \t\r\f]+".r // process linefeed separately, in order to parse one-line comments
 
   /**
-    * Parse the input stream and return the list of tokens. Although collecting the list of all tokens in memory is
-    * not optimal, TLC configurations files are tiny, so it should not be a big deal.
-    *
-    * @param reader a Java reader
-    * @return the list of parsed tokens
-    * @throws TlcConfigParseError when the lexer finds an error
-    */
+   * Parse the input stream and return the list of tokens. Although collecting the list of all tokens in memory is
+   * not optimal, TLC configurations files are tiny, so it should not be a big deal.
+   *
+   * @param reader a Java reader
+   * @return the list of parsed tokens
+   * @throws TlcConfigParseError when the lexer finds an error
+   */
   def apply(reader: Reader): List[TlcConfigToken] = parseAll(program, reader) match {
-    case Success(result, _) => result
+    case Success(result, _)   => result
     case NoSuccess(msg, next) => throw new TlcConfigParseError(msg, next.pos)
   }
 
@@ -36,9 +36,9 @@ object TlcConfigLexer extends RegexParsers {
 
   def token: Parser[TlcConfigToken] =
     positioned(
-      constant | init | next | specification | invariant | property | constraint | actionConstraint |
-        symmetry | view | alias | postcondition | checkDeadlock |
-        leftArrow | eq | leftBrace | rightBrace | comma | boolean | identifier | number | string
+        constant | init | next | specification | invariant | property | constraint | actionConstraint |
+          symmetry | view | alias | postcondition | checkDeadlock |
+          leftArrow | eq | leftBrace | rightBrace | comma | boolean | identifier | number | string | boolean
     ) ///
 
   // it is important that linefeed is not a whiteSpace, as otherwise singleComment consumes the whole input!
@@ -67,15 +67,15 @@ object TlcConfigLexer extends RegexParsers {
   }
 
   private def constant: Parser[CONST] = {
-    "CONSTANT(S|)".r  ^^ (_ => CONST())
+    "CONSTANT(S|)".r ^^ (_ => CONST())
   }
 
   private def init: Parser[INIT] = {
-    "INIT"  ^^ (_ => INIT())
+    "INIT" ^^ (_ => INIT())
   }
 
   private def next: Parser[NEXT] = {
-    "NEXT"  ^^ (_ => NEXT())
+    "NEXT" ^^ (_ => NEXT())
   }
 
   private def specification: Parser[SPECIFICATION] = {

--- a/tla-import/src/test/scala/at/forsyte/apalache/io/tlc/TestTlcConfigParserApalache.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/io/tlc/TestTlcConfigParserApalache.scala
@@ -1,15 +1,18 @@
 package at.forsyte.apalache.io.tlc
 
-import at.forsyte.apalache.io.tlc.config.{ConfigIntValue, ConfigModelValue, ConfigSetValue, ConfigStrValue, InitNextSpec, TemporalSpec, TlcConfigParseError}
+import at.forsyte.apalache.io.tlc.config.{
+  ConfigBoolValue, ConfigIntValue, ConfigModelValue, ConfigSetValue, ConfigStrValue, InitNextSpec, TemporalSpec,
+  TlcConfigParseError
+}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 /**
-  * Tests for the TLC configuration parser.
-  *
-  * @author Igor Konnov
-  */
+ * Tests for the TLC configuration parser.
+ *
+ * @author Igor Konnov
+ */
 @RunWith(classOf[JUnitRunner])
 class TestTlcConfigParserApalache extends FunSuite {
 
@@ -85,6 +88,21 @@ class TestTlcConfigParserApalache extends FunSuite {
     assert(config.constReplacements.isEmpty)
   }
 
+  test("CONSTANT assignments with Booleans") {
+    val text =
+      """
+        |CONSTANT
+        |N = TRUE
+        |K = FALSE
+        |INIT Init
+        |NEXT Next
+      """.stripMargin
+
+    val config = TlcConfigParserApalache(text)
+    assert(config.constAssignments == Map("N" -> ConfigBoolValue(true), "K" -> ConfigBoolValue(false)))
+    assert(config.constReplacements.isEmpty)
+  }
+
   test("CONSTANT assignments with strings") {
     val text =
       """
@@ -110,8 +128,9 @@ class TestTlcConfigParserApalache extends FunSuite {
       """.stripMargin
 
     val config = TlcConfigParserApalache(text)
-    assert(config.constAssignments ==
-      Map("N" -> ConfigSetValue(ConfigStrValue("foo"), ConfigSetValue(ConfigIntValue(1), ConfigModelValue("Moo")))))
+    assert(
+        config.constAssignments ==
+          Map("N" -> ConfigSetValue(ConfigStrValue("foo"), ConfigSetValue(ConfigIntValue(1), ConfigModelValue("Moo")))))
     assert(config.constReplacements.isEmpty)
   }
 


### PR DESCRIPTION
This PR fixes issue #512:

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
