### PR TITLE
Emojify docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,6 @@ jobs:
           mdbook-version: "0.4.5"
           # mdbook-version: 'latest'
 
-      # - name: Use OCaml 4.11.0
-      #   uses: actions-ml/setup-ocaml@8047ff86bc363ab5a0ba4323ac99e1800daaa622
-      #   with:
-      #     ocaml-version: 4.11.0
-
-      # - name: Install emojitsu
-      #   run: |
-      #     opam pin https://github.com/shonfeder/emojitsu.git#0.0.5
-
       - name: Build the mdBook
         run: |
           set -x
@@ -36,7 +27,7 @@ jobs:
           cd docs
 
           # Install emojitsu
-          wget https://github.com/shonfeder/emojitsu/releases/download/0.0.6/gh-actions-emojitsu
+          wget --no-verbose https://github.com/shonfeder/emojitsu/releases/download/0.0.6/gh-actions-emojitsu
           chmod +x gh-actions-emojitsu
 
           # Emojify the markdown
@@ -47,11 +38,11 @@ jobs:
           # jekyll rendering we use for the base site
           rm ../target/docs/.nojekyll
 
-      # - name: Deploy
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: ./target/docs
-      #     destination_dir: docs
-      #     # We use GitHub's builtin jekyll for rendering the main landing page
-      #     enable_jekyll: true
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/docs
+          destination_dir: docs
+          # We use GitHub's builtin jekyll for rendering the main landing page
+          enable_jekyll: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
           mdbook-version: "0.4.5"
           # mdbook-version: 'latest'
 
-      - name: Use OCaml 4.11.0
-        uses: actions-ml/setup-ocaml@8047ff86bc363ab5a0ba4323ac99e1800daaa622
-        with:
-          ocaml-version: 4.11.0
+      # - name: Use OCaml 4.11.0
+      #   uses: actions-ml/setup-ocaml@8047ff86bc363ab5a0ba4323ac99e1800daaa622
+      #   with:
+      #     ocaml-version: 4.11.0
 
       # - name: Install emojitsu
       #   run: |
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build the mdBook
         run: |
+          set -x
+
           cd docs
 
           # Install emojitsu

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - master
       # TODO Remove once deploying unstable versions separately
       - unstable
+      - shon/emojify-docs # FIXME
 
 jobs:
   deploy:
@@ -24,26 +25,31 @@ jobs:
         with:
           ocaml-version: 4.11.0
 
-      - name: Install emojitsu
-        run: |
-          opam pin https://github.com/shonfeder/emojitsu.git#0.0.5
+      # - name: Install emojitsu
+      #   run: |
+      #     opam pin https://github.com/shonfeder/emojitsu.git#0.0.5
 
       - name: Build the mdBook
         run: |
           cd docs
+
+          # Install emojitsu
+          wget https://github.com/shonfeder/emojitsu/releases/download/0.0.6/gh-actions-emojitsu
+          chmod +x gh-actions-emojitsu
+
           # Emojify the markdown
-          find . -type f -name "*.md" -exec opam exec -- emojitsu emojify -i {} \;
+          find . -type f -name "*.md" -exec ./gh-actions-emojitsu emojify -i {} \;
           # Build the book
           mdbook build
           # mdbook generates this file automatically but it breaks the gh-pages
           # jekyll rendering we use for the base site
           rm ../target/docs/.nojekyll
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/docs
-          destination_dir: docs
-          # We use GitHub's builtin jekyll for rendering the main landing page
-          enable_jekyll: true
+      # - name: Deploy
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: ./target/docs
+      #     destination_dir: docs
+      #     # We use GitHub's builtin jekyll for rendering the main landing page
+      #     enable_jekyll: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           # mdbook-version: 'latest'
 
       - name: Use OCaml 4.11.0
