### PR TITLE
close #482: reusing projections from set comprehensions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,3 +22,4 @@
 
 * Boolean values are now supported in TLC config files, see #512
 * Proper error on invalid type annotations, the parser is strengthened with Scalacheck, see #332
+* Typechecking quantifiers over tuples, see #482

--- a/test/tla/ExistTuple476.tla
+++ b/test/tla/ExistTuple476.tla
@@ -4,7 +4,11 @@
  *)
 EXTENDS Integers
 
-VARIABLES x, y
+VARIABLES
+    \* @type: Int;
+    x,
+    \* @type: Int;
+    y
 
 Init ==
     x = 0 /\ y = 0

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -866,6 +866,15 @@ The outcome is: Error
 
 ## running the typecheck command
 
+### check ExistTuple476.tla reports no error: regression for issues 476 and 482
+
+```sh
+$ apalache-mc check --length=1 ExistTuple476.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+```
+
 ### typecheck CarTalkPuzzleTyped.tla
 
 ```sh

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -871,7 +871,7 @@ The outcome is: Error
 ```sh
 $ apalache-mc typecheck ExistTuple476.tla | sed 's/I@.*//'
 ...
-The outcome is: NoError
+Type checker [OK]
 ...
 ```
 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -866,10 +866,10 @@ The outcome is: Error
 
 ## running the typecheck command
 
-### check ExistTuple476.tla reports no error: regression for issues 476 and 482
+### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482
 
 ```sh
-$ apalache-mc check --length=1 ExistTuple476.tla | sed 's/I@.*//'
+$ apalache-mc typecheck --length=1 ExistTuple476.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -869,7 +869,7 @@ The outcome is: Error
 ### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482
 
 ```sh
-$ apalache-mc typecheck --length=1 ExistTuple476.tla | sed 's/I@.*//'
+$ apalache-mc typecheck ExistTuple476.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -305,16 +305,24 @@ class ToEtcExpr(annotationStore: AnnotationStore, varPool: TypeVarPool) extends 
         // ~A
         mkExRefApp(OperT1(Seq(BoolT1()), BoolT1()), Seq(arg))
 
-      case OperEx(op, NameEx(bindingVar), bindingSet, pred) if op == TlaBoolOper.exists || op == TlaBoolOper.forall =>
+      case OperEx(op, bindingEx, bindingSet, pred) if op == TlaBoolOper.exists || op == TlaBoolOper.forall =>
         // \E x \in S: P, \A x \in S: P
-        // the principal type of \A and \E is (a => Bool) => Bool
-        val a = varPool.fresh
-        val quantType = OperT1(Seq(OperT1(Seq(a), BoolT1())), BoolT1())
-        // \E and \A implicitly introduce a lambda abstraction: λ x ∈ S. P
-        val lambda =
-          mkAbs(BlameRef(ex.ID), this(pred), (bindingVar, this(bindingSet)))
-        // the resulting expression is (((a => Bool) => a) (λ x ∈ S. P))
-        mkApp(ref, Seq(quantType), lambda)
+        // or, \E <<x, ..., z>> \in S: P
+
+        // 1. When there is one argument, a set element has type "a", no tuple is involved.
+        // 2. When there are multiple arguments,
+        //    a set element has type type <<a, b>>, that is, it is a tuple.
+        //    We can also have nested tuples like <<x, <<y, z>> >>, they are expanded.
+        val bindings = translateBindings((bindingEx, bindingSet))
+        val typeVars = varPool.fresh(bindings.length)
+        val funFrom =
+          if (bindings.length == 1) typeVars.head else TupT1(typeVars: _*)
+        // the principal type is ((a, b) => Bool) => Bool or just (a => Bool) => Bool
+        val principal = OperT1(Seq(OperT1(typeVars, BoolT1())), BoolT1())
+        // \E and \A implicitly introduce a lambda abstraction: λ x ∈ proj_x, λ x ∈ proj_y. P
+        val lambda = mkAbs(BlameRef(ex.ID), this(pred), bindings: _*)
+        // the resulting expression is (principal lambda)
+        mkApp(ref, Seq(principal), lambda)
 
       //******************************************** SETS **************************************************
       case OperEx(TlaSetOper.enumSet) =>

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -315,8 +315,6 @@ class ToEtcExpr(annotationStore: AnnotationStore, varPool: TypeVarPool) extends 
         //    We can also have nested tuples like <<x, <<y, z>> >>, they are expanded.
         val bindings = translateBindings((bindingEx, bindingSet))
         val typeVars = varPool.fresh(bindings.length)
-        val funFrom =
-          if (bindings.length == 1) typeVars.head else TupT1(typeVars: _*)
         // the principal type is ((a, b) => Bool) => Bool or just (a => Bool) => Bool
         val principal = OperT1(Seq(OperT1(typeVars, BoolT1())), BoolT1())
         // \E and \A implicitly introduce a lambda abstraction: λ x ∈ proj_x, λ x ∈ proj_y. P


### PR DESCRIPTION
This PR closes #482. It just applies the projection solution for set comprehensions to quantifiers.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- ~[ ] Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
