### PR TITLE
bugfix for a bug with - in a regex

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,3 +22,4 @@
 
 * Boolean values are now supported in TLC config files, see #512
 * Proper error on invalid type annotations, the parser is strengthened with Scalacheck, see #332
+* Fixed a parsing bug for strings that contain '-', see #539

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
@@ -55,7 +55,7 @@ object TlcConfigLexer extends RegexParsers {
   }
 
   private def string: Parser[STRING] = {
-    """"[a-zA-Z0-9_~!@#\\$%^&*-+=|(){}\[\],:;`'<>.?/ ]*"""".r ^^ { name => STRING(name.substring(1, name.length - 1)) }
+    """"[a-zA-Z0-9_~!@#\\$%^&*\-+=|(){}\[\],:;`'<>.?/ ]*"""".r ^^ { name => STRING(name.substring(1, name.length - 1)) }
   }
 
   private def number: Parser[NUMBER] = {

--- a/tla-import/src/test/scala/at/forsyte/apalache/io/tlc/TestTlcConfigParserApalache.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/io/tlc/TestTlcConfigParserApalache.scala
@@ -134,6 +134,23 @@ class TestTlcConfigParserApalache extends FunSuite {
     assert(config.constReplacements.isEmpty)
   }
 
+  test("CONSTANTS bug with minus in [...]") {
+    // a regression test
+    val text =
+      """
+        |CONSTANTS
+        |ChainIds = {"Chain-A", "Chain-B"}
+        |INIT Init
+        |NEXT Next
+      """.stripMargin
+
+    val config = TlcConfigParserApalache(text)
+    assert(
+        config.constAssignments ==
+          Map("ChainIds" -> ConfigSetValue(ConfigStrValue("Chain-A"), ConfigStrValue("Chain-B"))))
+    assert(config.constReplacements.isEmpty)
+  }
+
   test("CONSTANT assignments and SYMMETRY") {
     val text =
       """


### PR DESCRIPTION
Fixed a trivial bug in regex

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