-        uses: avsm/setup-ocaml@v1
+        uses: actions-ml/setup-ocaml@8047ff86bc363ab5a0ba4323ac99e1800daaa622
         with:
           ocaml-version: 4.11.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,11 @@ jobs:
           # jekyll rendering we use for the base site
           rm ../target/docs/.nojekyll
 
-      # - name: Deploy
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: ./target/docs
-      #     destination_dir: docs
-      #     # We use GitHub's builtin jekyll for rendering the main landing page
-      #     enable_jekyll: true
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/docs
+          destination_dir: docs
+          # We use GitHub's builtin jekyll for rendering the main landing page
+          enable_jekyll: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
       - master
       # TODO Remove once deploying unstable versions separately
       - unstable
-      - shon/emojify-docs # FIXME
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
       - master
       # TODO Remove once deploying unstable versions separately
       - unstable
-      - shon/emojify-docs
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - master
       # TODO Remove once deploying unstable versions separately
       - unstable
+      - shon/emojify-docs
 
 jobs:
   deploy:
@@ -19,18 +20,31 @@ jobs:
           mdbook-version: "0.4.5"
           # mdbook-version: 'latest'
 
-      - run: |
+      - name: Use OCaml 4.11.0
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: 4.11.0
+
+      - name: Install emojitsu
+        run: |
+          opam pin https://github.com/shonfeder/emojitsu.git#0.0.5
+
+      - name: Build the mdBook
+        run: |
           cd docs
+          # Emojify the markdown
+          find . -type f -name "*.md" -exec opam exec -- emojitsu emojify -i {} \;
+          # Build the book
           mdbook build
           # mdbook generates this file automatically but it breaks the gh-pages
           # jekyll rendering we use for the base site
           rm ../target/docs/.nojekyll
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/docs
-          destination_dir: docs
-          # We use GitHub's builtin jekyll for rendering the main landing page
-          enable_jekyll: true
+      # - name: Deploy
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: ./target/docs
+      #     destination_dir: docs
+      #     # We use GitHub's builtin jekyll for rendering the main landing page
+      #     enable_jekyll: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,30 @@ mdbook serve
 
 ## Notes on writing the documentation
 
+### Emoji
+
+We have hacked together support for _most_ GitHub emoji names in the docs. So,
+if you write
+
+```markdown
+:duck:
+```
+
+then, after compiling in our CI during deployment, it will render as
+
+```markdown
+🦆
+```
+
+Our CI uses the [emojitsu](https://github.com/shonfeder/emojitsu#emojitsu) CLI
+utility. You can also use this tool to lookup the name for an emoji if you have
+the unicode on hand or to see how a name will render.
+
+Note that GitHub cheats in it's rendering: it replaces emojinames with pngs, and
+includes some emojis which are not supported by the unicode standard. We don't
+stand for this standardless stuff at the moment, because it would be too tedious
+to implement.
+
 ### The Table of Contents
 
 The [./src/SUMMARY.md](./src/SUMMARY.md) specifies the table of contents shown

--- a/docs/src/lang/logic.md
+++ b/docs/src/lang/logic.md
@@ -318,7 +318,7 @@ design. Maybe it returns the first element of the set? Sets are not ordered, so
 there is no first element.
 
 Why should you use `CHOOSE`? Actually, you should not. Unless you have no other
-choice :bowtie:
+choice :ribbon:
 
 There are two common use cases, where the use of `CHOOSE` is well justified:
 


### PR DESCRIPTION
Closes #479 

Last weekend I hacked together a little command line utility for replacing and looking up GitHub emoji names, because I couldn't find any CLIs utilities to this in a unixy way and it seemed useful. You can find it at https://github.com/shonfeder/emojitsu .

This PR adds that utility into our deployment of the mdbook docs, so that the emoji names will be replaced with their unicode equivalents during deployment (if available).

I cheated a deployment into the CI for this PR, and you can see the results here: https://apalache.informal.systems/docs/idiomatic/index.html#the-idioms