### PR TITLE
Implicit type tag in TLA expressions

### DIFF
--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/AssignmentOperatorIntroduction.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/AssignmentOperatorIntroduction.scala
@@ -2,31 +2,31 @@ package at.forsyte.apalache.tla.assignments
 
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaActionOper, TlaOper}
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
 /**
-  * <p> Replaces ass assignment candidates of the form x' = e, which satisfy the predicate `isAssignment`,
-  * into a special assignment form, x' <- e, for optimization purposes. </p>
-  */
+ * <p> Replaces ass assignment candidates of the form x' = e, which satisfy the predicate `isAssignment`,
+ * into a special assignment form, x' <- e, for optimization purposes. </p>
+ */
 class AssignmentOperatorIntroduction(
-                                      isAssignment: UID => Boolean,
-                                      tracker: TransformationTracker
-                                    ) extends TlaExTransformation {
-  private var uidReplacementMap : Map[UID, UID] = Map.empty
+    isAssignment: UID => Boolean, tracker: TransformationTracker
+) extends TlaExTransformation {
+  private var uidReplacementMap: Map[UID, UID] = Map.empty
 
   override def apply(expr: TlaEx): TlaEx = {
     transform(expr)
   }
 
   def transform: TlaExTransformation = tracker.trackEx {
-    case ex@OperEx( TlaOper.eq, prime@OperEx( TlaActionOper.prime, _ : NameEx ), asgnVal ) if isAssignment( ex.ID ) =>
-      val ret = OperEx( BmcOper.assign, prime, asgnVal )
+    case ex @ OperEx(TlaOper.eq, prime @ OperEx(TlaActionOper.prime, _: NameEx), asgnVal) if isAssignment(ex.ID) =>
+      val ret = OperEx(BmcOper.assign, prime, asgnVal)
       uidReplacementMap += ex.ID -> ret.ID
       ret
-    case ex@OperEx( op, args@_* ) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map transform
       if (args == newArgs) ex else OperEx(op, newArgs: _*)
-    case ex@LetInEx( body, defs@_* ) =>
+    case ex @ LetInEx(body, defs @ _*) =>
       val newDefs = defs.map { x => x.copy(body = transform(x.body)) }
       val newBody = transform(body)
       if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
@@ -37,10 +37,11 @@ class AssignmentOperatorIntroduction(
 }
 
 object AssignmentOperatorIntroduction {
-  def predicateFromSet( set: Set[UID] ) : UID => Boolean = set.contains
+  def predicateFromSet(set: Set[UID]): UID => Boolean = set.contains
 
-  def apply( isAssignment : UID => Boolean, tracker : TransformationTracker ) : AssignmentOperatorIntroduction =
-    new AssignmentOperatorIntroduction( isAssignment, tracker )
-  def apply( assignments: Set[UID], tracker : TransformationTracker ) : AssignmentOperatorIntroduction =
-    new AssignmentOperatorIntroduction( predicateFromSet( assignments ), tracker )
+  def apply(isAssignment: UID => Boolean, tracker: TransformationTracker): AssignmentOperatorIntroduction =
+    new AssignmentOperatorIntroduction(isAssignment, tracker)
+
+  def apply(assignments: Set[UID], tracker: TransformationTracker): AssignmentOperatorIntroduction =
+    new AssignmentOperatorIntroduction(predicateFromSet(assignments), tracker)
 }

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/Reordering.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/Reordering.scala
@@ -3,42 +3,43 @@ package at.forsyte.apalache.tla.assignments
 import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
 import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * `Reordering` allows us to change the order of arguments passed to commutative operators (e.g. /\).
-  * This helps enforce a notion of, for example, left-to-right processing of arguments (like in TLC), which
-  * matters in variable assignments, which should always (syntactically) precede variable use cases.
-  * @param ord An ordering over `T`
-  * @param rankingFn Assigns a value in `T` to each `TlaEx`. This indirectly defines an ordering on `TlaEx`:
-  *                  e1 <= e2 iff ord.le( rankingFn(e1), rankingFn(e2) ) etc.
-  * @param tracker A transformation tracker.
-  * @tparam T An orderable domain. Default: Option[Int]
-  */
-class Reordering[T]( ord : Ordering[T], rankingFn : TlaEx => T, tracker : TransformationTracker ) {
+ * `Reordering` allows us to change the order of arguments passed to commutative operators (e.g. /\).
+ * This helps enforce a notion of, for example, left-to-right processing of arguments (like in TLC), which
+ * matters in variable assignments, which should always (syntactically) precede variable use cases.
+ *
+ * @param ord       An ordering over `T`
+ * @param rankingFn Assigns a value in `T` to each `TlaEx`. This indirectly defines an ordering on `TlaEx`:
+ *                  e1 <= e2 iff ord.le( rankingFn(e1), rankingFn(e2) ) etc.
+ * @param tracker   A transformation tracker.
+ * @tparam T An orderable domain. Default: Option[Int]
+ */
+class Reordering[T](ord: Ordering[T], rankingFn: TlaEx => T, tracker: TransformationTracker) {
 
-  def reorder : TlaExTransformation = tracker.trackEx {
+  def reorder: TlaExTransformation = tracker.trackEx {
     // For now, both /\ and \/ are reordered
-    case ex@OperEx( op@( TlaBoolOper.and | TlaBoolOper.or ), args@_* ) =>
-      val reorderedArgs = args.sortBy( rankingFn )( ord ) map reorder
-      if ( args == reorderedArgs ) ex
-      else OperEx( op, reorderedArgs : _* )
+    case ex @ OperEx(op @ (TlaBoolOper.and | TlaBoolOper.or), args @ _*) =>
+      val reorderedArgs = args.sortBy(rankingFn)(ord) map reorder
+      if (args == reorderedArgs) ex
+      else OperEx(op, reorderedArgs: _*)
 
-    case ex@OperEx( op, args@_* ) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map reorder
-      if ( args == newArgs ) ex
-      else OperEx( op, newArgs : _* )
+      if (args == newArgs) ex
+      else OperEx(op, newArgs: _*)
 
-    case ex@LetInEx( letInBody, defs@_* ) =>
+    case ex @ LetInEx(letInBody, defs @ _*) =>
       val newDefs = defs map {
         // Assignments can only appear in nullary operators
-        case TlaOperDecl( name, Nil, declBody ) =>
-          TlaOperDecl( name, Nil, reorder( declBody ) )
+        case TlaOperDecl(name, Nil, declBody) =>
+          TlaOperDecl(name, Nil, reorder(declBody))
         case d => d
       }
-      val newBody = reorder( letInBody )
-      if ( defs == newDefs && letInBody == newBody ) ex
-      else LetInEx( newBody, newDefs : _* )
-
+      val newBody = reorder(letInBody)
+      if (defs == newDefs && letInBody == newBody) ex
+      else LetInEx(newBody, newDefs: _*)
 
     case ex => ex
 
@@ -54,11 +55,11 @@ object Reordering {
   // Reordering with this Ordering pushes assignments to the front at each nesting level and preserves their relative order,
   // as defined by f.
   object IntOptOrdering extends Ordering[Option[Int]] {
-    def compare( x : Option[Int], y : Option[Int] ) : Int = (x, y) match {
-      case (Some( xVal ), Some( yVal )) => Ordering[Int].compare( xVal, yVal )
-      case (None, Some( _ )) => 1
-      case (Some( _ ), None) => -1
-      case _ => 0
+    def compare(x: Option[Int], y: Option[Int]): Int = (x, y) match {
+      case (Some(xVal), Some(yVal)) => Ordering[Int].compare(xVal, yVal)
+      case (None, Some(_))          => 1
+      case (Some(_), None)          => -1
+      case _                        => 0
     }
   }
 

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SymbTransGenerator.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SymbTransGenerator.scala
@@ -4,291 +4,312 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Constructs symbolic transitions from an assignment strategy.
-  */
-class SymbTransGenerator( tracker : TransformationTracker ) {
+ * Constructs symbolic transitions from an assignment strategy.
+ */
+class SymbTransGenerator(tracker: TransformationTracker) {
 
   private[assignments] object helperFunctions {
     type LabelMapType = Map[UID, Set[UID]]
     type AssignmentSelections = Set[Set[UID]]
     type SelMapType = Map[UID, AssignmentSelections]
-    type letInMapType = Map[String, (UID,SelMapType)]
+    type letInMapType = Map[String, (UID, SelMapType)]
 
-    def allCombinations[ValType]( p_sets : Seq[Set[Set[ValType]]] ) : Set[Set[ValType]] = {
-      if ( p_sets.isEmpty )
+    def allCombinations[ValType](p_sets: Seq[Set[Set[ValType]]]): Set[Set[ValType]] = {
+      if (p_sets.isEmpty)
         Set.empty[Set[ValType]]
-      else if ( p_sets.length == 1 )
+      else if (p_sets.length == 1)
         p_sets.head
       else {
         val one = p_sets.head
-        val rest = allCombinations( p_sets.tail )
+        val rest = allCombinations(p_sets.tail)
 
-        ( for {s <- one}
-          yield rest.map( st => st ++ s ) ).fold( Set.empty[Set[ValType]] )( _ ++ _ )
+        (for { s <- one } yield rest.map(st => st ++ s)).fold(Set.empty[Set[ValType]])(_ ++ _)
       }
     }
 
-    def labelsAt( p_ex : TlaEx, p_partialSel : SelMapType ) : Set[UID] = labelsAt( p_ex.ID, p_partialSel )
+    def labelsAt(p_ex: TlaEx, p_partialSel: SelMapType): Set[UID] = labelsAt(p_ex.ID, p_partialSel)
 
-    def labelsAt( p_id : UID, p_partialSel : SelMapType ) : Set[UID] = p_partialSel.getOrElse(
-      p_id,
-      Set.empty[Set[UID]]
-    ).fold(
-      Set.empty[UID]
-    )(
-      _ ++ _
-    )
+    def labelsAt(p_id: UID, p_partialSel: SelMapType): Set[UID] = p_partialSel
+      .getOrElse(
+          p_id,
+          Set.empty[Set[UID]]
+      )
+      .fold(
+          Set.empty[UID]
+      )(
+          _ ++ _
+      )
 
-    /** Given an assignment strategy A and a TLA+ expression \phi, computes
-      * { B \cap A | B \in Branches( \psi ) }
-      * for all expresisons \psi \in Sub(\phi)
-      *
-      * @param ex Top-level expression
-      * @param letInMap Auxiliary map, storing the already-computed branch-information for nullary LET-IN
-      *                 defined operators.
-      * @return A mapping of the form [e.ID |-> { B \cap A | B \in Branches( e ) } | e \in Sub(ex)]
-      */
-    def allSelections( ex : TlaEx, letInMap: letInMapType = Map.empty ) : SelMapType = ex match {
+    /**
+     * Given an assignment strategy A and a TLA+ expression \phi, computes
+     * { B \cap A | B \in Branches( \psi ) }
+     * for all expresisons \psi \in Sub(\phi)
+     *
+     * @param ex       Top-level expression
+     * @param letInMap Auxiliary map, storing the already-computed branch-information for nullary LET-IN
+     *                 defined operators.
+     * @return A mapping of the form [e.ID |-> { B \cap A | B \in Branches( e ) } | e \in Sub(ex)]
+     */
+    def allSelections(ex: TlaEx, letInMap: letInMapType = Map.empty): SelMapType = ex match {
       /** Base case, assignments */
-      case e@OperEx( BmcOper.assign, _, _ ) => Map( e.ID -> Set( Set( e.ID ) ) )
-      /**
-        * Branches( /\ \phi_i ) = { Br_1 U ... U Br_s | \forall i . Br_i \in Branches(\phi_i) }
-        * { S \cap A | S \in Branches( /\ phi_i ) } =
-        * { (Br_1 U ... U Br_s) \cap A | \forall i . Br_i \in Branches(\phi_i) } =
-        * { (Br_1 \cap A) U ... U (Br_s \cap A) | \forall i . Br_i \in Branches(\phi_i) } =
-        * { B_1 U ... U B_n | \forall i . B_i \in { T \cap A | T \in Branches(\phi_i)} }
-        */
-      case OperEx(TlaBoolOper.and, args@_*) =>
-        /** Unify all child maps, keysets are disjoint by construction */
-        val unifiedMap = (args map { allSelections( _, letInMap ) }).fold( Map.empty[UID, AssignmentSelections] ) { _ ++ _ }
+      case e @ OperEx(BmcOper.assign, _, _) => Map(e.ID -> Set(Set(e.ID)))
 
-        val childBranchSets = args.flatMap( x => unifiedMap.get( x.ID ) )
+      /**
+       * Branches( /\ \phi_i ) = { Br_1 U ... U Br_s | \forall i . Br_i \in Branches(\phi_i) }
+       * { S \cap A | S \in Branches( /\ phi_i ) } =
+       * { (Br_1 U ... U Br_s) \cap A | \forall i . Br_i \in Branches(\phi_i) } =
+       * { (Br_1 \cap A) U ... U (Br_s \cap A) | \forall i . Br_i \in Branches(\phi_i) } =
+       * { B_1 U ... U B_n | \forall i . B_i \in { T \cap A | T \in Branches(\phi_i)} }
+       */
+      case OperEx(TlaBoolOper.and, args @ _*) =>
+        /** Unify all child maps, keysets are disjoint by construction */
+        val unifiedMap = (args map {
+          allSelections(_, letInMap)
+        }).fold(Map.empty[UID, AssignmentSelections]) {
+          _ ++ _
+        }
+
+        val childBranchSets = args.flatMap(x => unifiedMap.get(x.ID))
 
         /** The set as computed from the lemma */
-        val mySet = allCombinations( childBranchSets )
-        if ( mySet.isEmpty || mySet.exists( _.isEmpty) ) unifiedMap else unifiedMap + ( ex.ID -> mySet )
+        val mySet = allCombinations(childBranchSets)
+        if (mySet.isEmpty || mySet.exists(_.isEmpty)) unifiedMap else unifiedMap + (ex.ID -> mySet)
 
       /**
-        * Branches( \/ \phi_i ) = U Branches(\phi_i)
-        * { S \cap A | S \in Branches( \/ \phi_i )} =
-        * { S \cap A | S \in U Branches(\phi_i)} =
-        * U { S \cap A | S \in Branches(\phi_i)}
-        */
-      case OperEx(TlaBoolOper.or, args@_*)  =>
-        val unifiedMap = (args map { allSelections( _, letInMap ) }).fold( Map.empty[UID, AssignmentSelections]) { _ ++ _ }
+       * Branches( \/ \phi_i ) = U Branches(\phi_i)
+       * { S \cap A | S \in Branches( \/ \phi_i )} =
+       * { S \cap A | S \in U Branches(\phi_i)} =
+       * U { S \cap A | S \in Branches(\phi_i)}
+       */
+      case OperEx(TlaBoolOper.or, args @ _*) =>
+        val unifiedMap = (args map {
+          allSelections(_, letInMap)
+        }).fold(Map.empty[UID, AssignmentSelections]) {
+          _ ++ _
+        }
 
-        val childBranchSets = args.flatMap( x => unifiedMap.get( x.ID ) )
+        val childBranchSets = args.flatMap(x => unifiedMap.get(x.ID))
 
-        val mySet = childBranchSets.fold( Set.empty[Set[UID]] )( _ ++ _ )
-        if ( mySet.isEmpty || mySet.exists( _.isEmpty) ) unifiedMap else unifiedMap + ( ex.ID -> mySet )
+        val mySet = childBranchSets.fold(Set.empty[Set[UID]])(_ ++ _)
+        if (mySet.isEmpty || mySet.exists(_.isEmpty)) unifiedMap else unifiedMap + (ex.ID -> mySet)
 
       /**
-        * Branches( \E x \in S . \phi ) = Branches( \phi )
-        * { S \cap A | S \in Branches( \E x \in S . \phi )} =
-        * { S \cap A | S \in Branches( \phi )} =
-        */
+       * Branches( \E x \in S . \phi ) = Branches( \phi )
+       * { S \cap A | S \in Branches( \E x \in S . \phi )} =
+       * { S \cap A | S \in Branches( \phi )} =
+       */
       case OperEx(TlaBoolOper.exists, _, _, phi) =>
-        val childMap = allSelections( phi, letInMap )
-        val mySet = childMap.getOrElse( phi.ID, Set( Set.empty[UID] ) )
-        if ( mySet.exists( _.isEmpty) ) childMap else childMap + ( ex.ID -> mySet )
+        val childMap = allSelections(phi, letInMap)
+        val mySet = childMap.getOrElse(phi.ID, Set(Set.empty[UID]))
+        if (mySet.exists(_.isEmpty)) childMap else childMap + (ex.ID -> mySet)
 
       /**
-        * Branches( ITE(\phi_c, \phi_t, \phi_e) ) = Branches( \phi_t ) U Branches( \phi_e )
-        * { S \cap A | S \in Branches( ITE(\phi_c, \phi_t, \phi_e) )} =
-        * { S \cap A | S \in Branches( \phi_t ) U Branches( \phi_e ) } =
-        * { S \cap A | S \in Branches( \phi_t ) } U { S \cap A | S \in Branches( \phi_e ) }
-        */
-      case OperEx(TlaControlOper.ifThenElse, _, thenAndElse@_*) =>
-        val unifiedMap = (thenAndElse map { allSelections( _, letInMap ) }).fold( Map.empty[UID, AssignmentSelections] ) { _ ++ _ }
+       * Branches( ITE(\phi_c, \phi_t, \phi_e) ) = Branches( \phi_t ) U Branches( \phi_e )
+       * { S \cap A | S \in Branches( ITE(\phi_c, \phi_t, \phi_e) )} =
+       * { S \cap A | S \in Branches( \phi_t ) U Branches( \phi_e ) } =
+       * { S \cap A | S \in Branches( \phi_t ) } U { S \cap A | S \in Branches( \phi_e ) }
+       */
+      case OperEx(TlaControlOper.ifThenElse, _, thenAndElse @ _*) =>
+        val unifiedMap = (thenAndElse map {
+          allSelections(_, letInMap)
+        }).fold(Map.empty[UID, AssignmentSelections]) {
+          _ ++ _
+        }
 
-        val childBranchSets = thenAndElse.flatMap( x => unifiedMap.get( x.ID ) )
+        val childBranchSets = thenAndElse.flatMap(x => unifiedMap.get(x.ID))
 
-        val mySet = childBranchSets.fold( Set.empty[Set[UID]] )( _ ++ _ )
-        if ( mySet.isEmpty || mySet.exists( _.isEmpty) ) unifiedMap else unifiedMap + ( ex.ID -> mySet )
+        val mySet = childBranchSets.fold(Set.empty[Set[UID]])(_ ++ _)
+        if (mySet.isEmpty || mySet.exists(_.isEmpty)) unifiedMap else unifiedMap + (ex.ID -> mySet)
 
-      case LetInEx( body, defs@_* ) =>
+      case LetInEx(body, defs @ _*) =>
         val defMap = (defs map { d =>
           d.name -> (d.body.ID, allSelections(d.body, letInMap))
         }).toMap
-        val childMap = allSelections( body, letInMap ++ defMap )
-        val mySet = childMap.getOrElse( body.ID, Set( Set.empty[UID] ) )
-        if ( mySet.exists( _.isEmpty) ) childMap else childMap + ( ex.ID -> mySet )
+        val childMap = allSelections(body, letInMap ++ defMap)
+        val mySet = childMap.getOrElse(body.ID, Set(Set.empty[UID]))
+        if (mySet.exists(_.isEmpty)) childMap else childMap + (ex.ID -> mySet)
 
       // Nullary apply
       case OperEx(TlaOper.apply, NameEx(operName)) =>
         // Apply may appear in higher order operators, so it might not be possible to pre-analyze
-        letInMap.get( operName ) match {
-          case Some( (uid, lim) ) =>
-            val mySet = lim.getOrElse( uid, Set( Set.empty[UID] ) )
-            if ( mySet.exists( _.isEmpty) ) lim else lim + ( ex.ID -> mySet )
+        letInMap.get(operName) match {
+          case Some((uid, lim)) =>
+            val mySet = lim.getOrElse(uid, Set(Set.empty[UID]))
+            if (mySet.exists(_.isEmpty)) lim else lim + (ex.ID -> mySet)
           case None => Map.empty[UID, AssignmentSelections]
         }
 
       case _ => Map.empty[UID, AssignmentSelections]
     }
 
-
-    def sliceWith( selection : Set[UID], allSelections: SelMapType ) : TlaExTransformation = tracker.trackEx {
+    def sliceWith(selection: Set[UID], allSelections: SelMapType): TlaExTransformation = tracker.trackEx {
       // Assignments are a base case, don't recurse on args
-      case ex@OperEx( BmcOper.assign, _* ) => ex
-      case ex@OperEx( TlaBoolOper.or, args@_* ) =>
+      case ex @ OperEx(BmcOper.assign, _*)        => ex
+      case ex @ OperEx(TlaBoolOper.or, args @ _*) =>
         /**
-          * Or-branches have the property that they either contain
-          * all assignments or none of them. Therefore it suffices to check for
-          * non-emptiness of the intersection.
-          */
+         * Or-branches have the property that they either contain
+         * all assignments or none of them. Therefore it suffices to check for
+         * non-emptiness of the intersection.
+         */
         /**
-          * Jure, 16.9.19: This is no longer true, with the inclusion of LET-IN, as assignments that
-          * happen within a LET-IN operator body can appear to belong to multiple branches.
-          * */
+         * Jure, 16.9.19: This is no longer true, with the inclusion of LET-IN, as assignments that
+         * happen within a LET-IN operator body can appear to belong to multiple branches.
+         */
 
         val newArgs = args.filter { x =>
           /**
-            * \E S \in allSelections( x ) . S \cap selection \ne \emptyset
-            * <=>
-            * \E S \in allSelections( x ) . \E y \in S . y \in selection
-            * <=>
-            * \E S \in allSelections( x ) . \E y \in selection . y \in S
-            * <=>
-            * \E y \in selection . y \in \bigcup allSelections( x )
-            */
-          labelsAt( x, allSelections ) exists { selection.contains }
+           * \E S \in allSelections( x ) . S \cap selection \ne \emptyset
+           * <=>
+           * \E S \in allSelections( x ) . \E y \in S . y \in selection
+           * <=>
+           * \E S \in allSelections( x ) . \E y \in selection . y \in S
+           * <=>
+           * \E y \in selection . y \in \bigcup allSelections( x )
+           */
+          labelsAt(x, allSelections) exists {
+            selection.contains
+          }
         }
 
 //        /**
 //          * If no assignments lie below, take the largest subformula.
 //          * It is guaranteed to belong to the union of branches.
 //          * Otherwise, take the one intersecting branch (recurse, since disjunctions aren't always expanded)
-//          */
-//        assert( newArgs.size < 2 )
+        //          */
+        //        assert( newArgs.size < 2 )
 
-//        newArgs.headOption.map( sliceWith( selection, allSelections) ).getOrElse( ex )
+        //        newArgs.headOption.map( sliceWith( selection, allSelections) ).getOrElse( ex )
         newArgs match {
-          case Nil => ex
-          case head +: Nil => sliceWith( selection, allSelections)(head)
-          case _ => OperEx( TlaBoolOper.or, newArgs map sliceWith( selection, allSelections) : _* )
+          case Nil         => ex
+          case head +: Nil => sliceWith(selection, allSelections)(head)
+          case _           => OperEx(TlaBoolOper.or, newArgs map sliceWith(selection, allSelections): _*)
         }
 
-      /** We replace ITE(a,b,c) with either a /\ b or ~a /\ c, depending
-        * on which branch has the assignment.
-        * This only applies if exactly branch has an assignment, otherwise keep all */
-      case ex@OperEx( TlaControlOper.ifThenElse, ifEx, args@_* ) =>
-        val newTail = args.map(
-          x => if ( labelsAt( x, allSelections ) exists {
-            selection.contains
-          } )
-            sliceWith( selection, allSelections )( x ) else ValEx(TlaBool(false))
+      /**
+       * We replace ITE(a,b,c) with either a /\ b or ~a /\ c, depending
+       * on which branch has the assignment.
+       * This only applies if exactly branch has an assignment, otherwise keep all
+       */
+      case ex @ OperEx(TlaControlOper.ifThenElse, ifEx, args @ _*) =>
+        val newTail = args.map(x =>
+          if (
+              labelsAt(x, allSelections) exists {
+                selection.contains
+              }
+          )
+            sliceWith(selection, allSelections)(x)
+          else ValEx(TlaBool(false))
         )
 
         newTail match {
           case ValEx(TlaBool(false)) +: ValEx(TlaBool(false)) +: Nil =>
             ex
           case newThen +: ValEx(TlaBool(false)) +: Nil =>
-            OperEx( TlaBoolOper.and, ifEx, newThen )
+            OperEx(TlaBoolOper.and, ifEx, newThen)
           case ValEx(TlaBool(false)) +: newElse +: Nil =>
-            OperEx( TlaBoolOper.and, OperEx( TlaBoolOper.not, ifEx ), newElse )
+            OperEx(TlaBoolOper.and, OperEx(TlaBoolOper.not, ifEx), newElse)
           case _ =>
             // Possible, because of LET-IN
-            OperEx( TlaControlOper.ifThenElse, ifEx +: newTail : _* )
+            OperEx(TlaControlOper.ifThenElse, ifEx +: newTail: _*)
         }
 
-      case ex@OperEx( op, args@_* ) =>
+      case ex @ OperEx(op, args @ _*) =>
         val childVals = args map {
-          sliceWith( selection, allSelections )
+          sliceWith(selection, allSelections)
         }
         // Make sure to avoid creating new UIDs if not absolutely needed, as filtering
         // is done on the basis of UIDs not syntax
-        if ( childVals == args ) ex else OperEx( op, childVals : _* )
+        if (childVals == args) ex else OperEx(op, childVals: _*)
 
-      case ex@LetInEx( body, defs@_* ) =>
-        val slice = sliceWith( selection, allSelections )
+      case ex @ LetInEx(body, defs @ _*) =>
+        val slice = sliceWith(selection, allSelections)
         val newDefs = defs map { d =>
-          d.copy( body = slice( d.body ) )
+          d.copy(body = slice(d.body))
         } // filterNot { _.body == ValEx( TlaFalse ) } ?
 
-        val newBody = slice( body )
+        val newBody = slice(body)
 
         val same = newDefs == defs && newBody == body
 
-        if ( same ) ex
-        else if ( newBody == ValEx(TlaBool(false)) ) newBody
-        else LetInEx( newBody, newDefs : _* )
+        if (same) ex
+        else if (newBody == ValEx(TlaBool(false))) newBody
+        else LetInEx(newBody, newDefs: _*)
 
       case ex => ex
     }
 
     /**
-      * Orders a selection by \prec_A
-      *
-      * @param selection A selection S \subseteq A
-      * @param strategy  An assignment strategy A.
-      * @return A sequence of elements s_1, ..., s_|S| from S, such that
-      *         s_1 \prec_A ... \prec_A s_|S|
-      */
+     * Orders a selection by \prec_A
+     *
+     * @param selection A selection S \subseteq A
+     * @param strategy  An assignment strategy A.
+     * @return A sequence of elements s_1, ..., s_|S| from S, such that
+     *         s_1 \prec_A ... \prec_A s_|S|
+     */
     def mkOrdered(
-                   selection : Set[UID],
-                   strategy : StrategyType
-                 ) : AssignmentType = {
-      strategy.filter( selection.contains ) // strategy is already ordered
+        selection: Set[UID], strategy: StrategyType
+    ): AssignmentType = {
+      strategy.filter(selection.contains) // strategy is already ordered
     }
 
     /**
-      * Gathers the orderedAssignments selections and their corresponding restricted formulas.
-      *
-      * @param ex         Input formula.
-      * @param strategy   Assignment strategy
-      * @param selections Map of partial assignment selections.
-      * @return A sequence of pairs of ordered assignment selections and their symbolic transitions.
-      */
+     * Gathers the orderedAssignments selections and their corresponding restricted formulas.
+     *
+     * @param ex         Input formula.
+     * @param strategy   Assignment strategy
+     * @param selections Map of partial assignment selections.
+     * @return A sequence of pairs of ordered assignment selections and their symbolic transitions.
+     */
     def getTransitions(
-                        ex : TlaEx,
-                        strategy : StrategyType,
-                        selections : SelMapType
-                      ) : Seq[SymbTrans] =
-      selections( ex.ID ).map { s =>
-        (mkOrdered( s, strategy ), sliceWith( s, selections )( ex ))
+        ex: TlaEx, strategy: StrategyType, selections: SelMapType
+    ): Seq[SymbTrans] =
+      selections(ex.ID).map { s =>
+        (mkOrdered(s, strategy), sliceWith(s, selections)(ex))
       }.toSeq
-    }
+  }
 
   /**
-    * Point of access method
-    *
-    * @param phi          TLA+ formula
-    * @param asgnStrategy Assignment strategy A for `p_phi`.
-    * @see [[AssignmentStrategyEncoder]]
-    * @return A collection of symbolic transitions, as defined by the equivalence classes of ~,,A,,
-    */
-  def apply( phi : TlaEx, asgnStrategy : StrategyType ) : Seq[SymbTrans] = {
+   * Point of access method
+   *
+   * @param phi          TLA+ formula
+   * @param asgnStrategy Assignment strategy A for `p_phi`.
+   * @see [[AssignmentStrategyEncoder]]
+   * @return A collection of symbolic transitions, as defined by the equivalence classes of ~,,A,,
+   */
+  def apply(phi: TlaEx, asgnStrategy: StrategyType): Seq[SymbTrans] = {
 
     import helperFunctions._
 
-    /** For certain purposes, we do not care about the order of assignments.
-      * It is therefore helpful to have a set structure, with faster lookups. */
+    /**
+     * For certain purposes, we do not care about the order of assignments.
+     * It is therefore helpful to have a set structure, with faster lookups.
+     */
     val stratSet = asgnStrategy.toSet
 
     /** Replace all assignments */
-    val asgnTransform = AssignmentOperatorIntroduction( stratSet, tracker )
-    val transformed = asgnTransform( phi )
+    val asgnTransform = AssignmentOperatorIntroduction(stratSet, tracker)
+    val transformed = asgnTransform(phi)
 
     /**
-      * Since the new assignments have different UIDs, the new strategy is obtained
-      * by replacing the UIDs in the old strategy (preserving order)
-      */
+     * Since the new assignments have different UIDs, the new strategy is obtained
+     * by replacing the UIDs in the old strategy (preserving order)
+     */
 
     // In the case of manual assignments, return own UID (no need to populate the map)
     val newStrat = asgnStrategy map { x => asgnTransform.getReplacements.getOrElse(x, x) }
 
     /** We compute the set of all branch intersections with `asgnStrategy` */
-    val selections = allSelections( transformed, Map.empty )
+    val selections = allSelections(transformed, Map.empty)
 
     /** Sanity check, all selections are the same size */
-    val allSizes = selections( transformed.ID ).map( _.size )
-    assert( allSizes.size == 1 )
+    val allSizes = selections(transformed.ID).map(_.size)
+    assert(allSizes.size == 1)
 
     /** We restrict the formula to each equivalence class (defined by an assignment selection) */
-    getTransitions( transformed, newStrat, selections )
+    getTransitions(transformed, newStrat, selections)
   }
 
 }

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
@@ -12,33 +12,32 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.NormalizedNames
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * This pass finds symbolic transitions in Init and Next.
-  */
-class TransitionPassImpl @Inject()(options: PassOptions,
-                                   sourceStore: SourceStore,
-                                   tracker: TransformationTracker,
-                                   changeListener: ChangeListener,
-                                   incrementalRenaming: IncrementalRenaming,
-                                   @Named("AfterTransitionFinder") nextPass: Pass with TlaModuleMixin)
-  extends TransitionPass with LazyLogging {
+ * This pass finds symbolic transitions in Init and Next.
+ */
+class TransitionPassImpl @Inject() (options: PassOptions, sourceStore: SourceStore, tracker: TransformationTracker,
+    changeListener: ChangeListener, incrementalRenaming: IncrementalRenaming,
+    @Named("AfterTransitionFinder") nextPass: Pass with TlaModuleMixin)
+    extends TransitionPass with LazyLogging {
+
   /**
-    * The name of the pass
-    *
-    * @return the name associated with the pass
-    */
+   * The name of the pass
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "TransitionFinderPass"
 
   /**
-    * Run the pass
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     val inModule = tlaModule.get
 
@@ -62,10 +61,10 @@ class TransitionPassImpl @Inject()(options: PassOptions,
 
         case Some(cinitName) =>
           logger.info(s"  > Found constant initializer $cinitName")
-          val cinitEx = findBodyOf(cinitName + "Primed", inModule.operDeclarations :_*)
+          val cinitEx = findBodyOf(cinitName + "Primed", inModule.operDeclarations: _*)
           // We don't perform the standard assignment-search on cinit,
           // we just replace EVERY x' = e with x' <- e
-          val tr = AssignmentOperatorIntroduction( { _ => true }, tracker )
+          val tr = AssignmentOperatorIntroduction({ _ => true }, tracker)
           val newEx = tr(cinitEx)
           Seq(ModuleAdapter.exprToOperDef(NormalizedNames.CONST_INIT, newEx))
       }
@@ -94,7 +93,7 @@ class TransitionPassImpl @Inject()(options: PassOptions,
 
     val transitionPairs = SmtFreeSymbolicTransitionExtractor(tracker, sourceLoc)(vars.toSet, primedName)
     // sort the transitions by their occurrence in the source code
-    val sorter = new TransitionOrder( sourceLoc )
+    val sorter = new TransitionOrder(sourceLoc)
     val sortedPairs = sorter.sortBySource(transitionPairs)
     if (sortedPairs.isEmpty) {
       throw new AssignmentException("Failed to find assignments and symbolic transitions in " + inOperName)
@@ -104,11 +103,11 @@ class TransitionPassImpl @Inject()(options: PassOptions,
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     tlaModule map { m =>
       nextPass.setModule(m)

--- a/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestAlphaTransform.scala
+++ b/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestAlphaTransform.scala
@@ -7,128 +7,131 @@ import at.forsyte.apalache.tla.lir.storage.{BodyMapFactory, ChangeListener}
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.pp.Desugarer
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestAlphaTransform extends FunSuite with TestingPredefs {
   val testFolderPath = "src/test/resources/assignmentSolver/"
 
-  def specFromFile(p_file : String, p_next : String = "Next") : TlaEx = {
+  def specFromFile(p_file: String, p_next: String = "Next"): TlaEx = {
     val declsRaw = declarationsFromFile(testFolderPath + p_file)
 
     val fakeModule = new TlaModule("test", declsRaw)
 
-    val tracker = TrackerWithListeners( new ChangeListener )
+    val tracker = TrackerWithListeners(new ChangeListener)
 
-    val renaming = new IncrementalRenaming( tracker )
+    val renaming = new IncrementalRenaming(tracker)
     val uniqueVarDecls =
       new TlaModule(
-        fakeModule.name,
-        renaming.syncAndNormalizeDs( fakeModule.declarations ).toSeq
+          fakeModule.name,
+          renaming.syncAndNormalizeDs(fakeModule.declarations).toSeq
       )
 
-    val bodyMap = BodyMapFactory.makeFromDecls( uniqueVarDecls.operDeclarations )
-    val inlined = ModuleByExTransformer( InlinerOfUserOper( bodyMap, tracker ) )( uniqueVarDecls )
-    val explLetIn = ModuleByExTransformer( LetInExpander( tracker, keepNullary = false ) )( inlined )
-    val afterDesugarer = ModuleByExTransformer(Desugarer(tracker)) (explLetIn)
-    val preprocessed = ModuleByExTransformer( PrimedEqualityToMembership( tracker ) )( afterDesugarer )
+    val bodyMap = BodyMapFactory.makeFromDecls(uniqueVarDecls.operDeclarations)
+    val inlined = ModuleByExTransformer(InlinerOfUserOper(bodyMap, tracker))(uniqueVarDecls)
+    val explLetIn = ModuleByExTransformer(LetInExpander(tracker, keepNullary = false))(inlined)
+    val afterDesugarer = ModuleByExTransformer(Desugarer(tracker))(explLetIn)
+    val preprocessed = ModuleByExTransformer(PrimedEqualityToMembership(tracker))(afterDesugarer)
 
-    findBodyOf( p_next, preprocessed.declarations : _* )
+    findBodyOf(p_next, preprocessed.declarations: _*)
   }
 
-  test( "Star abstraction" ) {
+  test("Star abstraction") {
 
     val ex1 = trueEx
-    val ex2 : TlaEx = 5
-    val ex3 : TlaEx = x_in_S
-    val ex4 : TlaEx = tla.choose( n_x, n_S, n_p )
-    val ex5 : TlaEx = tla.caseOther( n_c, n_p, n_a, n_q, n_b )
-    val ex6 : TlaEx = tla.card( n_S )
+    val ex2: TlaEx = 5
+    val ex3: TlaEx = x_in_S
+    val ex4: TlaEx = tla.choose(n_x, n_S, n_p)
+    val ex5: TlaEx = tla.caseOther(n_c, n_p, n_a, n_q, n_b)
+    val ex6: TlaEx = tla.card(n_S)
 
-    val exs = List( ex1, ex2, ex3, ex4, ex5, ex6 )
+    val exs = List(ex1, ex2, ex3, ex4, ex5, ex6)
 
-    assert( exs forall { ex =>
-      AlphaTransform( ex ) == Star( ex )
-    } )
+    assert(exs forall { ex =>
+      AlphaTransform(ex) == Star(ex)
+    })
 
   }
 
-  test( "No abstraction" ) {
+  test("No abstraction") {
 
     val ex1 = falseEx
-    val ex2 : TlaEx = tla.primeInSingleton( n_x, 1 )
-    val ex3 : TlaEx = tla.ite( n_p, n_a, n_b )
-    val ex4 : TlaEx = tla.or( ex1, ex2, ex3 )
-    val ex5 : TlaEx = tla.and( ex1, ex2, ex3 )
+    val ex2: TlaEx = tla.primeInSingleton(n_x, 1)
+    val ex3: TlaEx = tla.ite(n_p, n_a, n_b)
+    val ex4: TlaEx = tla.or(ex1, ex2, ex3)
+    val ex5: TlaEx = tla.and(ex1, ex2, ex3)
 
-    val exs = List( ex1, ex2, ex3, ex4, ex5 )
+    val exs = List(ex1, ex2, ex3, ex4, ex5)
 
-    assert( exs forall { ex =>
-      !AlphaTransform( ex ).isInstanceOf[Star]
-    } )
+    assert(exs forall { ex =>
+      !AlphaTransform(ex).isInstanceOf[Star]
+    })
 
   }
 
+  def correctRecursiveApplication(exs: Traversable[TlaEx]): Boolean = {
+    val trs = (exs map { ex => ex -> AlphaTransform(ex) }).toMap
 
-  def correctRecursiveApplication( exs: Traversable[TlaEx] ): Boolean = {
-    val trs = ( exs map { ex => ex -> AlphaTransform( ex ) } ).toMap
-    def argMatch( exargs: Traversable[TlaEx], args: Traversable[AlphaEx] ): Boolean =
-      ( exargs map { arg => trs.getOrElse(arg, AlphaTransform(arg)) } ) == args
+    def argMatch(exargs: Traversable[TlaEx], args: Traversable[AlphaEx]): Boolean =
+      (exargs map { arg => trs.getOrElse(arg, AlphaTransform(arg)) }) == args
 
-    trs forall { case (ex@OperEx( _, _* ), tr) => tr match {
-      case AndOr( OperEx( _, exargs@_* ), args@_* ) => argMatch( exargs, args )
-      case ITE( OperEx( _, exargs@_* ), i, t, e ) => argMatch( exargs, Seq(i,t,e) )
-      case Exists( OperEx( _, exargs@_* ), x, s, b ) => argMatch( exargs, Seq(x,s,b) )
-      case AsgnEx( OperEx( _, exargs@_* ), v, r ) => argMatch( exargs.tail, Seq(r)) // skip variable
-      case Star( e ) => e == ex
-      case _ => false
-    }
-    case (ex, tr) => tr == trs(ex)
+    trs forall {
+      case (ex @ OperEx(_, _*), tr) =>
+        tr match {
+          case AndOr(OperEx(_, exargs @ _*), args @ _*) => argMatch(exargs, args)
+          case ITE(OperEx(_, exargs @ _*), i, t, e)     => argMatch(exargs, Seq(i, t, e))
+          case Exists(OperEx(_, exargs @ _*), x, s, b)  => argMatch(exargs, Seq(x, s, b))
+          case AsgnEx(OperEx(_, exargs @ _*), v, r)     => argMatch(exargs.tail, Seq(r)) // skip variable
+          case Star(e)                                  => e == ex
+          case _                                        => false
+        }
+      case (ex, tr) => tr == trs(ex)
     }
   }
 
-  test( "And/Or nesting" ) {
+  test("And/Or nesting") {
 
     val ex1 = trueEx
     val ex2 = falseEx
-    val ex3 = tla.and( ex1, ex2 )
-    val ex4 = tla.or( ex1, ex2 )
+    val ex3 = tla.and(ex1, ex2)
+    val ex4 = tla.or(ex1, ex2)
 
-    val ex5 = tla.and( ex4, ex3 )
-    val ex6 = tla.or( ex5, ex4, ex3, ex2, ex1 )
+    val ex5 = tla.and(ex4, ex3)
+    val ex6 = tla.or(ex5, ex4, ex3, ex2, ex1)
 
-    val exs : List[TlaEx] = List( ex1, ex2, ex3, ex4, ex5, ex6 )
+    val exs: List[TlaEx] = List(ex1, ex2, ex3, ex4, ex5, ex6)
 
-    assert( correctRecursiveApplication( exs ) )
+    assert(correctRecursiveApplication(exs))
   }
 
-  test( "QuantAlt" ) {
-    val ex1 = tla.forall( n_x, n_S, tla.exists( n_y, n_T, tla.eql( 1, 2 ) ) )
-    val ex2 = tla.exists( n_x, n_S, tla.forall( n_y, n_T, tla.eql( 1, 2 ) ) )
+  test("QuantAlt") {
+    val ex1 = tla.forall(n_x, n_S, tla.exists(n_y, n_T, tla.eql(1, 2)))
+    val ex2 = tla.exists(n_x, n_S, tla.forall(n_y, n_T, tla.eql(1, 2)))
 
-    assert( correctRecursiveApplication( Seq(ex1, ex2) ) )
+    assert(correctRecursiveApplication(Seq(ex1, ex2)))
   }
 
-  test( "ITE nesting" ) {
-    val ex1 = tla.and( trueEx, falseEx, trueEx, trueEx, falseEx)
-    val ex2 = tla.exists( n_x, n_S, tla.primeInSingleton( n_t, n_x ) )
-    val ex3 = tla.ite( n_p, ex1, ex2 )
+  test("ITE nesting") {
+    val ex1 = tla.and(trueEx, falseEx, trueEx, trueEx, falseEx)
+    val ex2 = tla.exists(n_x, n_S, tla.primeInSingleton(n_t, n_x))
+    val ex3 = tla.ite(n_p, ex1, ex2)
 
-    assert( correctRecursiveApplication( Seq(ex1, ex2, ex3) ) )
+    assert(correctRecursiveApplication(Seq(ex1, ex2, ex3)))
   }
 
-  test( "Assignments" ) {
+  test("Assignments") {
     val ex1 = tla.primeInSingleton(n_x, 1)
-    val ex2 = tla.primeInSingleton( n_x, tla.primeInSingleton(n_x, 2) )
+    val ex2 = tla.primeInSingleton(n_x, tla.primeInSingleton(n_x, 2))
 
-    assert( correctRecursiveApplication( Seq(ex1, ex2) ) )
+    assert(correctRecursiveApplication(Seq(ex1, ex2)))
   }
 
-  test( "Real spec" ) {
-    val spec = specFromFile( "Paxos.tla" )
+  test("Real spec") {
+    val spec = specFromFile("Paxos.tla")
 
-    assert( correctRecursiveApplication( Seq(spec) ) )
+    assert(correctRecursiveApplication(Seq(spec)))
   }
 }

--- a/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSymbTransPass.scala
+++ b/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSymbTransPass.scala
@@ -4,7 +4,8 @@ import at.forsyte.apalache.tla.imp.declarationsFromFile
 import at.forsyte.apalache.tla.lir.storage.{BodyMapFactory, ChangeListener}
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.{Builder => bd,_}
+import at.forsyte.apalache.tla.lir.{Builder => bd, _}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.Desugarer
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -14,126 +15,126 @@ import org.scalatest.junit.JUnitRunner
 class TestSymbTransPass extends FunSuite with TestingPredefs {
   val testFolderPath = "src/test/resources/assignmentSolver/"
 
-  def testFromNext( p_next : TlaEx ) : Seq[SymbTrans] = {
-    testFromDecls( Seq( TlaOperDecl( "Next", List(), p_next ) ) )
+  def testFromNext(p_next: TlaEx): Seq[SymbTrans] = {
+    testFromDecls(Seq(TlaOperDecl("Next", List(), p_next)))
   }
 
-  def testFromDecls( p_decls : Seq[TlaDecl], p_next : String = "Next"   ) : Seq[SymbTrans]  = {
+  def testFromDecls(p_decls: Seq[TlaDecl], p_next: String = "Next"): Seq[SymbTrans] = {
     val fakeModule = new TlaModule("test", p_decls)
     val srcDB = new ChangeListener
 
-    val tracker = TrackerWithListeners( srcDB )
-    val renaming = new IncrementalRenaming( tracker )
+    val tracker = TrackerWithListeners(srcDB)
+    val renaming = new IncrementalRenaming(tracker)
     val uniqueVarDecls =
       new TlaModule(
-        fakeModule.name,
-        renaming.syncAndNormalizeDs( fakeModule.declarations ).toSeq
+          fakeModule.name,
+          renaming.syncAndNormalizeDs(fakeModule.declarations).toSeq
       )
 
-    val bodyMap = BodyMapFactory.makeFromDecls( uniqueVarDecls.operDeclarations )
-    val inlined = ModuleByExTransformer( InlinerOfUserOper( bodyMap, tracker ) )( uniqueVarDecls )
-    val explLetIn = ModuleByExTransformer( LetInExpander( tracker, keepNullary = false ) )( inlined )
-    val afterDesugarer = ModuleByExTransformer(Desugarer(tracker)) (explLetIn)
-    val preprocessed = ModuleByExTransformer( PrimedEqualityToMembership( tracker ) )( afterDesugarer )
+    val bodyMap = BodyMapFactory.makeFromDecls(uniqueVarDecls.operDeclarations)
+    val inlined = ModuleByExTransformer(InlinerOfUserOper(bodyMap, tracker))(uniqueVarDecls)
+    val explLetIn = ModuleByExTransformer(LetInExpander(tracker, keepNullary = false))(inlined)
+    val afterDesugarer = ModuleByExTransformer(Desugarer(tracker))(explLetIn)
+    val preprocessed = ModuleByExTransformer(PrimedEqualityToMembership(tracker))(afterDesugarer)
 
     val vars = preprocessed.varDeclarations.map(_.name)
 
     SymbolicTransitionExtractor(tracker)(vars, preprocessed.operDeclarations.find(_.name == p_next).get.body)
   }
 
-  def testFromFile( p_file : String, p_next : String = "Next" ) : Seq[SymbTrans] = {
+  def testFromFile(p_file: String, p_next: String = "Next"): Seq[SymbTrans] = {
 
     val decls = declarationsFromFile(testFolderPath + p_file)
 
-    val ret = testFromDecls( decls, p_next )
+    val ret = testFromDecls(decls, p_next)
 
-//    val saveWriter = new PrintWriter( new File( testFolderPath + "SymbNexts" + p_file ) )
+    //    val saveWriter = new PrintWriter( new File( testFolderPath + "SymbNexts" + p_file ) )
 
-//    ret.foreach( x => saveWriter.println( "%s : \n %s\n".format( x._1.map( UniqueDB.get ) , x._2 ) ) )
+    //    ret.foreach( x => saveWriter.println( "%s : \n %s\n".format( x._1.map( UniqueDB.get ) , x._2 ) ) )
 
-//    saveWriter.close()
+    //    saveWriter.close()
 
     ret
   }
 
-  test( "Test labelsAt" ){
-    val gen = new SymbTransGenerator( TrackerWithListeners() )
+  test("Test labelsAt") {
+    val gen = new SymbTransGenerator(TrackerWithListeners())
 
-    assert( gen.helperFunctions.labelsAt(NullEx, Map.empty[UID, Set[Set[UID]]]).isEmpty )
+    assert(gen.helperFunctions.labelsAt(NullEx, Map.empty[UID, Set[Set[UID]]]).isEmpty)
   }
 
-  test( "Test Complete Spec return + unsat spec" ){
-    val phi = bd.bool( false )
+  test("Test Complete Spec return + unsat spec") {
+    val phi = bd.bool(false)
     val encoder = new AssignmentStrategyEncoder()
-    val fullSpec = encoder( Set("x"), phi, complete = true )
+    val fullSpec = encoder(Set("x"), phi, complete = true)
 
-    val spec = encoder( Set("x"), phi, complete = false)
-    assert( fullSpec.nonEmpty )
+    val spec = encoder(Set("x"), phi, complete = false)
+    assert(fullSpec.nonEmpty)
 
-    assert( (new SMTInterface())(spec, encoder.m_varSym).isEmpty )
+    assert((new SMTInterface())(spec, encoder.m_varSym).isEmpty)
 
   }
 
-  test( "Test Next = single asgn, no connectives" ){
-    val next = bd.primeInSingleton( n_x, n_S )
+  test("Test Next = single asgn, no connectives") {
+    val next = bd.primeInSingleton(n_x, n_S)
 
-    val decls = Seq( TlaOperDecl( "Next", List(), next ), TlaVarDecl( "x" ) )
+    val decls = Seq(TlaOperDecl("Next", List(), next), TlaVarDecl("x"))
 
-    val symbNexts = testFromDecls( decls )
+    val symbNexts = testFromDecls(decls)
   }
 
-  test( "Test non-compliant SMT spec" ){
+  test("Test non-compliant SMT spec") {
     val spec = "( declare-fun f ( Int ) Int )\n ( declare-fun g ( Int ) Int )\n" +
       "(assert ( = ( f 0 ) ( g 0 ) ) )"
     val smt = new SMTInterface()
 
     val strat = smt(spec, "X")
 
-    assert( strat.isEmpty )
+    assert(strat.isEmpty)
 
   }
 
-  test( "Test no strat" ){
-    val next = bd.eql( bd.prime( n_x ), n_y )
-    val decls = Seq( TlaOperDecl( "Next", List(), next ), TlaVarDecl( "x" ), TlaVarDecl( "z" ) )
+  test("Test no strat") {
+    val next = bd.eql(bd.prime(n_x), n_y)
+    val decls = Seq(TlaOperDecl("Next", List(), next), TlaVarDecl("x"), TlaVarDecl("z"))
     val trans = testFromDecls(decls)
     assert(trans.isEmpty)
   }
 
-  ignore( "Test no Next"){
+  ignore("Test no Next") {
     // the new version of SymbolicTransitionExtractor accepts an expression, so nothing to test here
     // TODO: remove this test
-    val next = bd.primeInSingleton( n_x, n_S )
-    val decls = Seq( TlaOperDecl( "Next", List(), next ), TlaVarDecl( "x" ) )
+    val next = bd.primeInSingleton(n_x, n_S)
+    val decls = Seq(TlaOperDecl("Next", List(), next), TlaVarDecl("x"))
     assertThrows[AssignmentException](testFromDecls(decls, "NotNext"))
   }
 
-  test( "Test Selections" ){
-    val symbNexts = testFromFile( "Selections.tla" )
+  test("Test Selections") {
+    val symbNexts = testFromFile("Selections.tla")
   }
 
-  test( "Test Paxos (simplified)" ){
-    val symbNexts = testFromFile( "Paxos.tla" )
+  test("Test Paxos (simplified)") {
+    val symbNexts = testFromFile("Paxos.tla")
   }
 
   test("Test ITE_CASE") {
-    val symbNexts = testFromFile( "ITE_CASE.tla" )
+    val symbNexts = testFromFile("ITE_CASE.tla")
   }
 
   test("Test EWD840") {
-    val symbNexts = testFromFile( "EWD840.tla" )
+    val symbNexts = testFromFile("EWD840.tla")
   }
 
-  test( "AST" ){
-    val symbNexts = testFromFile( "ast.tla" )
+  test("AST") {
+    val symbNexts = testFromFile("ast.tla")
   }
 
-  test( "test1" ) {
-    val symbNexts = testFromFile( "test1.tla" )
+  test("test1") {
+    val symbNexts = testFromFile("test1.tla")
   }
 
-  test( "SimpT1" ) {
-    val symbNexts = testFromFile( "SimpT1.tla" )
-    val symbNexts2 = testFromFile( "SimpT1.tla", "NextNoFaults" )
+  test("SimpT1") {
+    val symbNexts = testFromFile("SimpT1.tla")
+    val symbNexts2 = testFromFile("SimpT1.tla", "NextNoFaults")
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
@@ -4,13 +4,15 @@ import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.immutable.HashMap
 
 object Arena {
+
   /**
-    * The prefix of all cells.
-    */
+   * The prefix of all cells.
+   */
   val namePrefix = "$C$"
 
   val falseName: String = namePrefix + "0"
@@ -20,16 +22,12 @@ object Arena {
   val intSetName: String = namePrefix + "4"
 
   def create(solverContext: SolverContext): Arena = {
-    var arena = new Arena(solverContext, 0,
-      new ArenaCell(-1, UnknownT()),
-      HashMap(),
-      new HashMap(),
-      new HashMap(),
-      new HashMap()
-    ) /////
+    var arena = new Arena(solverContext, 0, new ArenaCell(-1, UnknownT()), HashMap(), new HashMap(), new HashMap(),
+        new HashMap()) /////
     // by convention, the first cells have the following semantics:
     //  0 stores FALSE, 1 stores TRUE, 2 stores BOOLEAN, 3 stores Nat, 4 stores Int
-    arena = arena.appendCellWithoutDeclaration(BoolT())
+    arena = arena
+      .appendCellWithoutDeclaration(BoolT())
       .appendCellWithoutDeclaration(BoolT())
       .appendCellWithoutDeclaration(FinSetT(BoolT()))
       .appendCellWithoutDeclaration(InfSetT(IntT()))
@@ -57,21 +55,18 @@ object Arena {
 }
 
 /**
-  * <p>A memory arena represents a memory layout. The arena is dynamically populated, when new objects are created.
-  * Currently, an arena is a directed acyclic graph, where edges are pointing from a container object
-  * to the associated cells, e.g., a set cell points to the cells that store its elements.</p>
-  *
-  * <p>Do not use solverContext, as it is going to be removed in the future.</p>
-  *
-  * @author Igor Konnov
-  */
-class Arena private(val solverContext: SolverContext,
-                    val cellCount: Int,
-                    val topCell: ArenaCell,
-                    val cellMap: Map[String, ArenaCell],
-                    private val hasEdges: Map[ArenaCell, List[ArenaCell]],
-                    private val domEdges: Map[ArenaCell, ArenaCell],
-                    private val cdmEdges: Map[ArenaCell, ArenaCell]) extends Serializable {
+ * <p>A memory arena represents a memory layout. The arena is dynamically populated, when new objects are created.
+ * Currently, an arena is a directed acyclic graph, where edges are pointing from a container object
+ * to the associated cells, e.g., a set cell points to the cells that store its elements.</p>
+ *
+ * <p>Do not use solverContext, as it is going to be removed in the future.</p>
+ *
+ * @author Igor Konnov
+ */
+class Arena private (val solverContext: SolverContext, val cellCount: Int, val topCell: ArenaCell,
+    val cellMap: Map[String, ArenaCell], private val hasEdges: Map[ArenaCell, List[ArenaCell]],
+    private val domEdges: Map[ArenaCell, ArenaCell], private val cdmEdges: Map[ArenaCell, ArenaCell])
+    extends Serializable {
   // TODO: remove solverContext from Arena, see issue #105
   def setSolver(newSolverContext: SolverContext): Arena = {
     // this is a temporary solution
@@ -79,64 +74,69 @@ class Arena private(val solverContext: SolverContext,
   }
 
   /**
-    * A fixed cell that equals to false in the Boolean theory.
-    * @return the false cell
-    */
+   * A fixed cell that equals to false in the Boolean theory.
+   *
+   * @return the false cell
+   */
   def cellFalse(): ArenaCell = {
     cellMap(Arena.falseName)
   }
 
   /**
-    * A fixed cell that equals to true in the Boolean theory
-    * @return the true cell
-    */
+   * A fixed cell that equals to true in the Boolean theory
+   *
+   * @return the true cell
+   */
   def cellTrue(): ArenaCell = {
     cellMap(Arena.trueName)
   }
 
   /**
-    * A fixed cell that stores the set {false, true}, that is, the set BOOLEAN in TLA+.
-    * @return the cell for the BOOLEAN set
-    */
+   * A fixed cell that stores the set {false, true}, that is, the set BOOLEAN in TLA+.
+   *
+   * @return the cell for the BOOLEAN set
+   */
   def cellBooleanSet(): ArenaCell = {
     cellMap(Arena.booleanSetName)
   }
 
   /**
-    * A fixed cell that stores the set Nat. As this set is infinite, it is not pointing to any other cells.
-    * @return the cell for the Nat cell
-    */
+   * A fixed cell that stores the set Nat. As this set is infinite, it is not pointing to any other cells.
+   *
+   * @return the cell for the Nat cell
+   */
   def cellNatSet(): ArenaCell = {
     cellMap(Arena.natSetName)
   }
 
   /**
-    * A fixed cell that stores the set Int. As this set is infinite, it is not pointing to any other cells.
-    * @return the cell for the Int cell
-    */
+   * A fixed cell that stores the set Int. As this set is infinite, it is not pointing to any other cells.
+   *
+   * @return the cell for the Int cell
+   */
   def cellIntSet(): ArenaCell = {
     cellMap(Arena.intSetName)
   }
 
   /**
-    * Find a cell by its name.
-    *
-    * @param name the name returned by ArenaCell.toString
-    * @return the cell, if it exists
-    * @throws NoSuchElementException when no cell is found
-    */
+   * Find a cell by its name.
+   *
+   * @param name the name returned by ArenaCell.toString
+   * @return the cell, if it exists
+   * @throws NoSuchElementException when no cell is found
+   */
   def findCellByName(name: String): ArenaCell = {
     cellMap(name)
   }
 
   /**
-    * Find a cell by the name contained in a name expression.
-    *
-    * @param nameEx a name expression that follows the cell naming convention.
-    * @return the found cell
-    * @throws InvalidTlaExException  if the name does not follow the convention
-    * @throws NoSuchElementException when no cell is found
-    */
+   * Find a cell by the name contained in a name expression.
+   *
+   * @param nameEx a name expression that follows the cell naming convention.
+   * @return the found cell
+   * @throws InvalidTlaExException  if the name does not follow the convention
+   * @throws NoSuchElementException when no cell is found
+   */
   def findCellByNameEx(nameEx: TlaEx): ArenaCell = {
     nameEx match {
       case NameEx(name) if ArenaCell.isValidName(name) =>
@@ -149,12 +149,12 @@ class Arena private(val solverContext: SolverContext,
   }
 
   /**
-    * Append a new cell to arena. This method returns a new arena, not the new cell.
-    * The new cell can be accessed with topCell.
-    *
-    * @param cellType a cell type
-    * @return new arena
-    */
+   * Append a new cell to arena. This method returns a new arena, not the new cell.
+   * The new cell can be accessed with topCell.
+   *
+   * @param cellType a cell type
+   * @return new arena
+   */
   def appendCell(cellType: CellT): Arena = {
     val newArena = appendCellWithoutDeclaration(cellType)
     val newCell = newArena.topCell
@@ -163,12 +163,13 @@ class Arena private(val solverContext: SolverContext,
   }
 
   /**
-    * Append a sequence of cells to arena. This method returns a new arena and a sequence of the freshly
-    * created cells (the cells are ordered the same way as the sequence of types). This method provides us with a
-    * handy alternative to appendCell, when several cells should be created.
-    * @param types a sequence of cell types
-    * @return a pair: the new arena and a sequence of new cells
-    */
+   * Append a sequence of cells to arena. This method returns a new arena and a sequence of the freshly
+   * created cells (the cells are ordered the same way as the sequence of types). This method provides us with a
+   * handy alternative to appendCell, when several cells should be created.
+   *
+   * @param types a sequence of cell types
+   * @return a pair: the new arena and a sequence of new cells
+   */
   def appendCellSeq(types: CellT*): (Arena, Seq[ArenaCell]) = {
     def create(arena: Arena, ts: Seq[CellT]): (Arena, Seq[ArenaCell]) =
       ts match {
@@ -187,43 +188,47 @@ class Arena private(val solverContext: SolverContext,
   protected def appendCellWithoutDeclaration(cellType: CellT): Arena = {
     val newCell = new ArenaCell(cellCount, cellType)
     assert(!cellMap.contains(newCell.toString)) // this might happen, if we messed up arenas
-    new Arena(solverContext, cellCount + 1, newCell,
-      cellMap + (newCell.toString -> newCell), hasEdges, domEdges, cdmEdges)
+    new Arena(solverContext, cellCount + 1, newCell, cellMap + (newCell.toString -> newCell), hasEdges, domEdges,
+        cdmEdges)
   }
 
   /**
-    * Append 'has' edges that connect the first cell to the other cells, in the given order.
-    * The previously added edges come first. When this method is called as appendHas(X, Y1, ..., Ym),
-    * it adds a Boolean constant in_X_Yi for each i: 1 <= i <= m.
-    *
-    * @param parentCell the cell that points to the children cells
-    * @param childrenCells the cells that are pointed by the parent cell
-    * @return the updated arena
-    */
+   * Append 'has' edges that connect the first cell to the other cells, in the given order.
+   * The previously added edges come first. When this method is called as appendHas(X, Y1, ..., Ym),
+   * it adds a Boolean constant in_X_Yi for each i: 1 <= i <= m.
+   *
+   * @param parentCell    the cell that points to the children cells
+   * @param childrenCells the cells that are pointed by the parent cell
+   * @return the updated arena
+   */
   def appendHas(parentCell: ArenaCell, childrenCells: ArenaCell*): Arena = {
-    childrenCells.foldLeft(this) { (a, c) => a.appendOneHasEdge(addInPred = true, parentCell, c) }
+    childrenCells.foldLeft(this) { (a, c) =>
+      a.appendOneHasEdge(addInPred = true, parentCell, c)
+    }
   }
 
   /**
-    * Append 'has' edges that connect the first cell to the other cells, in the given order.
-    * The previously added edges come first. In contrast to appendHas, this method does not add any constants in SMT.
-    *
-    * @param parentCell the cell that points to the children cells
-    * @param childrenCells the cells that are pointed by the parent cell
-    * @return the updated arena
-    */
+   * Append 'has' edges that connect the first cell to the other cells, in the given order.
+   * The previously added edges come first. In contrast to appendHas, this method does not add any constants in SMT.
+   *
+   * @param parentCell    the cell that points to the children cells
+   * @param childrenCells the cells that are pointed by the parent cell
+   * @return the updated arena
+   */
   def appendHasNoSmt(parentCell: ArenaCell, childrenCells: ArenaCell*): Arena = {
-    childrenCells.foldLeft(this) { (a, c) => a.appendOneHasEdge(addInPred = false, parentCell, c) }
+    childrenCells.foldLeft(this) { (a, c) =>
+      a.appendOneHasEdge(addInPred = false, parentCell, c)
+    }
   }
 
   /**
-    * Append a 'has' edge to connect a cell that corresponds to a set with a cell that corresponds to its element.
-    *
-    * @param setCell  a set cell
-    * @param elemCell an element cell
-    * @param addInPred indicates whether the in_X_Y constant should be added in SMT.
-    * @return a new arena
-    */
+   * Append a 'has' edge to connect a cell that corresponds to a set with a cell that corresponds to its element.
+   *
+   * @param setCell   a set cell
+   * @param elemCell  an element cell
+   * @param addInPred indicates whether the in_X_Y constant should be added in SMT.
+   * @return a new arena
+   */
   private def appendOneHasEdge(addInPred: Boolean, setCell: ArenaCell, elemCell: ArenaCell): Arena = {
     if (addInPred) {
       solverContext.declareInPredIfNeeded(setCell, elemCell)
@@ -241,95 +246,93 @@ class Arena private(val solverContext: SolverContext,
   }
 
   /**
-    * Get all the edges that are labelled with 'has'.
-    *
-    * @param setCell a set cell
-    * @return all element cells that were added with appendHas, or an empty list, if none were added
-    */
+   * Get all the edges that are labelled with 'has'.
+   *
+   * @param setCell a set cell
+   * @return all element cells that were added with appendHas, or an empty list, if none were added
+   */
   def getHas(setCell: ArenaCell): List[ArenaCell] = {
     hasEdges.get(setCell) match {
       case Some(list) => list
-      case None => List()
+      case None       => List()
     }
   }
 
   /**
-    * Set a function domain.
-    *
-    * @param funCell a function cell.
-    * @param domCell a set cell
-    * @return a new arena
-    */
+   * Set a function domain.
+   *
+   * @param funCell a function cell.
+   * @param domCell a set cell
+   * @return a new arena
+   */
   def setDom(funCell: ArenaCell, domCell: ArenaCell): Arena = {
     if (domEdges.contains(funCell))
       throw new IllegalStateException("Trying to set function domain, whereas one is already set")
 
-    new Arena(solverContext,
-      cellCount, topCell, cellMap, hasEdges, domEdges + (funCell -> domCell), cdmEdges)
+    new Arena(solverContext, cellCount, topCell, cellMap, hasEdges, domEdges + (funCell -> domCell), cdmEdges)
   }
 
   /**
-    * Set a function co-domain.
-    *
-    * @param funCell a function cell.
-    * @param cdmCell a set cell
-    * @return a new arena
-    */
+   * Set a function co-domain.
+   *
+   * @param funCell a function cell.
+   * @param cdmCell a set cell
+   * @return a new arena
+   */
   def setCdm(funCell: ArenaCell, cdmCell: ArenaCell): Arena = {
     if (cdmEdges.contains(funCell))
       throw new IllegalStateException("Trying to set function co-domain, whereas one is already set")
 
-    new Arena(solverContext,
-      cellCount, topCell, cellMap, hasEdges, domEdges, cdmEdges + (funCell -> cdmCell))
+    new Arena(solverContext, cellCount, topCell, cellMap, hasEdges, domEdges, cdmEdges + (funCell -> cdmCell))
   }
 
   /**
-    * Get the domain cell associated with a function.
-    *
-    * @param funCell a function cell.
-    * @return the domain cell
-    */
+   * Get the domain cell associated with a function.
+   *
+   * @param funCell a function cell.
+   * @return the domain cell
+   */
   def getDom(funCell: ArenaCell): ArenaCell = {
     domEdges.apply(funCell)
   }
 
   /**
-    * Get the co-domain cell associated with a function.
-    *
-    * @param funCell a function cell.
-    * @return the co-domain cell
-    */
+   * Get the co-domain cell associated with a function.
+   *
+   * @param funCell a function cell.
+   * @return the co-domain cell
+   */
   def getCdm(funCell: ArenaCell): ArenaCell = {
     cdmEdges.apply(funCell)
   }
 
   /**
-    * Check, whether a cell has an associated domain edge.
-    *
-    * @param cell a cell
-    * @return true, if cell has an edge labelled with 'dom'
-    */
+   * Check, whether a cell has an associated domain edge.
+   *
+   * @param cell a cell
+   * @return true, if cell has an edge labelled with 'dom'
+   */
   def hasDom(cell: ArenaCell): Boolean = {
     domEdges.contains(cell)
   }
 
   /**
-    * Check, whether a cell has an associated co-domain edge.
-    *
-    * @param cell a cell
-    * @return true, if cell has an edge labelled with 'cdm'
-    */
+   * Check, whether a cell has an associated co-domain edge.
+   *
+   * @param cell a cell
+   * @return true, if cell has an edge labelled with 'cdm'
+   */
   def hasCdm(cell: ArenaCell): Boolean = {
     cdmEdges.contains(cell)
   }
 
   /**
-    * Check, whether two cells are connected with a 'has' edge.
-    *
-    * @param src an edge origin
-    * @param dst an edge destination
-    * @return true, if src has an edge to dst labelled with 'has'
-    */
+   * Check, whether two cells are connected with a 'has' edge.
+   *
+   * @param src an edge origin
+   * @param dst an edge destination
+   * @return true, if src has an edge to dst labelled with 'has'
+   */
   def isLinkedViaHas(src: ArenaCell, dst: ArenaCell): Boolean = {
     def default(c: ArenaCell): List[ArenaCell] = List()
 
@@ -337,19 +340,19 @@ class Arena private(val solverContext: SolverContext,
   }
 
   /**
-    * Find all the cells of a given type.
-    *
-    * @return all the cells that have exactly the same type as the argument (no unification involved)
-    */
+   * Find all the cells of a given type.
+   *
+   * @return all the cells that have exactly the same type as the argument (no unification involved)
+   */
   def findCellsByType(cellType: CellT): List[ArenaCell] = {
     cellMap.values.filter(_.cellType == cellType).toList
   }
 
   /**
-    * Print the graph structure induced by 'has' edges starting with root.
-    *
-    * @param root a cell to start from
-    */
+   * Print the graph structure induced by 'has' edges starting with root.
+   *
+   * @param root a cell to start from
+   */
   def subgraphToString(root: ArenaCell): String = {
     val builder = StringBuilder.newBuilder
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ArenaCell.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ArenaCell.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.Arena.namePrefix
 import at.forsyte.apalache.tla.bmcmt.types.CellT
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 object ArenaCell {
   def isValidName(name: String): Boolean = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelChecker.scala
@@ -16,6 +16,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.io._
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.immutable.SortedMap

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.bmcmt.trex.{ExecutionSnapshot, TransitionExecutor
 import at.forsyte.apalache.tla.lir.io.CounterexampleWriter
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -9,15 +9,16 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.immutable.{HashSet, SortedSet}
 
 /**
-  * This class dumps relevant values from an SMT model using an arena.
-  *
-  * @author Igor Konnov
-  */
+ * This class dumps relevant values from an SMT model using an arena.
+ *
+ * @author Igor Konnov
+ */
 class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter) extends LazyLogging {
   // a simple decoder that dumps values into a text file, in the future we need better recovery code
   def dumpArena(state: SymbState, writer: PrintWriter): Unit = {
@@ -105,9 +106,9 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
       val relation = arena.getCdm(cell)
       val args =
         decodeCellToTlaEx(arena, relation) match {
-          case OperEx(TlaSetOper.enumSet, elems@_*) =>
+          case OperEx(TlaSetOper.enumSet, elems @ _*) =>
             def untuple(e: TlaEx) = e match {
-              case OperEx(TlaFunOper.tuple, pair@_*) =>
+              case OperEx(TlaFunOper.tuple, pair @ _*) =>
                 pair
 
               case _ => throw new RewriterException("Corrupted function: " + relation, NullEx)
@@ -133,10 +134,10 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
         case _ => throw new RewriterException("Corrupted sequence: " + startEndFun, NullEx)
       }
 
-    case r@RecordT(_) =>
+    case r @ RecordT(_) =>
       def exToStr(ex: TlaEx): TlaStr = ex match {
-        case ValEx(s@TlaStr(_)) => s
-        case _ => throw new RewriterException("Expected a string, found: " + ex, ex)
+        case ValEx(s @ TlaStr(_)) => s
+        case _                    => throw new RewriterException("Expected a string, found: " + ex, ex)
       }
 
       // Note that the domain may have fewer fields than the record type is saying.
@@ -160,17 +161,18 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
       if (keysAndValues.nonEmpty) {
         OperEx(TlaFunOper.enum, keysAndValues: _*)
       } else {
-        logger.error(s"Decoder: Found an empty record $cell when decoding a counterexample, domain = $domCell. This is a bug.")
+        logger.error(
+            s"Decoder: Found an empty record $cell when decoding a counterexample, domain = $domCell. This is a bug.")
         // for debugging purposes, just return a string
         ValEx(TlaStr(s"Empty record domain $domCell"))
       }
 
-    case t@TupleT(_) =>
+    case t @ TupleT(_) =>
       val tupleElems = arena.getHas(cell)
       val elemAsExprs = tupleElems.map(c => decodeCellToTlaEx(arena, c))
       tla.tuple(elemAsExprs: _*)
 
-    case PowSetT(t@FinSetT(_)) =>
+    case PowSetT(t @ FinSetT(_)) =>
       tla.powSet(decodeCellToTlaEx(arena, arena.getDom(cell)))
 
     case InfSetT(elemT) if cell == arena.cellIntSet() =>
@@ -185,7 +187,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
 
   private def decodeSet(arena: Arena, set: ArenaCell): Seq[TlaEx] = {
     decodeCellToTlaEx(arena, set) match {
-      case OperEx(TlaSetOper.enumSet, elems@_*) =>
+      case OperEx(TlaSetOper.enumSet, elems @ _*) =>
         elems
 
       case _ =>
@@ -206,7 +208,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
       case NameEx(name) =>
         if (name != cell.name) ex else NameEx(varName)
 
-      case OperEx(oper, args@_*) =>
+      case OperEx(oper, args @ _*) =>
         OperEx(oper, args map rec: _*)
 
       case _ =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -4,7 +4,9 @@ import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.{Continue, Done, NoRule, 
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.caches._
 import at.forsyte.apalache.tla.bmcmt.profiler.RuleStatListener
-import at.forsyte.apalache.tla.bmcmt.rewriter.{MetricProfilerListener, Recoverable, RewriterConfig, SymbStateRewriterSnapshot}
+import at.forsyte.apalache.tla.bmcmt.rewriter.{
+  MetricProfilerListener, Recoverable, RewriterConfig, SymbStateRewriterSnapshot
+}
 import at.forsyte.apalache.tla.bmcmt.rules._
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
@@ -14,128 +16,125 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.mutable
 
 /**
-  * <p>This class rewrites a symbolic state.
-  * This is the place where all the action regarding the operational semantics is happening.</p>
-  *
-  * <p>This class implements StackableContext by delegating the respective operations to all the internal caches
-  * and the SMT context. Thus, it is a central access point for context operations.</p>
-  *
-  * <p>TODO: rename this class to RewriterImpl?</p>
-  *
-  * @param _solverContext  a fresh solver context that will be populated with constraints
-  * @param typeFinder     a type finder (assuming that typeFinder.inferAndSave has been called already)
-  * @param exprGradeStore a labeling scheme that associated a grade with each expression;
-  *                       it is required to distinguish between state-level and action-level expressions.
-  * @param profilerListener optional listener that is used to profile the rewriting rules
-  *
-  * @author Igor Konnov
-  */
-class SymbStateRewriterImpl(private var _solverContext: SolverContext,
-                            var typeFinder: TypeFinder[CellT],
-                            val exprGradeStore: ExprGradeStore = new ExprGradeStoreImpl(),
-                            val profilerListener: Option[MetricProfilerListener] = None
-                           )
+ * <p>This class rewrites a symbolic state.
+ * This is the place where all the action regarding the operational semantics is happening.</p>
+ *
+ * <p>This class implements StackableContext by delegating the respective operations to all the internal caches
+ * and the SMT context. Thus, it is a central access point for context operations.</p>
+ *
+ * <p>TODO: rename this class to RewriterImpl?</p>
+ *
+ * @param _solverContext   a fresh solver context that will be populated with constraints
+ * @param typeFinder       a type finder (assuming that typeFinder.inferAndSave has been called already)
+ * @param exprGradeStore   a labeling scheme that associated a grade with each expression;
+ *                         it is required to distinguish between state-level and action-level expressions.
+ * @param profilerListener optional listener that is used to profile the rewriting rules
+ * @author Igor Konnov
+ */
+class SymbStateRewriterImpl(private var _solverContext: SolverContext, var typeFinder: TypeFinder[CellT],
+    val exprGradeStore: ExprGradeStore = new ExprGradeStoreImpl(),
+    val profilerListener: Option[MetricProfilerListener] = None)
     extends SymbStateRewriter with Serializable with Recoverable[SymbStateRewriterSnapshot] {
 
-
   /**
-    * <p>A solver context that is populated by the rewriter.</p>
-    *
-    * <p>This method will be removed when solving #105.</p>
-    */
+   * <p>A solver context that is populated by the rewriter.</p>
+   *
+   * <p>This method will be removed when solving #105.</p>
+   */
   override def solverContext: SolverContext = _solverContext
 
   /**
-    * <p>Set the new solver context. Warning: the new context should be at the same stack depth as the rewriter.
-    * Otherwise, pop may produce unexpected results.</p>
-    *
-    * <p>This method will be removed when solving #105.</p>
-    *
-    * @param newContext new context
-    */
+   * <p>Set the new solver context. Warning: the new context should be at the same stack depth as the rewriter.
+   * Otherwise, pop may produce unexpected results.</p>
+   *
+   * <p>This method will be removed when solving #105.</p>
+   *
+   * @param newContext new context
+   */
   override def solverContext_=(newContext: SolverContext): Unit = {
     _solverContext = newContext
   }
 
   /**
-    * We collect the sequence of expressions in the rewriting process,
-    * in order to diagnose an error when an exception occurs. The latest expression in on top.
-    */
+   * We collect the sequence of expressions in the rewriting process,
+   * in order to diagnose an error when an exception occurs. The latest expression in on top.
+   */
   private var rewritingStack: Seq[TlaEx] = Seq()
 
   /**
-    * The difference between the number of pushes and pops so far.
-    */
+   * The difference between the number of pushes and pops so far.
+   */
   private var level: Int = 0
 
   /**
-    * Configuration options
-    *
-    * @return the rewriter options
-    */
+   * Configuration options
+   *
+   * @return the rewriter options
+   */
   var config: RewriterConfig = new RewriterConfig
 
   /**
-    * The cache for lazy equalities, to avoid generating the same equality constraints many times.
-    */
+   * The cache for lazy equalities, to avoid generating the same equality constraints many times.
+   */
   val lazyEq = new LazyEquality(this)
 
   /**
-    * A cache for integer literals.
-    */
+   * A cache for integer literals.
+   */
   val intValueCache = new IntValueCache(solverContext)
 
   /**
-    * A cache for integer ranges a..b.
-    */
+   * A cache for integer ranges a..b.
+   */
   val intRangeCache = new IntRangeCache(solverContext, intValueCache)
 
   /**
-    * A cache for string literals.
-    */
+   * A cache for string literals.
+   */
   val strValueCache = new StrValueCache(solverContext)
 
   /**
-    * A cache of record domains.
-    */
+   * A cache of record domains.
+   */
   val recordDomainCache = new RecordDomainCache(solverContext, strValueCache)
 
   /**
-    * An expression cache that is initialized by grade storage, by default, empty.
-    * Set it to a new object, if you want to use a grade storage.
-    */
+   * An expression cache that is initialized by grade storage, by default, empty.
+   * Set it to a new object, if you want to use a grade storage.
+   */
   val exprCache = new ExprCache(exprGradeStore)
 
   @transient
   private lazy val substRule = new SubstRule(this)
 
   /**
-    * The store that contains formula hints. By default, empty.
-    */
+   * The store that contains formula hints. By default, empty.
+   */
   var formulaHintsStore: FormulaHintsStore = new FormulaHintsStoreImpl()
 
   /**
-    * A storage for the messages associated with assertion failures, see MessageStorage.
-    */
+   * A storage for the messages associated with assertion failures, see MessageStorage.
+   */
   private var messages: mutable.Map[Int, String] = new mutable.HashMap()
 
   /**
-    * Get the current context level, that is the difference between the number of pushes and pops made so far.
-    *
-    * @return the current level, always non-negative.
-    */
+   * Get the current context level, that is the difference between the number of pushes and pops made so far.
+   *
+   * @return the current level, always non-negative.
+   */
   def contextLevel: Int = level
 
   /**
-    * Statistics listener
-    *
-    * TODO: remove this listener, as it does not seem to be compatible with serialization.
-    * TODO: does this listener consume too many resources?
-    */
+   * Statistics listener
+   *
+   * TODO: remove this listener, as it does not seem to be compatible with serialization.
+   * TODO: does this listener consume too many resources?
+   */
   @transient
   lazy val statListener: RuleStatListener = new RuleStatListener()
   solverContext.setSmtListener(statListener) // subscribe to the SMT solver
@@ -144,175 +143,164 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   // We use simple expressions to generate the keys.
   // For each key, there is a short list of rules that may be applicable.
   @transient
-  lazy val ruleLookupTable: Map[String, List[RewritingRule]] = { Map(
-    // the order is only important to improve readability
+  lazy val ruleLookupTable: Map[String, List[RewritingRule]] = {
+    Map(
+        // the order is only important to improve readability
 
-    // substitution
-    key(NameEx("x"))
-      -> List(substRule),
-    key(tla.prime(NameEx("x")))
-      -> List(new PrimeRule(this)),
-
-    // assignment
-    key( OperEx( BmcOper.assign, tla.name("x"), tla.name("y") ) )
-      -> List( new AssignmentRule(this) ),
-
-    // constants
-    key(ValEx(TlaBool(true)))
-      -> List(new BuiltinConstRule(this)),
-    key(ValEx(TlaBoolSet))
-      -> List(new BuiltinConstRule(this)),
-    key(ValEx(TlaIntSet))
-      -> List(new BuiltinConstRule(this)),
-    key(ValEx(TlaNatSet))
-      -> List(new BuiltinConstRule(this)),
-    key(ValEx(TlaInt(1)))
-      -> List(new IntConstRule(this)),
-    key(ValEx(TlaStr("red")))
-      -> List(new StrConstRule(this)),
-
-    // logic
-    key(tla.eql(tla.name("x"), tla.name("y")))
-      -> List(new EqRule(this)),
-    key(tla.or(tla.name("x"), tla.name("y")))
-      -> List(new OrRule(this)),
-    key(tla.and(tla.name("x"), tla.name("y")))
-      -> List(new AndRule(this)),
-    key(tla.not(tla.name("x")))
-      -> List(new NegRule(this)),
-    key(OperEx(BmcOper.skolem, tla.exists(tla.name("x"),
-               tla.name("S"), tla.name("p"))))
-      -> List(new QuantRule(this)),
-    key(tla.exists(tla.name("x"), tla.name("S"), tla.name("p")))
-      -> List(new QuantRule(this)),
-    key(tla.forall(tla.name("x"), tla.name("S"), tla.name("p")))
-      -> List(new QuantRule(this)),
-    key(tla.choose(tla.name("x"), tla.name("S"), tla.name("p")))
-      -> List(new ChooseRule(this)),
-
-    // control flow
-    key(tla.ite(tla.name("cond"), tla.name("then"), tla.name("else")))
-      -> List(new IfThenElseRule(this)),
-    key(tla.letIn(tla.int(1), TlaOperDecl("A", List(), tla.int(2))))
-      -> List(new LetInRule(this)),
-      // TODO, rethink TlaOper.apply rule
-    key(tla.appDecl( TlaOperDecl("userOp", List(), tla.int(3)) ) ) ->
-      List(new UserOperRule(this)),
-
-    // sets
-    key(tla.in(tla.name("x"), tla.name("S")))
-      -> List( new SetInRule(this) ),
-    key(tla.enumSet(tla.name("x"))) ->
-      List(new SetCtorRule(this)),
-    key(tla.subseteq(tla.name("x"), tla.name("S")))
-      -> List(new SetInclusionRule(this)),
-    key(tla.cup(tla.name("X"), tla.name("Y")))
-      -> List(new SetCupRule(this)),
-    key(tla.filter(tla.name("x"), tla.name("S"), tla.name("p")))
-      -> List(new SetFilterRule(this)),
-    key(tla.map(tla.name("e"), tla.name("x"), tla.name("S")))
-      -> List(new SetMapRule(this)),
-    key(OperEx(BmcOper.expand, tla.name("X")))
-      -> List(new SetExpandRule(this)),
-    key(tla.powSet(tla.name("X")))
-      -> List(new PowSetCtorRule(this)),
-    key(tla.union(tla.enumSet()))
-      -> List(new SetUnionRule(this)),
-    key(tla.dotdot(tla.int(1), tla.int(10)))
-      -> List(new IntDotDotRule(this, intRangeCache)),
-
-    // integers
-    key(tla.lt(tla.int(1), tla.int(2)))
-      -> List(new IntCmpRule(this)),
-    key(tla.le(tla.int(1), tla.int(2)))
-      -> List(new IntCmpRule(this)),
-    key(tla.gt(tla.int(1), tla.int(2)))
-      -> List(new IntCmpRule(this)),
-    key(tla.ge(tla.int(1), tla.int(2)))
-      -> List(new IntCmpRule(this)),
-    key(tla.plus(tla.int(1), tla.int(2)))
-      -> List(new IntArithRule(this)),
-    key(tla.minus(tla.int(1), tla.int(2)))
-      -> List(new IntArithRule(this)),
-    key(tla.mult(tla.int(1), tla.int(2)))
-      -> List(new IntArithRule(this)),
-    key(tla.div(tla.int(1), tla.int(2)))
-      -> List(new IntArithRule(this)),
-    key(tla.mod(tla.int(1), tla.int(2)))
-      -> List(new IntArithRule(this)),
-    key(tla.exp(tla.int(2), tla.int(3)))
-      -> List(new IntArithRule(this)),
-    key(tla.uminus(tla.int(1)))
-      -> List(new IntArithRule(this)),
-
-    // functions
-    key(tla.funDef(tla.name("e"), tla.name("x"), tla.name("S")))
-      -> List(new FunCtorRule(this)),
-    key(tla.appFun(tla.name("f"), tla.name("x")))
-      -> List(new FunAppRule(this)),
-    key(tla.except(tla.name("f"), tla.int(1), tla.int(42)))
-      -> List(new FunExceptRule(this)),
-    key(tla.funSet(tla.name("X"), tla.name("Y")))
-      -> List(new FunSetCtorRule(this)),
-    key(tla.dom(tla.funDef(tla.name("e"), tla.name("x"), tla.name("S"))))
-      -> List(new DomainRule(this, intRangeCache)), // also works for records
-    key(tla.recFunDef(tla.name("e"), tla.name("x"), tla.name("S")))
-      -> List(new RecFunDefAndRefRule(this)),
-    key(tla.recFunRef())
-      -> List(new RecFunDefAndRefRule(this)),
-
-    // tuples, records, and sequences
-    key(tla.tuple(tla.name("x"), tla.int(2)))
-      -> List(new TupleOrSeqCtorRule(this)),
-    key(tla.enumFun(tla.str("a"), tla.int(2)))
-      -> List(new RecCtorRule(this)),
-    key(tla.head(tla.tuple(tla.name("x"))))
-      -> List(new SeqOpsRule(this)),
-    key(tla.tail(tla.tuple(tla.name("x"))))
-      -> List(new SeqOpsRule(this)),
-    key(tla.subseq(tla.tuple(tla.name("x")), tla.int(2), tla.int(4)))
-      -> List(new SeqOpsRule(this)),
-    key(tla.len(tla.tuple(tla.name("x"))))
-      -> List(new SeqOpsRule(this)),
-    key(tla.append(tla.tuple(tla.name("x")), tla.int(10)))
-      -> List(new SeqOpsRule(this)),
-    key(tla.concat(tla.name("Seq1"), tla.name("Seq2")))
-      -> List(new SeqOpsRule(this)),
-
-   // FiniteSets
-    key(OperEx(BmcOper.constCard, tla.ge(tla.card(tla.name("S")), tla.int(3))))
-      -> List(new CardinalityConstRule(this)),
-    key(OperEx(TlaFiniteSetOper.cardinality, tla.name("S")))
-      -> List(new CardinalityRule(this)),
-    key(OperEx(TlaFiniteSetOper.isFiniteSet, tla.name("S")))
-      -> List(new IsFiniteSetRule(this)),
-
-    // misc
-    key(OperEx(TlaOper.label, tla.str("lab"), tla.str("x")))
-      -> List(new LabelRule(this)),
-    key(OperEx(BmcOper.withType, tla.int(1), ValEx(TlaIntSet)))
-      -> List(new TypeAnnotationRule(this)),
-
-    // TLC
-    key(OperEx(TlcOper.print, tla.bool(true), tla.str("msg")))
-      -> List(new TlcRule(this)),
-    key(OperEx(TlcOper.printT, tla.str("msg")))
-      -> List(new TlcRule(this)),
-    key(OperEx(TlcOper.assert, tla.bool(true), tla.str("msg")))
-      -> List(new TlcRule(this)),
-    key(OperEx(TlcOper.colonGreater, tla.int(1), tla.int(2))) // :>
-      -> List(new TlcRule(this)),
-    key(OperEx(TlcOper.atat, NameEx("fun"), NameEx("pair")))  // @@
-      -> List(new TlcRule(this))
-  ) } ///// ADD YOUR RULES ABOVE
-
+        // substitution
+        key(NameEx("x"))
+          -> List(substRule),
+        key(tla.prime(NameEx("x")))
+          -> List(new PrimeRule(this)),
+        // assignment
+        key(OperEx(BmcOper.assign, tla.name("x"), tla.name("y")))
+          -> List(new AssignmentRule(this)),
+        // constants
+        key(ValEx(TlaBool(true)))
+          -> List(new BuiltinConstRule(this)),
+        key(ValEx(TlaBoolSet))
+          -> List(new BuiltinConstRule(this)),
+        key(ValEx(TlaIntSet))
+          -> List(new BuiltinConstRule(this)),
+        key(ValEx(TlaNatSet))
+          -> List(new BuiltinConstRule(this)),
+        key(ValEx(TlaInt(1)))
+          -> List(new IntConstRule(this)),
+        key(ValEx(TlaStr("red")))
+          -> List(new StrConstRule(this)),
+        // logic
+        key(tla.eql(tla.name("x"), tla.name("y")))
+          -> List(new EqRule(this)),
+        key(tla.or(tla.name("x"), tla.name("y")))
+          -> List(new OrRule(this)),
+        key(tla.and(tla.name("x"), tla.name("y")))
+          -> List(new AndRule(this)),
+        key(tla.not(tla.name("x")))
+          -> List(new NegRule(this)),
+        key(OperEx(BmcOper.skolem, tla.exists(tla.name("x"), tla.name("S"), tla.name("p"))))
+          -> List(new QuantRule(this)),
+        key(tla.exists(tla.name("x"), tla.name("S"), tla.name("p")))
+          -> List(new QuantRule(this)),
+        key(tla.forall(tla.name("x"), tla.name("S"), tla.name("p")))
+          -> List(new QuantRule(this)),
+        key(tla.choose(tla.name("x"), tla.name("S"), tla.name("p")))
+          -> List(new ChooseRule(this)),
+        // control flow
+        key(tla.ite(tla.name("cond"), tla.name("then"), tla.name("else")))
+          -> List(new IfThenElseRule(this)),
+        key(tla.letIn(tla.int(1), TlaOperDecl("A", List(), tla.int(2))))
+          -> List(new LetInRule(this)),
+        // TODO, rethink TlaOper.apply rule
+        key(tla.appDecl(TlaOperDecl("userOp", List(), tla.int(3)))) ->
+          List(new UserOperRule(this)),
+        // sets
+        key(tla.in(tla.name("x"), tla.name("S")))
+          -> List(new SetInRule(this)),
+        key(tla.enumSet(tla.name("x"))) ->
+          List(new SetCtorRule(this)),
+        key(tla.subseteq(tla.name("x"), tla.name("S")))
+          -> List(new SetInclusionRule(this)),
+        key(tla.cup(tla.name("X"), tla.name("Y")))
+          -> List(new SetCupRule(this)),
+        key(tla.filter(tla.name("x"), tla.name("S"), tla.name("p")))
+          -> List(new SetFilterRule(this)),
+        key(tla.map(tla.name("e"), tla.name("x"), tla.name("S")))
+          -> List(new SetMapRule(this)),
+        key(OperEx(BmcOper.expand, tla.name("X")))
+          -> List(new SetExpandRule(this)),
+        key(tla.powSet(tla.name("X")))
+          -> List(new PowSetCtorRule(this)),
+        key(tla.union(tla.enumSet()))
+          -> List(new SetUnionRule(this)),
+        key(tla.dotdot(tla.int(1), tla.int(10)))
+          -> List(new IntDotDotRule(this, intRangeCache)),
+        // integers
+        key(tla.lt(tla.int(1), tla.int(2)))
+          -> List(new IntCmpRule(this)),
+        key(tla.le(tla.int(1), tla.int(2)))
+          -> List(new IntCmpRule(this)),
+        key(tla.gt(tla.int(1), tla.int(2)))
+          -> List(new IntCmpRule(this)),
+        key(tla.ge(tla.int(1), tla.int(2)))
+          -> List(new IntCmpRule(this)),
+        key(tla.plus(tla.int(1), tla.int(2)))
+          -> List(new IntArithRule(this)),
+        key(tla.minus(tla.int(1), tla.int(2)))
+          -> List(new IntArithRule(this)),
+        key(tla.mult(tla.int(1), tla.int(2)))
+          -> List(new IntArithRule(this)),
+        key(tla.div(tla.int(1), tla.int(2)))
+          -> List(new IntArithRule(this)),
+        key(tla.mod(tla.int(1), tla.int(2)))
+          -> List(new IntArithRule(this)),
+        key(tla.exp(tla.int(2), tla.int(3)))
+          -> List(new IntArithRule(this)),
+        key(tla.uminus(tla.int(1)))
+          -> List(new IntArithRule(this)),
+        // functions
+        key(tla.funDef(tla.name("e"), tla.name("x"), tla.name("S")))
+          -> List(new FunCtorRule(this)),
+        key(tla.appFun(tla.name("f"), tla.name("x")))
+          -> List(new FunAppRule(this)),
+        key(tla.except(tla.name("f"), tla.int(1), tla.int(42)))
+          -> List(new FunExceptRule(this)),
+        key(tla.funSet(tla.name("X"), tla.name("Y")))
+          -> List(new FunSetCtorRule(this)),
+        key(tla.dom(tla.funDef(tla.name("e"), tla.name("x"), tla.name("S"))))
+          -> List(new DomainRule(this, intRangeCache)), // also works for records
+        key(tla.recFunDef(tla.name("e"), tla.name("x"), tla.name("S")))
+          -> List(new RecFunDefAndRefRule(this)),
+        key(tla.recFunRef())
+          -> List(new RecFunDefAndRefRule(this)),
+        // tuples, records, and sequences
+        key(tla.tuple(tla.name("x"), tla.int(2)))
+          -> List(new TupleOrSeqCtorRule(this)),
+        key(tla.enumFun(tla.str("a"), tla.int(2)))
+          -> List(new RecCtorRule(this)),
+        key(tla.head(tla.tuple(tla.name("x"))))
+          -> List(new SeqOpsRule(this)),
+        key(tla.tail(tla.tuple(tla.name("x"))))
+          -> List(new SeqOpsRule(this)),
+        key(tla.subseq(tla.tuple(tla.name("x")), tla.int(2), tla.int(4)))
+          -> List(new SeqOpsRule(this)),
+        key(tla.len(tla.tuple(tla.name("x"))))
+          -> List(new SeqOpsRule(this)),
+        key(tla.append(tla.tuple(tla.name("x")), tla.int(10)))
+          -> List(new SeqOpsRule(this)),
+        key(tla.concat(tla.name("Seq1"), tla.name("Seq2")))
+          -> List(new SeqOpsRule(this)),
+        // FiniteSets
+        key(OperEx(BmcOper.constCard, tla.ge(tla.card(tla.name("S")), tla.int(3))))
+          -> List(new CardinalityConstRule(this)),
+        key(OperEx(TlaFiniteSetOper.cardinality, tla.name("S")))
+          -> List(new CardinalityRule(this)),
+        key(OperEx(TlaFiniteSetOper.isFiniteSet, tla.name("S")))
+          -> List(new IsFiniteSetRule(this)),
+        // misc
+        key(OperEx(TlaOper.label, tla.str("lab"), tla.str("x")))
+          -> List(new LabelRule(this)),
+        key(OperEx(BmcOper.withType, tla.int(1), ValEx(TlaIntSet)))
+          -> List(new TypeAnnotationRule(this)),
+        // TLC
+        key(OperEx(TlcOper.print, tla.bool(true), tla.str("msg")))
+          -> List(new TlcRule(this)),
+        key(OperEx(TlcOper.printT, tla.str("msg")))
+          -> List(new TlcRule(this)),
+        key(OperEx(TlcOper.assert, tla.bool(true), tla.str("msg")))
+          -> List(new TlcRule(this)),
+        key(OperEx(TlcOper.colonGreater, tla.int(1), tla.int(2))) // :>
+          -> List(new TlcRule(this)),
+        key(OperEx(TlcOper.atat, NameEx("fun"), NameEx("pair"))) // @@
+          -> List(new TlcRule(this))
+    )
+  } ///// ADD YOUR RULES ABOVE
 
   /**
-    * Rewrite a symbolic expression by applying at most one rewriting rule.
-    *
-    * @param state a symbolic state
-    * @return the new symbolic state obtained by rewriting state
-    */
+   * Rewrite a symbolic expression by applying at most one rewriting rule.
+   *
+   * @param state a symbolic state
+   * @return the new symbolic state obtained by rewriting state
+   */
   def rewriteOnce(state: SymbState): RewritingResult = {
     state.ex match {
       case NameEx(name) if ArenaCell.isValidName(name) =>
@@ -325,8 +313,9 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
           var nextState = substRule.apply(substRule.logOnEntry(solverContext, state))
           nextState = substRule.logOnReturn(solverContext, nextState)
           if (nextState.arena.cellCount < state.arena.cellCount) {
-            throw new RewriterException("Implementation error: the number of cells decreased from %d to %d"
-              .format(state.arena.cellCount, nextState.arena.cellCount), state.ex)
+            throw new RewriterException(
+                "Implementation error: the number of cells decreased from %d to %d"
+                  .format(state.arena.cellCount, nextState.arena.cellCount), state.ex)
           }
           statListener.exitRule()
           Done(nextState)
@@ -344,8 +333,9 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
             statListener.enterRule(r.getClass.getSimpleName)
             val nextState = r.logOnReturn(solverContext, r.apply(r.logOnEntry(solverContext, state)))
             if (nextState.arena.cellCount < state.arena.cellCount) {
-              throw new RewriterException("Implementation error in rule %s: the number of cells decreased from %d to %d"
-                .format(r.getClass.getSimpleName, state.arena.cellCount, nextState.arena.cellCount), state.ex)
+              throw new RewriterException(
+                  "Implementation error in rule %s: the number of cells decreased from %d to %d"
+                    .format(r.getClass.getSimpleName, state.arena.cellCount, nextState.arena.cellCount), state.ex)
             }
             statListener.exitRule()
             Continue(nextState)
@@ -357,18 +347,19 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   }
 
   /**
-    * Rewrite one expression until converged to a single cell, or no rule applies.
-    *
-    * @param state a state to rewrite
-    * @return the final state
-    * @throws RewriterException if no rule applies
-    */
+   * Rewrite one expression until converged to a single cell, or no rule applies.
+   *
+   * @param state a state to rewrite
+   * @return the final state
+   * @throws RewriterException if no rule applies
+   */
   def rewriteUntilDone(state: SymbState): SymbState = {
     // the main reason for using a recursive function here instead of a loop is that it is easier to debug
     def doRecursive(ncalls: Int, st: SymbState): SymbState = {
       if (ncalls >= Limits.RECURSION_LIMIT) {
-        throw new RewriterException("Recursion limit of %d steps is reached. A cycle in the rewriting system?"
-          .format(Limits.RECURSION_LIMIT), state.ex)
+        throw new RewriterException(
+            "Recursion limit of %d steps is reached. A cycle in the rewriting system?"
+              .format(Limits.RECURSION_LIMIT), state.ex)
       } else {
         rewritingStack +:= state.ex // push the expression on the stack
         rewriteOnce(st) match {
@@ -403,19 +394,21 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
         // as the new expressions there will not have source information.
         val smtWatermark = solverContext.metrics()
         val nextState = doRecursive(0, state)
-        profilerListener.foreach{ _.onRewrite(state.ex, solverContext.metrics().delta(smtWatermark)) }
+        profilerListener.foreach {
+          _.onRewrite(state.ex, solverContext.metrics().delta(smtWatermark))
+        }
         exprCache.put(state.ex, nextState.ex) // the grade is not important
         nextState
     }
   }
 
   /**
-    * Rewrite all expressions in a sequence.
-    *
-    * @param state a state to start with
-    * @param es    a sequence of expressions to rewrite
-    * @return a pair (the new state with the original expression, the rewritten expressions)
-    */
+   * Rewrite all expressions in a sequence.
+   *
+   * @param state a state to start with
+   * @param es    a sequence of expressions to rewrite
+   * @return a pair (the new state with the original expression, the rewritten expressions)
+   */
   def rewriteSeqUntilDone(state: SymbState, es: Seq[TlaEx]): (SymbState, Seq[TlaEx]) = {
     var newState = state // it is easier to write this code with a side effect on the state
     // we should be very careful about propagating arenas here
@@ -431,12 +424,12 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   }
 
   /**
-    * An extended version of rewriteSeqUntilDone, where expressions are accompanied with bindings.
-    *
-    * @param state a state to start with
-    * @param es    a sequence of expressions to rewrite accompanied with bindings
-    * @return a pair (the old state in a new context, the rewritten expressions)
-    */
+   * An extended version of rewriteSeqUntilDone, where expressions are accompanied with bindings.
+   *
+   * @param state a state to start with
+   * @param es    a sequence of expressions to rewrite accompanied with bindings
+   * @return a pair (the old state in a new context, the rewritten expressions)
+   */
   def rewriteBoundSeqUntilDone(state: SymbState, es: Seq[(Binding, TlaEx)]): (SymbState, Seq[TlaEx]) = {
     var newState = state // it is easier to write this code with a side effect on the state
     // we should be very careful about propagating arenas here
@@ -453,24 +446,22 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
   /**
-    * Take a snapshot and return it
-    *
-    * @return the snapshot
-    */
+   * Take a snapshot and return it
+   *
+   * @return the snapshot
+   */
   override def snapshot(): SymbStateRewriterSnapshot = {
-    new SymbStateRewriterSnapshot(typeFinder.asInstanceOf[TrivialTypeFinder].snapshot(),
-      intValueCache.snapshot(),
-      intRangeCache.snapshot(), strValueCache.snapshot(), recordDomainCache.snapshot(), exprCache.snapshot())
+    new SymbStateRewriterSnapshot(typeFinder.asInstanceOf[TrivialTypeFinder].snapshot(), intValueCache.snapshot(),
+        intRangeCache.snapshot(), strValueCache.snapshot(), recordDomainCache.snapshot(), exprCache.snapshot())
   }
 
   /**
-    * Recover a previously saved snapshot (not necessarily saved by this object).
-    * Note that caches have a reference to SolverContext, which is not recovered!
-    *
-    * @param shot a snapshot
-    */
+   * Recover a previously saved snapshot (not necessarily saved by this object).
+   * Note that caches have a reference to SolverContext, which is not recovered!
+   *
+   * @param shot a snapshot
+   */
   override def recover(shot: SymbStateRewriterSnapshot): Unit = {
     typeFinder.asInstanceOf[TrivialTypeFinder].recover(shot.typeFinderSnapshot)
     intValueCache.recover(shot.intValueCacheSnapshot)
@@ -479,9 +470,10 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
     recordDomainCache.recover(shot.recordDomainCache)
     exprCache.recover(shot.exprCacheSnapshot)
   }
-/**
-    * Save the current context and push it on the stack for a later recovery with pop.
-    */
+
+  /**
+   * Save the current context and push it on the stack for a later recovery with pop.
+   */
   override def push(): Unit = {
     level += 1
     intValueCache.push()
@@ -494,9 +486,9 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   }
 
   /**
-    * Pop the previously saved context. Importantly, pop may be called multiple times and thus it is not sufficient
-    * to save only the latest context.
-    */
+   * Pop the previously saved context. Importantly, pop may be called multiple times and thus it is not sufficient
+   * to save only the latest context.
+   */
   override def pop(): Unit = {
     assert(level > 0)
     intValueCache.pop()
@@ -510,10 +502,10 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   }
 
   /**
-    * Call pop several times.
-    *
-    * @param n the number of times to call pop
-    */
+   * Call pop several times.
+   *
+   * @param n the number of times to call pop
+   */
   override def pop(n: Int): Unit = {
     assert(level >= n)
     intValueCache.pop(n)
@@ -531,8 +523,8 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   }
 
   /**
-    * Clean the context
-    */
+   * Clean the context
+   */
   override def dispose(): Unit = {
     flushStatistics()
     exprCache.dispose()
@@ -545,44 +537,42 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
     profilerListener.foreach { _.dispose() }
   }
 
-
   /**
-    * Add a text message to the storage.
-    *
-    * @param id      an id of the object, e.g., ArenaCell.id
-    * @param message a text message
-    */
+   * Add a text message to the storage.
+   *
+   * @param id      an id of the object, e.g., ArenaCell.id
+   * @param message a text message
+   */
   override def addMessage(id: Int, message: String): Unit = {
     messages += id -> message
   }
 
   /**
-    * Find a message associated with the given id
-    *
-    * @param id an id of the object, e.g., ArenaCell.id
-    * @return a text message, if exists
-    * @throws NoSuchElementException if there is no message associated with the given id
-    */
+   * Find a message associated with the given id
+   *
+   * @param id an id of the object, e.g., ArenaCell.id
+   * @return a text message, if exists
+   * @throws NoSuchElementException if there is no message associated with the given id
+   */
   override def findMessage(id: Int): String = {
     messages(id)
   }
 
-
   /**
-    * Get the stack of expressions that is generated by the methods rewrite(.*)UntilDone.
-    * This stack is non-empty only during the rewriting process.
-    * Basically, it is only useful if the rewriter has thrown an exception.
-    *
-    * @return a list of TLA+ expressions
-    */
+   * Get the stack of expressions that is generated by the methods rewrite(.*)UntilDone.
+   * This stack is non-empty only during the rewriting process.
+   * Basically, it is only useful if the rewriter has thrown an exception.
+   *
+   * @return a list of TLA+ expressions
+   */
   override def getRewritingStack(): Seq[TlaEx] = rewritingStack
 
   /**
-    * Compute a key of a TLA+ expression to quickly decide on a short sequence of rules to try.
-    *
-    * @param ex a TLA+ expression
-    * @return a string that gives us an equivalence class for similar operations (see the code)
-    */
+   * Compute a key of a TLA+ expression to quickly decide on a short sequence of rules to try.
+   *
+   * @param ex a TLA+ expression
+   * @return a string that gives us an equivalence class for similar operations (see the code)
+   */
   private def key(ex: TlaEx): String = {
     ex match {
       // TODO: Is this correct?

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
@@ -6,24 +6,25 @@ import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.DeepCopy
 import at.forsyte.apalache.tla.pp.NormalizedNames
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * Generator of verification conditions. In the current implementation, VCGenerator takes an invariant candidate,
-  * decomposes the invariant into smaller invariant candidates and produces negations of the invariant candidates.
-  * In the future, we would temporal formulas as well.
-  *
-  * @author Igor Konnov
-  */
+ * Generator of verification conditions. In the current implementation, VCGenerator takes an invariant candidate,
+ * decomposes the invariant into smaller invariant candidates and produces negations of the invariant candidates.
+ * In the future, we would temporal formulas as well.
+ *
+ * @author Igor Konnov
+ */
 class VCGenerator(tracker: TransformationTracker) extends LazyLogging {
 
   /**
-    * Given a module and the name of an invariant candidate, add verification conditions in the module.
-    *
-    * @param module an input module
-    * @param invName the name of an invariant
-    * @return a transformed module
-    */
+   * Given a module and the name of an invariant candidate, add verification conditions in the module.
+   *
+   * @param module  an input module
+   * @param invName the name of an invariant
+   * @return a transformed module
+   */
   def gen(module: TlaModule, invName: String): TlaModule = {
     module.declarations.find(_.name == invName) match {
       case Some(inv: TlaOperDecl) if inv.formalParams.isEmpty =>
@@ -46,7 +47,8 @@ class VCGenerator(tracker: TransformationTracker) extends LazyLogging {
     def mapToDecls(smallInv: TlaEx, index: Int): Seq[TlaOperDecl] = {
       val deepCopy = DeepCopy(tracker)
       val positive = TlaOperDecl(NormalizedNames.VC_INV_PREFIX + index, List(), deepCopy.deepCopyEx(smallInv))
-      val negative = TlaOperDecl(NormalizedNames.VC_NOT_INV_PREFIX + index, List(), tla.not(deepCopy.deepCopyEx(smallInv)))
+      val negative =
+        TlaOperDecl(NormalizedNames.VC_NOT_INV_PREFIX + index, List(), tla.not(deepCopy.deepCopyEx(smallInv)))
       Seq(positive, negative)
     }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -4,23 +4,24 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.KeraLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * <p>This analysis tracks down the exponentially expensive expressions such as SUBSET S and [S -> T].
-  * When such an expression has to be expanded in the arena, the expression is wrapped with BmcOper!Expand.
-  * The user also receives a warning that this operation is going to be expensive.</p>
-  *
-  * <p>TODO: This is a simple form of constraint generation. Perhaps, we should lift the rewriting framework
-  * to collecting constraints, rather than eagerly and lazily expanding the sets.</p>
-  *
-  * <p>It is a simple form of type inference on top of our type system.
-  *    Can we integrate this class into the type system?</p>
-  *
-  * @author Igor Konnov
-  */
-class ExpansionMarker @Inject()(tracker: TransformationTracker) extends TlaExTransformation with LazyLogging {
+ * <p>This analysis tracks down the exponentially expensive expressions such as SUBSET S and [S -> T].
+ * When such an expression has to be expanded in the arena, the expression is wrapped with BmcOper!Expand.
+ * The user also receives a warning that this operation is going to be expensive.</p>
+ *
+ * <p>TODO: This is a simple form of constraint generation. Perhaps, we should lift the rewriting framework
+ * to collecting constraints, rather than eagerly and lazily expanding the sets.</p>
+ *
+ * <p>It is a simple form of type inference on top of our type system.
+ * Can we integrate this class into the type system?</p>
+ *
+ * @author Igor Konnov
+ */
+class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTransformation with LazyLogging {
 
   override def apply(e: TlaEx): TlaEx = {
     LanguageWatchdog(KeraLanguagePred()).check(e)
@@ -54,8 +55,7 @@ class ExpansionMarker @Inject()(tracker: TransformationTracker) extends TlaExTra
     // simple propagation analysis that tells us what to expand
     case OperEx(op @ BmcOper.`skolem`, OperEx(TlaBoolOper.exists, name, set, pred)) =>
       // a skolemizable existential is allowed to keep its set unexpanded
-      OperEx(op,
-        OperEx(TlaBoolOper.exists, name, transform(false)(set), transform(false)(pred)))
+      OperEx(op, OperEx(TlaBoolOper.exists, name, transform(false)(set), transform(false)(pred)))
 
     case OperEx(op @ TlaOper.chooseBounded, name, set, pred) =>
       // CHOOSE is essentially a skolemizable existential with the constraint of uniqueness
@@ -77,13 +77,12 @@ class ExpansionMarker @Inject()(tracker: TransformationTracker) extends TlaExTra
       // For the moment, we require the set to be expanded. However, we could think of collecting constraints on the way.
       OperEx(op, name, transform(true)(set), transform(false)(pred))
 
-    case OperEx(op, body, args @ _*)
-        if op == TlaSetOper.map || op == TlaFunOper.funDef || op == TlaFunOper.recFunDef =>
+    case OperEx(op, body, args @ _*) if op == TlaSetOper.map || op == TlaFunOper.funDef || op == TlaFunOper.recFunDef =>
       val tbody: TlaEx = transform(false)(body)
       val targs = args map transform(true)
       OperEx(op, tbody +: targs: _*)
 
-    case LetInEx(body, defs@_*) =>
+    case LetInEx(body, defs @ _*) =>
       // at this point, we only have nullary let-in definitions
       def mapDef(df: TlaOperDecl) = {
         TlaOperDecl(df.name, df.formalParams, transform(shallExpand)(df.body))
@@ -95,7 +94,7 @@ class ExpansionMarker @Inject()(tracker: TransformationTracker) extends TlaExTra
       // transform the expression, but not the annotation! See https://github.com/informalsystems/apalache/issues/292
       OperEx(BmcOper.withType, transform(shallExpand)(expr), annot)
 
-    case OperEx(oper, args@_*) =>
+    case OperEx(oper, args @ _*) =>
       // try to descend in the children, which may contain Boolean operations, e.g., { \E x \in S: P }
       OperEx(oper, args map transform(shallExpand): _*)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
@@ -2,28 +2,29 @@ package at.forsyte.apalache.tla.bmcmt.analyses
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaActionOper, TlaBoolOper, TlaTempOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 
 /**
-  * An analysis that computes expression grades, which are used by the rewriter's caches.
-  *
-  * TODO: add tests
-  *
-  * @author Igor Konnov
-  */
-class ExprGradeAnalysis @Inject()(val store: ExprGradeStoreImpl) {
+ * An analysis that computes expression grades, which are used by the rewriter's caches.
+ *
+ * TODO: add tests
+ *
+ * @author Igor Konnov
+ */
+class ExprGradeAnalysis @Inject() (val store: ExprGradeStoreImpl) {
   private def update(e: TlaEx, grade: ExprGrade.Value): ExprGrade.Value = {
     store.store.update(e.ID, grade)
     grade
   }
 
   /**
-    * Label all subexpressions of an expression with their grades. The grades are stored in the store.
-    *
-    * @param consts names that are treated as TLA+ constants
-    * @param vars   names that are treated as TLA+ variables
-    * @param expr   an expression to label
-    */
+   * Label all subexpressions of an expression with their grades. The grades are stored in the store.
+   *
+   * @param consts names that are treated as TLA+ constants
+   * @param vars   names that are treated as TLA+ variables
+   * @param expr   an expression to label
+   */
   def labelExpr(consts: Set[String], vars: Set[String], expr: TlaEx): ExprGrade.Value = {
     def eachExpr(e: TlaEx): ExprGrade.Value = e match {
       case ValEx(_) =>
@@ -48,18 +49,16 @@ class ExprGradeAnalysis @Inject()(val store: ExprGradeStoreImpl) {
         // e.g., x'
         update(e, ExprGrade.join(ExprGrade.ActionFree, eachExpr(arg)))
 
-      case OperEx(TlaTempOper.AA, _*) | OperEx(TlaTempOper.EE, _*)
-           | OperEx(TlaTempOper.box, _*) | OperEx(TlaTempOper.diamond, _*)
-           | OperEx(TlaTempOper.guarantees, _*) | OperEx(TlaTempOper.leadsTo, _*)
-           | OperEx(TlaTempOper.strongFairness, _*)
-           | OperEx(TlaTempOper.weakFairness, _*) =>
+      case OperEx(TlaTempOper.AA, _*) | OperEx(TlaTempOper.EE, _*) | OperEx(TlaTempOper.box, _*) |
+          OperEx(TlaTempOper.diamond, _*) | OperEx(TlaTempOper.guarantees, _*) | OperEx(TlaTempOper.leadsTo, _*) |
+          OperEx(TlaTempOper.strongFairness, _*) | OperEx(TlaTempOper.weakFairness, _*) =>
         e.asInstanceOf[OperEx].args.foreach(eachExpr)
         update(e, ExprGrade.Higher)
 
       case OperEx(_) =>
         update(e, ExprGrade.Constant)
 
-      case OperEx(_, args@_*) =>
+      case OperEx(_, args @ _*) =>
         val grades = args map eachExpr
         update(e, grades reduce ExprGrade.join)
 
@@ -71,10 +70,11 @@ class ExprGradeAnalysis @Inject()(val store: ExprGradeStoreImpl) {
   }
 
   /**
-    * Replace disjunctions with orParallel when the expression is action-level or higher.
-    * @param expr a TLA+ expression
-    * @return an updated expression, all grades are updated if needed.
-    */
+   * Replace disjunctions with orParallel when the expression is action-level or higher.
+   *
+   * @param expr a TLA+ expression
+   * @return an updated expression, all grades are updated if needed.
+   */
   def refineOrInExpr(expr: TlaEx): TlaEx = {
     expr match {
       case OperEx(TlaBoolOper.or, args @ _*) =>
@@ -88,7 +88,7 @@ class ExprGradeAnalysis @Inject()(val store: ExprGradeStoreImpl) {
         }
 
       case OperEx(oper, args @ _*) =>
-        OperEx(oper, args map refineOrInExpr :_*)
+        OperEx(oper, args map refineOrInExpr: _*)
 
       case _ =>
         expr

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/SkolemizationMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/SkolemizationMarker.scala
@@ -3,28 +3,30 @@ package at.forsyte.apalache.tla.bmcmt.analyses
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.values.TlaInt
 
 /**
-  * <p>The skolemization analysis finds the existential quantifiers that can be safely replace by constants
-  * (Skolemizable). This class is not a pure analysis but a transformer, that is, it modifies an argument expression.
-  * Additionally, this analysis finds the cardinality comparisons like Cardinality(S) >= 4 that can be checked
-  * more optimally than the direct computation of the cardinalities.</p>
-  *
-  * <p>The previous version of this class was storing the identifiers of the Skolemizable expressions.
-  * This had two disadvantages: (1) the code carried around the respective analysis store, and (2) the Skolemizable
-  * expressions were not visible to the user in the intermediate output. By wrapping Skolemizable expressions
-  * with skolemExists, we solve the problem more elegantly.</p>
-  *
-  * @author Igor Konnov
-  */
-class SkolemizationMarker @Inject()(tracker: TransformationTracker)
-    extends TlaExTransformation with LazyLogging {
+ * <p>The skolemization analysis finds the existential quantifiers that can be safely replace by constants
+ * (Skolemizable). This class is not a pure analysis but a transformer, that is, it modifies an argument expression.
+ * Additionally, this analysis finds the cardinality comparisons like Cardinality(S) >= 4 that can be checked
+ * more optimally than the direct computation of the cardinalities.</p>
+ *
+ * <p>The previous version of this class was storing the identifiers of the Skolemizable expressions.
+ * This had two disadvantages: (1) the code carried around the respective analysis store, and (2) the Skolemizable
+ * expressions were not visible to the user in the intermediate output. By wrapping Skolemizable expressions
+ * with skolemExists, we solve the problem more elegantly.</p>
+ *
+ * @author Igor Konnov
+ */
+class SkolemizationMarker @Inject() (tracker: TransformationTracker) extends TlaExTransformation with LazyLogging {
 
-  override def apply(e: TlaEx): TlaEx = { transform(e) }
+  override def apply(e: TlaEx): TlaEx = {
+    transform(e)
+  }
 
   def transform: TlaExTransformation = tracker.trackEx {
     case OperEx(TlaBoolOper.exists, name, set, pred) =>
@@ -42,25 +44,26 @@ class SkolemizationMarker @Inject()(tracker: TransformationTracker)
     case ex @ OperEx(TlaBoolOper.not, _) =>
       ex // stop here. This should be a leaf (and rare) expression, as we are dealing with the NNF.
 
-    case OperEx(TlaBoolOper.and, args@_*) =>
-      tla.and(args map transform :_*)
+    case OperEx(TlaBoolOper.and, args @ _*) =>
+      tla.and(args map transform: _*)
 
-    case OperEx(TlaBoolOper.or, args@_*) =>
-      tla.or(args map transform :_*)
+    case OperEx(TlaBoolOper.or, args @ _*) =>
+      tla.or(args map transform: _*)
 
     case OperEx(TlaControlOper.ifThenElse, cond, left, right) =>
       // try to identify existentials in the both arms
       tla.ite(cond, transform(left), transform(right))
-      // We omit skolemization of the existentials in the predicate,
-      // as the predicate is used in both the negated and non-negated forms.
-      // Effectively, IF-THEN-ELSE requires both \E and \A forms
+    // We omit skolemization of the existentials in the predicate,
+    // as the predicate is used in both the negated and non-negated forms.
+    // Effectively, IF-THEN-ELSE requires both \E and \A forms
 
     case LetInEx(body, defs @ _*) =>
       // at this point, we only have nullary let-in definitions
       def mapDef(df: TlaOperDecl) = {
         TlaOperDecl(df.name, df.formalParams, transform(df.body))
       }
-      LetInEx(transform(body), defs map mapDef :_*)
+
+      LetInEx(transform(body), defs map mapDef: _*)
 
     case ex @ OperEx(oper, args @ _*) =>
       // bugfix for #148: do not descend into value expressions, as Skolemization of non-formulas is unsound

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
@@ -6,12 +6,13 @@ import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * A cache for integer constants that maps an integer to an integer constant in SMT.
-  *
-  * @author Igor Konnov
-  */
+ * A cache for integer constants that maps an integer to an integer constant in SMT.
+ *
+ * @author Igor Konnov
+ */
 class IntValueCache(solverContext: SolverContext) extends AbstractCache[Arena, BigInt, ArenaCell] with Serializable {
 
   def create(arena: Arena, intValue: BigInt): (Arena, ArenaCell) = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
@@ -10,24 +10,24 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.ModuleByExTransformer
 import at.forsyte.apalache.tla.lir.{NullEx, TlaAssumeDecl, TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * Find free-standing existential quantifiers, grade expressions, and produce hints about some formulas.
-  */
-class AnalysisPassImpl @Inject()(val options: PassOptions,
-                                 hintsStoreImpl: FormulaHintsStoreImpl,
-                                 exprGradeStoreImpl: ExprGradeStoreImpl,
-                                 tracker: TransformationTracker,
-                                 @Named("AfterAnalysis") nextPass: Pass with TlaModuleMixin)
-  extends AnalysisPass with LazyLogging {
+ * Find free-standing existential quantifiers, grade expressions, and produce hints about some formulas.
+ */
+class AnalysisPassImpl @Inject() (val options: PassOptions, hintsStoreImpl: FormulaHintsStoreImpl,
+    exprGradeStoreImpl: ExprGradeStoreImpl, tracker: TransformationTracker,
+    @Named("AfterAnalysis") nextPass: Pass with TlaModuleMixin)
+    extends AnalysisPass with LazyLogging {
+
   /**
-    * The pass name.
-    *
-    * @return the name associated with the pass
-    */
+   * The pass name.
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "AnalysisPass"
 
   object StringOrdering extends Ordering[Object] {
@@ -35,10 +35,10 @@ class AnalysisPassImpl @Inject()(val options: PassOptions,
   }
 
   /**
-    * Run the pass.
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass.
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     if (tlaModule.isEmpty) {
       throw new CheckerException(s"The input of $name pass is not initialized", NullEx)
@@ -46,15 +46,14 @@ class AnalysisPassImpl @Inject()(val options: PassOptions,
 
     val transformationSequence =
       List(
-        new SkolemizationMarker(tracker),
-        new ExpansionMarker(tracker)
+          new SkolemizationMarker(tracker),
+          new ExpansionMarker(tracker)
       ) ///
 
     logger.info(" > Marking skolemizable existentials and sets to be expanded...")
-    val marked = transformationSequence.foldLeft(tlaModule.get) {
-      case (m, tr) =>
-        logger.info("  > %s".format(tr.getClass.getSimpleName))
-        ModuleByExTransformer(tr).apply(m)
+    val marked = transformationSequence.foldLeft(tlaModule.get) { case (m, tr) =>
+      logger.info("  > %s".format(tr.getClass.getSimpleName))
+      ModuleByExTransformer(tr).apply(m)
     }
 
     logger.info(" > Running analyzers...")
@@ -71,9 +70,9 @@ class AnalysisPassImpl @Inject()(val options: PassOptions,
     }
 
     marked.declarations.foreach {
-      case d: TlaOperDecl => analyzeExpr(d.body)
+      case d: TlaOperDecl   => analyzeExpr(d.body)
       case a: TlaAssumeDecl => analyzeExpr(a.body)
-      case _ => ()
+      case _                => ()
     }
 
     nextPass.setModule(marked)
@@ -88,11 +87,11 @@ class AnalysisPassImpl @Inject()(val options: PassOptions,
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     Some(nextPass)
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
@@ -8,32 +8,32 @@ import at.forsyte.apalache.tla.bmcmt.{CheckerException, VCGenerator}
 import at.forsyte.apalache.tla.lir.NullEx
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * The pass that generates verification conditions.
-  *
-  * @author Igor Konnov
-  */
-class VCGenPassImpl @Inject()(options: PassOptions,
-                              tracker: TransformationTracker,
-                              @Named("AfterVCGen") nextPass: Pass with TlaModuleMixin)
-  extends VCGenPass with LazyLogging {
+ * The pass that generates verification conditions.
+ *
+ * @author Igor Konnov
+ */
+class VCGenPassImpl @Inject() (options: PassOptions, tracker: TransformationTracker,
+    @Named("AfterVCGen") nextPass: Pass with TlaModuleMixin)
+    extends VCGenPass with LazyLogging {
 
   /**
-    * The pass name.
-    *
-    * @return the name associated with the pass
-    */
+   * The pass name.
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "VCGen"
 
   /**
-    * Run the pass.
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass.
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     if (tlaModule.isEmpty) {
       throw new CheckerException(s"The input of $name pass is not initialized", NullEx)
@@ -42,7 +42,7 @@ class VCGenPassImpl @Inject()(options: PassOptions,
     val newModule =
       options.get[List[String]]("checker", "inv") match {
         case Some(invariants) =>
-          invariants.foldLeft(tlaModule.get){ (mod, invName) =>
+          invariants.foldLeft(tlaModule.get) { (mod, invName) =>
             logger.info(s"  > Producing verification conditions from the invariant $invName")
             new VCGenerator(tracker).gen(mod, invName)
           }
@@ -59,11 +59,11 @@ class VCGenPassImpl @Inject()(options: PassOptions,
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     Some(nextPass)
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
@@ -1,44 +1,44 @@
 package at.forsyte.apalache.tla.bmcmt.rewriter
 
 import at.forsyte.apalache.tla.bmcmt.Arena
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.ConstSimplifierBase
 
 /**
-  * <p>A simplifier of constant TLA+ expressions, e.g., rewriting 1 + 2 to 3.
-  * This simplifier is using some knowledge about SMT.</p>
-  *
-  * <p>Bugfix #450: make sure that the integers are simplified with BigInt.</p>
-  *
-  * @author Igor Konnov
-  */
+ * <p>A simplifier of constant TLA+ expressions, e.g., rewriting 1 + 2 to 3.
+ * This simplifier is using some knowledge about SMT.</p>
+ *
+ * <p>Bugfix #450: make sure that the integers are simplified with BigInt.</p>
+ *
+ * @author Igor Konnov
+ */
 class ConstSimplifierForSmt extends ConstSimplifierBase {
   def isFalseConst(ex: TlaEx): Boolean = {
     ex match {
       case ValEx(TlaBool(false)) => true
-      case NameEx(name) => name == Arena.falseName
-      case _ => false
+      case NameEx(name)          => name == Arena.falseName
+      case _                     => false
     }
   }
 
   def isTrueConst(ex: TlaEx): Boolean = {
     ex match {
       case ValEx(TlaBool(true)) => true
-      case NameEx(name) => name == Arena.trueName
-      case _ => false
+      case NameEx(name)         => name == Arena.trueName
+      case _                    => false
     }
   }
 
   def isBoolConst(ex: TlaEx): Boolean = isFalseConst(ex) || isTrueConst(ex)
 
   /**
-    * A shallow simplification that does not recurse into the expression structure.
-    */
+   * A shallow simplification that does not recurse into the expression structure.
+   */
   override def simplifyShallow: TlaEx => TlaEx = {
-      // Here we only do SMT-specific simplifications. The general simplifications are done in the parent.
+    // Here we only do SMT-specific simplifications. The general simplifications are done in the parent.
 
     case ex @ (NameEx(_) | ValEx(_)) =>
       if (isFalseConst(ex)) {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/BuiltinConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/BuiltinConstRule.scala
@@ -4,17 +4,18 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.{NameEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Rewriting BOOLEAN, Int, and Nat into predefined cells.
-  *
-  * @author Igor Konnov
-   */
+ * Rewriting BOOLEAN, Int, and Nat into predefined cells.
+ *
+ * @author Igor Konnov
+ */
 class BuiltinConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
-      case ValEx(TlaBool(false)) | ValEx(TlaBool(true))
-           | ValEx(TlaBoolSet) | ValEx(TlaNatSet) | ValEx(TlaIntSet) => true
+      case ValEx(TlaBool(false)) | ValEx(TlaBool(true)) | ValEx(TlaBoolSet) | ValEx(TlaNatSet) | ValEx(TlaIntSet) =>
+        true
       case _ => false
     }
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
@@ -8,20 +8,20 @@ import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaArithOper, TlaFiniteSetOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
-
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Optimization for Cardinality(S) >= k, where k is constant. See [docs/smt/Cardinality.md].
-  *
-  * @author Igor Konnov
-  */
+ * Optimization for Cardinality(S) >= k, where k is constant. See [docs/smt/Cardinality.md].
+ *
+ * @author Igor Konnov
+ */
 class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val pickRule = new CherryPick(rewriter)
 
   override def isApplicable(state: SymbState): Boolean = {
     state.ex match {
-      case OperEx(BmcOper.constCard,
-      OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, _), ValEx(TlaInt(_)))) =>
+      case OperEx(BmcOper.constCard, OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, _), ValEx(
+                      TlaInt(_)))) =>
         true
 
       case _ =>
@@ -31,8 +31,8 @@ class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
-      case OperEx(BmcOper.constCard,
-      OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, setEx), ValEx(TlaInt(thresholdBigInt)))) =>
+      case OperEx(BmcOper.constCard, OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, setEx), ValEx(
+                      TlaInt(thresholdBigInt)))) =>
         val threshold = thresholdBigInt.toInt
         var nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
         val setCell = nextState.asCell
@@ -56,7 +56,7 @@ class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
     var nextState = state
     nextState = nextState.updateArena(_.appendCell(BoolT()))
     val emptyPred = nextState.arena.topCell
-    solverAssert(tla.eql(emptyPred, tla.and(elems.map(e => tla.not(tla.in(e.toNameEx, set.toNameEx))) :_*)))
+    solverAssert(tla.eql(emptyPred, tla.and(elems.map(e => tla.not(tla.in(e.toNameEx, set.toNameEx))): _*)))
 
     // pick `threshold` cells that will act as witnesses
     def pick(i: Int): ArenaCell = {
@@ -72,7 +72,7 @@ class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
     // create the inequality predicate
     val witnesses = 1.to(threshold).map(pick).toList
     (witnesses cross witnesses).filter(p => p._1.id < p._2.id).foreach(cacheEq)
-    val witnessesNotEq = OperEx(BmcOper.distinct, witnesses.map(_.toNameEx) :_*)
+    val witnessesNotEq = OperEx(BmcOper.distinct, witnesses.map(_.toNameEx): _*)
     nextState = nextState.updateArena(_.appendCell(BoolT()))
     val pred = nextState.arena.topCell
     // either the set is empty and threshold <= 0, or all witnesses are not equal to each other

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -7,12 +7,13 @@ import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Rewriting EXCEPT for functions, tuples, and records.
-  *
-  * @author Igor Konnov
-  */
+ * Rewriting EXCEPT for functions, tuples, and records.
+ *
+ * @author Igor Konnov
+ */
 class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private def cacheEq(s: SymbState, l: ArenaCell, r: ArenaCell) = rewriter.lazyEq.cacheOneEqConstraint(s, l, r)
 
@@ -21,13 +22,13 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaFunOper.except, _*) => true
-      case _ => false
+      case _                             => false
     }
   }
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
-      case OperEx(TlaFunOper.except, args@_*) =>
+      case OperEx(TlaFunOper.except, args @ _*) =>
         val funEx = args.head
         val indexEs = args.tail.zipWithIndex.filter(_._2 % 2 == 0).map(_._1)
         // first, unpack singleton tuples in indices, see the comment to the method
@@ -39,17 +40,19 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val (groundState: SymbState, groundArgs: Seq[TlaEx]) =
           rewriter.rewriteSeqUntilDone(state, funEx +: (unpackedIndices ++ valEs))
         val funCell = groundState.arena.findCellByNameEx(groundArgs.head)
-        val indexCells = groundArgs.slice(1, 1 + unpackedIndices.size)
+        val indexCells = groundArgs
+          .slice(1, 1 + unpackedIndices.size)
           .map(groundState.arena.findCellByNameEx)
         val valueCells = groundArgs
           .slice(1 + unpackedIndices.size, 1 + unpackedIndices.size + valEs.size)
           .map(groundState.arena.findCellByNameEx)
         funCell.cellType match {
-          case FunT(_, _) => rewriteFun(groundState, funCell, indexCells, valueCells)
+          case FunT(_, _)      => rewriteFun(groundState, funCell, indexCells, valueCells)
           case rt @ RecordT(_) => rewriteRec(groundState, funCell, rt, unpackedIndices, valueCells)
-          case tt @ TupleT(_) => rewriteTuple(groundState, funCell, tt, unpackedIndices, valueCells)
-          case _ => throw new NotImplementedError(
-            s"EXCEPT is not implemented for ${funCell.cellType}. Write a feature request.")
+          case tt @ TupleT(_)  => rewriteTuple(groundState, funCell, tt, unpackedIndices, valueCells)
+          case _ =>
+            throw new NotImplementedError(
+                s"EXCEPT is not implemented for ${funCell.cellType}. Write a feature request.")
         }
 
       case _ =>
@@ -57,10 +60,8 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
   }
 
-  def rewriteFun(state: SymbState,
-                 funCell: ArenaCell,
-                 indexCells: Seq[ArenaCell],
-                 valueCells: Seq[ArenaCell]): SymbState = {
+  def rewriteFun(state: SymbState, funCell: ArenaCell, indexCells: Seq[ArenaCell],
+      valueCells: Seq[ArenaCell]): SymbState = {
     // rewrite tuples <<j_i, e_i>> to cells
     val updatePairs = indexCells.zip(valueCells) // ![j_i] = e_i
     def mkPair(indexCell: ArenaCell, resCell: ArenaCell): TlaEx = tla.tuple(indexCell.toNameEx, resCell.toNameEx)
@@ -112,45 +113,43 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
       .setRex(newFunCell)
   }
 
-  def rewriteRec(state: SymbState,
-                 recCell: ArenaCell,
-                 recType: RecordT,
-                 indexEs: Seq[TlaEx],
-                 valueCells: Seq[ArenaCell]): SymbState = {
+  def rewriteRec(state: SymbState, recCell: ArenaCell, recType: RecordT, indexEs: Seq[TlaEx],
+      valueCells: Seq[ArenaCell]): SymbState = {
     def indexToStr: TlaEx => String = {
       case ValEx(TlaStr(key)) => key
-      case ex => throw new RewriterException("Expected a string when updating a record, found: " + ex, ex)
+      case ex                 => throw new RewriterException("Expected a string when updating a record, found: " + ex, ex)
     }
 
     val updatedKeys = indexEs map indexToStr
-    val unchangedKeys = recType.fields.keySet.diff(Set(updatedKeys :_*))
+    val unchangedKeys = recType.fields.keySet.diff(Set(updatedKeys: _*))
+
     // create a new record
     def mkUnchanged(key: String): (TlaEx, TlaEx) = {
       (tla.str(key), tla.appFun(recCell.toNameEx, tla.str(key)))
     }
+
     def flattenPairs(list: Seq[TlaEx], pair: (TlaEx, TlaEx)): Seq[TlaEx] = {
       pair._1 +: pair._2 +: list
     }
+
     // [ [k1, v1], [k2, v2], ... ]
     val updatedPairs: Seq[(TlaEx, TlaEx)] = indexEs.zip(valueCells.map(_.toNameEx))
     val unchangedPairs: Seq[(TlaEx, TlaEx)] = unchangedKeys.toList.map(mkUnchanged)
-    val newRecEx = OperEx(TlaFunOper.enum,
-      (updatedPairs ++ unchangedPairs).reverse.foldLeft(Seq[TlaEx]())(flattenPairs) :_*)
+    val newRecEx =
+      OperEx(TlaFunOper.enum, (updatedPairs ++ unchangedPairs).reverse.foldLeft(Seq[TlaEx]())(flattenPairs): _*)
     rewriter.rewriteUntilDone(state.setRex(newRecEx)) // let the rewriter handle this
   }
 
-  def rewriteTuple(state: SymbState,
-                   tupleCell: ArenaCell,
-                   tupleT: TupleT,
-                   indexEs: Seq[TlaEx],
-                   valueCells: Seq[ArenaCell]): SymbState = {
+  def rewriteTuple(state: SymbState, tupleCell: ArenaCell, tupleT: TupleT, indexEs: Seq[TlaEx],
+      valueCells: Seq[ArenaCell]): SymbState = {
     def indexToInt: TlaEx => Int = {
       case ValEx(TlaInt(index)) => index.toInt
-      case ex => throw new RewriterException("Expected a number when updating a tuple, found: " + ex, ex)
+      case ex                   => throw new RewriterException("Expected a number when updating a tuple, found: " + ex, ex)
     }
 
     val updatedIndices = indexEs map indexToInt
-    val updateMap = Map(updatedIndices.zip(valueCells) :_*)
+    val updateMap = Map(updatedIndices.zip(valueCells): _*)
+
     def updateOrKeep(i: Int): TlaEx = {
       if (updateMap.contains(i)) {
         updateMap(i)
@@ -160,7 +159,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
 
     val tupleSize = tupleT.args.size
-    val newTuple = tla.tuple(1.to(tupleSize) map updateOrKeep :_*)
+    val newTuple = tla.tuple(1.to(tupleSize) map updateOrKeep: _*)
     rewriter.rewriteUntilDone(state.setRex(newTuple)) // let the rewriter handle this
   }
 
@@ -177,7 +176,6 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
   def addEqualities(state: SymbState, lhs: ArenaCell, rhs: ArenaCell): SymbState = {
     rewriter.lazyEq.cacheOneEqConstraint(state, lhs, rhs)
   }
-
 
   // This is an important step. As we receive expressions from SANY, every index argument to EXCEPT
   // is always a tuple]. For instance, the expression [f EXCEPT ![1] = 2] will be represented
@@ -200,7 +198,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private def checkType(cellType: CellT): Unit = {
     cellType match {
       case FunT(_, _) => () // o.k.
-      case _ => throw new NotImplementedError(s"EXCEPT is not implemented for $cellType. Write a feature request.")
+      case _          => throw new NotImplementedError(s"EXCEPT is not implemented for $cellType. Write a feature request.")
     }
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
@@ -7,26 +7,23 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Integer arithmetic operations: +, -, *, div, mod.
-  *
-  * @author Igor Konnov
-  */
+ * Integer arithmetic operations: +, -, *, div, mod.
+ *
+ * @author Igor Konnov
+ */
 class IntArithRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val intConstRule: IntConstRule = new IntConstRule(rewriter)
   private val simplifier = new ConstSimplifierForSmt()
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
-      case OperEx(TlaArithOper.plus, _, _)
-           | OperEx(TlaArithOper.minus, _, _)
-           | OperEx(TlaArithOper.mult, _, _)
-           | OperEx(TlaArithOper.div, _, _)
-           | OperEx(TlaArithOper.mod, _, _)
-           | OperEx(TlaArithOper.exp, _, _)
-           | OperEx(TlaArithOper.uminus, _)
-      => true
+      case OperEx(TlaArithOper.plus, _, _) | OperEx(TlaArithOper.minus, _, _) | OperEx(TlaArithOper.mult, _, _) |
+          OperEx(TlaArithOper.div, _, _) | OperEx(TlaArithOper.mod, _, _) | OperEx(TlaArithOper.exp, _, _) |
+          OperEx(TlaArithOper.uminus, _) =>
+        true
 
       case _ => false
     }
@@ -34,10 +31,9 @@ class IntArithRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = state.ex match {
     case OperEx(oper: TlaArithOper, _, _)
-      if (oper == TlaArithOper.plus || oper == TlaArithOper.minus
-        || oper == TlaArithOper.mult || oper == TlaArithOper.div
-        || oper == TlaArithOper.mod || oper == TlaArithOper.exp)
-    =>
+        if (oper == TlaArithOper.plus || oper == TlaArithOper.minus
+          || oper == TlaArithOper.mult || oper == TlaArithOper.div
+          || oper == TlaArithOper.mod || oper == TlaArithOper.exp) =>
       rewriteGeneral(state, state.ex)
 
     case OperEx(TlaArithOper.uminus, _) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -6,24 +6,23 @@ import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Integer comparisons: <, <=, >, >=. For equality and inequality, check EqRule and NeqRule.
-  *
-  * @author Igor Konnov
-  */
+ * Integer comparisons: <, <=, >, >=. For equality and inequality, check EqRule and NeqRule.
+ *
+ * @author Igor Konnov
+ */
 class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val simplifier = new ConstSimplifierForSmt()
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
-      case OperEx(TlaArithOper.lt, _, _)
-           | OperEx(TlaArithOper.le, _, _)
-           | OperEx(TlaArithOper.gt, _, _)
-           | OperEx(TlaArithOper.ge, _, _)
-      => true
+      case OperEx(TlaArithOper.lt, _, _) | OperEx(TlaArithOper.le, _, _) | OperEx(TlaArithOper.gt, _, _) |
+          OperEx(TlaArithOper.ge, _, _) =>
+        true
 
-        // Note that there is no equality, as it is handled by EqRule. Inequality is rewritten by Keramelizer.
+      // Note that there is no equality, as it is handled by EqRule. Inequality is rewritten by Keramelizer.
 
       case _ => false
     }
@@ -31,9 +30,8 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = state.ex match {
     case OperEx(oper: TlaArithOper, _, _)
-      if (oper == TlaArithOper.lt || oper == TlaArithOper.le
-        || oper == TlaArithOper.gt || oper == TlaArithOper.ge)
-    =>
+        if (oper == TlaArithOper.lt || oper == TlaArithOper.le
+          || oper == TlaArithOper.gt || oper == TlaArithOper.ge) =>
       rewriteGeneral(state, state.ex)
 
     case _ =>
@@ -52,9 +50,7 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
       var arena = rightState.arena.appendCell(BoolT())
       val eqPred = arena.topCell
       val cons =
-        OperEx(TlaOper.eq,
-          eqPred.toNameEx,
-          OperEx(oper, leftState.ex, rightState.ex))
+        OperEx(TlaOper.eq, eqPred.toNameEx, OperEx(oper, leftState.ex, rightState.ex))
       rewriter.solverContext.assertGroundExpr(cons)
       rightState.setArena(arena).setRex(eqPred.toNameEx)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PrimeRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PrimeRule.scala
@@ -3,17 +3,18 @@ package at.forsyte.apalache.tla.bmcmt.rules
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Rename x' to NameEx("x'"). We only consider the case when prime is applied to a variable.
-  *
-  * @author Igor Konnov
-  */
+ * Rename x' to NameEx("x'"). We only consider the case when prime is applied to a variable.
+ *
+ * @author Igor Konnov
+ */
 class PrimeRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaActionOper.prime, _) => true
-      case _ => false
+      case _                              => false
     }
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
@@ -8,22 +8,23 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.TlaIntSet
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * This rule translates the definition of a recursive function. It is similar to CHOOSE.
-  * Unlike CHOOSE, it does not have a fallback option, when the definition has no solution.
-  * Hence, an infeasible definition of a recursive function may lead to a deadlock.
-  *
-  * @author Igor Konnov
-  */
+ * This rule translates the definition of a recursive function. It is similar to CHOOSE.
+ * Unlike CHOOSE, it does not have a fallback option, when the definition has no solution.
+ * Hence, an infeasible definition of a recursive function may lead to a deadlock.
+ *
+ * @author Igor Konnov
+ */
 class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val pick = new CherryPick(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaFunOper.recFunDef, _*) => true
-      case OperEx(TlaFunOper.recFunRef) => true
-      case _ => false
+      case OperEx(TlaFunOper.recFunRef)     => true
+      case _                                => false
     }
   }
 
@@ -42,8 +43,9 @@ class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
         }
 
       case _ =>
-        throw new RewriterException("%s is not applicable to %s"
-          .format(getClass.getSimpleName, state.ex), state.ex)
+        throw new RewriterException(
+            "%s is not applicable to %s"
+              .format(getClass.getSimpleName, state.ex), state.ex)
     }
   }
 
@@ -53,13 +55,13 @@ class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
     val domainCell = nextState.asCell
     val elemT = domainCell.cellType match {
       case FinSetT(et) => et
-      case t@_ => throw new RewriterException("Expected a finite set, found: " + t, state.ex)
+      case t @ _       => throw new RewriterException("Expected a finite set, found: " + t, state.ex)
     }
     // find the type of the target expression and of the target set
     val resultT = rewriter.typeFinder.computeRec(mapEx)
     val codomain =
       resultT match {
-        case IntT() => ValEx(TlaIntSet)
+        case IntT()  => ValEx(TlaIntSet)
         case BoolT() => tla.booleanSet()
         case _ =>
           val msg = "A result of a recursive function must belong to Int or BOOLEAN. Found: " + resultT
@@ -77,14 +79,17 @@ class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
     // pick a function from the function set
     nextState = pick.pickFunFromFunSet(funT, funSetCell, nextState)
     val funCell = nextState.asCell
-    nextState = nextState.setBinding(new Binding(nextState.binding.toMap + (TlaFunOper.recFunRef.uniqueName -> funCell)))
+    nextState = nextState.setBinding(
+        new Binding(nextState.binding.toMap + (TlaFunOper.recFunRef.uniqueName -> funCell)))
     // for every element of the domain, add the constraint imposed by the definition
     val domainCells = nextState.arena.getHas(domainCell)
     for (elem <- domainCells) {
       val oldBinding = nextState.binding
       // compute the right-hand side of the constraint by the recursive function
-      nextState = rewriter.rewriteUntilDone(nextState.setRex(mapEx)
-        .setBinding(new Binding(oldBinding.toMap + (varName -> elem))))
+      nextState = rewriter.rewriteUntilDone(
+          nextState
+            .setRex(mapEx)
+            .setBinding(new Binding(oldBinding.toMap + (varName -> elem))))
       val rhs = nextState.asCell
       // Compute the left-hand side of the constraint, that is, f[elem].
       nextState = nextState.setBinding(oldBinding)
@@ -96,7 +101,8 @@ class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
 
     // that's it
-    nextState.setRex(funCell.toNameEx)
+    nextState
+      .setRex(funCell.toNameEx)
       .setBinding(new Binding(nextState.binding.toMap - TlaFunOper.recFunRef.uniqueName))
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCtorRule.scala
@@ -4,23 +4,24 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types.FinSetT
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Rewrites the set constructor {e_1, ..., e_k}.
-  *
-  * @author Igor Konnov
-  */
+ * Rewrites the set constructor {e_1, ..., e_k}.
+ *
+ * @author Igor Konnov
+ */
 class SetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaSetOper.enumSet, _*) => true
-      case _ => false
+      case _                              => false
     }
   }
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
-      case OperEx(TlaSetOper.enumSet, elems@_*) =>
+      case OperEx(TlaSetOper.enumSet, elems @ _*) =>
         // switch to cell theory
         val (newState: SymbState, newEs: Seq[TlaEx]) =
           rewriter.rewriteSeqUntilDone(state, elems)
@@ -28,7 +29,7 @@ class SetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
         // compute the set type using the type finder
         val elemType = rewriter.typeFinder.compute(state.ex, cells.map(_.cellType): _*) match {
           case FinSetT(et) => et
-          case setT @ _ => throw new TypeException("Expected a finite set, found: " + setT, state.ex)
+          case setT @ _    => throw new TypeException("Expected a finite set, found: " + setT, state.ex)
         }
         val arena = newState.arena.appendCell(FinSetT(elemType))
         val newCell = arena.topCell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
@@ -4,17 +4,18 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{NameEx, NullEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Rewrites a set comprehension { x \in S: P }.
-  *
-  * @author Igor Konnov
-  */
+ * Rewrites a set comprehension { x \in S: P }.
+ *
+ * @author Igor Konnov
+ */
 class SetFilterRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaSetOper.filter, _*) => true
-      case _ => false
+      case _                             => false
     }
   }
 
@@ -25,7 +26,7 @@ class SetFilterRule(rewriter: SymbStateRewriter) extends RewritingRule {
         var newState = rewriter.rewriteUntilDone(state.setRex(setEx))
         newState = newState.asCell.cellType match {
           case FinSetT(_) => newState
-          case tp @ _ => throw new NotImplementedError("A set filter over %s is not implemented".format(tp))
+          case tp @ _     => throw new NotImplementedError("A set filter over %s is not implemented".format(tp))
         }
         val setCell = newState.asCell
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
@@ -6,17 +6,18 @@ import at.forsyte.apalache.tla.bmcmt.types.FinSetT
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSetOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Implements the rule for a union of all set elements, that is, UNION S for a set S that contains sets as elements.
-  *
-  * @author Igor Konnov
-  */
+ * Implements the rule for a union of all set elements, that is, UNION S for a set S that contains sets as elements.
+ *
+ * @author Igor Konnov
+ */
 class SetUnionRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaSetOper.union, set) => true
-      case _ => false
+      case _                             => false
     }
   }
 
@@ -29,13 +30,13 @@ class SetUnionRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val elemType =
           topSetCell.cellType match {
             case FinSetT(FinSetT(et)) => et
-            case _ => throw new TypeException(s"Applying UNION to $topSet of type ${topSetCell.cellType}", state.ex)
+            case _                    => throw new TypeException(s"Applying UNION to $topSet of type ${topSetCell.cellType}", state.ex)
           }
 
-        val sets = Set(nextState.arena.getHas(topSetCell) :_*).toList // remove duplicates too
-        val elemsOfSets = sets map (s => Set(nextState.arena.getHas(s) :_*))
+        val sets = Set(nextState.arena.getHas(topSetCell): _*).toList // remove duplicates too
+        val elemsOfSets = sets map (s => Set(nextState.arena.getHas(s): _*))
 
-        val unionOfSets = elemsOfSets.foldLeft(Set[ArenaCell]()) (_.union(_))
+        val unionOfSets = elemsOfSets.foldLeft(Set[ArenaCell]())(_.union(_))
         // introduce a set cell
         nextState = nextState.updateArena(_.appendCell(FinSetT(elemType)))
         val newSetCell = nextState.arena.topCell
@@ -64,7 +65,7 @@ class SetUnionRule(rewriter: SymbStateRewriter) extends RewritingRule {
               tla.and(tla.in(set, topSetCell), tla.in(elemCell, set))
             }
 
-            val existsIncludingSet = tla.or(pointingSets map inPointingSet :_*)
+            val existsIncludingSet = tla.or(pointingSets map inPointingSet: _*)
             val inUnionSet = tla.in(elemCell, newSetCell)
             val iff = OperEx(TlaOper.eq, inUnionSet, existsIncludingSet)
             rewriter.solverContext.assertGroundExpr(iff)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SubstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SubstRule.scala
@@ -2,13 +2,14 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.NameEx
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Substitutes a bound name with a cell. For instance, it substitutes a name that is declared with VARIABLE or CONSTANT,
-  * as well as bound variables declared with \A, \E, set operations, etc.
-  *
-  * @author Igor Konnov
-   */
+ * Substitutes a bound name with a cell. For instance, it substitutes a name that is declared with VARIABLE or CONSTANT,
+ * as well as bound variables declared with \A, \E, set operations, etc.
+ *
+ * @author Igor Konnov
+ */
 class SubstRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(state: SymbState): Boolean = {
     state.ex match {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
@@ -7,29 +7,29 @@ import at.forsyte.apalache.tla.bmcmt.util.IntTupleIterator
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.mutable
 
 /**
-  * The base rules for a set map {e : x ∈ S}. This class was extracted from SetMapRule, as it was used in other rules
-  * that are now obsolete. Due to the general nature of this mapping, we keep it in a separate class.
-  *
-  * @param rewriter the symbolic rewriter
-  * @author Igor Konnov
-  */
+ * The base rules for a set map {e : x ∈ S}. This class was extracted from SetMapRule, as it was used in other rules
+ * that are now obsolete. Due to the general nature of this mapping, we keep it in a separate class.
+ *
+ * @param rewriter the symbolic rewriter
+ * @author Igor Konnov
+ */
 class MapBase(rewriter: SymbStateRewriter) {
-  /**
-   <p>Implement a mapping { e: x_1 ∈ S_1, ..., x_n ∈ S_n }.</p>
 
-   <p>This implementation computes the cross product and maps every cell using the map expression.
-    It is not truly symbolic, we have to find a better way.</p>
-    */
-  def rewriteSetMapManyArgs(state: SymbState,
-                            mapEx: TlaEx,
-                            varNames: Seq[String],
-                            setEs: Seq[TlaEx]): SymbState = {
+  /**
+   * <p>Implement a mapping { e: x_1 ∈ S_1, ..., x_n ∈ S_n }.</p>
+   *
+   * <p>This implementation computes the cross product and maps every cell using the map expression.
+   * It is not truly symbolic, we have to find a better way.</p>
+   */
+  def rewriteSetMapManyArgs(state: SymbState, mapEx: TlaEx, varNames: Seq[String], setEs: Seq[TlaEx]): SymbState = {
     // first, rewrite the variable domains S_1, ..., S_n
     var (nextState, sets) = rewriter.rewriteSeqUntilDone(state, setEs)
+
     def findSetCellAndElemType(setCell: ArenaCell): (ArenaCell, CellT) = {
       setCell.cellType match {
         case FinSetT(elemType) =>
@@ -51,7 +51,9 @@ class MapBase(rewriter: SymbStateRewriter) {
 
     // enumerate all possible indices and map the corresponding tuples to cells
     def byIndex(indices: Seq[Int]): Seq[ArenaCell] =
-      elemsOfSets.zip(indices) map Function.tupled { (s, i) => s(i) }
+      elemsOfSets.zip(indices) map Function.tupled { (s, i) =>
+        s(i)
+      }
 
     val tupleIter = new IntTupleIterator(setLimits).map(byIndex)
 
@@ -63,12 +65,8 @@ class MapBase(rewriter: SymbStateRewriter) {
     newState.setRex(resultSetCell.toNameEx)
   }
 
-  private def mapCellsManyArgs(state: SymbState,
-                               targetSetCell: ArenaCell,
-                               mapEx: TlaEx,
-                               varNames: Seq[String],
-                               setsAsCells: Seq[ArenaCell],
-                               cellsIter: Iterator[Seq[ArenaCell]]): (SymbState, Iterable[ArenaCell]) = {
+  private def mapCellsManyArgs(state: SymbState, targetSetCell: ArenaCell, mapEx: TlaEx, varNames: Seq[String],
+      setsAsCells: Seq[ArenaCell], cellsIter: Iterator[Seq[ArenaCell]]): (SymbState, Iterable[ArenaCell]) = {
     // we could have done it with foldLeft, but that would be even less readable
     var newState = state
     // Collect target cells and the possible membership expressions in a hash map.
@@ -77,7 +75,8 @@ class MapBase(rewriter: SymbStateRewriter) {
     // https://github.com/informalsystems/apalache/issues/365
     var resultsToSource = new HashMap[ArenaCell, Set[TlaEx]] with MultiMap[ArenaCell, TlaEx]
     for (argCells <- cellsIter) {
-      val (ns, resultCell, memEx) = mapCellsManyArgsOnce(newState, targetSetCell, mapEx, varNames, setsAsCells, argCells)
+      val (ns, resultCell, memEx) =
+        mapCellsManyArgsOnce(newState, targetSetCell, mapEx, varNames, setsAsCells, argCells)
       newState = ns
       resultsToSource.addBinding(resultCell, memEx)
     }
@@ -99,12 +98,8 @@ class MapBase(rewriter: SymbStateRewriter) {
     (newState, resultsToSource.keys)
   }
 
-  private def mapCellsManyArgsOnce(state: SymbState,
-                                   targetSetCell: ArenaCell,
-                                   mapEx: TlaEx,
-                                   varNames: Seq[String],
-                                   setsAsCells: Seq[ArenaCell],
-                                   valuesAsCells: Seq[ArenaCell]): (SymbState, ArenaCell, TlaEx) = {
+  private def mapCellsManyArgsOnce(state: SymbState, targetSetCell: ArenaCell, mapEx: TlaEx, varNames: Seq[String],
+      setsAsCells: Seq[ArenaCell], valuesAsCells: Seq[ArenaCell]): (SymbState, ArenaCell, TlaEx) = {
     // bind the variables to the corresponding cells
     val newBinding: Binding = varNames.zip(valuesAsCells).foldLeft(state.binding)((m, p) => Binding(m.toMap + p))
     val mapState = state.setBinding(newBinding).setRex(mapEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/NeqRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/NeqRule.scala
@@ -1,21 +1,21 @@
 package at.forsyte.apalache.tla.bmcmt.rules.deprecated
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
+import at.forsyte.apalache.tla.lir.OperEx
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper}
-import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
 
 /**
-  * Implements the rule: SE-NE1.
-  *
-  * @author Igor Konnov
-  */
+ * Implements the rule: SE-NE1.
+ *
+ * @author Igor Konnov
+ */
 @deprecated("It should be handled by Keramelizer")
 class NeqRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaOper.ne, _, _) => true
-      case _ => false
+      case _                        => false
     }
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.bmcmt.smt.PreproSolverContext.{PreproEqEntry, Pre
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 object PreproSolverContext {
   sealed abstract class PreproCacheEntry {
@@ -23,35 +24,35 @@ object PreproSolverContext {
 }
 
 /**
-  * <p>A preprocessor of the SolverContext that caches the following types of constraints and propagates them
-  * before pushing the constraints to the actual solver:</p>
-  *
-  * <ul>
-  *   <li>Equalities between two cells: tla.eql(c1, c2) and tla.neq(c1, c2)</li>
-  *   <li>Set membership assertions between two cells: tla.in(c1, c2) and tla.not(tla.in(c1, c2)).
-  * </ul>
-  *
-  * <p>This is helpful as our rewriting rules
-  * introduce lots of redundant variables that can be easily eliminated by propagation.
-  * We use delegation instead of inheritance, as we will integrate with other solvers in the future.</p>
-  *
-  * @author Igor Konnov
-  */
+ * <p>A preprocessor of the SolverContext that caches the following types of constraints and propagates them
+ * before pushing the constraints to the actual solver:</p>
+ *
+ * <ul>
+ * <li>Equalities between two cells: tla.eql(c1, c2) and tla.neq(c1, c2)</li>
+ * <li>Set membership assertions between two cells: tla.in(c1, c2) and tla.not(tla.in(c1, c2)).
+ * </ul>
+ *
+ * <p>This is helpful as our rewriting rules
+ * introduce lots of redundant variables that can be easily eliminated by propagation.
+ * We use delegation instead of inheritance, as we will integrate with other solvers in the future.</p>
+ *
+ * @author Igor Konnov
+ */
 class PreproSolverContext(context: SolverContext) extends SolverContext {
   private val simplifier = new ConstSimplifierForSmt()
   // FIXME: it would be much better to use cells here, but we do not have access to the arena
   private val cache: SimpleCache[(String, String), PreproCacheEntry] = new SimpleCache()
 
   /**
-    * Configuration parameters.
-    */
+   * Configuration parameters.
+   */
   override val config: SolverConfig = context.config
 
   /**
-    * Assert that a Boolean TLA+ expression holds true.
-    *
-    * @param ex a simplified TLA+ expression over cells
-    */
+   * Assert that a Boolean TLA+ expression holds true.
+   *
+   * @param ex a simplified TLA+ expression over cells
+   */
   override def assertGroundExpr(ex: TlaEx): Unit = {
     // there are plenty of top-level constraints like (= c1 c2) or tla.in(c1, c2)
     val ppex = simplifier.simplifyShallow(preprocess(simplifier.simplifyShallow(ex)))
@@ -93,13 +94,13 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
   }
 
   /**
-    * Evaluate a ground TLA+ expression in the current model, which is available after a call to sat().
-    * This method assumes that the outcome is either a Boolean or integer.
-    * If not, it throws SmtEncodingException.
-    *
-    * @param ex an expression to evaluate
-    * @return a TLA+ value
-    */
+   * Evaluate a ground TLA+ expression in the current model, which is available after a call to sat().
+   * This method assumes that the outcome is either a Boolean or integer.
+   * If not, it throws SmtEncodingException.
+   *
+   * @param ex an expression to evaluate
+   * @return a TLA+ value
+   */
   override def evalGroundExpr(ex: TlaEx): TlaEx = {
     context.evalGroundExpr(preprocess(ex))
   }
@@ -110,26 +111,26 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
         val pair = if (left.compareTo(right) <= 0) (left, right) else (right, left)
         cache.get(pair) match {
           case Some(cached) => cached.asTlaEx(negate = false)
-          case None => ex
+          case None         => ex
         }
 
       case OperEx(TlaOper.ne, NameEx(left), NameEx(right)) =>
         val pair = if (left.compareTo(right) <= 0) (left, right) else (right, left)
         cache.get(pair) match {
           case Some(cached) => cached.asTlaEx(negate = true)
-          case None => ex
+          case None         => ex
         }
 
       case OperEx(TlaSetOper.in, NameEx(left), NameEx(right)) =>
         cache.get((left, right)) match {
           case Some(cached) => cached.asTlaEx(negate = false)
-          case None => ex
+          case None         => ex
         }
 
       case OperEx(TlaSetOper.notin, NameEx(left), NameEx(right)) =>
         cache.get((left, right)) match {
           case Some(cached) => cached.asTlaEx(negate = true)
-          case None => ex
+          case None         => ex
         }
 
       case OperEx(TlaSetOper.in, _*) | OperEx(TlaSetOper.notin, _*) =>
@@ -142,114 +143,109 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
         OperEx(TlaFunOper.app, fun, preprocess(elem))
 
       case OperEx(oper, args @ _*) =>
-        OperEx(oper, args map preprocess :_*)
+        OperEx(oper, args map preprocess: _*)
 
       case _ => ex
     }
   }
 
-
   ////////////////// the rest is just delegation to context
 
-
-
   /**
-    * Declare a constant for an arena cell.
-    *
-    * @param cell a (previously undeclared) cell
-    */
+   * Declare a constant for an arena cell.
+   *
+   * @param cell a (previously undeclared) cell
+   */
   override def declareCell(cell: ArenaCell): Unit = context.declareCell(cell)
 
   /**
-    * Declare an arena edge of type 'has'. This method introduces a Boolean variable for the edge.
-    *
-    * @param set the containing set
-    * @param elem a set element
-    */
+   * Declare an arena edge of type 'has'. This method introduces a Boolean variable for the edge.
+   *
+   * @param set  the containing set
+   * @param elem a set element
+   */
   def declareInPredIfNeeded(set: ArenaCell, elem: ArenaCell): Unit = context.declareInPredIfNeeded(set, elem)
 
   /**
-    * Check whether the current view of the SMT solver is consistent with arena.
-    *
-    * @param arena an arena
-    */
+   * Check whether the current view of the SMT solver is consistent with arena.
+   *
+   * @param arena an arena
+   */
   override def checkConsistency(arena: Arena): Unit = context.checkConsistency(arena)
 
   /**
-    * Write a message to the log file. This is helpful to debug the SMT encoding.
-    *
-    * @param message message text, call-by-name
-    */
+   * Write a message to the log file. This is helpful to debug the SMT encoding.
+   *
+   * @param message message text, call-by-name
+   */
   override def log(message: => String): Unit = context.log(message)
 
   /**
-    * Is the current context satisfiable?
-    *
-    * @return true if and only if the context is satisfiable
-    */
+   * Is the current context satisfiable?
+   *
+   * @return true if and only if the context is satisfiable
+   */
   override def sat(): Boolean = context.sat()
 
-
   /**
-    * Check satisfiability of the context with a timeout
-    *
-    * @param timeoutSec the timeout in seconds. If timeout <= 0, it is not effective
-    * @return Some(result), if no timeout happened; otherwise, None
-    */
+   * Check satisfiability of the context with a timeout
+   *
+   * @param timeoutSec the timeout in seconds. If timeout <= 0, it is not effective
+   * @return Some(result), if no timeout happened; otherwise, None
+   */
   override def satOrTimeout(timeoutSec: Long): Option[Boolean] = context.satOrTimeout(timeoutSec)
 
   /**
-    * Register an SMT listener
-    *
-    * @param listener register a listener, overrides the previous listener, if it was set before
-    */
+   * Register an SMT listener
+   *
+   * @param listener register a listener, overrides the previous listener, if it was set before
+   */
   override def setSmtListener(listener: SmtListener): Unit = context.setSmtListener(listener)
 
   /**
-    * Get the current context level, that is the difference between the number of pushes and pops made so far.
-    *
-    * @return the current level, always non-negative.
-    */
+   * Get the current context level, that is the difference between the number of pushes and pops made so far.
+   *
+   * @return the current level, always non-negative.
+   */
   override def contextLevel: Int = context.contextLevel
 
-
   /**
-    * Get the current metrics in the solver context. The metrics may change when the other methods are called.
-    *
-    * @return the current metrics
-    */
+   * Get the current metrics in the solver context. The metrics may change when the other methods are called.
+   *
+   * @return the current metrics
+   */
   override def metrics(): SolverContextMetrics = context.metrics()
 
   /**
-    * Save the current context and push it on the stack for a later recovery with pop.
-    */
+   * Save the current context and push it on the stack for a later recovery with pop.
+   */
   override def push(): Unit = {
     context.push()
     cache.push()
   }
 
   /**
-    * Pop the previously saved context. Importantly, pop may be called multiple times and thus it is not sufficient
-    * to save only the latest context.
-    */
+   * Pop the previously saved context. Importantly, pop may be called multiple times and thus it is not sufficient
+   * to save only the latest context.
+   */
   override def pop(): Unit = {
     cache.pop()
     context.pop()
   }
 
   /**
-    * Pop the context as many times as needed to reach a given level.
-    *
-    * @param n pop n times, if n > 0, otherwise, do nothing
-    */
+   * Pop the context as many times as needed to reach a given level.
+   *
+   * @param n pop n times, if n > 0, otherwise, do nothing
+   */
   override def pop(n: Int): Unit = {
     cache.pop(n)
     context.pop(n)
   }
 
   /**
-    * Clean the context
-    */
+   * Clean the context
+   */
   override def dispose(): Unit = {
     cache.dispose()
     context.dispose()

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -11,37 +11,37 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.microsoft.z3._
 import com.microsoft.z3.enumerations.Z3_lbool
 
 import scala.collection.mutable
 
 /**
-  * <p>
-  * An implementation of a SolverContext using Z3. Note that this class overrides the global z3 settings
-  * `sat.random_seed`, `smt.random_seed`, `fp.spacer.random_seed`, and `sls.random_seed` with `config.randomSeed`.
-  * Although it is usually not a good idea to override the global settings, we do it to isolate the code
-  * specific to z3 in this class.
-  * </p>
-  *
-  * @author Igor Konnov
-  */
+ * <p>
+ * An implementation of a SolverContext using Z3. Note that this class overrides the global z3 settings
+ * `sat.random_seed`, `smt.random_seed`, `fp.spacer.random_seed`, and `sls.random_seed` with `config.randomSeed`.
+ * Although it is usually not a good idea to override the global settings, we do it to isolate the code
+ * specific to z3 in this class.
+ * </p>
+ *
+ * @author Igor Konnov
+ */
 class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   private val id: Long = Z3SolverContext.createId()
 
   /**
-    * A log writer, for debugging purposes.
-    */
+   * A log writer, for debugging purposes.
+   */
   private val logWriter: PrintWriter = initLog()
 
   // dump the configuration parameters in the log
   // set the global configuration parameters for z3 modules
-  Z3SolverContext.RANDOM_SEED_PARAMS.foreach {
-    p =>
-      Global.setParameter(p, config.randomSeed.toString)
-      logWriter.println(";; %s = %s".format(p, config.randomSeed))
-//    the following fails with an exception: java.lang.NoSuchFieldError: value
-//      logWriter.println(";; %s = %s".format(p, Global.getParameter(p)))
+  Z3SolverContext.RANDOM_SEED_PARAMS.foreach { p =>
+    Global.setParameter(p, config.randomSeed.toString)
+    logWriter.println(";; %s = %s".format(p, config.randomSeed))
+  //    the following fails with an exception: java.lang.NoSuchFieldError: value
+  //      logWriter.println(";; %s = %s".format(p, Global.getParameter(p)))
   }
 
   var level: Int = 0
@@ -53,44 +53,44 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   private var _metrics: SolverContextMetrics = SolverContextMetrics.empty
 
   /**
-    * Caching one uninterpreted sort for each cell signature. For integers, the integer sort.
-    */
+   * Caching one uninterpreted sort for each cell signature. For integers, the integer sort.
+   */
   private val cellSorts: mutable.Map[String, (Sort, Int)] =
     new mutable.HashMap[String, (Sort, Int)]
 
   /**
-    * Uninterpreted functions C -> C associated with function cells.
-    * Since context operations may clear function declaration,
-    * we carry the context level in the map and clean the function declarations on pop.
-    */
+   * Uninterpreted functions C -> C associated with function cells.
+   * Since context operations may clear function declaration,
+   * we carry the context level in the map and clean the function declarations on pop.
+   */
   private val funDecls: mutable.Map[String, (FuncDecl, Int)] =
     new mutable.HashMap[String, (FuncDecl, Int)]()
 
   /**
-    * The calls to z3context.mkConst consume 20% of the running time, according to VisualVM.
-    * Let's cache the constants, if Z3 cannot do it well.
-    * Again, the cache carries the context level, to support push and pop.
-    */
+   * The calls to z3context.mkConst consume 20% of the running time, according to VisualVM.
+   * Let's cache the constants, if Z3 cannot do it well.
+   * Again, the cache carries the context level, to support push and pop.
+   */
   private val cellCache: mutable.Map[Int, (Expr, CellT, Int)] =
     new mutable.HashMap[Int, (Expr, CellT, Int)]
 
   /**
-    * A cache for the in-relation between a set and its potential element.
-    */
+   * A cache for the in-relation between a set and its potential element.
+   */
   private val inCache: mutable.Map[(Int, Int), (Expr, Int)] =
     new mutable.HashMap[(Int, Int), (Expr, Int)]
 
   /**
-    * Sometimes, we lose a fresh arena in the rewriting rules. As this situation is very hard to debug,
-    * we are tracking here the largest cell id per SMT context. If the user is trying to add a cell
-    * with a smaller id, there is a good chance that a fresher arena was overwritten with an older one.
-    * To find bugs as soon as possible, we crash immediately.
-    */
+   * Sometimes, we lose a fresh arena in the rewriting rules. As this situation is very hard to debug,
+   * we are tracking here the largest cell id per SMT context. If the user is trying to add a cell
+   * with a smaller id, there is a good chance that a fresher arena was overwritten with an older one.
+   * To find bugs as soon as possible, we crash immediately.
+   */
   private var maxCellIdPerContext = List(-1)
 
   /**
-    * Dispose whatever has to be disposed in the end.
-    */
+   * Dispose whatever has to be disposed in the end.
+   */
   override def dispose(): Unit = {
     z3context.close()
     logWriter.close()
@@ -101,10 +101,10 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Declare a constant for an arena cell.
-    *
-    * @param cell a (previously undeclared) cell
-    */
+   * Declare a constant for an arena cell.
+   *
+   * @param cell a (previously undeclared) cell
+   */
   override def declareCell(cell: ArenaCell): Unit = {
     smtListener.onIntroCell(cell.id)
 
@@ -167,7 +167,8 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         val elemT = cellCache(elemId)._2
         val name = s"in_${elemT.signature}${elemId}_${setT.signature}$setId"
         logWriter.flush() // flush the SMT log
-        throw new IllegalStateException(s"SMT $id: The Boolean constant $name (set membership) is missing from the SMT context")
+        throw new IllegalStateException(
+            s"SMT $id: The Boolean constant $name (set membership) is missing from the SMT context")
 
       case Some((const, _)) =>
         const
@@ -175,10 +176,10 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Check whether the current view of the SMT solver is consistent with arena.
-    *
-    * @param arena an arena
-    */
+   * Check whether the current view of the SMT solver is consistent with arena.
+   *
+   * @param arena an arena
+   */
   override def checkConsistency(arena: Arena): Unit = {
     val topId = arena.topCell.id
     if (maxCellIdPerContext.head > topId) {
@@ -191,10 +192,10 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Assert that a Boolean TLA+ expression holds true.
-    *
-    * @param ex a simplified TLA+ expression over cells
-    */
+   * Assert that a Boolean TLA+ expression holds true.
+   *
+   * @param ex a simplified TLA+ expression over cells
+   */
   def assertGroundExpr(ex: TlaEx): Unit = {
     log(s";; assert ${UTFPrinter.apply(ex)}")
     val (z3expr, size) = toExpr(ex)
@@ -205,13 +206,13 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Evaluate a ground TLA+ expression in the current model, which is available after a call to sat().
-    * This method assumes that the outcome is one of the basic types: a Boolean, integer, or a cell constant.
-    * If not, it throws SmtEncodingException.
-    *
-    * @param ex an expression to evaluate
-    * @return a TLA+ value
-    */
+   * Evaluate a ground TLA+ expression in the current model, which is available after a call to sat().
+   * This method assumes that the outcome is one of the basic types: a Boolean, integer, or a cell constant.
+   * If not, it throws SmtEncodingException.
+   *
+   * @param ex an expression to evaluate
+   * @return a TLA+ value
+   */
   def evalGroundExpr(ex: TlaEx): TlaEx = {
     val (smtEx, _) = toExpr(ex)
     val z3expr = z3solver.getModel.eval(smtEx, true)
@@ -242,10 +243,10 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Log message to the logging file. This is helpful to debug the SMT encoding.
-    *
-    * @param message message text, called by name, so evaluated only when needed
-    */
+   * Log message to the logging file. This is helpful to debug the SMT encoding.
+   *
+   * @param message message text, called by name, so evaluated only when needed
+   */
   def log(message: => String): Unit = {
     if (config.debug) {
       logWriter.println(message)
@@ -253,12 +254,12 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Introduce an uninterpreted function associated with a cell.
-    *
-    * @param argType    an argument type
-    * @param resultType a result type
-    * @return the name of the new function (declared in SMT)
-    */
+   * Introduce an uninterpreted function associated with a cell.
+   *
+   * @param argType    an argument type
+   * @param resultType a result type
+   * @return the name of the new function (declared in SMT)
+   */
   def declareCellFun(cellName: String, argType: CellT, resultType: CellT): Unit = {
     val domSig = argType.signature
     val resSig = resultType.signature
@@ -278,15 +279,15 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Get the current context level, that is the difference between the number of pushes and pops made so far.
-    *
-    * @return the current level, always non-negative.
-    */
+   * Get the current context level, that is the difference between the number of pushes and pops made so far.
+   *
+   * @return the current level, always non-negative.
+   */
   override def contextLevel: Int = level
 
   /**
-    * Push SMT context
-    */
+   * Push SMT context
+   */
   override def push(): Unit = {
     log("(push) ;; becomes %d".format(level + 1))
     logWriter.flush() // good time to flush
@@ -296,8 +297,8 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Pop SMT context
-    */
+   * Pop SMT context
+   */
   override def pop(): Unit = {
     if (level > 0) {
       log("(pop) ;; becomes %d".format(level - 1))
@@ -358,18 +359,18 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
       setTimeout(Int.MaxValue)
       logWriter.flush() // good time to flush
       status match {
-        case Status.SATISFIABLE => Some(true)
+        case Status.SATISFIABLE   => Some(true)
         case Status.UNSATISFIABLE => Some(false)
-        case Status.UNKNOWN => None
+        case Status.UNKNOWN       => None
       }
     }
   }
 
   /**
-    * Print the collected constraints in the SMTLIB2 format using Z3 API.
-    *
-    * @return a long string of statements in SMTLIB2 format as provided by Z3
-    */
+   * Print the collected constraints in the SMTLIB2 format using Z3 API.
+   *
+   * @return a long string of statements in SMTLIB2 format as provided by Z3
+   */
   def toSmtlib2: String = {
     z3solver.toString
   }
@@ -378,12 +379,11 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
     smtListener = listener
   }
 
-
   /**
-    * Get the current metrics in the solver context. The metrics may change when the other methods are called.
-    *
-    * @return the current metrics
-    */
+   * Get the current metrics in the solver context. The metrics may change when the other methods are called.
+   *
+   * @return the current metrics
+   */
   override def metrics(): SolverContextMetrics = _metrics
 
   private def getOrMkCellSort(cellType: CellT): Sort = {
@@ -448,7 +448,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         // convert to an arithmetic expression
         toArithExpr(ex)
 
-      case OperEx(TlaOper.eq, lhs@NameEx(lname), rhs@NameEx(rname)) =>
+      case OperEx(TlaOper.eq, lhs @ NameEx(lname), rhs @ NameEx(rname)) =>
         if (ArenaCell.isValidName(lname) && ArenaCell.isValidName(rname)) {
           // just comparing cells
           val eq = z3context.mkEq(cellCache(ArenaCell.idFromName(lname))._1, cellCache(ArenaCell.idFromName(rname))._1)
@@ -473,18 +473,27 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
 
       case OperEx(BmcOper.distinct, args @ _*) =>
         val (es, ns) = (args map toExpr).unzip
-        val distinct = z3context.mkDistinct(es :_*)
-        (distinct, ns.foldLeft(1L){ _ + _ })
+        val distinct = z3context.mkDistinct(es: _*)
+        (distinct,
+            ns.foldLeft(1L) {
+          _ + _
+        })
 
-      case OperEx(TlaBoolOper.and, args@_*) =>
+      case OperEx(TlaBoolOper.and, args @ _*) =>
         val (es, ns) = (args map toExpr).unzip
-        val and = z3context.mkAnd(es.map(_.asInstanceOf[BoolExpr]) :_*)
-        (and, ns.foldLeft(1L){ _ + _ })
+        val and = z3context.mkAnd(es.map(_.asInstanceOf[BoolExpr]): _*)
+        (and,
+            ns.foldLeft(1L) {
+          _ + _
+        })
 
       case OperEx(TlaBoolOper.or, args @ _*) =>
         val (es, ns) = (args map toExpr).unzip
-        val or = z3context.mkOr(es.map(_.asInstanceOf[BoolExpr]) :_*)
-        (or, ns.foldLeft(1L){ _ + _ })
+        val or = z3context.mkOr(es.map(_.asInstanceOf[BoolExpr]): _*)
+        (or,
+            ns.foldLeft(1L) {
+          _ + _
+        })
 
       case OperEx(TlaBoolOper.implies, lhs, rhs) =>
         val (lhsZ3, ln) = toExpr(lhs)
@@ -521,8 +530,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         (getInPred(setId, elemId), 1)
 
       // the old implementation allowed us to do that, but the new one is encoding edges directly
-    case OperEx(TlaSetOper.in, ValEx(TlaInt(_)), NameEx(_))
-          | OperEx(TlaSetOper.in, ValEx(TlaBool(_)), NameEx(_)) =>
+      case OperEx(TlaSetOper.in, ValEx(TlaInt(_)), NameEx(_)) | OperEx(TlaSetOper.in, ValEx(TlaBool(_)), NameEx(_)) =>
         flushAndThrow(new InvalidTlaExException(s"SMT $id: Preprocessing introduced a literal inside tla.in: $ex", ex))
 
       case _ =>
@@ -532,8 +540,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
 
   private def toEqExpr(le: Expr, re: Expr) = {
     (le, re) match {
-      case (_: BoolExpr, _: BoolExpr)
-           | (_: IntExpr, _: IntExpr) =>
+      case (_: BoolExpr, _: BoolExpr) | (_: IntExpr, _: IntExpr) =>
         z3context.mkEq(le, re)
 
       case (_: IntExpr, _: Expr) =>
@@ -624,11 +631,11 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   /**
-    * Flush the SMT log and throw the provided exception.
-    *
-    * @param e an exception to throw
-    * @return nothing, as an exception is unconditionally thrown
-    */
+   * Flush the SMT log and throw the provided exception.
+   *
+   * @param e an exception to throw
+   * @return nothing, as an exception is unconditionally thrown
+   */
   private def flushAndThrow(e: Exception): Nothing = {
     logWriter.flush() // flush the SMT log
     throw e
@@ -643,8 +650,8 @@ object Z3SolverContext {
   }
 
   /**
-    * The names of all parameters that are used to set the random seeds in z3.
-    */
+   * The names of all parameters that are used to set the random seeds in z3.
+   */
   val RANDOM_SEED_PARAMS: List[String] =
     List("sat.random_seed", "smt.random_seed", "fp.spacer.random_seed", "sls.random_seed")
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/AnnotationParser.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/AnnotationParser.scala
@@ -6,20 +6,23 @@ import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaFunOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import at.forsyte.apalache.tla.lir.{NullEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.immutable.SortedMap
 
 /**
-  * A parser for type annotations, which are written as TLA+ expressions.
-  *
-  * @author Igor Konnov
-  */
+ * A parser for type annotations, which are written as TLA+ expressions.
+ *
+ * @author Igor Konnov
+ */
 object AnnotationParser {
+
   /**
-    * Parse a TLA+ expression that encodes a type.
-    * @param annot a type annotation that is a TLA+ expression.
-    * @return a cell type
-    */
+   * Parse a TLA+ expression that encodes a type.
+   *
+   * @param annot a type annotation that is a TLA+ expression.
+   * @return a cell type
+   */
   def fromTla(annot: TlaEx): CellT = {
     annot match {
       case ValEx(TlaIntSet) =>
@@ -41,18 +44,18 @@ object AnnotationParser {
             FinSetT(elemType)
         }
 
-      case OperEx(TlaFunOper.enum, kv@_*) =>
+      case OperEx(TlaFunOper.enum, kv @ _*) =>
         val keys = kv.zipWithIndex.filter(_._2 % 2 == 0).map(_._1) // pick the even indices (starting with 0)
-      def toStr(key: TlaEx) = key match {
-        case ValEx(TlaStr(s)) => s
-        case _ => throw new TypeException("Expected a string, found: %s".format(key), annot)
-      }
+        def toStr(key: TlaEx) = key match {
+          case ValEx(TlaStr(s)) => s
+          case _                => throw new TypeException("Expected a string, found: %s".format(key), annot)
+        }
 
         val vals = kv.zipWithIndex.filter(_._2 % 2 == 1).map(_._1) // pick the odd indices (starting with 0)
         val types = vals map fromTla
         RecordT(SortedMap(keys.map(toStr).zip(types): _*))
 
-      case OperEx(TlaFunOper.tuple, args@_*) =>
+      case OperEx(TlaFunOper.tuple, args @ _*) =>
         val types = args map fromTla
         TupleT(types)
 
@@ -65,14 +68,14 @@ object AnnotationParser {
         val resType = fromTla(resAnnot)
         FunT(FinSetT(argType), resType)
 
-      case OperEx(TlaSetOper.recSet, args@_* ) =>
+      case OperEx(TlaSetOper.recSet, args @ _*) =>
         // We know |args| = 0 (mod 2)
-        val argPairs = args.grouped( 2 ).toSeq map {
-          case Seq( ValEx( TlaStr( s ) ), value ) =>
-            (s, fromTla( value ))
+        val argPairs = args.grouped(2).toSeq map {
+          case Seq(ValEx(TlaStr(s)), value) =>
+            (s, fromTla(value))
           case e => throw new TypeException("Expected a Seq(string, _) found: %s".format(e), annot)
         }
-        RecordT( SortedMap( argPairs : _* ) )
+        RecordT(SortedMap(argPairs: _*))
 
       case OperEx(BmcOper.withType, _, otherAnnot) =>
         throw new TypeException(s"Found another annotation ${otherAnnot} inside the annotation: $annot", annot)
@@ -83,29 +86,32 @@ object AnnotationParser {
   }
 
   /**
-    * Convert a cell type into a TLA+ expression that encodes a respective type annotation.
-    * @param tp a cell type
-    * @return a TLA+ expression
-    */
+   * Convert a cell type into a TLA+ expression that encodes a respective type annotation.
+   *
+   * @param tp a cell type
+   * @return a TLA+ expression
+   */
   def toTla(tp: CellT): TlaEx = {
     tp match {
-      case BoolT() => ValEx(TlaBoolSet)
-      case IntT() => ValEx(TlaIntSet)
-      case ConstT() => ValEx(TlaStrSet)
-      case FinSetT(elemT) => tla.enumSet(toTla(elemT))
-      case PowSetT(domT) => tla.enumSet(toTla(domT))
-      case FunT(domT, resT) => tla.funSet(toTla(domT), tla.enumSet(toTla(resT)))
+      case BoolT()                   => ValEx(TlaBoolSet)
+      case IntT()                    => ValEx(TlaIntSet)
+      case ConstT()                  => ValEx(TlaStrSet)
+      case FinSetT(elemT)            => tla.enumSet(toTla(elemT))
+      case PowSetT(domT)             => tla.enumSet(toTla(domT))
+      case FunT(domT, resT)          => tla.funSet(toTla(domT), tla.enumSet(toTla(resT)))
       case FinFunSetT(domT, cdmType) => tla.enumSet(tla.funSet(toTla(domT), toTla(cdmType)))
-      case TupleT(es) => tla.tuple(es map toTla: _*)
-      case SeqT(elemT) => tla.seqSet(toTla(elemT))
+      case TupleT(es)                => tla.tuple(es map toTla: _*)
+      case SeqT(elemT)               => tla.seqSet(toTla(elemT))
       case RecordT(fields) =>
         val keys = fields.keys.toSeq
+
         def fieldOrVal(i: Int) = {
           val k = keys(i / 2)
           if (i % 2 == 0) tla.str(k) else toTla(fields(k))
         }
+
         val args = 0.until(2 * fields.size) map fieldOrVal
-        OperEx(TlaFunOper.enum, args :_*)
+        OperEx(TlaFunOper.enum, args: _*)
 
       case _ =>
         throw new TypeException("No translation of type %s to a TLA+ expression".format(tp), NullEx)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.bmcmt.implicitConversions._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -13,8 +14,8 @@ class TestCherryPick extends RewriterBase with TestingPredefs {
   private def emptySetWithType(elemT: CellT): TlaEx =
     tla.withType(tla.enumSet(), AnnotationParser.toTla(FinSetT(elemT)))
 
-  private def assertEqWhenChosen(rewriter: SymbStateRewriter, state: SymbState,
-                                 oracle: Oracle, position: Int, expected: TlaEx): SymbState = {
+  private def assertEqWhenChosen(rewriter: SymbStateRewriter, state: SymbState, oracle: Oracle, position: Int,
+      expected: TlaEx): SymbState = {
     rewriter.push()
     solverContext.assertGroundExpr(oracle.whenEqualTo(state, position))
     val ns = rewriter.rewriteUntilDone(state.setRex(tla.eql(state.ex, expected)))
@@ -105,8 +106,8 @@ class TestCherryPick extends RewriterBase with TestingPredefs {
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
-    def mkSeq(args : Int*): ArenaCell = {
-      val tuple = tla.tuple(args map tla.int :_*)
+    def mkSeq(args: Int*): ArenaCell = {
+      val tuple = tla.tuple(args map tla.int: _*)
       val annot = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
       state = rewriter.rewriteUntilDone(state.setRex(annot))
       state.asCell
@@ -211,9 +212,8 @@ class TestCherryPick extends RewriterBase with TestingPredefs {
       state.asCell
     }
 
-    val sets = Seq(rewriteEx(tla.enumSet(tla.enumSet(1, 2),
-      tla.enumSet(3, 4))),
-      rewriteEx(tla.enumSet(tla.enumSet(5, 6))))
+    val sets =
+      Seq(rewriteEx(tla.enumSet(tla.enumSet(1, 2), tla.enumSet(3, 4))), rewriteEx(tla.enumSet(tla.enumSet(5, 6))))
     state = new CherryPick(rewriter).pickSet(FinSetT(FinSetT(IntT())), state, oracle, sets, state.arena.cellFalse())
     assert(solverContext.sat())
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestModelChecker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestModelChecker.scala
@@ -3,18 +3,15 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.search.BfsStrategy
 import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
-import at.forsyte.apalache.tla.imp.SanyImporter
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
-
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}
-
-import scala.io.Source
 
 @RunWith(classOf[JUnitRunner])
 class TestModelChecker extends FunSuite with BeforeAndAfter {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterKeraSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterKeraSet.scala
@@ -4,14 +4,15 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{Keramelizer, UniqueNameGenerator}
 
 /**
-  * Tests for the TLA+ operators that are deal with by rewriting into KerA+.
-  * Although they are not needed to test the rewriting rules, we keep them for regression.
-  *
-  * @author Igor Konnov
-  */
+ * Tests for the TLA+ operators that are deal with by rewriting into KerA+.
+ * Although they are not needed to test the rewriting rules, we keep them for regression.
+ *
+ * @author Igor Konnov
+ */
 class TestRewriterKeraSet extends RewriterBase with TestingPredefs {
   private var keramelizer = new Keramelizer(new UniqueNameGenerator, TrackerWithListeners())
 
@@ -42,7 +43,6 @@ class TestRewriterKeraSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     assertTlaExAndRestore(rewriter, state)
   }
-
 
   test("""SE-SET-CUP: regression""") {
     // 2019-01-18, Igor: this bug originally appeared in TwoPhase.tla, the MWE can be found in Bug20190118.tla

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelChecker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelChecker.scala
@@ -12,6 +12,7 @@ import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{AnnotationParser, FinSetT, IntT, Seq
 import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -177,8 +178,7 @@ class TestSymbStateDecoder extends RewriterBase {
 
   test("decode sequence") {
     val seqEx =
-      tla.withType(tla.tuple(tla.int(1), tla.int(2), tla.int(3), tla.int(4)),
-        AnnotationParser.toTla(SeqT(IntT())))
+      tla.withType(tla.tuple(tla.int(1), tla.int(2), tla.int(3), tla.int(4)), AnnotationParser.toTla(SeqT(IntT())))
     val subseqEx = tla.subseq(seqEx, tla.int(2), tla.int(3))
     val state = new SymbState(subseqEx, arena, Binding())
     val rewriter = create()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
@@ -1,10 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.Continue
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -6,15 +6,16 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import scala.collection.immutable.{SortedMap, SortedSet, TreeMap}
 
 /**
-  * Tests for assignments. The assignments were at the core of Apalache 0.5.x. In Apalache 0.6.x, they are preprocessed
-  * into Skolemizable existential quantifiers. We keep the tests for regression.
-  */
+ * Tests for assignments. The assignments were at the core of Apalache 0.5.x. In Apalache 0.6.x, they are preprocessed
+ * into Skolemizable existential quantifiers. We keep the tests for regression.
+ */
 @RunWith(classOf[JUnitRunner])
 class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
   private val set12: OperEx = tla.enumSet(tla.int(1), tla.int(2))
@@ -53,8 +54,8 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
   test("""SE-IN-ASSIGN1(int): assign in conjunction""") {
     val and =
       tla.and(
-        tla.assign(x_prime, tla.int(1)),
-        tla.assign(y_prime, tla.int(2))
+          tla.assign(x_prime, tla.int(1)),
+          tla.assign(y_prime, tla.int(2))
       )
 
     val state = new SymbState(and, arena, Binding())
@@ -97,13 +98,11 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
   test("""SE-IN-ASSIGN1(int): \E t \in \in {t_2 \in {1}: FALSE}: x' \in {t} ~~> FALSE""") {
     // a regression test
     def empty(set: TlaEx): TlaEx = {
-      tla.filter(tla.name("t_2"),
-        set,
-        tla.bool(false))
+      tla.filter(tla.name("t_2"), set, tla.bool(false))
     }
 
-    val assign = OperEx(BmcOper.skolem,
-      tla.exists(boundName, empty(tla.enumSet(tla.int(1))), tla.assign(x_prime, boundName)))
+    val assign =
+      OperEx(BmcOper.skolem, tla.exists(boundName, empty(tla.enumSet(tla.int(1))), tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -143,10 +142,8 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-IN-ASSIGN1(set): \E t \in {{1, 2}, {2, 3}}: x' \in {t} ~~> TRUE and [x -> $C$k]""") {
-    val set = tla.enumSet(set12,
-      tla.enumSet(tla.int(2), tla.int(3)))
-    val assign = OperEx(BmcOper.skolem,
-      tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+    val set = tla.enumSet(set12, tla.enumSet(tla.int(2), tla.int(3)))
+    val assign = OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -186,16 +183,13 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     // equal elements in different sets mess up picking from a set
     def setminus(left: TlaEx, right: TlaEx): TlaEx = {
       // this is how Keramelizer translates setminus
-      tla.filter(tla.name("t_2"),
-        left,
-        tla.not(tla.eql(tla.name("t_2"), right)))
+      tla.filter(tla.name("t_2"), left, tla.not(tla.eql(tla.name("t_2"), right)))
     }
 
     val twoSets = tla.enumSet(tla.enumSet(1, 2), tla.enumSet(tla.plus(1, 1), 2, 3))
     val minus = setminus(twoSets, tla.enumSet(2, 3))
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, minus, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, minus, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -241,8 +235,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
   test("""SE-IN-ASSIGN1(set): \E t \in SUBSET {1, 2}: x' \in {t} ~~> TRUE and [x -> $C$k]""") {
     val set = tla.powSet(set12)
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -303,8 +296,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     val fun2 = tla.funDef(tla.int(2), tla.name("x4"), tla.booleanSet())
     val set = tla.enumSet(fun0, fun1)
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -344,8 +336,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     val fun2 = tla.funDef(tla.int(2), tla.name("x"), tla.booleanSet())
     val set = tla.funSet(tla.booleanSet(), tla.enumSet(tla.int(0), tla.int(1)))
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -390,8 +381,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     // regression
     val set = tla.funSet(tla.enumSet(), tla.enumSet(tla.int(0), tla.int(1)))
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -407,8 +397,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     val domain = tla.dotdot(tla.int(0), tla.minus(tla.int(5), tla.int(1)))
     val set = tla.funSet(domain, boolset)
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -430,8 +419,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     val domain = tla.dotdot(tla.int(0), tla.int(4))
     val set = tla.funSet(domain, ValEx(TlaNatSet))
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -445,8 +433,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     val domain = tla.dotdot(tla.int(0), tla.int(4))
     val set = tla.funSet(domain, ValEx(TlaIntSet))
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -463,8 +450,7 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
     val tuple2 = tla.tuple(tla.int(2), tla.bool(true), set2)
     val set = tla.enumSet(tuple1, tuple2)
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, set, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, set, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -475,13 +461,8 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
         assert(TupleT(List(IntT(), BoolT(), FinSetT(IntT()))) == cell.cellType)
 
         val membershipTest =
-          tla.and(tla.in(tla.appFun(x_prime, tla.int(1)),
-            set12),
-            tla.in(tla.appFun(x_prime, tla.int(2)),
-              boolset),
-            tla.in(tla.appFun(x_prime, tla.int(3)),
-              tla.enumSet(set1, set2))
-          ) ///
+          tla.and(tla.in(tla.appFun(x_prime, tla.int(1)), set12), tla.in(tla.appFun(x_prime, tla.int(2)), boolset),
+              tla.in(tla.appFun(x_prime, tla.int(3)), tla.enumSet(set1, set2))) ///
 
         assertTlaExAndRestore(rewriter, nextState.setRex(membershipTest))
 
@@ -491,18 +472,16 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
   }
 
   // the model checker will never meet such an expression, as it will be optimized into several existentials by ExprOptimizer
-  test("""SE-IN-ASSIGN1(record): \E t \in {{"a" -> 1, "b" -> FALSE}, {"a" -> 2, "b" -> TRUE, "c" -> {3, 4}}}: x' \in {t}""") {
+  test(
+      """SE-IN-ASSIGN1(record): \E t \in {{"a" -> 1, "b" -> FALSE}, {"a" -> 2, "b" -> TRUE, "c" -> {3, 4}}}: x' \in {t}""") {
     val annotation = AnnotationParser.toTla(RecordT(SortedMap("a" -> IntT(), "b" -> BoolT(), "c" -> FinSetT(IntT()))))
     // records in a set can have different sets of keys, although the field types should be compatible for each field
-    val record1 = tla.enumFun(tla.str("a"), tla.int(1),
-      tla.str("b"), tla.bool(false))
+    val record1 = tla.enumFun(tla.str("a"), tla.int(1), tla.str("b"), tla.bool(false))
     val set34 = tla.enumSet(tla.int(3), tla.int(4))
-    val record2 = tla.enumFun(tla.str("a"), tla.int(2),
-      tla.str("b"), tla.bool(true), tla.str("c"), set34)
+    val record2 = tla.enumFun(tla.str("a"), tla.int(2), tla.str("b"), tla.bool(true), tla.str("c"), set34)
     val recordSet = tla.enumSet(tla.withType(record1, annotation), record2)
     val assign =
-      OperEx(BmcOper.skolem,
-        tla.exists(boundName, recordSet, tla.assign(x_prime, boundName)))
+      OperEx(BmcOper.skolem, tla.exists(boundName, recordSet, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(assign, arena, Binding())
     val rewriter = create()
@@ -513,16 +492,15 @@ class TestSymbStateRewriterAssignment extends RewriterBase with TestingPredefs {
         val cell = nextState.binding("x'")
         // x' is assigned a record from recordSet
         assert(cell.cellType.isInstanceOf[RecordT])
-        assert(cell.cellType.asInstanceOf[RecordT].fields
-          == TreeMap("a" -> IntT(), "b" -> BoolT(), "c" -> FinSetT(IntT())))
+        assert(
+            cell.cellType.asInstanceOf[RecordT].fields
+              == TreeMap("a" -> IntT(), "b" -> BoolT(), "c" -> FinSetT(IntT())))
 
         val a_of_x_prime = tla.appFun(x_prime, tla.str("a"))
         val b_of_x_prime = tla.appFun(x_prime, tla.str("b"))
         val c_of_x_prime = tla.appFun(x_prime, tla.str("c"))
         val membershipTest =
-          tla.and(
-            tla.in(a_of_x_prime, set12),
-            tla.in(b_of_x_prime, boolset))
+          tla.and(tla.in(a_of_x_prime, set12), tla.in(b_of_x_prime, boolset))
         // interestingly, we cannot expect that x'.c \in { 3, 4 },
         // as the value of the field c is unknown for the first record
         //            tla.in(c_of_x_prime, tla.enumSet(set34))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{FailPredT, IntT}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -128,7 +129,6 @@ class TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     }
   }
 
-
   test("""SE-ITE[5]: IF 1 = 1 THEN {2} ELSE {1} ] ~~> $C$k""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
 
@@ -139,7 +139,7 @@ class TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.push()
         solverContext.assertGroundExpr(tla.not(nextState.ex))
@@ -150,12 +150,10 @@ class TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
         assert(solverContext.sat())
         solverContext.pop()
 
-
       case _ =>
         fail("Unexpected rewriting result")
     }
   }
-
 
   test("""SE-ITE[5]: IF 2 < 3 THEN {1, 2} ELSE {2, 3} ~~> {1, 2}""") {
     val pred = tla.lt(tla.int(2), tla.int(3))
@@ -236,7 +234,7 @@ class TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
       val rewriter = create()
       val nextState = rewriter.rewriteUntilDone(state)
       nextState.ex match {
-        case res@NameEx(name) =>
+        case res @ NameEx(name) =>
           rewriter.push()
           solverContext.assertGroundExpr(tla.eql(icell.toNameEx, i))
           solverContext.assertGroundExpr(tla.eql(1 + (i % 3), res))
@@ -245,7 +243,8 @@ class TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
           rewriter.push()
           val failureOccurs = tla.or(nextState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
           solverContext.assertGroundExpr(failureOccurs)
-          assert(solverContext.sat()) // this possible since there is no OTHER case and the constraints do not restrict us
+          assert(
+              solverContext.sat()) // this possible since there is no OTHER case and the constraints do not restrict us
           rewriter.pop()
           rewriter.push()
           solverContext.assertGroundExpr(tla.eql(icell.toNameEx, i))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -18,10 +19,8 @@ class TestSymbStateRewriterExpand extends RewriterBase {
     val powCell = nextState.asCell
     // check equality
     val eq = tla.eql(nextState.ex,
-      tla.enumSet(tla.withType(tla.enumSet(), AnnotationParser.toTla(FinSetT(IntT()))),
-        tla.enumSet(tla.int(1)),
-        tla.enumSet(tla.int(2)),
-          tla.enumSet(tla.int(1), tla.int(2))))
+        tla.enumSet(tla.withType(tla.enumSet(), AnnotationParser.toTla(FinSetT(IntT()))), tla.enumSet(tla.int(1)),
+            tla.enumSet(tla.int(2)), tla.enumSet(tla.int(1), tla.int(2))))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
@@ -48,8 +47,8 @@ class TestSymbStateRewriterExpand extends RewriterBase {
       val mapEx = tla.ite(tla.eql(NameEx("x"), tla.int(1)), tla.bool(v1), tla.bool(v2))
       tla.funDef(mapEx, tla.name("x"), domain)
     }
-    val expected = tla.enumSet(mkFun(false, false), mkFun(false, true),
-                               mkFun(true, false), mkFun(true, true))
+
+    val expected = tla.enumSet(mkFun(false, false), mkFun(false, true), mkFun(true, false), mkFun(true, true))
     assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(expected, funSetCell.toNameEx)))
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
@@ -3,13 +3,14 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestSymbStateRewriterFiniteSets extends RewriterBase {
   test("""Cardinality({1, 2, 3}) = 3""") {
-    val set = tla.enumSet(1.to(3).map(tla.int) :_*)
+    val set = tla.enumSet(1.to(3).map(tla.int): _*)
     val card = tla.card(set)
     val state = new SymbState(card, arena, Binding())
     val rewriter = create()
@@ -19,7 +20,7 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Cardinality({1, 2, 2, 2, 3, 3}) = 3""") {
-    val set = tla.enumSet(Seq(1, 2, 2, 2, 3, 3).map(tla.int) :_*)
+    val set = tla.enumSet(Seq(1, 2, 2, 2, 3, 3).map(tla.int): _*)
     val card = tla.card(set)
     val state = new SymbState(card, arena, Binding())
     val rewriter = create()
@@ -29,7 +30,7 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""BMC!ConstCard(Cardinality({1, 2, 3}) >= 3)""") {
-    val set = tla.enumSet(1.to(3).map(tla.int) :_*)
+    val set = tla.enumSet(1.to(3).map(tla.int): _*)
     val cardCmp = OperEx(BmcOper.constCard, tla.ge(tla.card(set), tla.int(3)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create()
@@ -40,7 +41,7 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""BMC!ConstCard(Cardinality({1, 2, 3}) >= 4)""") {
-    val set = tla.enumSet(1.to(3).map(tla.int) :_*)
+    val set = tla.enumSet(1.to(3).map(tla.int): _*)
     val cardCmp = OperEx(BmcOper.constCard, tla.ge(tla.card(set), tla.int(4)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create()
@@ -51,7 +52,7 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""BMC!ConstCard(Cardinality({1, 2, 2, 3}) >= 4)""") {
-    val set = tla.enumSet(List(1, 2, 2, 3).map(tla.int) :_*)
+    val set = tla.enumSet(List(1, 2, 2, 3).map(tla.int): _*)
     val cardCmp = OperEx(BmcOper.constCard, tla.ge(tla.card(set), tla.int(4)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create()
@@ -62,7 +63,7 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""BMC!ConstCard(Cardinality({1, 2, 2, 3, 3}) >= 4)""") {
-    val set = tla.enumSet(List(1, 2, 2, 3).map(tla.int) :_*)
+    val set = tla.enumSet(List(1, 2, 2, 3).map(tla.int): _*)
     val cardCmp = OperEx(BmcOper.constCard, tla.ge(tla.card(set), tla.int(4)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create()
@@ -118,12 +119,10 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
 
   test("""Cardinality({1, 2, 3} \ {2}) = 2""") {
     def setminus(set: TlaEx, intVal: Int): TlaEx = {
-      tla.filter(tla.name("t"),
-        set,
-        tla.not(tla.eql(tla.name("t"), tla.int(intVal))))
+      tla.filter(tla.name("t"), set, tla.not(tla.eql(tla.name("t"), tla.int(intVal))))
     }
 
-    val set = setminus(tla.enumSet(1.to(3).map(tla.int) :_*), 2)
+    val set = setminus(tla.enumSet(1.to(3).map(tla.int): _*), 2)
     val card = tla.card(set)
     val state = new SymbState(card, arena, Binding())
     val rewriter = create()
@@ -133,7 +132,7 @@ class TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""IsFiniteSet({1, 2, 3}) = TRUE""") {
-    val set = tla.enumSet(1.to(3).map(tla.int) :_*)
+    val set = tla.enumSet(1.to(3).map(tla.int): _*)
     val card = tla.isFin(set)
     val state = new SymbState(card, arena, Binding())
     val rewriter = create()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -7,9 +7,9 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaBoolSet
 import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-
 
 @RunWith(classOf[JUnitRunner])
 class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
@@ -24,7 +24,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         val cell = nextState.arena.findCellByName(name)
         cell.cellType match {
@@ -46,11 +46,9 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     def intSet(i: Int) = tla.enumSet(tla.int(i))
 
     val mapping = tla.ite(
-      tla.eql(tla.name("x"), tla.int(1)),
-      intSet(2),
-      tla.ite(tla.eql(tla.name("x"), tla.int(2)),
-        intSet(3),
-        intSet(1))
+        tla.eql(tla.name("x"), tla.int(1)),
+        intSet(2),
+        tla.ite(tla.eql(tla.name("x"), tla.int(2)), intSet(3), intSet(1))
     )
     ////
     val fun = tla.funDef(mapping, tla.name("x"), set)
@@ -59,7 +57,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
 
       case _ =>
@@ -79,7 +77,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case result@NameEx(name) =>
+      case result @ NameEx(name) =>
         solverContext.push()
         solverContext.assertGroundExpr(result)
         assert(solverContext.sat())
@@ -105,7 +103,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         val failureOccurs = tla.or(nextState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -118,7 +116,6 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
         solverContext.assertGroundExpr(tla.not(nextState.ex))
         assert(!solverContext.sat())
         solverContext.pop()
-
 
       case _ =>
         fail("Unexpected rewriting result")
@@ -136,7 +133,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         val failureOccurs = tla.or(nextState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -149,7 +146,6 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
         solverContext.assertGroundExpr(tla.not(nextState.ex))
         assert(!solverContext.sat())
         solverContext.pop()
-
 
       case _ =>
         fail("Unexpected rewriting result")
@@ -168,7 +164,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         val cell = nextState.arena.findCellByName(name)
         cell.cellType match {
@@ -201,7 +197,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         // In the previous version, we were using failure predicates to detect failures.
         // However, they were an unnecessary burden and produced tonnes of constraints.
         // In the new version, we just return some value,
@@ -216,7 +212,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
       assert(solverContext.sat())
       solverContext.assertGroundExpr(tla.not(failureOccurs))
       assert(!solverContext.sat())
-      */
+       */
 
       case _ =>
         fail("Unexpected rewriting result")
@@ -254,7 +250,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         val cell = nextState.arena.findCellByName(name)
         cell.cellType match {
@@ -272,7 +268,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val appEq = tla.eql(nextState.ex, tla.enumSet(tla.int(1), tla.int(3)))
     val eqState = nextState.setRex(appEq)
     create().rewriteUntilDone(eqState).ex match {
-      case eqEx@NameEx(name) =>
+      case eqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(eqEx)
         assert(solverContext.sat())
 
@@ -283,7 +279,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val appNeq = tla.not(tla.eql(nextState.ex, tla.enumSet(tla.int(1), tla.int(3))))
     val neqState = nextState.setRex(appNeq)
     rewriter.rewriteUntilDone(neqState).ex match {
-      case eqEx@NameEx(name) =>
+      case eqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(eqEx)
         assert(!solverContext.sat())
 
@@ -310,7 +306,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
@@ -332,7 +328,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         val failureOccurs = tla.or(nextState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
         rewriter.push()
@@ -354,7 +350,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         val failureOccurs = tla.or(nextState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
         rewriter.push()
@@ -383,7 +379,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         val cell = nextState.arena.findCellByName(name)
         cell.cellType match {
@@ -401,7 +397,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val appEq = tla.eql(nextState.ex, boolNegFun)
     val eqState = rewriter.rewriteUntilDone(nextState.setRex(appEq))
     eqState.ex match {
-      case eqEx@NameEx(name) =>
+      case eqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(eqEx)
         val isSat = solverContext.sat()
         assert(isSat)
@@ -414,7 +410,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val appNeq = tla.not(tla.eql(nextState.ex, boolNegFun))
     val neqState = rewriter.rewriteUntilDone(nextState.setRex(appNeq))
     neqState.ex match {
-      case neqEx@NameEx(name) =>
+      case neqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(neqEx)
         val failureOccurs = tla.or(neqState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -438,7 +434,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case resFunEx@NameEx(name) =>
+      case resFunEx @ NameEx(name) =>
         solverContext.assertGroundExpr(resFunEx)
         val failureOccurs = tla.or(nextState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -460,7 +456,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case resFunEx@NameEx(name) =>
+      case resFunEx @ NameEx(name) =>
         // check the function domain and co-domain
         val resFun = nextState.asCell
         // no domain anymore
@@ -484,13 +480,13 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
 
     // make sure that not equals gives us sat
     cmpState.ex match {
-      case neqEx@NameEx(name) =>
+      case neqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(neqEx)
         /*
         // not using failure predicates anymore
         val failureOccurs = tla.or(cmpState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
-        */
+         */
         assertUnsatOrExplain(rewriter, cmpState)
 
       case _ =>
@@ -509,7 +505,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case resFunEx@NameEx(name) =>
+      case resFunEx @ NameEx(name) =>
         // check the function domain and co-domain
         val resFun = nextState.arena.findCellByName(name)
         // no domain anymore
@@ -533,7 +529,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
 
     // make sure that not equals gives us sat
     cmpState.ex match {
-      case neqEx@NameEx(name) =>
+      case neqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(neqEx)
         val failureOccurs = tla.or(cmpState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -555,7 +551,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case resFunEx@NameEx(name) =>
+      case resFunEx @ NameEx(name) =>
         // check the function domain and co-domain
         val resFun = nextState.arena.findCellByName(name)
         // no domain anymore
@@ -579,7 +575,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
 
     // make sure that not equals gives us sat
     cmpState.ex match {
-      case neqEx@NameEx(name) =>
+      case neqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(neqEx)
         val failureOccurs = tla.or(cmpState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -601,7 +597,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case resFunEx@NameEx(name) =>
+      case resFunEx @ NameEx(name) =>
         // check the function domain and co-domain
         val resFun = nextState.arena.findCellByName(name)
         // no domain anymore
@@ -625,7 +621,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
 
     // make sure that not equals gives us sat
     cmpState.ex match {
-      case neqEx@NameEx(name) =>
+      case neqEx @ NameEx(name) =>
         solverContext.assertGroundExpr(neqEx)
         val failureOccurs = tla.or(cmpState.arena.findCellsByType(FailPredT()).map(_.toNameEx): _*)
         solverContext.assertGroundExpr(tla.not(failureOccurs))
@@ -640,10 +636,7 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     // this test was failing in the buggy implementation with PICK .. FROM and FUN-MERGE
     val fun1 = tla.funDef(tla.not(tla.name("y")), tla.name("y"), ValEx(TlaBoolSet))
     val exists =
-      OperEx(BmcOper.skolem,
-        tla.exists(tla.name("x"),
-          tla.enumSet(fun1),
-          tla.appFun(NameEx("x"), tla.bool(false))))
+      OperEx(BmcOper.skolem, tla.exists(tla.name("x"), tla.enumSet(fun1), tla.appFun(NameEx("x"), tla.bool(false))))
 
     // here, we have to overred FreeExistentialsStore, and thus cannot use SymbStateRewriterAuto
     val typeFinder = new TrivialTypeFinder()
@@ -679,14 +672,13 @@ class TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     // regression
     val fun = tla.funDef(tla.bool(true), "y", "Oper:X")
     val app = tla.appFun(fun, 2)
-    val ex = tla.letIn(app,
-      tla.declOp("X", tla.cap(tla.enumSet(1, 2), tla.enumSet(2))))
+    val ex = tla.letIn(app, tla.declOp("X", tla.cap(tla.enumSet(1, 2), tla.enumSet(2))))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat()) // it should be sat
         rewriter.push()
         val failPreds = nextState.arena.findCellsByType(FailPredT())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -36,8 +37,7 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
 
   test("""SE-FUNSET2: [{1, 2} -> Expand(SUBSET {FALSE, TRUE})]""") {
     val domain = tla.enumSet(tla.int(1), tla.int(2))
-    val codomain = OperEx(BmcOper.expand,
-      tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true))))
+    val codomain = OperEx(BmcOper.expand, tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true))))
     val state = new SymbState(tla.funSet(domain, codomain), arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
@@ -80,10 +80,7 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
     val codomain = tla.powSet(tla.enumSet(tla.bool(false)))
     val pred = tla.eql(tla.appFun(tla.name("f"), tla.int(1)), tla.enumSet(tla.bool(true)))
     val exists =
-      tla.exists(
-        tla.name("f"),
-        tla.funSet(domain, codomain),
-        pred)
+      tla.exists(tla.name("f"), tla.funSet(domain, codomain), pred)
     val skolem = OperEx(BmcOper.skolem, exists)
     val state = new SymbState(skolem, arena, Binding())
     val rewriter = create()
@@ -117,9 +114,7 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
     val domain = tla.enumSet(tla.int(1), tla.int(2))
     val codomain = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
     val funset = tla.funSet(domain, codomain)
-    val fun = tla.funDef(tla.enumSet(tla.eql(tla.name("x"), tla.int(1))),
-                         tla.name("x"),
-                         domain)
+    val fun = tla.funDef(tla.enumSet(tla.eql(tla.name("x"), tla.int(1))), tla.name("x"), domain)
     val state = new SymbState(tla.in(fun, funset), arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
@@ -142,9 +137,7 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
     val domain = tla.enumSet(tla.int(1), tla.int(2))
     val codomain = tla.enumSet(tla.int(3), tla.int(4))
     val funset = tla.funSet(domain, codomain)
-    val fun = tla.funDef(tla.int(3),
-                         tla.name("x"),
-                         domain)
+    val fun = tla.funDef(tla.int(3), tla.name("x"), domain)
     val state = new SymbState(tla.in(fun, funset), arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
@@ -156,18 +149,14 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
   test("""SE-FUNSET2: [x \in {0, 1, 2} \ {0} |-> 3] \in [{1, 2} -> {3, 4}]""") {
     // although 0 is in the function domain at the arena level, it does not belong to the set difference
     def setminus(set: TlaEx, intVal: Int): TlaEx = {
-      tla.filter(tla.name("t"),
-        set,
-        tla.not(tla.eql(tla.name("t"), tla.int(intVal))))
+      tla.filter(tla.name("t"), set, tla.not(tla.eql(tla.name("t"), tla.int(intVal))))
     }
 
     val domain1 = setminus(tla.enumSet(0.to(2).map(tla.int): _*), 0)
     val domain2 = tla.enumSet(1.to(2).map(tla.int): _*)
     val codomain = tla.enumSet(tla.int(3), tla.int(4))
     val funset = tla.funSet(domain2, codomain)
-    val fun = tla.funDef(tla.int(3),
-                         tla.name("x"),
-                         domain1)
+    val fun = tla.funDef(tla.int(3), tla.name("x"), domain1)
     val state = new SymbState(tla.in(fun, funset), arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
@@ -180,9 +169,7 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
     val domain = tla.enumSet(tla.int(1), tla.int(2))
     val codomain = tla.powSet(tla.enumSet(tla.bool(false)))
     val funset = tla.funSet(domain, codomain)
-    val fun = tla.funDef(tla.enumSet(tla.bool(true)),
-                         tla.name("x"),
-                         domain)
+    val fun = tla.funDef(tla.enumSet(tla.bool(true)), tla.name("x"), domain)
     val state = new SymbState(tla.in(fun, funset), arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
@@ -195,9 +182,7 @@ class TestSymbStateRewriterFunSet extends RewriterBase {
     val domain = tla.enumSet(tla.int(1), tla.int(2))
     val codomain = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
     val funset = tla.funSet(domain, codomain)
-    val fun = tla.funDef(tla.enumSet(tla.bool(true)),
-                         tla.name("x"),
-                         domain)
+    val fun = tla.funDef(tla.enumSet(tla.bool(true)), tla.name("x"), domain)
     val state = new SymbState(tla.in(fun, funset), arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -19,7 +20,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftCell.toNameEx, ValEx(TlaInt(22))))
         rewriter.push()
@@ -41,7 +42,6 @@ class TestSymbStateRewriterInt extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
 
-
       case _ =>
         fail("Unexpected rewriting result")
     }
@@ -56,7 +56,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftInt, ValEx(TlaInt(22))))
         rewriter.push()
@@ -91,7 +91,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case cmpEx@NameEx(name) =>
+      case cmpEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftCell.toNameEx, ValEx(TlaInt(4))))
@@ -120,7 +120,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case cmpEx@NameEx(name) =>
+      case cmpEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftCell.toNameEx, ValEx(TlaInt(4))))
@@ -149,7 +149,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case cmpEx@NameEx(name) =>
+      case cmpEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftCell.toNameEx, ValEx(TlaInt(4))))
@@ -199,7 +199,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case cmpEx@NameEx(name) =>
+      case cmpEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftCell.toNameEx, ValEx(TlaInt(4))))
@@ -228,7 +228,7 @@ class TestSymbStateRewriterInt extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, leftInt, ValEx(TlaInt(22))))
         rewriter.push()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{AnnotationParser, FinSetT, IntT, Pow
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -133,13 +134,12 @@ class TestSymbStateRewriterPowerset extends RewriterBase {
     // a regression test that failed in the previous versions
     val set = tla.enumSet(tla.int(1), tla.int(2))
     val ex =
-      OperEx(BmcOper.skolem,
-        tla.exists(tla.name("X"), tla.powSet(set), tla.bool(true)))
+      OperEx(BmcOper.skolem, tla.exists(tla.name("X"), tla.powSet(set), tla.bool(true)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -153,14 +153,13 @@ class TestSymbStateRewriterPowerset extends RewriterBase {
     // a regression test that failed in the previous versions
     val set = tla.enumSet(tla.int(1), tla.int(2))
     val ex =
-      OperEx(BmcOper.skolem,
-        tla.exists(tla.name("X"), tla.powSet(set), tla.bool(false)))
+      OperEx(BmcOper.skolem, tla.exists(tla.name("X"), tla.powSet(set), tla.bool(false)))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)
@@ -182,10 +181,8 @@ class TestSymbStateRewriterPowerset extends RewriterBase {
     rewriter.typeFinder.reset(rewriter.typeFinder.varTypes + (powCell.toString -> powCell.cellType))
     // check equality
     val eq = tla.eql(nextState.ex,
-      tla.enumSet(tla.withType(tla.enumSet(), AnnotationParser.toTla(FinSetT(IntT()))),
-        tla.enumSet(tla.int(1)),
-        tla.enumSet(tla.int(2)),
-          tla.enumSet(tla.int(1), tla.int(2))))
+        tla.enumSet(tla.withType(tla.enumSet(), AnnotationParser.toTla(FinSetT(IntT()))), tla.enumSet(tla.int(1)),
+            tla.enumSet(tla.int(2)), tla.enumSet(tla.int(1), tla.int(2))))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
@@ -3,9 +3,9 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.TlaIntSet
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-
 
 @RunWith(classOf[JUnitRunner])
 class TestSymbStateRewriterRecFun extends RewriterBase with TestingPredefs {
@@ -17,9 +17,9 @@ class TestSymbStateRewriterRecFun extends RewriterBase with TestingPredefs {
     val ref = tla.withType(tla.recFunRef(), tla.funSet(ValEx(TlaIntSet), ValEx(TlaIntSet)))
 
     val map = ite(
-      le(tla.name("n"), int(1)),
-      int(2),
-      mult(int(2), appFun(ref, minus(tla.name("n"), int(1))))
+        le(tla.name("n"), int(1)),
+        int(2),
+        mult(int(2), appFun(ref, minus(tla.name("n"), int(1))))
     ) ///
 
     val fun = recFunDef(map, tla.name("n"), set)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -30,7 +31,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-CTOR: <<1, 2, 3>> <: Seq(Int)""") {
-    val tuple = TlaFunOper.mkTuple(1.to(3) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(1.to(3) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
 
     val state = new SymbState(annotatedTuple, arena, Binding())
@@ -48,7 +49,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-APP: (<<3, 4, 5>> <: Seq(Int))[2]""") {
-    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
 
     val state = new SymbState(annotatedTuple, arena, Binding())
@@ -56,12 +57,9 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
     val seq = nextState.asCell
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(seq.toNameEx, tla.int(1)), tla.int(3))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(seq.toNameEx, tla.int(2)), tla.int(4))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(seq.toNameEx, tla.int(3)), tla.int(5))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(seq.toNameEx, tla.int(1)), tla.int(3))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(seq.toNameEx, tla.int(2)), tla.int(4))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(seq.toNameEx, tla.int(3)), tla.int(5))))
   }
 
   test("""SE-SEQ-APP: (<<>> <: Seq(Int))[1]""") {
@@ -76,7 +74,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-HEAD: Head(<<3, 4, 5>> <: Seq(Int))""") {
-    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val seqApp = tla.head(annotatedTuple)
 
@@ -90,7 +88,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-LEN: Len(<<3, 4, 5>> <: Seq(Int))""") {
-    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val seqApp = tla.len(annotatedTuple)
 
@@ -104,7 +102,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-TAIL: Tail(<<3, 4, 5>> <: Seq(Int))""") {
-    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(5) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val seqTail = tla.tail(annotatedTuple)
 
@@ -114,10 +112,8 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
     val result = nextState.asCell
     assert(SeqT(IntT()) == result.cellType)
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
   }
 
   test("""regression: Tail(<<>> <: Seq(Int)) does not unsat and its length is zero""") {
@@ -135,7 +131,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-SUBSEQ: SubSeq(S, 2, 4)""") {
-    val tuple = TlaFunOper.mkTuple(3.to(6) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(6) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val subseqEx = tla.subseq(annotatedTuple, tla.int(2), tla.int(3))
 
@@ -145,16 +141,13 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
     val result = nextState.asCell
     assert(SeqT(IntT()) == result.cellType)
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.len(result.toNameEx), tla.int(2))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.len(result.toNameEx), tla.int(2))))
   }
 
   test("""regression: SE-SEQ-SUBSEQ: SubSeq(S, 3, 1) does not unsat and has length 0""") {
-    val tuple = TlaFunOper.mkTuple(3.to(6) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(6) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val subseqEx = tla.subseq(annotatedTuple, tla.int(3), tla.int(1))
 
@@ -168,7 +161,7 @@ class TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SE-SEQ-APPEND: Append(S, 10)""") {
-    val tuple = TlaFunOper.mkTuple(4.to(5) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(4.to(5) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val append = tla.append(annotatedTuple, tla.int(10))
 
@@ -178,18 +171,14 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
     val result = nextState.asCell
     assert(SeqT(IntT()) == result.cellType)
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(3)), tla.int(10))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.len(result.toNameEx), tla.int(3))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(3)), tla.int(10))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.len(result.toNameEx), tla.int(3))))
   }
 
   test("""SE-SEQ-APPEND: Append(SubSeq(S, 2, 3), 10)""") {
-    val tuple = TlaFunOper.mkTuple(3.to(6) map tla.int :_*)
+    val tuple = TlaFunOper.mkTuple(3.to(6) map tla.int: _*)
     val annotatedTuple = tla.withType(tuple, AnnotationParser.toTla(SeqT(IntT())))
     val subseqEx = tla.subseq(annotatedTuple, tla.int(2), tla.int(3))
     val append = tla.append(subseqEx, tla.int(10))
@@ -200,22 +189,17 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
     val result = nextState.asCell
     assert(SeqT(IntT()) == result.cellType)
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(3)), tla.int(10))))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.len(result.toNameEx), tla.int(3))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(1)), tla.int(4))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(2)), tla.int(5))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.appFun(result.toNameEx, tla.int(3)), tla.int(10))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.len(result.toNameEx), tla.int(3))))
   }
 
-
   test("""SE-SEQ-EQ: <<4, 5>> = SubSeq(<<3, 4, 5, 6>>, 2, 3)""") {
-    val tuple3456 = TlaFunOper.mkTuple(3.to(6) map tla.int :_*)
+    val tuple3456 = TlaFunOper.mkTuple(3.to(6) map tla.int: _*)
     val annot3456 = tla.withType(tuple3456, AnnotationParser.toTla(SeqT(IntT())))
     val subseqEx = tla.subseq(annot3456, tla.int(2), tla.int(3))
-    val tuple45 = TlaFunOper.mkTuple(4.to(5) map tla.int :_*)
+    val tuple45 = TlaFunOper.mkTuple(4.to(5) map tla.int: _*)
     val annot45 = tla.withType(tuple45, AnnotationParser.toTla(SeqT(IntT())))
     val eq = tla.eql(annot45, subseqEx)
 
@@ -225,12 +209,11 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
     val result = nextState.asCell
     assert(BoolT() == result.cellType)
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.bool(true), nextState.ex)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.bool(true), nextState.ex)))
   }
 
   test("""SE-SEQ-DOMAIN: DOMAIN SubSeq(<<3, 4, 5, 6>>, 2, 3) = {2, 3}""") {
-    val tuple3456 = TlaFunOper.mkTuple(3.to(6) map tla.int :_*)
+    val tuple3456 = TlaFunOper.mkTuple(3.to(6) map tla.int: _*)
     val annot3456 = tla.withType(tuple3456, AnnotationParser.toTla(SeqT(IntT())))
     val subseqEx = tla.subseq(annot3456, tla.int(2), tla.int(3))
     val domEx = tla.dom(subseqEx)
@@ -239,12 +222,11 @@ class TestSymbStateRewriterSequence extends RewriterBase {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.eql(tla.enumSet(tla.int(2), tla.int(3)), nextState.ex)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.enumSet(tla.int(2), tla.int(3)), nextState.ex)))
   }
 
   test("""SEQ-CONCAT: <<9, 10>> \o SubSeq(S, 2, 3)""") {
-    val tuple3_6 = TlaFunOper.mkTuple(3.to(6) map tla.int :_*)
+    val tuple3_6 = TlaFunOper.mkTuple(3.to(6) map tla.int: _*)
     val seqT = AnnotationParser.toTla(SeqT(IntT()))
     val annotatedTuple = tla.withType(tuple3_6, seqT)
     val subseq = tla.subseq(annotatedTuple, tla.int(2), tla.int(3)) // <<4, 5>>

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaIntSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -16,7 +15,6 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   private def emptySetWithType(elemT: CellT): TlaEx =
     tla.withType(tla.enumSet(), AnnotationParser.toTla(FinSetT(elemT)))
 
-
   test("""SE-SET-CTOR[1-2]: {x, y, z} ~~> c_set""") {
     val ex = OperEx(TlaSetOper.enumSet, NameEx("x"), NameEx("y"), NameEx("z"))
     val binding = Binding("x" -> arena.cellFalse(), "y" -> arena.cellTrue(), "z" -> arena.cellFalse())
@@ -24,11 +22,11 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     create().rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
-          case set@NameEx(name) =>
+          case set @ NameEx(name) =>
             solverContext.assertGroundExpr(OperEx(TlaSetOper.in, arena.cellFalse().toNameEx, set))
             assert(solverContext.sat())
-            solverContext.assertGroundExpr(OperEx(TlaBoolOper.not,
-              OperEx(TlaSetOper.in, arena.cellTrue().toNameEx, set)))
+            solverContext
+              .assertGroundExpr(OperEx(TlaBoolOper.not, OperEx(TlaSetOper.in, arena.cellTrue().toNameEx, set)))
             assert(!solverContext.sat())
 
           case _ =>
@@ -46,7 +44,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     create().rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
-          case set@NameEx(name) =>
+          case set @ NameEx(name) =>
             assert(solverContext.sat())
           case _ =>
             fail("Unexpected rewriting result")
@@ -59,9 +57,8 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-IN1: {} \in {} ~~> $B$0""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
-    val ex = OperEx(TlaSetOper.in,
-      emptySetWithType(IntT()),
-      emptySetWithType(FinSetT(IntT())))
+
+    val ex = OperEx(TlaSetOper.in, emptySetWithType(IntT()), emptySetWithType(FinSetT(IntT())))
     val state = new SymbState(ex, arena, Binding())
     val nextState = create().rewriteUntilDone(state)
     assert(nextState.arena.cellFalse().toNameEx == nextState.ex)
@@ -70,14 +67,12 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   test("""SE-SET-IN1: 3 \in {1, 3, 5} ~~> $B$k""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
 
-    val ex = OperEx(TlaSetOper.in,
-      ValEx(TlaInt(3)),
-      mkSet(ValEx(TlaInt(1)), ValEx(TlaInt(3)), ValEx(TlaInt(5))))
+    val ex = OperEx(TlaSetOper.in, ValEx(TlaInt(3)), mkSet(ValEx(TlaInt(1)), ValEx(TlaInt(3)), ValEx(TlaInt(5))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -92,13 +87,13 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-IN1: {3} \in {{1}, {3}, {5}} ~~> $B$k""") {
     val ex = tla.in(tla.enumSet(tla.int(3)),
-      tla.enumSet(tla.enumSet(tla.int(1)), tla.enumSet(tla.int(3)), tla.enumSet(tla.int(5))))
+        tla.enumSet(tla.enumSet(tla.int(1)), tla.enumSet(tla.int(3)), tla.enumSet(tla.int(5))))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -114,14 +109,12 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   test("""SE-SET-IN1: 2 \in {1, 3, 5} ~~> $B$k""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
 
-    val ex = OperEx(TlaSetOper.in,
-      ValEx(TlaInt(2)),
-      mkSet(ValEx(TlaInt(1)), ValEx(TlaInt(3)), ValEx(TlaInt(5))))
+    val ex = OperEx(TlaSetOper.in, ValEx(TlaInt(2)), mkSet(ValEx(TlaInt(1)), ValEx(TlaInt(3)), ValEx(TlaInt(5))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
@@ -163,8 +156,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""type inference 3 \in {{1}, {3}, {5}}""") {
     // this test worked in the previous versions, but now it just reports a type inference error
-    val ex = tla.in(tla.int(3),
-      tla.enumSet(tla.enumSet(tla.int(1)), tla.enumSet(tla.int(3)), tla.enumSet(tla.int(5))))
+    val ex = tla.in(tla.int(3), tla.enumSet(tla.enumSet(tla.int(1)), tla.enumSet(tla.int(3)), tla.enumSet(tla.int(5))))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
@@ -174,8 +166,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-SET-NOTIN1: ~({} \in {}) ~~> $B$1""") {
-    val ex = tla.not(tla.in(emptySetWithType(FinSetT(IntT())),
-      emptySetWithType(FinSetT(FinSetT(IntT())))))
+    val ex = tla.not(tla.in(emptySetWithType(FinSetT(IntT())), emptySetWithType(FinSetT(FinSetT(IntT())))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
@@ -191,15 +182,14 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-IN2: \FALSE \in {\FALSE, \TRUE} ~~> b_new""") {
     val ex =
-      OperEx(TlaSetOper.in,
-        ValEx(TlaBool(false)),
-        OperEx(TlaSetOper.enumSet, ValEx(TlaBool(false)), ValEx(TlaBool(true))))
+      OperEx(TlaSetOper.in, ValEx(TlaBool(false)),
+          OperEx(TlaSetOper.enumSet, ValEx(TlaBool(false)), ValEx(TlaBool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     rewriter.rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
-          case predEx@NameEx(name) =>
+          case predEx @ NameEx(name) =>
             rewriter.push()
             solverContext.assertGroundExpr(OperEx(TlaBoolOper.not, predEx))
             assert(!solverContext.sat())
@@ -218,12 +208,11 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-NOTIN1: ~(\FALSE \in {\FALSE, \TRUE}) ~~> b_new""") {
     val ex =
-      tla.not(tla.in(tla.bool(false),
-        tla.enumSet(tla.bool(false), tla.bool(true))))
+      tla.not(tla.in(tla.bool(false), tla.enumSet(tla.bool(false), tla.bool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     rewriter.rewriteUntilDone(state).ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(OperEx(TlaBoolOper.not, predEx))
         assert(solverContext.sat())
@@ -240,15 +229,13 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     arena = arena.appendCell(BoolT())
     val cell = arena.topCell
     val ex =
-      OperEx(TlaSetOper.in,
-        cell.toNameEx,
-        OperEx(TlaSetOper.enumSet, ValEx(TlaBool(true)), ValEx(TlaBool(true))))
+      OperEx(TlaSetOper.in, cell.toNameEx, OperEx(TlaSetOper.enumSet, ValEx(TlaBool(true)), ValEx(TlaBool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     rewriter.rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
-          case predEx@NameEx(name) =>
+          case predEx @ NameEx(name) =>
             rewriter.push()
             // cell = \TRUE
             solverContext.assertGroundExpr(OperEx(TlaOper.eq, arena.cellTrue().toNameEx, cell.toNameEx))
@@ -281,7 +268,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         nextState.arena.appendCell(IntT()) // the buggy rule implementation triggered an error here
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
@@ -301,13 +288,11 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     arena = arena.appendCell(BoolT())
     val cell = arena.topCell
     val ex =
-      tla.not(tla.in(
-        cell.toNameEx,
-        tla.enumSet(tla.bool(true), tla.bool(true))))
+      tla.not(tla.in(cell.toNameEx, tla.enumSet(tla.bool(true), tla.bool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     rewriter.rewriteUntilDone(state).ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // cell = \TRUE
         solverContext.assertGroundExpr(OperEx(TlaOper.eq, arena.cellTrue().toNameEx, cell.toNameEx))
@@ -341,7 +326,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // and membership holds true
         solverContext.assertGroundExpr(predEx)
@@ -371,7 +356,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // set membership should not hold
         solverContext.assertGroundExpr(predEx)
@@ -388,7 +373,8 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-EQ1: {{}} = {} ~~> $B$... (false)""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
-    def intSet() = emptySetWithType(IntT())           // empty sets need types
+
+    def intSet() = emptySetWithType(IntT()) // empty sets need types
     def int2Set() = emptySetWithType(FinSetT(IntT())) // empty sets need types
 
     val ex = tla.eql(tla.enumSet(intSet()), int2Set())
@@ -396,7 +382,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // not equal
         solverContext.assertGroundExpr(predEx)
@@ -419,7 +405,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // not equal
         solverContext.assertGroundExpr(predEx)
@@ -441,7 +427,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // not equal
         solverContext.assertGroundExpr(predEx)
@@ -465,7 +451,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // equal
         solverContext.assertGroundExpr(predEx)
@@ -484,9 +470,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     // Now we enforce type correctness, and reject this expression right after type checking.
     val setOfOne = tla.enumSet(tla.int(1))
     val setOfFalse = tla.enumSet(tla.bool(false))
-    val ex = OperEx(TlaOper.eq,
-      tla.setminus(setOfFalse, setOfFalse),
-      tla.setminus(setOfOne, setOfOne))
+    val ex = OperEx(TlaOper.eq, tla.setminus(setOfFalse, setOfFalse), tla.setminus(setOfOne, setOfOne))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create()
     assertThrows[TypeInferenceException] {
@@ -505,7 +489,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         // not equal
         solverContext.assertGroundExpr(predEx)
@@ -526,7 +510,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case newSet@NameEx(name) =>
+      case newSet @ NameEx(name) =>
         rewriter.push()
         assert(solverContext.sat())
       // we check actual membership in another test
@@ -548,7 +532,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
@@ -568,14 +552,13 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val filteredSet = tla.filter("x", "Oper:X", filter)
     val ex =
       OperEx(BmcOper.skolem,
-        tla.letIn(tla.eql(tla.enumSet(), filteredSet),
-          tla.declOp("X", tla.cap(tla.enumSet(1, 2), tla.enumSet(2)))))
+          tla.letIn(tla.eql(tla.enumSet(), filteredSet), tla.declOp("X", tla.cap(tla.enumSet(1, 2), tla.enumSet(2)))))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = new SymbStateRewriterImpl(solverContext, new TrivialTypeFinder())
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         val failPreds = nextState.arena.findCellsByType(FailPredT())
         val failureOccurs = tla.or(failPreds.map(_.toNameEx): _*)
@@ -588,7 +571,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-SET-FILTER: {Q \in Expand(SUBSET {1,2,3}) : ~(2 \in Q)}""") {
-    val set = tla.enumSet(1.to(3).map(tla.int) :_*)
+    val set = tla.enumSet(1.to(3).map(tla.int): _*)
 
     val predEx = tla.not(tla.in(tla.int(2), tla.name("Q")))
     val expandedPowSet = OperEx(BmcOper.expand, tla.powSet(set))
@@ -597,10 +580,9 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.in(tla.enumSet(tla.int(1), tla.int(3)), nextState.ex)))
     assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.in(tla.enumSet(tla.int(1), tla.int(3)), nextState.ex)))
-    assertTlaExAndRestore(rewriter,
-      nextState.setRex(tla.not(tla.in(tla.enumSet(tla.int(1), tla.int(2)), nextState.ex))))
+        nextState.setRex(tla.not(tla.in(tla.enumSet(tla.int(1), tla.int(2)), nextState.ex))))
   }
 
   test("""SE-SET-FILTER[1-2]: \E SUBSET X {1} IN {} = {x \in X : [y \in X |-> TRUE][x]} ~~> $B$k""") {
@@ -609,14 +591,13 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val filter = tla.appFun(tla.funDef(tla.bool(true), "y", "X"), "x")
     val filteredSet = tla.filter("x", "X", filter)
     val ex =
-      OperEx(BmcOper.skolem,
-        tla.exists("X", tla.powSet(baseSet), tla.eql(tla.enumSet(), filteredSet)))
+      OperEx(BmcOper.skolem, tla.exists("X", tla.powSet(baseSet), tla.eql(tla.enumSet(), filteredSet)))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = new SymbStateRewriterImpl(solverContext, new TrivialTypeFinder())
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
         rewriter.push()
         val failPreds = nextState.arena.findCellsByType(FailPredT())
@@ -635,27 +616,26 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val filter = tla.appFun(tla.funDef(tla.bool(true), "y", tla.enumSet(1)), "x")
     val filteredSet = tla.filter("x", "X", filter)
     val ex =
-      OperEx(BmcOper.skolem,
-        tla.exists("X", tla.powSet(tla.enumSet(1, 2)), tla.eql(tla.enumSet(), filteredSet)))
+      OperEx(BmcOper.skolem, tla.exists("X", tla.powSet(tla.enumSet(1, 2)), tla.eql(tla.enumSet(), filteredSet)))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = new SymbStateRewriterImpl(solverContext, new TrivialTypeFinder())
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         // the new implementation just returns a default value, as in the classical TLA+ interpretation
         assert(solverContext.sat())
         // the result should be true, although some values may be undefined
         solverContext.assertGroundExpr(nextState.ex)
         assert(solverContext.sat())
-        /*
+      /*
         // the old implementation with failure predicates
         rewriter.push()
         val failPreds = nextState.arena.findCellsByType(FailPredT())
         val failureOccurs = tla.or(failPreds.map(_.toNameEx): _*)
         solverContext.assertGroundExpr(failureOccurs)
         assert(solverContext.sat()) // failure should be possible
-        */
+       */
 
       case _ =>
         fail("Unexpected rewriting result")
@@ -675,7 +655,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(!solverContext.sat())
@@ -689,14 +669,14 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-SET-MAP[1-2]: {x / 3: x \in {1,2,3,4}} ~~> $C$k""") {
-    val set = tla.enumSet(1 to 4 map tla.int :_*)
+    val set = tla.enumSet(1 to 4 map tla.int: _*)
     val mapping = tla.div(tla.name("x"), tla.int(3))
     val mappedSet = tla.map(mapping, tla.name("x"), set)
 
     val state = new SymbState(mappedSet, arena, Binding())
     val nextState = create().rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         assert(solverContext.sat())
       // membership tests are in the tests below
 
@@ -706,7 +686,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-SET-MAP[1-2]: 0 \in {x / 3: x \in {1,2,3,4}} ~~> $B$k""") {
-    val set = tla.enumSet(1 to 4 map tla.int :_*)
+    val set = tla.enumSet(1 to 4 map tla.int: _*)
     val mapping = tla.div(tla.name("x"), tla.int(3))
     val mappedSet = tla.map(mapping, tla.name("x"), set)
     val inMappedSet = tla.in(tla.int(0), mappedSet)
@@ -715,7 +695,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
@@ -729,7 +709,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-SET-MAP[1-2]: 2 \in {x / 3: x \in {1,2,3,4}} ~~> $B$k""") {
-    val set = tla.enumSet(1 to 4 map tla.int :_*)
+    val set = tla.enumSet(1 to 4 map tla.int: _*)
     val mapping = tla.div(tla.name("x"), tla.int(3))
     val mappedSet = tla.map(mapping, tla.name("x"), set)
     val inMappedSet = tla.in(tla.int(2), mappedSet)
@@ -738,7 +718,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(!solverContext.sat())
@@ -763,7 +743,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   }
 
   test("""SE-SET-MAP[1-2]: <<2, true>> \in {<<x, y>>: x \in {1,2,3}, y \in {FALSE, TRUE}} ~~> $B$k""") {
-    val set123 = tla.enumSet(1 to 3 map tla.int :_*)
+    val set123 = tla.enumSet(1 to 3 map tla.int: _*)
     val setBool = tla.enumSet(tla.bool(false), tla.bool(true))
     val mapping = tla.tuple(tla.name("x"), tla.name("y"))
     val mappedSet = tla.map(mapping, tla.name("x"), set123, tla.name("y"), setBool)
@@ -773,7 +753,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
@@ -789,9 +769,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
   test("""SE-SET-MAP[1-2]: <<TRUE>> \in {<<y>>: x \in {1,2} \ {2}, y \in {FALSE, TRUE}}""") {
     // this expression tests regressions in cached expressions
     // we express {1, 2} \ {2} as a filter, as set difference is not in KerA+
-    val set12minus2 = tla.filter(tla.name("z"),
-      tla.enumSet(tla.int(1),
-        tla.int(2)), tla.eql(tla.name("z"), tla.int(1)))
+    val set12minus2 = tla.filter(tla.name("z"), tla.enumSet(tla.int(1), tla.int(2)), tla.eql(tla.name("z"), tla.int(1)))
     val setBool = tla.enumSet(tla.bool(false), tla.bool(true))
     val mapping = tla.tuple(tla.name("y"))
     val mappedSet = tla.map(mapping, tla.name("x"), set12minus2, tla.name("y"), setBool)
@@ -801,7 +779,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case membershipEx@NameEx(name) =>
+      case membershipEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
@@ -837,7 +815,8 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   // Regression for the issue 365: https://github.com/informalsystems/apalache/issues/365
   // This test captures the core of the functional test in `test/tla/Fix365_ExistsSubset3.tla`.
-  test("""MAP: \E S \in SUBSET { [a: "a", b: 1], [a: "a", b: 2] }:  "a" \in { r.a: r \in S } /\ \A x \in S: x.b = 2""") {
+  test(
+      """MAP: \E S \in SUBSET { [a: "a", b: 1], [a: "a", b: 2] }:  "a" \in { r.a: r \in S } /\ \A x \in S: x.b = 2""") {
     // this tests reveals a deep bug in the encoding: SUBSET {[a: 1, b: 1], [a: 1, b: 2]} produces a powerset,
     // whose elements are sets that refer to the same cells,
     // namely the cells for the records [a: 1, b: 1] and [a: 1, b: 2].
@@ -849,11 +828,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val powerset = tla.powSet(base)
     val map = tla.map(tla.appFun(tla.name("r"), tla.str("a")), tla.name("r"), tla.name("S"))
     val mem = tla.in(tla.str("a"), map)
-    val forall = tla.forall(tla.name("x"),
-      tla.name("S"),
-      tla.eql(tla.appFun(tla.name("x"),
-              tla.str("b")),
-              tla.int(2)))
+    val forall = tla.forall(tla.name("x"), tla.name("S"), tla.eql(tla.appFun(tla.name("x"), tla.str("b")), tla.int(2)))
     val and = tla.and(mem, forall)
     val exists = OperEx(BmcOper.skolem, tla.exists(tla.name("S"), powerset, and))
 
@@ -875,7 +850,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         assert(solverContext.sat())
         // check equality
         rewriter.push()
@@ -898,7 +873,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -919,7 +894,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -941,7 +916,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -963,7 +938,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)
@@ -986,7 +961,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1008,7 +983,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1031,7 +1006,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1054,7 +1029,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)
@@ -1077,7 +1052,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1099,7 +1074,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)
@@ -1122,7 +1097,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1145,7 +1120,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)
@@ -1181,7 +1156,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1203,7 +1178,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)
@@ -1226,7 +1201,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -1249,7 +1224,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
     val rewriter = create()
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assertUnsatOrExplain(rewriter, nextState)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import at.forsyte.apalache.tla.lir.{NameEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -13,7 +14,7 @@ class TestSymbStateRewriterStr extends RewriterBase {
     val rewriter = create()
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         assert(solverContext.sat())
         val redEqBlue = tla.eql(tla.str("blue"), tla.str("red"))
         val nextStateEq = rewriter.rewriteUntilDone(nextStateRed.setRex(redEqBlue))
@@ -23,7 +24,6 @@ class TestSymbStateRewriterStr extends RewriterBase {
         rewriter.pop()
         solverContext.assertGroundExpr(tla.not(nextStateEq.ex))
         assert(solverContext.sat())
-
 
       case _ =>
         fail("Unexpected rewriting result")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{BoolT, FailPredT}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlcOper
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -15,7 +16,7 @@ class TestSymbStateRewriterTlc extends RewriterBase {
     val rewriter = create()
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         solverContext.assertGroundExpr(nextStateRed.ex)
         assert(solverContext.sat())
         val failPreds = state.arena.findCellsByType(FailPredT())
@@ -33,7 +34,7 @@ class TestSymbStateRewriterTlc extends RewriterBase {
     val rewriter = create()
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         solverContext.assertGroundExpr(nextStateRed.ex)
         assert(solverContext.sat())
         val failPreds = state.arena.findCellsByType(FailPredT())
@@ -51,7 +52,7 @@ class TestSymbStateRewriterTlc extends RewriterBase {
     val rewriter = create()
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         solverContext.assertGroundExpr(nextStateRed.ex)
         assert(solverContext.sat())
         val failPreds = nextStateRed.arena.findCellsByType(FailPredT())
@@ -69,7 +70,7 @@ class TestSymbStateRewriterTlc extends RewriterBase {
     val rewriter = create()
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         solverContext.assertGroundExpr(nextStateRed.ex)
         assert(solverContext.sat())
         val failPreds = nextStateRed.arena.findCellsByType(FailPredT())
@@ -87,14 +88,12 @@ class TestSymbStateRewriterTlc extends RewriterBase {
 
   // the failure predicates should be refactored
   ignore("SE-TLC-ASSERT: IF FALSE THEN Assert(FALSE, _) ELSE TRUE -> TRUE") {
-    val assertEx = tla.ite(tla.bool(false),
-      OperEx(TlcOper.assert, tla.bool(false), tla.str("oops")),
-      tla.bool(true))
+    val assertEx = tla.ite(tla.bool(false), OperEx(TlcOper.assert, tla.bool(false), tla.str("oops")), tla.bool(true))
     val state = new SymbState(assertEx, arena, Binding())
     val rewriter = create()
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         solverContext.assertGroundExpr(nextStateRed.ex)
         assert(solverContext.sat())
         val failPreds = nextStateRed.arena.findCellsByType(FailPredT())
@@ -113,13 +112,12 @@ class TestSymbStateRewriterTlc extends RewriterBase {
     // see Specifying Systems, Sec. 14.2.2, p. 231.
     arena = arena.appendCell(BoolT())
     val x = arena.topCell // we use a variable to avoid constant optimizations
-    val assertEx = tla.or(x.toNameEx,
-      OperEx(TlcOper.assert, tla.bool(false), tla.str("oops")))
+    val assertEx = tla.or(x.toNameEx, OperEx(TlcOper.assert, tla.bool(false), tla.str("oops")))
     val rewriter = create()
     val state = new SymbState(assertEx, arena, Binding())
     val nextStateRed = rewriter.rewriteUntilDone(state)
     nextStateRed.ex match {
-      case predEx@NameEx(name) =>
+      case predEx @ NameEx(name) =>
         solverContext.assertGroundExpr(nextStateRed.ex)
         val failPreds = nextStateRed.arena.findCellsByType(FailPredT())
         assert(failPreds.length == 1)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -44,7 +45,7 @@ class TestSymbStateRewriterTuple extends RewriterBase {
             solverContext.assertGroundExpr(tla.eql(cell.toNameEx, tla.bool(true)))
             assert(!solverContext.sat())
 
-            // we check the actual contents in the later tests that access elements
+          // we check the actual contents in the later tests that access elements
 
           case _ =>
             fail("Expected Boolean type")
@@ -115,7 +116,7 @@ class TestSymbStateRewriterTuple extends RewriterBase {
 
   // Keramelizer rewrites \X
   ignore("""SE-TUPLE-SET: {<<1, FALSE>>, <<2, FALSE>>, <<1, TRUE>>, <<2, TRUE>> = {1,2} \X  {FALSE, TRUE} ~~> $B$k""") {
-    val set12 = tla.enumSet(1 to 2 map tla.int :_*)
+    val set12 = tla.enumSet(1 to 2 map tla.int: _*)
     val setBool = tla.enumSet(tla.bool(false), tla.bool(true))
     val prod = tla.times(set12, setBool)
     def tup(i: Int, b: Boolean) = tla.tuple(tla.int(i), tla.bool(b))
@@ -134,7 +135,7 @@ class TestSymbStateRewriterTuple extends RewriterBase {
 
   test("""SE-TUPLE-DOM: DOMAIN <<2, FALSE>> = {1, 2}""") {
     val tuple = TlaFunOper.mkTuple(tla.int(2), tla.bool(false), tla.str("c"))
-    val set123 = tla.enumSet(1.to(3) map tla.int :_*)
+    val set123 = tla.enumSet(1.to(3) map tla.int: _*)
     val eq = tla.eql(tla.dom(tuple), set123)
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestTrivialTypeFinder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestTrivialTypeFinder.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -51,31 +52,39 @@ class TestTrivialTypeFinder extends RewriterBase {
     val set1 = tla.name("S")
     val set2 = tla.name("T")
     // good cases
-    assert(BoolT() ==
-      typeFinder.compute(tla.eql(set1, set2), FinSetT(IntT()), FinSetT(IntT())))
-    assert(BoolT() ==
-      typeFinder.compute(tla.neql(set1, set2), FinSetT(IntT()), FinSetT(IntT())))
-    assert(IntT() ==
-      typeFinder.compute(tla.choose(x, set1, p), IntT(), FinSetT(IntT()), BoolT()))
-    assert(IntT() ==
-      typeFinder.compute(tla.choose(x, p), IntT(), BoolT()))
-    assert(IntT() ==
-      typeFinder.compute(OperEx(TlaOper.chooseIdiom, set1), FinSetT(IntT())))
-    assert(FinSetT(IntT())
-      == typeFinder.compute(tla.label(set1, "lab", "a"), FinSetT(IntT()), ConstT(), ConstT()))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.eql(set1, set2), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.neql(set1, set2), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        IntT() ==
+          typeFinder.compute(tla.choose(x, set1, p), IntT(), FinSetT(IntT()), BoolT()))
+    assert(
+        IntT() ==
+          typeFinder.compute(tla.choose(x, p), IntT(), BoolT()))
+    assert(
+        IntT() ==
+          typeFinder.compute(OperEx(TlaOper.chooseIdiom, set1), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT())
+          == typeFinder.compute(tla.label(set1, "lab", "a"), FinSetT(IntT()), ConstT(), ConstT()))
     // bad cases
     typeFinder.compute(tla.eql(set1, set2), FinSetT(IntT()), FinSetT(BoolT()))
     assert(typeFinder.typeErrors.nonEmpty)
 
     typeFinder.compute(tla.neql(set1, set2), FinSetT(IntT()), FinSetT(BoolT()))
     assert(typeFinder.typeErrors.nonEmpty)
-    assert(IntT() ==
-      typeFinder.compute(tla.choose(x, set1, p), BoolT(), FinSetT(IntT()), BoolT()))
+    assert(
+        IntT() ==
+          typeFinder.compute(tla.choose(x, set1, p), BoolT(), FinSetT(IntT()), BoolT()))
     assert(typeFinder.typeErrors.nonEmpty)
     typeFinder.compute(tla.choose(x, set1, p), IntT(), IntT(), BoolT())
     assert(typeFinder.typeErrors.nonEmpty)
-    assert(IntT() ==
-      typeFinder.compute(tla.choose(x, set1, p), IntT(), FinSetT(IntT()), IntT()))
+    assert(
+        IntT() ==
+          typeFinder.compute(tla.choose(x, set1, p), IntT(), FinSetT(IntT()), IntT()))
     assert(typeFinder.typeErrors.nonEmpty)
     assert(IntT() == typeFinder.compute(tla.choose(x, p), IntT(), IntT()))
     assert(typeFinder.typeErrors.nonEmpty)
@@ -189,14 +198,17 @@ class TestTrivialTypeFinder extends RewriterBase {
     val y = NameEx("y")
     val z = NameEx("z")
     // good cases
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.ite(p, x, y), BoolT(), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.ite(p, x, y), BoolT(), FinSetT(IntT()), FinSetT(IntT())))
     val caseEx = tla.caseSplit(p, x, q, y)
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(caseEx, BoolT(), FinSetT(IntT()), BoolT(), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(caseEx, BoolT(), FinSetT(IntT()), BoolT(), FinSetT(IntT())))
     val caseOtherEx = tla.caseOther(z, p, x, q, y)
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(caseOtherEx, FinSetT(IntT()), BoolT(), FinSetT(IntT()), BoolT(), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(caseOtherEx, FinSetT(IntT()), BoolT(), FinSetT(IntT()), BoolT(), FinSetT(IntT())))
 
     val decl = TlaOperDecl("A", List(), tla.plus(tla.int(1), tla.int(2)))
     val letIn = tla.letIn(tla.plus(tla.int(1), tla.appDecl(decl)), decl)
@@ -222,18 +234,24 @@ class TestTrivialTypeFinder extends RewriterBase {
     val set12 = tla.enumSet(tla.int(1), tla.int(2))
     val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
     // good cases
-    assert(BoolT() ==
-      typeFinder.compute(tla.in(int1, set12), IntT(), FinSetT(IntT())))
-    assert(BoolT() ==
-      typeFinder.compute(tla.notin(int1, set12), IntT(), FinSetT(IntT())))
-    assert(BoolT() ==
-      typeFinder.compute(tla.subset(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
-    assert(BoolT() ==
-      typeFinder.compute(tla.subseteq(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
-    assert(BoolT() ==
-      typeFinder.compute(tla.supset(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
-    assert(BoolT() ==
-      typeFinder.compute(tla.supseteq(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.in(int1, set12), IntT(), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.notin(int1, set12), IntT(), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.subset(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.subseteq(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.supset(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.supseteq(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
     // bad cases
     typeFinder.compute(tla.in(set12, set12), FinSetT(IntT()), FinSetT(IntT()))
     assert(typeFinder.typeErrors.nonEmpty)
@@ -261,12 +279,15 @@ class TestTrivialTypeFinder extends RewriterBase {
     val set12 = tla.enumSet(tla.int(1), tla.int(2))
     val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
     // good cases
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.cup(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.cap(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.setminus(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.cup(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.cap(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.setminus(set12, set123), FinSetT(IntT()), FinSetT(IntT())))
     // bad cases
     typeFinder.compute(tla.cup(int1, set123), IntT(), FinSetT(IntT()))
     assert(typeFinder.typeErrors.nonEmpty)
@@ -281,8 +302,9 @@ class TestTrivialTypeFinder extends RewriterBase {
     val int1 = tla.int(1)
     val set12 = tla.enumSet(tla.int(1), tla.int(2))
     // good cases
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.filter(NameEx("x"), set12, tla.bool(true)), IntT(), FinSetT(IntT()), BoolT()))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.filter(NameEx("x"), set12, tla.bool(true)), IntT(), FinSetT(IntT()), BoolT()))
     // bad cases
     typeFinder.compute(tla.filter(NameEx("x"), int1, tla.bool(true)), IntT(), IntT(), BoolT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -295,14 +317,17 @@ class TestTrivialTypeFinder extends RewriterBase {
     val int1 = tla.int(1)
     val set12 = tla.enumSet(tla.int(1), tla.int(2))
     // good cases
-    assert(FinSetT(BoolT()) ==
-      typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), set12), BoolT(), IntT(), FinSetT(IntT())))
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), set12), IntT(), BoolT(), FinSetT(BoolT())))
+    assert(
+        FinSetT(BoolT()) ==
+          typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), set12), BoolT(), IntT(), FinSetT(IntT())))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), set12), IntT(), BoolT(), FinSetT(BoolT())))
     // bad cases
     typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), int1), BoolT(), IntT(), IntT())
     assert(typeFinder.typeErrors.nonEmpty)
-    typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), set12, NameEx("y"), int1), BoolT(), IntT(), FinSetT(IntT()), IntT(), IntT())
+    typeFinder.compute(tla.map(tla.bool(true), NameEx("x"), set12, NameEx("y"), int1), BoolT(), IntT(), FinSetT(IntT()),
+        IntT(), IntT())
     assert(typeFinder.typeErrors.nonEmpty)
   }
 
@@ -312,8 +337,9 @@ class TestTrivialTypeFinder extends RewriterBase {
     val set12 = tla.enumSet(tla.int(1), tla.int(2))
     val set3 = tla.enumSet(tla.int(3))
     // good cases
-    assert(FinSetT(IntT()) ==
-      typeFinder.compute(tla.union(tla.enumSet(set12, set3)), FinSetT(FinSetT(IntT()))))
+    assert(
+        FinSetT(IntT()) ==
+          typeFinder.compute(tla.union(tla.enumSet(set12, set3)), FinSetT(FinSetT(IntT()))))
     // bad cases
     typeFinder.compute(tla.union(set12), FinSetT(IntT()))
     assert(typeFinder.typeErrors.nonEmpty)
@@ -326,8 +352,9 @@ class TestTrivialTypeFinder extends RewriterBase {
     val set3 = tla.enumSet(tla.int(3))
 
     // good cases
-    assert(FinSetT(FinSetT(IntT())) ==
-      typeFinder.compute(tla.powSet(set12), FinSetT(IntT())))
+    assert(
+        FinSetT(FinSetT(IntT())) ==
+          typeFinder.compute(tla.powSet(set12), FinSetT(IntT())))
     // bad cases
     typeFinder.compute(tla.powSet(int1), IntT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -341,7 +368,7 @@ class TestTrivialTypeFinder extends RewriterBase {
 
     // good cases
     assert(FinSetT(TupleT(Seq(IntT(), BoolT()))) ==
-      typeFinder.compute(tla.times(set12, set3), FinSetT(IntT()), FinSetT(BoolT())))
+          typeFinder.compute(tla.times(set12, set3), FinSetT(IntT()), FinSetT(BoolT())))
     // bad cases
     typeFinder.compute(tla.times(set12, int1), FinSetT(IntT()), IntT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -355,7 +382,7 @@ class TestTrivialTypeFinder extends RewriterBase {
 
     // good cases
     assert(FinSetT(FunT(FinSetT(IntT()), BoolT())) ==
-      typeFinder.compute(tla.funSet(set12, boolSet), FinSetT(IntT()), FinSetT(BoolT())))
+          typeFinder.compute(tla.funSet(set12, boolSet), FinSetT(IntT()), FinSetT(BoolT())))
     // bad cases
     typeFinder.compute(tla.funSet(set12, tla.bool(false)), FinSetT(IntT()), BoolT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -371,9 +398,11 @@ class TestTrivialTypeFinder extends RewriterBase {
 
     // good cases
     assert(FinSetT(RecordT(SortedMap("a" -> IntT(), "b" -> BoolT()))) ==
-      typeFinder.compute(tla.recSet(tla.str("a"), set12, tla.str("b"), boolSet), ConstT(), FinSetT(IntT()), ConstT(), FinSetT(BoolT())))
+          typeFinder.compute(tla.recSet(tla.str("a"), set12, tla.str("b"), boolSet), ConstT(), FinSetT(IntT()),
+              ConstT(), FinSetT(BoolT())))
     // bad cases
-    typeFinder.compute(tla.recSet(tla.str("a"), int1, tla.str("b"), boolSet), ConstT(), IntT(), ConstT(), FinSetT(BoolT()))
+    typeFinder.compute(tla.recSet(tla.str("a"), int1, tla.str("b"), boolSet), ConstT(), IntT(), ConstT(),
+        FinSetT(BoolT()))
     assert(typeFinder.typeErrors.nonEmpty)
   }
 
@@ -399,10 +428,12 @@ class TestTrivialTypeFinder extends RewriterBase {
     val typeFinder = new TrivialTypeFinder()
     val tup = tla.tuple(tla.int(1), tla.bool(false))
     val tupleType = TupleT(Seq(IntT(), BoolT()))
-    assert(IntT() ==
-      typeFinder.compute(tla.appFun(tup, tla.int(1)), tupleType, IntT()))
-    assert(BoolT() ==
-      typeFinder.compute(tla.appFun(tup, tla.int(2)), tupleType, IntT()))
+    assert(
+        IntT() ==
+          typeFinder.compute(tla.appFun(tup, tla.int(1)), tupleType, IntT()))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.appFun(tup, tla.int(2)), tupleType, IntT()))
     // out-of-range expressions
     typeFinder.compute(tla.appFun(tup, tla.int(0)), tupleType, IntT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -418,10 +449,12 @@ class TestTrivialTypeFinder extends RewriterBase {
     val rec = tla.enumFun(tla.str("a"), tla.int(1), tla.str("b"), tla.bool(false))
     val recType = RecordT(SortedMap("a" -> IntT(), "b" -> BoolT()))
 
-    assert(IntT() ==
-      typeFinder.compute(tla.appFun(rec, tla.str("a")), recType, ConstT()))
-    assert(BoolT() ==
-      typeFinder.compute(tla.appFun(rec, tla.str("b")), recType, ConstT()))
+    assert(
+        IntT() ==
+          typeFinder.compute(tla.appFun(rec, tla.str("a")), recType, ConstT()))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.appFun(rec, tla.str("b")), recType, ConstT()))
     // out-of-range expressions
     typeFinder.compute(tla.appFun(rec, tla.str("c")), recType, ConstT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -435,8 +468,9 @@ class TestTrivialTypeFinder extends RewriterBase {
     val fun = tla.name("f") // we know just the name
     val funType = FunT(FinSetT(IntT()), BoolT())
 
-    assert(BoolT() ==
-      typeFinder.compute(tla.appFun(fun, tla.int(1)), funType, IntT()))
+    assert(
+        BoolT() ==
+          typeFinder.compute(tla.appFun(fun, tla.int(1)), funType, IntT()))
     // wrong argument type
     typeFinder.compute(tla.appFun(fun, tla.str("c")), funType, ConstT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -484,9 +518,9 @@ class TestTrivialTypeFinder extends RewriterBase {
     val e = tla.name("e")
     // good cases
     assert(FunT(FinSetT(IntT()), BoolT()) ==
-      typeFinder.compute(tla.funDef(e, x, S), BoolT(), IntT(), FinSetT(IntT())))
+          typeFinder.compute(tla.funDef(e, x, S), BoolT(), IntT(), FinSetT(IntT())))
     assert(FunT(FinSetT(TupleT(Seq(IntT(), ConstT()))), BoolT()) ==
-      typeFinder.compute(tla.funDef(e, x, S, y, T), BoolT(), IntT(), FinSetT(IntT()), ConstT(), FinSetT(ConstT())))
+          typeFinder.compute(tla.funDef(e, x, S, y, T), BoolT(), IntT(), FinSetT(IntT()), ConstT(), FinSetT(ConstT())))
     // bad cases
     assertThrows[TypeException] {
       typeFinder.compute(tla.funDef(e, x, S), BoolT(), ConstT(), IntT())
@@ -501,11 +535,13 @@ class TestTrivialTypeFinder extends RewriterBase {
     // good cases
     val funT = FunT(FinSetT(IntT()), BoolT())
     // TlaFunOper.except expects an index (single-dimensional as well as multi-dimensional) wrapped into a tuple
-    assert(funT ==
-      typeFinder.compute(tla.except(f, e, g), funT, TupleT(Seq(IntT())), BoolT()))
+    assert(
+        funT ==
+          typeFinder.compute(tla.except(f, e, g), funT, TupleT(Seq(IntT())), BoolT()))
     val fun2T = FunT(FinSetT(TupleT(Seq(IntT(), ConstT()))), BoolT())
-    assert(fun2T ==
-      typeFinder.compute(tla.except(f, e, g), fun2T, TupleT(Seq(TupleT(Seq(IntT(), ConstT())))), BoolT()))
+    assert(
+        fun2T ==
+          typeFinder.compute(tla.except(f, e, g), fun2T, TupleT(Seq(TupleT(Seq(IntT(), ConstT())))), BoolT()))
     // bad cases
     typeFinder.compute(tla.except(f, e, g), funT, IntT(), BoolT())
     assert(typeFinder.typeErrors.nonEmpty)
@@ -602,8 +638,8 @@ class TestTrivialTypeFinder extends RewriterBase {
     // double assignment is fine as soon as the types are preserved
     val assign =
       tla.or(
-        tla.assignPrime(x, tla.int(1)),
-        tla.assignPrime(x, tla.int(3))
+          tla.assignPrime(x, tla.int(1)),
+          tla.assignPrime(x, tla.int(3))
       )
     assert(typeFinder.inferAndSave(assign).contains(BoolT()))
     assert(IntT() == typeFinder.varTypes("x'"))
@@ -730,108 +766,117 @@ class TestTrivialTypeFinder extends RewriterBase {
   test("inferAndSave from the wild") {
     import IncrementalRenaming.makeName
     val init = tla.declOp(makeName("RenamedInit", 0),
-      tla.and(
-        tla.assignPrime(
-          tla.name("recOne"),
-          tla.withType(
-            tla.enumFun(
-              tla.str("x"),
-              tla.str("y")
+        tla.and(
+            tla.assignPrime(
+                tla.name("recOne"),
+                tla.withType(
+                    tla.enumFun(
+                        tla.str("x"),
+                        tla.str("y")
+                    ),
+                    tla.enumFun(
+                        tla.str("x"),
+                        ValEx(TlaStrSet),
+                        tla.str("y"),
+                        ValEx(TlaIntSet)
+                    )
+                )
             ),
-            tla.enumFun(
-              tla.str("x"), ValEx(TlaStrSet),
-              tla.str("y"), ValEx(TlaIntSet)
+            tla.assignPrime(
+                tla.name("recTwo"),
+                tla.withType(
+                    tla.enumFun(
+                        tla.str("x"),
+                        tla.str("x")
+                    ),
+                    tla.enumFun(
+                        tla.str("x"),
+                        ValEx(TlaStrSet),
+                        tla.str("z"),
+                        tla.enumSet(ValEx(TlaIntSet))
+                    )
+                )
             )
-          )
-        ),
-        tla.assignPrime(
-          tla.name("recTwo"),
-          tla.withType(
-            tla.enumFun(
-              tla.str("x"),
-              tla.str("x")
-            ),
-            tla.enumFun(
-              tla.str("x"), ValEx(TlaStrSet),
-              tla.str("z"), tla.enumSet(ValEx(TlaIntSet))
-            )
-          )
-        )
-      )
-    )
+        ))
 
     val next1 = tla.declOp(makeName("RenamedNext", 0),
-      tla.and(
-        tla.assignPrime(
-          tla.name("recOne"),
-          tla.withType(
-            tla.enumFun(
-              tla.str("x"),
-              tla.str("x")
+        tla.and(
+            tla.assignPrime(
+                tla.name("recOne"),
+                tla.withType(
+                    tla.enumFun(
+                        tla.str("x"),
+                        tla.str("x")
+                    ),
+                    tla.enumFun(
+                        tla.str("x"),
+                        ValEx(TlaStrSet),
+                        tla.str("y"),
+                        ValEx(TlaIntSet)
+                    )
+                )
             ),
-            tla.enumFun(
-              tla.str("x"), ValEx(TlaStrSet),
-              tla.str("y"), ValEx(TlaIntSet)
+            tla.assignPrime(
+                tla.name("recTwo"),
+                tla.withType(
+                    tla.enumFun(
+                        tla.str("x"),
+                        tla.str("x")
+                    ),
+                    tla.enumFun(
+                        tla.str("x"),
+                        ValEx(TlaStrSet),
+                        tla.str("z"),
+                        tla.enumSet(ValEx(TlaIntSet))
+                    )
+                )
             )
-          )
-        ),
-        tla.assignPrime(
-          tla.name("recTwo"),
-          tla.withType(
-            tla.enumFun(
-              tla.str("x"),
-              tla.str("x")
-            ),
-            tla.enumFun(
-              tla.str("x"), ValEx(TlaStrSet),
-              tla.str("z"), tla.enumSet(ValEx(TlaIntSet))
-            )
-          )
-        )
-      )
-    )
+        ))
 
     val next2 = tla.declOp(makeName("RenamedNext", 1),
-      tla.and(
-        tla.assignPrime(
-          tla.name("recOne"),
-          tla.withType(
-            tla.enumFun(
-              tla.str("x"),
-              tla.str("x")
+        tla.and(
+            tla.assignPrime(
+                tla.name("recOne"),
+                tla.withType(
+                    tla.enumFun(
+                        tla.str("x"),
+                        tla.str("x")
+                    ),
+                    tla.enumFun(
+                        tla.str("x"),
+                        ValEx(TlaStrSet),
+                        tla.str("y"),
+                        ValEx(TlaIntSet)
+                    )
+                )
             ),
-            tla.enumFun(
-              tla.str("x"), ValEx(TlaStrSet),
-              tla.str("y"), ValEx(TlaIntSet)
+            tla.assignPrime(
+                tla.name("recTwo"),
+                tla.withType(
+                    tla.enumFun(
+                        tla.str("x"),
+                        tla.str("z")
+                    ),
+                    tla.enumFun(
+                        tla.str("x"),
+                        ValEx(TlaStrSet),
+                        tla.str("z"),
+                        tla.enumSet(ValEx(TlaIntSet))
+                    )
+                )
             )
-          )
-        ),
-        tla.assignPrime(
-          tla.name("recTwo"),
-          tla.withType(
-            tla.enumFun(
-              tla.str("x"),
-              tla.str("z")
-            ),
-            tla.enumFun(
-              tla.str("x"), ValEx(TlaStrSet),
-              tla.str("z"), tla.enumSet(ValEx(TlaIntSet))
-            )
-          )
-        )
-      )
-    )
+        ))
 
     val decls = Seq(
-      init,
-      next1,
-      next2
+        init,
+        next1,
+        next2
     )
 
     val ttf = new TrivialTypeFinder
 
-    decls foreach {
-      d => ttf.inferAndSave(d.body)
+    decls foreach { d =>
+      ttf.inferAndSave(d.body)
     }
 
     assert(ttf.typeErrors.isEmpty)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner
@@ -32,41 +33,33 @@ class TestExpansionMarker extends FunSuite with BeforeAndAfterEach {
     val input = tla.cup(tla.enumSet(tla.int(1)), tla.powSet(tla.name("S")))
     val output = marker.apply(input)
     val expected =
-      tla.cup(
-        tla.enumSet(tla.int(1)),
-        OperEx(BmcOper.expand, tla.powSet(tla.name("S"))))
+      tla.cup(tla.enumSet(tla.int(1)), OperEx(BmcOper.expand, tla.powSet(tla.name("S"))))
 
     assert(expected == output)
   }
 
   // although the optimizing phase should simplify this expression, we like to know what happens, if not
   test("""marked: {} \cup [S -> T]""") {
-    val input = tla.in(
-      tla.name("x"),
-      tla.cup(tla.emptySet(),
-        tla.funSet(tla.name("S"), tla.name("T"))))
+    val input = tla.in(tla.name("x"), tla.cup(tla.emptySet(), tla.funSet(tla.name("S"), tla.name("T"))))
     val output = marker.apply(input)
-    val expected = tla.in(
-      tla.name("x"),
-      tla.cup(tla.emptySet(),
-        OperEx(BmcOper.expand,
-          tla.funSet(tla.name("S"), tla.name("T")))))
+    val expected =
+      tla.in(tla.name("x"), tla.cup(tla.emptySet(), OperEx(BmcOper.expand, tla.funSet(tla.name("S"), tla.name("T")))))
 
     assert(expected == output)
   }
 
   test("""marked: \A x \in SUBSET S: P""") {
     val input = tla.forall(
-      tla.name("x"),
-      tla.powSet(tla.name("S")),
-      tla.name("P")
+        tla.name("x"),
+        tla.powSet(tla.name("S")),
+        tla.name("P")
     ) ///
 
     val output = marker.apply(input)
     val expected = tla.forall(
-      tla.name("x"),
-      OperEx(BmcOper.expand, tla.powSet(tla.name("S"))),
-      tla.name("P")
+        tla.name("x"),
+        OperEx(BmcOper.expand, tla.powSet(tla.name("S"))),
+        tla.name("P")
     ) ///
 
     assert(expected == output)
@@ -74,16 +67,16 @@ class TestExpansionMarker extends FunSuite with BeforeAndAfterEach {
 
   test("""marked: \E x \in SUBSET S: P""") {
     val input = tla.exists(
-      tla.name("x"),
-      tla.powSet(tla.name("S")),
-      tla.name("P")
+        tla.name("x"),
+        tla.powSet(tla.name("S")),
+        tla.name("P")
     ) ///
 
     val output = marker.apply(input)
     val expected = tla.exists(
-      tla.name("x"),
-      OperEx(BmcOper.expand, tla.powSet(tla.name("S"))),
-      tla.name("P")
+        tla.name("x"),
+        OperEx(BmcOper.expand, tla.powSet(tla.name("S"))),
+        tla.name("P")
     ) ///
 
     assert(expected == output)
@@ -92,11 +85,11 @@ class TestExpansionMarker extends FunSuite with BeforeAndAfterEach {
   test("""not marked: Skolem(\E x \in SUBSET S: P)""") {
     val input =
       OperEx(BmcOper.skolem,
-        tla.exists(
-          tla.name("x"),
-          tla.powSet(tla.name("S")),
-          tla.name("P")
-        )) ///
+          tla.exists(
+              tla.name("x"),
+              tla.powSet(tla.name("S")),
+              tla.name("P")
+          )) ///
 
     val output = marker.apply(input)
 
@@ -106,12 +99,9 @@ class TestExpansionMarker extends FunSuite with BeforeAndAfterEach {
   test("""not marked: x \in {} <: {[Int -> Int]}""") {
     val input =
       tla.exists(
-        tla.name("x"),
-        OperEx(BmcOper.withType,
-          tla.enumSet(),
-          tla.enumSet(tla.funSet(tla.intSet(), tla.intSet()))
-        ),
-        tla.bool(true)
+          tla.name("x"),
+          OperEx(BmcOper.withType, tla.enumSet(), tla.enumSet(tla.funSet(tla.intSet(), tla.intSet()))),
+          tla.bool(true)
       ) //
 
     val output = marker.apply(input)
@@ -121,11 +111,11 @@ class TestExpansionMarker extends FunSuite with BeforeAndAfterEach {
 
   test("""not marked: \CHOOSE x \in SUBSET S: P""") {
     val input =
-        tla.choose(
+      tla.choose(
           tla.name("x"),
           tla.powSet(tla.name("S")),
           tla.name("P")
-        ) ///
+      ) ///
 
     val output = marker.apply(input)
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestSkolemizationMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestSkolemizationMarker.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
@@ -37,8 +38,7 @@ class TestSkolemizationMarker extends FunSuite with BeforeAndAfterEach {
   // see the issue #148
   test("""no mark: x' <- \E y \in S: P""") {
     val input =
-      tla.assignPrime(tla.name("x"),
-        tla.exists(tla.name("y"), tla.name("S"), tla.name("P")))
+      tla.assignPrime(tla.name("x"), tla.exists(tla.name("y"), tla.name("S"), tla.name("P")))
 
     val output = marker(input)
     assert(input == output)

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfig.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfig.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.io.tlc.config.ConfigModelValue.STR_PREFIX
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.util.parsing.input.NoPosition
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.{TlaDecimal, TlaInt, TlaStr}
 import at.forsyte.apalache.io.annotations.store._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 import tla2sany.semantic._
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import tla2sany.semantic._
 
 /**
@@ -121,7 +122,7 @@ class OpApplTranslator(
         }
         .orElse {
           // a library value
-          StandardLibrary.libraryValues.get((modName, operatorName)).map(ValEx)
+          StandardLibrary.libraryValues.get((modName, operatorName)).map(ValEx(_))
         }
     }
   }

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpDefTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpDefTranslator.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.imp.src.{SaveToStoreTracker, SourceLocation, Sour
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.transformations.standard.ReplaceFixed
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.io.annotations.store._
 import tla2sany.semantic.{OpApplNode, OpDefNode}
 
@@ -45,7 +46,7 @@ class OpDefTranslator(
               NameEx(nodeName),
               recFunRef,
               new SaveToStoreTracker(sourceStore)
-          )(body)
+          )(Untyped())(body)
           // store the source location
           sourceStore.addRec(replaced, SourceLocation(node.getBody.getLocation))
           // return the operator whose body is a recursive function

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaTempOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 import tla2sany.semantic._
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.{CyclicDependencyError, TlaModule}
 import at.forsyte.apalache.tla.lir.io.{JsonReader, JsonWriter, PrettyWriter}
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.standard.DeclarationSorter
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -10,6 +10,7 @@ import at.forsyte.apalache.tla.lir.src.{SourcePosition, SourceRegion}
 import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, ValEx, _}
 import at.forsyte.apalache.io.annotations.store._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalactic.source.Position
 import org.scalatest.{BeforeAndAfter, FunSuite}

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/AbstractTransformer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/AbstractTransformer.scala
@@ -4,23 +4,25 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
 /**
-  * <p>An abstract transformer that calls partial functions.<p>
-  *
-  * <p>TODO: move to *.apalache.tla.lir.transformations?</p>
-  *
-  * @author Igor Konnov
-  */
-abstract class AbstractTransformer(tracker: TransformationTracker) extends TlaExTransformation {
+ * <p>An abstract transformer that calls partial functions.<p>
+ *
+ * <p>TODO: move to *.apalache.tla.lir.transformations?</p>
+ *
+ * @author Igor Konnov
+ */
+abstract class AbstractTransformer(tracker: TransformationTracker)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
+
   /**
-    * The sequence of partial transformers
-    */
+   * The sequence of partial transformers
+   */
   protected val partialTransformers: Seq[PartialFunction[TlaEx, TlaEx]]
 
   /**
-    * Transform an expression recursively by calling transformers that are implemented as partial functions.
-    *
-    * @return a new expression
-    */
+   * Transform an expression recursively by calling transformers that are implemented as partial functions.
+   *
+   * @return a new expression
+   */
   def transform: TlaExTransformation = tracker.trackEx {
     case oper @ OperEx(op, args @ _*) =>
       val newArgs = args map transform
@@ -39,16 +41,17 @@ abstract class AbstractTransformer(tracker: TransformationTracker) extends TlaEx
         TlaOperDecl(d.name, d.formalParams, transform(d.body))
       }
 
-      LetInEx(transform(body), defs.map(mapDecl) :_*)
+      LetInEx(transform(body), defs.map(mapDecl): _*)
 
     case ex =>
       transformOneLevel(ex)
   }
 
   /**
-    * Transform an expression without looking into the arguments.
-    * @return a new expression
-    */
+   * Transform an expression without looking into the arguments.
+   *
+   * @return a new expression
+   */
   private def transformOneLevel: TlaExTransformation = {
     // chain partial functions to handle different types of operators with different functions
     tracker.trackEx(allTransformers reduceLeft (_ orElse _))
@@ -57,5 +60,3 @@ abstract class AbstractTransformer(tracker: TransformationTracker) extends TlaEx
   private val identity: PartialFunction[TlaEx, TlaEx] = { case e => e }
   private lazy val allTransformers = partialTransformers :+ identity
 }
-
-

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Cacher.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Cacher.scala
@@ -3,105 +3,98 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
-class Cacher( nameGenerator: UniqueNameGenerator, tracker : TransformationTracker ) extends TlaModuleTransformation {
+class Cacher(nameGenerator: UniqueNameGenerator, tracker: TransformationTracker) extends TlaModuleTransformation {
 
-  def prepareAppMap( operNames: Set[String], init : Map[TlaEx, String] = Map.empty ) : TlaEx => Map[TlaEx, String] = {
+  def prepareAppMap(operNames: Set[String], init: Map[TlaEx, String] = Map.empty): TlaEx => Map[TlaEx, String] = {
     def inner(
-               initialMap : Map[TlaEx, String],
-               ex : TlaEx
-             ) : Map[TlaEx, String]
-    = ex match {
-      case OperEx( TlaOper.apply, NameEx( operName ), args@_* ) if operNames.contains(operName) =>
+        initialMap: Map[TlaEx, String], ex: TlaEx
+    ): Map[TlaEx, String] = ex match {
+      case OperEx(TlaOper.apply, NameEx(operName), args @ _*) if operNames.contains(operName) =>
         val newMap = // args will be syntactically matched
-          if ( initialMap.contains( ex ) ) initialMap
-          else initialMap + ( ex -> nameGenerator.newName() )
-        args.foldLeft( newMap ) {
+          if (initialMap.contains(ex)) initialMap
+          else initialMap + (ex -> nameGenerator.newName())
+        args.foldLeft(newMap) {
           inner
         }
-      case OperEx( _, args@_* ) =>
-        args.foldLeft( initialMap ) {
+      case OperEx(_, args @ _*) =>
+        args.foldLeft(initialMap) {
           inner
         }
-      case LetInEx( body, defs@_* ) =>
-        defs.map( _.body ).foldLeft( inner( initialMap, body ) ) {
+      case LetInEx(body, defs @ _*) =>
+        defs.map(_.body).foldLeft(inner(initialMap, body)) {
           inner
         }
       case _ => initialMap
     }
 
-    inner(init,_)
+    inner(init, _)
   }
 
   def replaceApplicationsWithNullary(
-                                      operNames: Set[String],
-                                      appMap: Map[TlaEx, String],
-                                      letInDecisionFn: TlaOperDecl => Boolean
-                                    ) : TlaExTransformation = tracker.trackEx {
-    case ex@OperEx( TlaOper.apply, opName@NameEx( operName ), args@_* ) if operNames.contains(operName) =>
+      operNames: Set[String], appMap: Map[TlaEx, String], letInDecisionFn: TlaOperDecl => Boolean
+  ): TlaExTransformation = tracker.trackEx {
+    case ex @ OperEx(TlaOper.apply, opName @ NameEx(operName), args @ _*) if operNames.contains(operName) =>
       // Assume ex is in the domain of appMap
-      appMap.get( ex ).map(
-        n => OperEx( TlaOper.apply, NameEx( n ) )
-      ).getOrElse {
+      appMap.get(ex).map(n => OperEx(TlaOper.apply, NameEx(n))).getOrElse {
         val newArgs = args map replaceApplicationsWithNullary(operNames, appMap, letInDecisionFn)
-        if ( args == newArgs ) ex else OperEx( TlaOper.apply, opName +: newArgs : _* )
+        if (args == newArgs) ex else OperEx(TlaOper.apply, opName +: newArgs: _*)
       }
 
-    case ex@OperEx( op, args@_* ) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map replaceApplicationsWithNullary(operNames, appMap, letInDecisionFn)
-      if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
-    case ex@LetInEx( body, defs@_* ) =>
+      if (args == newArgs) ex else OperEx(op, newArgs: _*)
+    case ex @ LetInEx(body, defs @ _*) =>
       // LET-IN introduces new operators which may or may not be added
-      val extendedOperNames = operNames ++ defs.withFilter( letInDecisionFn ).map( _.name )
-      val modifiedDefs = defs map { cacheApplicaitons(extendedOperNames, letInDecisionFn)(_).asInstanceOf[TlaOperDecl] }
-      val extendedAppMap = prepareAppMap( extendedOperNames, appMap )( body )
+      val extendedOperNames = operNames ++ defs.withFilter(letInDecisionFn).map(_.name)
+      val modifiedDefs = defs map {
+        cacheApplicaitons(extendedOperNames, letInDecisionFn)(_).asInstanceOf[TlaOperDecl]
+      }
+      val extendedAppMap = prepareAppMap(extendedOperNames, appMap)(body)
       val diffMap = extendedAppMap -- appMap.keySet
-      val extendedDefs = diffMap.toSeq map {
-        case (k, v) => TlaOperDecl( v, List.empty,
-          fixPointRepeat( replaceApplicationsWithNullary( extendedOperNames, diffMap - k, letInDecisionFn ), k )
-        )
+      val extendedDefs = diffMap.toSeq map { case (k, v) =>
+        TlaOperDecl(v, List.empty,
+            fixPointRepeat(replaceApplicationsWithNullary(extendedOperNames, diffMap - k, letInDecisionFn), k))
       }
       val newDefs = modifiedDefs ++ extendedDefs
-      val newBody = replaceApplicationsWithNullary(extendedOperNames, extendedAppMap, letInDecisionFn )( body )
-      if ( defs == newDefs && body == newBody ) ex
-      else LetInEx( newBody, newDefs : _* )
+      val newBody = replaceApplicationsWithNullary(extendedOperNames, extendedAppMap, letInDecisionFn)(body)
+      if (defs == newDefs && body == newBody) ex
+      else LetInEx(newBody, newDefs: _*)
     case ex => ex
   }
 
-  def fixPointRepeat[T]( fn : T => T, arg : T, limit : Int = 10 ) : T = {
-    if ( limit <= 0 ) arg
+  def fixPointRepeat[T](fn: T => T, arg: T, limit: Int = 10): T = {
+    if (limit <= 0) arg
     else {
-      val newArg = fn( arg )
-      if ( newArg == arg ) newArg
-      else fixPointRepeat( fn, newArg, limit - 1 )
+      val newArg = fn(arg)
+      if (newArg == arg) newArg
+      else fixPointRepeat(fn, newArg, limit - 1)
     }
   }
 
-
   def cacheApplicaitons(
-                         operNames: Set[String],
-                         letInDecisionFn: TlaOperDecl => Boolean
-                       ) : TlaDecl => TlaDecl = {
-    case decl@TlaOperDecl( _, _, body ) =>
-      val appMap = prepareAppMap( operNames )( body )
+      operNames: Set[String], letInDecisionFn: TlaOperDecl => Boolean
+  ): TlaDecl => TlaDecl = {
+    case decl @ TlaOperDecl(_, _, body) =>
+      val appMap = prepareAppMap(operNames)(body)
       val letInBodyCandidate =
-        replaceApplicationsWithNullary( operNames, appMap, letInDecisionFn )( body )
+        replaceApplicationsWithNullary(operNames, appMap, letInDecisionFn)(body)
       if (body == letInBodyCandidate)
         decl
       else {
 
         val newBody =
-          if ( appMap.isEmpty ) {
+          if (appMap.isEmpty) {
             letInBodyCandidate
           } else {
-            val defs = appMap.toSeq map {
-              case (k, v) => TlaOperDecl( v, List.empty,
-                fixPointRepeat( replaceApplicationsWithNullary( operNames, appMap - k, letInDecisionFn ), k )
-              )
+            val defs = appMap.toSeq map { case (k, v) =>
+              TlaOperDecl(v, List.empty,
+                  fixPointRepeat(replaceApplicationsWithNullary(operNames, appMap - k, letInDecisionFn), k))
             }
-            LetInEx( letInBodyCandidate, defs : _* )
+            LetInEx(letInBodyCandidate, defs: _*)
           }
-        val newDecl = decl.copy( body = newBody )
+        val newDecl = decl.copy(body = newBody)
         // copy does not preserve _.isRecursive
         newDecl.isRecursive = decl.isRecursive
         newDecl
@@ -109,29 +102,28 @@ class Cacher( nameGenerator: UniqueNameGenerator, tracker : TransformationTracke
     case decl => decl
   }
 
-  override def apply( module : TlaModule ) : TlaModule = {
+  override def apply(module: TlaModule): TlaModule = {
 
     val operDecls = module.operDeclarations
 
-    val recursive = operDecls.withFilter( _.isRecursive ).map( _.name ).toSet
+    val recursive = operDecls.withFilter(_.isRecursive).map(_.name).toSet
     val newDecls = module.declarations map {
-      cacheApplicaitons( recursive, Cacher.DecisionFns.recursive )
+      cacheApplicaitons(recursive, Cacher.DecisionFns.recursive)
     }
 
-    new TlaModule( module.name, newDecls )
+    new TlaModule(module.name, newDecls)
 
   }
 }
 
-
 object Cacher {
 
   object DecisionFns {
-    val recursive : TlaOperDecl => Boolean = _.isRecursive
-    val all : TlaOperDecl => Boolean = { _ => true}
+    val recursive: TlaOperDecl => Boolean = _.isRecursive
+    val all: TlaOperDecl => Boolean = { _ => true }
   }
 
-  def apply( nameGenerator: UniqueNameGenerator, tracker : TransformationTracker ) : Cacher = {
-    new Cacher( nameGenerator, tracker )
+  def apply(nameGenerator: UniqueNameGenerator, tracker: TransformationTracker): Cacher = {
+    new Cacher(nameGenerator, tracker)
   }
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.{DeclarationSorter, ModuleByExTransformer, ReplaceFixed}
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
@@ -4,15 +4,13 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.FlatLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
-
-import scala.annotation.tailrec
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * A simplifier of constant TLA+ expressions, e.g., rewriting 1 + 2 to 3.
-  *
-  * @author Igor Konnov
-  */
+ * A simplifier of constant TLA+ expressions, e.g., rewriting 1 + 2 to 3.
+ *
+ * @author Igor Konnov
+ */
 class ConstSimplifier(tracker: TransformationTracker) extends ConstSimplifierBase with TlaExTransformation {
   override def apply(expr: TlaEx): TlaEx = {
     LanguageWatchdog(FlatLanguagePred()).check(expr)
@@ -29,13 +27,13 @@ class ConstSimplifier(tracker: TransformationTracker) extends ConstSimplifierBas
     case ex @ NameEx(_) => ex
 
     case OperEx(oper, args @ _*) =>
-      simplifyShallow(OperEx(oper, args map rewriteDeep :_*))
+      simplifyShallow(OperEx(oper, args map rewriteDeep: _*))
 
     case LetInEx(body, defs @ _*) =>
-      val newDefs = defs.map {
-        d => TlaOperDecl(d.name, d.formalParams, simplify(d.body))
+      val newDefs = defs.map { d =>
+        TlaOperDecl(d.name, d.formalParams, simplify(d.body))
       }
-      LetInEx(simplify(body), newDefs :_*)
+      LetInEx(simplify(body), newDefs: _*)
 
     case ex => ex
   }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -3,20 +3,22 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.math.BigInt
 
 /**
-  * <p>A base class for constant simplification that is shared by more specialized simplifiers.</p>
-  *
-  * <p>Bugfix #450: make sure that the integers are simplified with BigInt.</p>
-  *
-  * @author Igor Konnov
-  */
+ * <p>A base class for constant simplification that is shared by more specialized simplifiers.</p>
+ *
+ * <p>Bugfix #450: make sure that the integers are simplified with BigInt.</p>
+ *
+ * @author Igor Konnov
+ */
 abstract class ConstSimplifierBase {
+
   /**
-    * A shallow simplification that does not recurse into the expression structure.
-    */
+   * A shallow simplification that does not recurse into the expression structure.
+   */
   def simplifyShallow: TlaEx => TlaEx = {
     case OperEx(TlaSetOper.notin, lhs, rhs) =>
       OperEx(TlaBoolOper.not, OperEx(TlaSetOper.in, lhs, rhs))
@@ -103,24 +105,28 @@ abstract class ConstSimplifierBase {
       if (left == right) ValEx(TlaBool(false)) else ex
 
     // boolean operations
-    case OperEx(TlaBoolOper.and, args @ _*)  =>
-      val simpArgs = args.filterNot { _ == ValEx(TlaBool(true)) }
+    case OperEx(TlaBoolOper.and, args @ _*) =>
+      val simpArgs = args.filterNot {
+        _ == ValEx(TlaBool(true))
+      }
       if (simpArgs.isEmpty) {
         ValEx(TlaBool(true)) // an empty conjunction is true
       } else if (simpArgs.contains(ValEx(TlaBool(false)))) {
         ValEx(TlaBool(false)) // one false make conjunction false
       } else {
-        OperEx(TlaBoolOper.and, simpArgs :_*)
+        OperEx(TlaBoolOper.and, simpArgs: _*)
       }
 
-    case OperEx(TlaBoolOper.or, args @ _*)  =>
-      val simpArgs = args.filterNot { _ == ValEx(TlaBool(false)) }
+    case OperEx(TlaBoolOper.or, args @ _*) =>
+      val simpArgs = args.filterNot {
+        _ == ValEx(TlaBool(false))
+      }
       if (simpArgs.isEmpty) {
         ValEx(TlaBool(false)) // an empty disjunction is true
       } else if (simpArgs.contains(ValEx(TlaBool(true)))) {
         ValEx(TlaBool(true)) // one true make disjunction true
       } else {
-        OperEx(TlaBoolOper.or, simpArgs :_*)
+        OperEx(TlaBoolOper.or, simpArgs: _*)
       }
 
     case OperEx(TlaBoolOper.not, ValEx(TlaBool(b))) =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import javax.inject.Singleton
 
@@ -194,7 +195,7 @@ class Desugarer(tracker: TransformationTracker) extends TlaExTransformation {
     val subs = boundEs.foldLeft(Map[String, TlaEx]())(collectSubstitutions)
     val newMapEx = substituteNames(subs, mapEx)
     // collect the arguments back
-    newMapEx +: TlaOper.interleave(boundNames.map(NameEx), setEs)
+    newMapEx +: TlaOper.interleave(boundNames.map(NameEx(_)), setEs)
   }
 
   private def collectSubstitutions(subs: Map[String, TlaEx], ex: TlaEx): Map[String, TlaEx] = {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -6,18 +6,19 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.transformations.standard.{FlatLanguagePred, ReplaceFixed}
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import javax.inject.Singleton
 
 import scala.math.BigInt
 
 /**
-  * <p>An optimizer of KerA+ expressions.</p>
-  *
-  * @author Igor Konnov
-  */
+ * <p>An optimizer of KerA+ expressions.</p>
+ *
+ * @author Igor Konnov
+ */
 @Singleton
 class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker)
-  extends AbstractTransformer(tracker) with TlaExTransformation {
+    extends AbstractTransformer(tracker) with TlaExTransformation {
 
   override val partialTransformers = List(transformFuns, transformSets, transformCard, transformExistsOverSets)
 
@@ -27,27 +28,27 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
   }
 
   /**
-    * Function transformations.
-    *
-    * @return a transformed fun expression
-    */
+   * Function transformations.
+   *
+   * @return a transformed fun expression
+   */
   private def transformFuns: PartialFunction[TlaEx, TlaEx] = {
-    case OperEx(TlaFunOper.app, OperEx(TlaFunOper.enum, ctorArgs@_*), ValEx(TlaStr(accessedKey))) =>
+    case OperEx(TlaFunOper.app, OperEx(TlaFunOper.enum, ctorArgs @ _*), ValEx(TlaStr(accessedKey))) =>
       val rewrittenArgs = ctorArgs map transform
-      val found = rewrittenArgs.grouped(2).find {
-        case Seq(ValEx(TlaStr(key)), _) => key == accessedKey
+      val found = rewrittenArgs.grouped(2).find { case Seq(ValEx(TlaStr(key)), _) =>
+        key == accessedKey
       }
       found match {
         case Some(pair) => pair(1) // get the value
-        case _ => throw new IllegalArgumentException(s"Access to non-existent record field $accessedKey")
+        case _          => throw new IllegalArgumentException(s"Access to non-existent record field $accessedKey")
       }
   }
 
   /**
-    * Set transformations.
-    *
-    * @return a transformed expression
-    */
+   * Set transformations.
+   *
+   * @return a transformed expression
+   */
   private def transformSets: PartialFunction[TlaEx, TlaEx] = {
     case OperEx(TlaSetOper.in, mem, OperEx(TlaArithOper.dotdot, left, right)) =>
       // Transform e \in a..b into a <= e /\ e <= b.
@@ -56,13 +57,12 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
   }
 
   /**
-    * Cardinality transformations.
-    *
-    * @return a transformed expression
-    */
+   * Cardinality transformations.
+   *
+   * @return a transformed expression
+   */
   private def transformCard: PartialFunction[TlaEx, TlaEx] = {
-    case OperEx(TlaOper.eq, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal)))
-      if intVal == BigInt(0) =>
+    case OperEx(TlaOper.eq, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal))) if intVal == BigInt(0) =>
       // Cardinality(Set) = 0, that is, Set = {}.
       // Rewrite it into \A t1 \in Set: FALSE.
       // If Set = {}, then the conjunction over the empty set is true.
@@ -71,23 +71,22 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
       tla.forall(tla.name(nameGen.newName()), set, tla.bool(false))
 
     case OperEx(TlaArithOper.gt, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal)))
-      if intVal == BigInt(0) =>
+        if intVal == BigInt(0) =>
       // We can find this pattern in real TLA+ benchmarks more often than one would think.
       // Rewrite into \E t1 \in set: TRUE
       tla.exists(tla.name(nameGen.newName()), set, tla.bool(true))
 
     case OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal)))
-      if intVal == BigInt(1) =>
+        if intVal == BigInt(1) =>
       // same as above
       tla.exists(tla.name(nameGen.newName()), set, tla.bool(true))
 
-    case OperEx(TlaOper.ne, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal)))
-      if intVal == BigInt(0) =>
+    case OperEx(TlaOper.ne, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal))) if intVal == BigInt(0) =>
       // same as above
       tla.exists(tla.name(nameGen.newName()), set, tla.bool(true))
 
     case OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal)))
-      if intVal == BigInt(2) =>
+        if intVal == BigInt(2) =>
       // We can find this pattern in real TLA+ benchmarks more often than one would think.
       // Rewrite into LET T3 = set IN \E t1 \in T3: \E t2 \in T3: t1 /= t2.
       // We use let to save on complex occurrences of set.
@@ -96,14 +95,13 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
       val setName = nameGen.newName()
       val letApp = tla.appOp(NameEx(setName))
       tla.letIn(
-        tla.exists(tla.name(tmp1), letApp,
-          tla.exists(tla.name(tmp2), letApp,
-            tla.not(tla.eql(tla.name(tmp1), tla.name(tmp2))))),
-        TlaOperDecl(setName, List(), set)
+          tla.exists(tla.name(tmp1), letApp,
+              tla.exists(tla.name(tmp2), letApp, tla.not(tla.eql(tla.name(tmp1), tla.name(tmp2))))),
+          TlaOperDecl(setName, List(), set)
       ) ///
 
-      // these rewriting rules are implemented more efficiently in CardinalityConstRule.
-      /*
+    // these rewriting rules are implemented more efficiently in CardinalityConstRule.
+    /*
     case OperEx(TlaArithOper.lt, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal)))
       if intVal.isValidInt =>
       val k = intVal.toInt
@@ -135,20 +133,19 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
         mkForAll(letInExistsEq, allNames),
         TlaOperDecl(setAlias, List(), set)
       ) ///
-      */
+     */
 
-
-    case OperEx(TlaArithOper.gt, card@OperEx(TlaFiniteSetOper.cardinality, _), ValEx(TlaInt(intVal)))
-      if intVal.isValidInt =>
+    case OperEx(TlaArithOper.gt, card @ OperEx(TlaFiniteSetOper.cardinality, _), ValEx(TlaInt(intVal)))
+        if intVal.isValidInt =>
       // Cardinality(S) > k becomes Cardinality(S) >= k + 1
       transformCard(tla.ge(card, tla.int(intVal.toInt + 1)))
   }
 
   /**
-    * Transformations for existential quantification over sets: \exists x \in SetExpr: P.
-    *
-    * @return a transformed \exists expression
-    */
+   * Transformations for existential quantification over sets: \exists x \in SetExpr: P.
+   *
+   * @return a transformed \exists expression
+   */
   private def transformExistsOverSets: PartialFunction[TlaEx, TlaEx] = {
     case OperEx(TlaBoolOper.exists, NameEx(x), OperEx(TlaSetOper.filter, NameEx(y), s, e), g) =>
       // \E x \in {y \in S: e}: g becomes \E y \in S: e /\ g [x replaced with y]
@@ -156,7 +153,7 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
       val result = tla.exists(tla.name(y), s, newPred)
       transformExistsOverSets.applyOrElse(result, { _: TlaEx => result }) // apply recursively to the result
 
-    case OperEx(TlaBoolOper.exists, NameEx(boundVar), OperEx(TlaSetOper.map, mapEx, varsAndSets@_*), pred) =>
+    case OperEx(TlaBoolOper.exists, NameEx(boundVar), OperEx(TlaSetOper.map, mapEx, varsAndSets @ _*), pred) =>
       // e.g., \E x \in {e: y \in S}: g becomes \E y \in S: LET tmp == e IN g [x replaced with e]
       // LET x == e IN g in the example above
       val letName = nameGen.newName()
@@ -164,8 +161,8 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
 
       val letIn: TlaEx = LetInEx(newPred, TlaOperDecl(letName, List(), mapEx))
       // \E y \in S: ... in the example above
-      val pairs = varsAndSets.grouped(2).toSeq.collect {
-        case Seq(NameEx(name), set) => (name, set)
+      val pairs = varsAndSets.grouped(2).toSeq.collect { case Seq(NameEx(name), set) =>
+        (name, set)
       }
 
       // create an exists-expression and optimize it again
@@ -185,4 +182,3 @@ object ExprOptimizer {
     new ExprOptimizer(uniqueNameGenerator, tracker)
   }
 }
-

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/OperAppToLetInDef.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/OperAppToLetInDef.scala
@@ -4,76 +4,76 @@ import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaOper}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
-/** Replaces instances of user-defined operator applications with a LET-IN wrapper.
-  *
-  * Example:
-  * A(x,y) ~~> LET App_1 == A(x,y) IN App_1
-  *
-  * Operator constants and formal parameters are ignored.
-  */
+/**
+ * Replaces instances of user-defined operator applications with a LET-IN wrapper.
+ *
+ * Example:
+ * A(x,y) ~~> LET App_1 == A(x,y) IN App_1
+ *
+ * Operator constants and formal parameters are ignored.
+ */
 class OperAppToLetInDef(
-               nameGenerator : UniqueNameGenerator,
-               tracker : TransformationTracker
-             ) {
+    nameGenerator: UniqueNameGenerator, tracker: TransformationTracker
+) {
 
   import OperAppToLetInDef.NAME_PREFIX
 
-  private def setTracking( oldEx : => TlaEx, newEx : => TlaEx ) : TlaEx = {
-    val tr = tracker.trackEx {
-      _ => newEx
+  private def setTracking(oldEx: => TlaEx, newEx: => TlaEx): TlaEx = {
+    val tr = tracker.trackEx { _ =>
+      newEx
     }
-    tr( oldEx )
+    tr(oldEx)
   }
 
-  def wrap( wrappableNames : Set[String] ) : TlaExTransformation = tracker.trackEx {
-    case ex@OperEx( TlaOper.apply, NameEx( opName ), args@_* ) if wrappableNames.contains( opName ) && args.nonEmpty =>
-      val newArgs = args map wrap( wrappableNames )
+  def wrap(wrappableNames: Set[String]): TlaExTransformation = tracker.trackEx {
+    case ex @ OperEx(TlaOper.apply, NameEx(opName), args @ _*) if wrappableNames.contains(opName) && args.nonEmpty =>
+      val newArgs = args map wrap(wrappableNames)
       val newEx =
-        if ( args == newArgs ) ex
-        else setTracking( ex, Builder.appOp( NameEx( opName ), newArgs : _* ) )
+        if (args == newArgs) ex
+        else setTracking(ex, Builder.appOp(NameEx(opName), newArgs: _*))
 
-      val baseName = IncrementalRenaming.getBase( opName )
+      val baseName = IncrementalRenaming.getBase(opName)
       val newName = s"${NAME_PREFIX}_${baseName}_${nameGenerator.newName()}"
-      val newDecl = TlaOperDecl( newName, List.empty, newEx )
-      LetInEx( Builder.appDecl( newDecl ), newDecl )
-      // On type annot. ignore the RHS
-    case ex@OperEx( BmcOper.withType, argEx, typeEx ) =>
-      val newArg = wrap( wrappableNames )(argEx)
-      if ( argEx == newArg )
+      val newDecl = TlaOperDecl(newName, List.empty, newEx)
+      LetInEx(Builder.appDecl(newDecl), newDecl)
+    // On type annot. ignore the RHS
+    case ex @ OperEx(BmcOper.withType, argEx, typeEx) =>
+      val newArg = wrap(wrappableNames)(argEx)
+      if (argEx == newArg)
         ex
       else
-        OperEx( BmcOper.withType, newArg, typeEx )
-    case ex@OperEx( oper, args@_* ) =>
-      val newArgs = args map wrap( wrappableNames )
-      if ( args == newArgs )
+        OperEx(BmcOper.withType, newArg, typeEx)
+    case ex @ OperEx(oper, args @ _*) =>
+      val newArgs = args map wrap(wrappableNames)
+      if (args == newArgs)
         ex
       else
-        OperEx( oper, newArgs : _* )
-    case ex@LetInEx( body, defs@_* ) =>
+        OperEx(oper, newArgs: _*)
+    case ex @ LetInEx(body, defs @ _*) =>
       // Assumption: let-in defined operators are defined in dependency order
-      val (newWrappable, newDefs) = defs.foldLeft( (wrappableNames, Seq.empty[TlaOperDecl]) ) {
+      val (newWrappable, newDefs) = defs.foldLeft((wrappableNames, Seq.empty[TlaOperDecl])) {
         case ((partialSet, partialDecls), decl) =>
-          val newDecl = decl.copy( body = wrap( partialSet )( decl.body ) )
+          val newDecl = decl.copy(body = wrap(partialSet)(decl.body))
           newDecl.isRecursive = decl.isRecursive
           (partialSet + decl.name, partialDecls :+ newDecl)
       }
-      val newBody = wrap( newWrappable )( body )
-      if ( body == newBody && defs == newDefs )
+      val newBody = wrap(newWrappable)(body)
+      if (body == newBody && defs == newDefs)
         ex
       else
-        LetInEx( newBody, newDefs : _* )
+        LetInEx(newBody, newDefs: _*)
     case ex => ex
   }
 
-  def moduleTransform( wrappableNames : Set[String] ): TlaModuleTransformation = { m =>
-
+  def moduleTransform(wrappableNames: Set[String]): TlaModuleTransformation = { m =>
     val newDecls = m.declarations map {
-      case TlaOperDecl( name, params, body ) =>
-        TlaOperDecl( name, params, wrap( wrappableNames )(body) )
+      case TlaOperDecl(name, params, body) =>
+        TlaOperDecl(name, params, wrap(wrappableNames)(body))
       case d => d
     }
-    new TlaModule( m.name, newDecls )
+    new TlaModule(m.name, newDecls)
   }
 }
 
@@ -81,7 +81,6 @@ object OperAppToLetInDef {
   val NAME_PREFIX = "CALL"
 
   def apply(
-             nameGenerator : UniqueNameGenerator,
-             tracker : TransformationTracker
-           ) = new OperAppToLetInDef( nameGenerator, tracker )
+      nameGenerator: UniqueNameGenerator, tracker: TransformationTracker
+  ) = new OperAppToLetInDef(nameGenerator, tracker)
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ParameterNormalizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ParameterNormalizer.scala
@@ -4,102 +4,103 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.transformations.standard.ReplaceFixed
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
-  * Transforms a declaration A(x,y(_,_)) == e
-  * into parameter-normal form, i.e.
-  * A(x,y(_,_)) == LET x_new == x
-  *               y_new(p1, p2) == y(p1,p2)
-  *           IN e[ x_new/x, y_new/y ]
-  * This allows us to limit the number of substitutions when inlining A.
-  * @param decisionFn Normal-form transformation will only be applied to operator declarations (both top-level and LET-IN),
-  *                   for which `decisionFn` evaluates to true. Default: returns true for all recursive operators.
-  */
+ * Transforms a declaration A(x,y(_,_)) == e
+ * into parameter-normal form, i.e.
+ * A(x,y(_,_)) == LET x_new == x
+ * y_new(p1, p2) == y(p1,p2)
+ * IN e[ x_new/x, y_new/y ]
+ * This allows us to limit the number of substitutions when inlining A.
+ *
+ * @param decisionFn Normal-form transformation will only be applied to operator declarations (both top-level and LET-IN),
+ *                   for which `decisionFn` evaluates to true. Default: returns true for all recursive operators.
+ */
 class ParameterNormalizer(
-                           nameGenerator: UniqueNameGenerator,
-                           tracker: TransformationTracker,
-                           decisionFn: TlaOperDecl => Boolean
-                         ) {
+    nameGenerator: UniqueNameGenerator, tracker: TransformationTracker, decisionFn: TlaOperDecl => Boolean
+) {
+
   /** Declaration-level transformation */
-  def normalizeDeclaration( decl : TlaOperDecl ) : TlaOperDecl = {
+  def normalizeDeclaration(decl: TlaOperDecl): TlaOperDecl = {
     // Since the body may contain LET-IN defined operators, we first normalize all of them
-    val normalizedBody = normalizeInternalLetIn( decl.body )
+    val normalizedBody = normalizeInternalLetIn(decl.body)
     val newBody =
-      if ( decisionFn( decl ) ) normalizeParametersInEx( decl.formalParams )( normalizedBody )
+      if (decisionFn(decl)) normalizeParametersInEx(decl.formalParams)(normalizedBody)
       else normalizedBody
-    val newDecl = decl.copy( body = newBody )
+    val newDecl = decl.copy(body = newBody)
     // Copy doesn't preserve .isRecursive!
     newDecl.isRecursive = decl.isRecursive
     newDecl
   }
 
   /** Expression-level LET-IN transformation, applies `mkParamNormalForm` to all LET-IN declarations */
-  private def normalizeInternalLetIn : TlaExTransformation = tracker.trackEx {
-    case ex@LetInEx( body, defs@_* ) =>
-      val newDefs = defs map { d => normalizeDeclaration( d ) }
-      val newBody = normalizeInternalLetIn( body )
-      if ( defs == newDefs && body == newBody ) ex
-      else LetInEx( newBody, newDefs : _* )
+  private def normalizeInternalLetIn: TlaExTransformation = tracker.trackEx {
+    case ex @ LetInEx(body, defs @ _*) =>
+      val newDefs = defs map { d => normalizeDeclaration(d) }
+      val newBody = normalizeInternalLetIn(body)
+      if (defs == newDefs && body == newBody) ex
+      else LetInEx(newBody, newDefs: _*)
 
-    case ex@OperEx( op, args@_* ) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map normalizeInternalLetIn
-      if ( args == newArgs ) ex
-      else OperEx( op, newArgs : _* )
+      if (args == newArgs) ex
+      else OperEx(op, newArgs: _*)
 
     case ex => ex
 
   }
 
   /** Iteratively introduces a new operator for each formal parameter */
-  private def normalizeParametersInEx( paramNames : List[FormalParam] ) : TlaExTransformation = tracker.trackEx { ex =>
-    paramNames.foldLeft( ex ) {
-      case (partialEx, fParam) =>
-        val paramOperName = nameGenerator.newName()
-        fParam match {
-          case SimpleFormalParam( name ) =>
-            // We replace all instances of `fParam` with `paramOperName`
-            // however, since paramOperName is an operator, we have to replace with application
-            val tr = ReplaceFixed(
-              NameEx( fParam.name ),
-              OperEx( TlaOper.apply, NameEx( paramOperName ) ),
+  private def normalizeParametersInEx(paramNames: List[FormalParam]): TlaExTransformation = tracker.trackEx { ex =>
+    paramNames.foldLeft(ex) { case (partialEx, fParam) =>
+      val paramOperName = nameGenerator.newName()
+      fParam match {
+        case SimpleFormalParam(name) =>
+          // We replace all instances of `fParam` with `paramOperName`
+          // however, since paramOperName is an operator, we have to replace with application
+          val tr = ReplaceFixed(
+              NameEx(fParam.name),
+              OperEx(TlaOper.apply, NameEx(paramOperName)),
               tracker
-            )
-            val replaced = tr( partialEx )
-            // if fParam is simple, the introduced operator is nullary
-            val letInDef = TlaOperDecl( paramOperName, List.empty, NameEx( name ) )
-            LetInEx( replaced, letInDef )
+          )
+          val replaced = tr(partialEx)
+          // if fParam is simple, the introduced operator is nullary
+          val letInDef = TlaOperDecl(paramOperName, List.empty, NameEx(name))
+          LetInEx(replaced, letInDef)
 
-          case OperFormalParam( name, arity ) =>
-            // We again replace all instances of `fParam` with `paramOperName`
-            // As both are operators, we don't need to introduce application
-            val tr = ReplaceFixed(
-              NameEx( fParam.name ),
-              NameEx( paramOperName ),
+        case OperFormalParam(name, arity) =>
+          // We again replace all instances of `fParam` with `paramOperName`
+          // As both are operators, we don't need to introduce application
+          val tr = ReplaceFixed(
+              NameEx(fParam.name),
+              NameEx(paramOperName),
               tracker
-            )
-            val replaced = tr( partialEx )
+          )
+          val replaced = tr(partialEx)
 
-            // This time, the introduced operator is not nullary, so we need to invent parameters
-            val inventedParams = List.fill( arity ) {
-              nameGenerator.newName()
-            }
-            // The body is just the operator applied to all the parameters
-            val newBody = OperEx(
-              TlaOper.apply, name +: inventedParams map NameEx : _*
-            )
-            val letInDef = TlaOperDecl( paramOperName, inventedParams map SimpleFormalParam, newBody )
-            LetInEx( replaced, letInDef )
-        }
+          // This time, the introduced operator is not nullary, so we need to invent parameters
+          val inventedParams = List.fill(arity) {
+            nameGenerator.newName()
+          }
+          // The body is just the operator applied to all the parameters
+          val newBody = OperEx(
+              TlaOper.apply,
+              name +: inventedParams map (NameEx(_)): _*
+          )
+          val letInDef = TlaOperDecl(paramOperName, inventedParams map SimpleFormalParam, newBody)
+          LetInEx(replaced, letInDef)
+      }
     }
   }
 
   /** Module-level transformation, calls `mkParamNormalForm` on all operator declarations */
-  def normalizeModule : TlaModuleTransformation = { m =>
+  def normalizeModule: TlaModuleTransformation = { m =>
     val newDecls = m.declarations map {
-      case d : TlaOperDecl => normalizeDeclaration( d )
-      case d => d
+      case d: TlaOperDecl => normalizeDeclaration(d)
+      case d              => d
     }
-    new TlaModule( m.name, newDecls )
+    new TlaModule(m.name, newDecls)
 
   }
 
@@ -109,14 +110,14 @@ object ParameterNormalizer {
 
   // Two standard options for `decisionFn`
   object DecisionFn {
-    def all : TlaOperDecl => Boolean = _ => true
-    def recursive : TlaOperDecl => Boolean = _.isRecursive
+    def all: TlaOperDecl => Boolean = _ => true
+
+    def recursive: TlaOperDecl => Boolean = _.isRecursive
   }
 
   def apply(
-             nameGenerator : UniqueNameGenerator,
-             tracker : TransformationTracker,
-             decisionFn : TlaOperDecl => Boolean = DecisionFn.recursive
-           ) : ParameterNormalizer =
-    new ParameterNormalizer( nameGenerator, tracker, decisionFn )
+      nameGenerator: UniqueNameGenerator, tracker: TransformationTracker,
+      decisionFn: TlaOperDecl => Boolean = DecisionFn.recursive
+  ): ParameterNormalizer =
+    new ParameterNormalizer(nameGenerator, tracker, decisionFn)
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
@@ -4,68 +4,64 @@ import at.forsyte.apalache.io.tlc.config._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * <p>An importer of all components of a parsed TLC config into a TLA module.</p>
-  *
-  * <p>Igor: This class does not compose well with the rest of ConfigurationPassImpl. So we are not using the result
-  * of rewriting. We should come back to this class later.</p>
-  *
-  * @author Andrey Kuprianov
-  */
-class TlcConfigImporter(config: TlcConfig, tracker: TransformationTracker) extends TlaModuleTransformation with LazyLogging {
+ * <p>An importer of all components of a parsed TLC config into a TLA module.</p>
+ *
+ * <p>Igor: This class does not compose well with the rest of ConfigurationPassImpl. So we are not using the result
+ * of rewriting. We should come back to this class later.</p>
+ *
+ * @author Andrey Kuprianov
+ */
+class TlcConfigImporter(config: TlcConfig, tracker: TransformationTracker)
+    extends TlaModuleTransformation with LazyLogging {
   override def apply(mod: TlaModule): TlaModule = {
 
-    val assignments = config.constAssignments.map{
-      case (param, value) =>
-        TlaOperDecl(ConstAndDefRewriter.OVERRIDE_PREFIX + param, List(), value.toTlaEx)
+    val assignments = config.constAssignments.map { case (param, value) =>
+      TlaOperDecl(ConstAndDefRewriter.OVERRIDE_PREFIX + param, List(), value.toTlaEx)
     }
-    val operators = Set(mod.declarations.collect {
-      case TlaOperDecl(name, _, _) => name
-    }:_*)
-    val replacements = config.constReplacements.map {
-      case (param, value) =>
-        if(operators.contains(value))
-          TlaOperDecl(ConstAndDefRewriter.OVERRIDE_PREFIX + param, List(), OperEx(TlaOper.apply, NameEx(value)))
-        else
-          TlaOperDecl(ConstAndDefRewriter.OVERRIDE_PREFIX + param, List(), NameEx(value))
+    val operators = Set(mod.declarations.collect { case TlaOperDecl(name, _, _) =>
+      name
+    }: _*)
+    val replacements = config.constReplacements.map { case (param, value) =>
+      if (operators.contains(value))
+        TlaOperDecl(ConstAndDefRewriter.OVERRIDE_PREFIX + param, List(), OperEx(TlaOper.apply, NameEx(value)))
+      else
+        TlaOperDecl(ConstAndDefRewriter.OVERRIDE_PREFIX + param, List(), NameEx(value))
     }
-    val stateConstraints = config.stateConstraints.zipWithIndex.map{
-      case (value, index) =>
-        TlaOperDecl(TlcConfigImporter.STATE_PREFIX + index, List(), NameEx(value))
+    val stateConstraints = config.stateConstraints.zipWithIndex.map { case (value, index) =>
+      TlaOperDecl(TlcConfigImporter.STATE_PREFIX + index, List(), NameEx(value))
     }
-    val actionConstraints = config.actionConstraints.zipWithIndex.map{
-      case (value, index) =>
-        TlaOperDecl(TlcConfigImporter.ACTION_PREFIX + index, List(), NameEx(value))
+    val actionConstraints = config.actionConstraints.zipWithIndex.map { case (value, index) =>
+      TlaOperDecl(TlcConfigImporter.ACTION_PREFIX + index, List(), NameEx(value))
     }
-    val invariants = config.invariants.zipWithIndex.map{
-      case (value, index) =>
-        TlaOperDecl(TlcConfigImporter.INVARIANT_PREFIX + index, List(), NameEx(value))
+    val invariants = config.invariants.zipWithIndex.map { case (value, index) =>
+      TlaOperDecl(TlcConfigImporter.INVARIANT_PREFIX + index, List(), NameEx(value))
     }
-    val temporalProps = config.temporalProps.zipWithIndex.map{
-      case (value, index) =>
-        TlaOperDecl(TlcConfigImporter.TEMPORAL_PREFIX + index, List(), NameEx(value))
+    val temporalProps = config.temporalProps.zipWithIndex.map { case (value, index) =>
+      TlaOperDecl(TlcConfigImporter.TEMPORAL_PREFIX + index, List(), NameEx(value))
     }
     val behaviorSpec = config.behaviorSpec match {
       case InitNextSpec(init, next) =>
         List(
-          TlaOperDecl(TlcConfigImporter.INIT, List(), NameEx(init)),
-          TlaOperDecl(TlcConfigImporter.NEXT, List(), NameEx(next))
+            TlaOperDecl(TlcConfigImporter.INIT, List(), NameEx(init)),
+            TlaOperDecl(TlcConfigImporter.NEXT, List(), NameEx(next))
         )
 
       case TemporalSpec(name) =>
         List(
-          TlaOperDecl(TlcConfigImporter.SPEC, List(), NameEx(name))
+            TlaOperDecl(TlcConfigImporter.SPEC, List(), NameEx(name))
         )
 
       case NullSpec() =>
         throw new TLCConfigurationError("Neither INIT and NEXT, nor SPECIFICATION found in the TLC configuration file")
     }
-    new TlaModule(mod.name, mod.declarations
-      ++ assignments ++ replacements ++ stateConstraints ++ actionConstraints
-      ++ invariants ++ temporalProps ++ behaviorSpec
-    )
+    new TlaModule(mod.name,
+        mod.declarations
+          ++ assignments ++ replacements ++ stateConstraints ++ actionConstraints
+          ++ invariants ++ temporalProps ++ behaviorSpec)
   }
 }
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Unroller.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Unroller.scala
@@ -1,228 +1,231 @@
 package at.forsyte.apalache.tla.pp
 
-import at.forsyte.apalache.tla.lir.aux.{ExceptionOrValue, FailWith, SucceedWith}
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.aux.{ExceptionOrValue, FailWith, SucceedWith}
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.storage.{BodyMap, BodyMapFactory}
-import at.forsyte.apalache.tla.lir.transformations.standard.{IncrementalRenaming, InlinerOfUserOper, ReplaceFixed}
+import at.forsyte.apalache.tla.lir.transformations.standard.{IncrementalRenaming, InlinerOfUserOper}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 
 /**
-  * Replaces definitions of user-defined recursive operators with a bounded chain of the operator bodies.
-  *
-  * For each recursive operator A the user must define two additional TLA+ operators,
-  *  - [UNROLL_TIMES_PREFIX]_A
-  *  - [UNROLL_DEFAULT_PREFIX]_A
-  *
-  * Let U be the name of the operator produced by unrolling A with the above parameters.
-  * The operator [UNROLL_TIMES_PREFIX]_A must evaluate to an integer `k` (with `ConstSimplifier`) and represents the
-  * depth of the unrolling. If the computation of A, for a given argument `x`, requires k or fewer recursive calls, then
-  * the value of U(x) is equal to A(x).
-  * The operator [UNROLL_DEFAULT_PREFIX]_A must have the same type as that returned by A. If the computation of A,
-  * for a given argument `x`, requires more than k recursive calls,
-  * then the value of U(x) is equal to [UNROLL_DEFAULT_PREFIX]_A.
-  *
-  * Example:
-  * Fact(n) == IF n <= 0 THEN 1 ELSE n * Fact(n-1)
-  * UNROLL_TIMES_Fact == 1
-  * UNROLL_DEFAULT_Fact == 0
-  *
-  *    |
-  *    |
-  *    V
-  *
-  * Unrolled_Fact(n) ==
-  *  IF n <= 0
-  *  THEN 1
-  *  ELSE n * (
-  *    IF n-1 <= 0
-  *    THEN 1
-  *    ELSE (n-1) * 0
-  *    )
-  *
-  * Unrolled_Fact(0) = 1, Unrolled_Fact(1) = 1, but for k > 1 Unrolled_Fact(k) = 0
-  */
-class Unroller( nameGenerator : UniqueNameGenerator, tracker : TransformationTracker, renaming: IncrementalRenaming ) extends TlaModuleTransformation {
+ * Replaces definitions of user-defined recursive operators with a bounded chain of the operator bodies.
+ *
+ * For each recursive operator A the user must define two additional TLA+ operators,
+ *  - [UNROLL_TIMES_PREFIX]_A
+ *  - [UNROLL_DEFAULT_PREFIX]_A
+ *
+ * Let U be the name of the operator produced by unrolling A with the above parameters.
+ * The operator [UNROLL_TIMES_PREFIX]_A must evaluate to an integer `k` (with `ConstSimplifier`) and represents the
+ * depth of the unrolling. If the computation of A, for a given argument `x`, requires k or fewer recursive calls, then
+ * the value of U(x) is equal to A(x).
+ * The operator [UNROLL_DEFAULT_PREFIX]_A must have the same type as that returned by A. If the computation of A,
+ * for a given argument `x`, requires more than k recursive calls,
+ * then the value of U(x) is equal to [UNROLL_DEFAULT_PREFIX]_A.
+ *
+ * Example:
+ * Fact(n) == IF n <= 0 THEN 1 ELSE n * Fact(n-1)
+ * UNROLL_TIMES_Fact == 1
+ * UNROLL_DEFAULT_Fact == 0
+ *
+ * |
+ * |
+ * V
+ *
+ * Unrolled_Fact(n) ==
+ * IF n <= 0
+ * THEN 1
+ * ELSE n * (
+ * IF n-1 <= 0
+ * THEN 1
+ * ELSE (n-1) * 0
+ * )
+ *
+ * Unrolled_Fact(0) = 1, Unrolled_Fact(1) = 1, but for k > 1 Unrolled_Fact(k) = 0
+ */
+class Unroller(nameGenerator: UniqueNameGenerator, tracker: TransformationTracker, renaming: IncrementalRenaming)
+    extends TlaModuleTransformation {
 
   import Unroller._
+  import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
   // unrollLetIn performs unrolling on all recursive LET-IN defined operators in the expression
   private def unrollLetIn(
-                           bodyMap : BodyMap
-                         ) : TlaExTransformation = tracker.trackEx {
-    case ex@LetInEx( body, defs@_* ) =>
-      val newMap = BodyMapFactory.makeFromDecls( defs, bodyMap )
-      val defaultsMap = getDefaults( newMap ).getOrThrow
-      val replaceTr = replaceWithDefaults( defaultsMap )
-      val inliner = InlinerOfUserOper( newMap, tracker )
+      bodyMap: BodyMap
+  ): TlaExTransformation = tracker.trackEx {
+    case ex @ LetInEx(body, defs @ _*) =>
+      val newMap = BodyMapFactory.makeFromDecls(defs, bodyMap)
+      val defaultsMap = getDefaults(newMap).getOrThrow
+      val replaceTr = replaceWithDefaults(defaultsMap)
+      val inliner = InlinerOfUserOper(newMap, tracker)
       // since unrolling preserves operator names, the only thing we need to do at this point is recursively unroll
       // all the LET-definitions
       val newDefs = defs map {
-        replaceRecursiveDecl( _, newMap, inliner, replaceTr ).asInstanceOf[TlaOperDecl]
+        replaceRecursiveDecl(_, newMap, inliner, replaceTr).asInstanceOf[TlaOperDecl]
       }
 
       // Since the body may contain more LET-expressions we call unrollLetIn again
-      val newBody = unrollLetIn( newMap )( body )
-      if ( defs == newDefs && body == newBody )
+      val newBody = unrollLetIn(newMap)(body)
+      if (defs == newDefs && body == newBody)
         ex
       else
-        LetInEx( newBody, newDefs : _* )
-    case ex@OperEx( op, args@_* ) =>
-      val newArgs = args map unrollLetIn( bodyMap )
-      if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
+        LetInEx(newBody, newDefs: _*)
+    case ex @ OperEx(op, args @ _*) =>
+      val newArgs = args map unrollLetIn(bodyMap)
+      if (args == newArgs) ex else OperEx(op, newArgs: _*)
     case ex => ex
   }
 
   /**
-    * Replaces all instances of operator application, for which a default body exists in `defaultsMap`
-    * with the default value.
-    */
-  private def replaceWithDefaults( defaultsMap : Map[String, TlaEx] ) : TlaExTransformation = tracker.trackEx {
-    case ex@OperEx( TlaOper.apply, NameEx( name ), _* ) if defaultsMap.contains( name ) =>
+   * Replaces all instances of operator application, for which a default body exists in `defaultsMap`
+   * with the default value.
+   */
+  private def replaceWithDefaults(defaultsMap: Map[String, TlaEx]): TlaExTransformation = tracker.trackEx {
+    case ex @ OperEx(TlaOper.apply, NameEx(name), _*) if defaultsMap.contains(name) =>
       // Get the default body, ignore the args
       defaultsMap(name)
     // recursive processing of composite operators and let-in definitions
-    case ex@LetInEx( body, defs@_* ) =>
+    case ex @ LetInEx(body, defs @ _*) =>
       // transform bodies of all op.defs
-      val transform = replaceWithDefaults( defaultsMap )
+      val transform = replaceWithDefaults(defaultsMap)
       val newDefs = defs.map { x =>
-        x.copy( body = transform( x.body ) )
+        x.copy(body = transform(x.body))
       }
-      val newBody = transform( body )
-      if ( defs == newDefs && body == newBody ) ex
-      else LetInEx( newBody, newDefs : _* )
+      val newBody = transform(body)
+      if (defs == newDefs && body == newBody) ex
+      else LetInEx(newBody, newDefs: _*)
 
-    case ex@OperEx( op, args@_* ) =>
-      val newArgs = args map replaceWithDefaults( defaultsMap )
-      if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
+    case ex @ OperEx(op, args @ _*) =>
+      val newArgs = args map replaceWithDefaults(defaultsMap)
+      if (args == newArgs) ex else OperEx(op, newArgs: _*)
 
     case ex => ex
   }
 
   /** Given an operator name, A, extracts the value of [UNROLL_TIMES_PREFIX]_A or throws a `TlaInputError` */
-  private def getUnrollLimit( name : String, bodyMap : BodyMap ) : ExceptionOrValue[BigInt] = {
+  private def getUnrollLimit(name: String, bodyMap: BodyMap): ExceptionOrValue[BigInt] = {
     // We get the unrolling limit, which should be an operator in bodyMap.
     // note that operators inside named instances have a qualified name, e.g., I!Foo. Replace "!" with "_".
     val unrollLimitOperName = s"$UNROLL_TIMES_PREFIX$name".replace('!', '_')
-    bodyMap.get( unrollLimitOperName ) match {
-      case Some( unrollLimitDecl ) =>
+    bodyMap.get(unrollLimitOperName) match {
+      case Some(unrollLimitDecl) =>
         // The unrollLimit operator must not be recursive ...
-        if ( unrollLimitDecl.isRecursive ) {
+        if (unrollLimitDecl.isRecursive) {
           val msg = s"Expected an integer bound in $unrollLimitOperName, found a recursive operator. See: $MANUAL_LINK"
-          FailWith( new TlaInputError( msg ) )
+          FailWith(new TlaInputError(msg))
         } else {
           // ... and must evaluate to a single integer
-          ConstSimplifier( tracker )(
-            InlinerOfUserOper( bodyMap, tracker )( unrollLimitDecl.body )
+          ConstSimplifier(tracker)(
+              InlinerOfUserOper(bodyMap, tracker)(implicitly[TypeTag])(unrollLimitDecl.body)
           ) match {
-            case ValEx( TlaInt( n ) ) =>
-              SucceedWith( n )
+            case ValEx(TlaInt(n)) =>
+              SucceedWith(n)
             case e =>
-              FailWith( new TlaInputError( s"Expected an integer bound in $unrollLimitOperName, found: $e"  ) )
+              FailWith(new TlaInputError(s"Expected an integer bound in $unrollLimitOperName, found: $e"))
           }
         }
 
       case None =>
         val msg = s"Recursive operator $name requires an annotation $unrollLimitOperName. See: $MANUAL_LINK"
-        FailWith( new TlaInputError( msg ) )
+        FailWith(new TlaInputError(msg))
     }
   }
 
   /** Given an operator name, A, extracts the value of [UNROLL_DEFAULT_PREFIX]_A or propmts a `TlaInputError` */
-  private def getDefaultBody( name : String, bodyMap : BodyMap ) : ExceptionOrValue[TlaEx] = {
+  private def getDefaultBody(name: String, bodyMap: BodyMap): ExceptionOrValue[TlaEx] = {
     // note that operators inside named instances have a qualified name, e.g., I!Foo. Replace "!" with "_".
     val defaultOperName = s"$UNROLL_DEFAULT_PREFIX$name".replace('!', '_')
-    bodyMap.get( defaultOperName ) match {
-      case Some( defaultDecl ) =>
+    bodyMap.get(defaultOperName) match {
+      case Some(defaultDecl) =>
         // ... which must not be recursive ...
-        if ( defaultDecl.isRecursive ) {
+        if (defaultDecl.isRecursive) {
           val msg = s"Expected a default value in $defaultOperName, found a recursive operator. See: $MANUAL_LINK"
-          FailWith( new TlaInputError( msg ) )
+          FailWith(new TlaInputError(msg))
         } else {
           // ... but may be defined using other operators, so we call transform on it
-          SucceedWith( InlinerOfUserOper( bodyMap, tracker )( defaultDecl.body ) )
+          SucceedWith(InlinerOfUserOper(bodyMap, tracker)(implicitly[TypeTag])(defaultDecl.body))
         }
 
       case None =>
-        FailWith( new TlaInputError( s"Recursive operator $name requires an annotation $defaultOperName. See: $MANUAL_LINK " ) )
+        FailWith(
+            new TlaInputError(s"Recursive operator $name requires an annotation $defaultOperName. See: $MANUAL_LINK "))
     }
   }
 
   /** Performs unrolling on the declaration and all recursively defined LET-IN declarations within */
   private def replaceRecursiveDecl(
-                                    decl : TlaDecl,
-                                    bodyMap : BodyMap,
-                                    inliner : InlinerOfUserOper,
-                                    replaceWithDefaultsTr : TlaExTransformation
-                                  ) : TlaDecl = decl match {
-    case d@TlaOperDecl( name, fparams, body ) if d.isRecursive =>
+      decl: TlaDecl, bodyMap: BodyMap, inliner: InlinerOfUserOper, replaceWithDefaultsTr: TlaExTransformation
+  ): TlaDecl = decl match {
+    case d @ TlaOperDecl(name, fparams, body) if d.isRecursive =>
       // Read the unroll limit
-      val unrollLimit = getUnrollLimit( name, bodyMap ).getOrThrow
+      val unrollLimit = getUnrollLimit(name, bodyMap).getOrThrow
       // Defines inlining k-times
-      val kStepInline = inliner.kStepInline( unrollLimit, renaming )
+      val kStepInline = inliner.kStepInline(unrollLimit, renaming)
       // Unroll all LET-IN definitions afterward
-      val unrolledLetIn = unrollLetIn( bodyMap )( body )
-      val inlined = kStepInline( unrolledLetIn )
+      val unrolledLetIn = unrollLetIn(bodyMap)(body)
+      val inlined = kStepInline(unrolledLetIn)
       // Any remaining applications are default-replaced
-      val defaultReplaced = replaceWithDefaultsTr( inlined )
-      TlaOperDecl( name, fparams, defaultReplaced )
-    case d@TlaOperDecl( name, fparams, body ) => // d.isRecursive = false
+      val defaultReplaced = replaceWithDefaultsTr(inlined)
+      TlaOperDecl(name, fparams, defaultReplaced)
+    case d @ TlaOperDecl(name, fparams, body) => // d.isRecursive = false
       // Even though `name` is not recursive, it still may define recursive LET-IN operators inside
-      val unrolledLetIn = unrollLetIn( bodyMap )( body )
-      if ( body == unrolledLetIn ) d
-      else TlaOperDecl( name, fparams, unrolledLetIn )
-    case TlaRecFunDecl( name, arg, dom, body ) =>
+      val unrolledLetIn = unrollLetIn(bodyMap)(body)
+      if (body == unrolledLetIn) d
+      else TlaOperDecl(name, fparams, unrolledLetIn)
+    case TlaRecFunDecl(name, arg, dom, body) =>
       // Ignore for now
       decl
     case _ => decl
   }
 
-  /** Prepares a map of default values, obtained from getDefaultBody  */
-  private def getDefaults( bodyMap : BodyMap ) : ExceptionOrValue[Map[String, TlaEx]] = {
+  /** Prepares a map of default values, obtained from getDefaultBody */
+  private def getDefaults(bodyMap: BodyMap): ExceptionOrValue[Map[String, TlaEx]] = {
     val defMap = bodyMap.values withFilter {
       _.isRecursive
-    } map {
-      decl => decl.name -> getDefaultBody( decl.name, bodyMap )
+    } map { decl =>
+      decl.name -> getDefaultBody(decl.name, bodyMap)
     }
     // We need to prepare a single ExceptionOrValue
     // If multiple keys point to a `FailWith`, we take the 1st
-    val init : ExceptionOrValue[Map[String, TlaEx]] = SucceedWith( Map.empty[String, TlaEx] )
-    defMap.foldLeft( init ) {
-      case (SucceedWith( m ), (k, SucceedWith( v ))) =>
-        SucceedWith( m + ( k -> v ) )
-      case (fail : FailWith[Map[String, TlaEx]], _) => fail
-      case (_, (_, fail : FailWith[TlaEx])) => FailWith[Map[String, TlaEx]]( fail.e )
+    val init: ExceptionOrValue[Map[String, TlaEx]] = SucceedWith(Map.empty[String, TlaEx])
+    defMap.foldLeft(init) {
+      case (SucceedWith(m), (k, SucceedWith(v))) =>
+        SucceedWith(m + (k -> v))
+      case (fail: FailWith[Map[String, TlaEx]], _) =>
+        fail
+      case (_, (_, fail: FailWith[TlaEx])) =>
+        FailWith[Map[String, TlaEx]](fail.e)
     }
   }
 
-  override def apply( module : TlaModule ) : TlaModule = {
+  override def apply(module: TlaModule): TlaModule = {
     // Before unrolling we transform all recursive operators into parameter-normal form
     // This reduces the number of inlining calls when operator arguments aren't primitive
-    val parameterNormalizer = ParameterNormalizer( nameGenerator, tracker, ParameterNormalizer.DecisionFn.recursive )
+    val parameterNormalizer = ParameterNormalizer(nameGenerator, tracker, ParameterNormalizer.DecisionFn.recursive)
     val paramNormModule = parameterNormalizer.normalizeModule(module)
 
     // Next we prepare the various maps and transformations ...
     val operDecls = paramNormModule.operDeclarations
-    val bodyMap = BodyMapFactory.makeFromDecls( operDecls )
-    val defaultsMap = getDefaults( bodyMap ).getOrThrow
-    val replaceTr = replaceWithDefaults( defaultsMap )
-    val inliner = InlinerOfUserOper( bodyMap, tracker )
+    val bodyMap = BodyMapFactory.makeFromDecls(operDecls)
+    val defaultsMap = getDefaults(bodyMap).getOrThrow
+    val replaceTr = replaceWithDefaults(defaultsMap)
+    val inliner = InlinerOfUserOper(bodyMap, tracker)
     // ... and unroll all declarations
     val newDecls = paramNormModule.declarations map {
-      replaceRecursiveDecl( _, bodyMap, inliner, replaceTr )
+      replaceRecursiveDecl(_, bodyMap, inliner, replaceTr)
     }
 
-    new TlaModule( paramNormModule.name, newDecls )
+    new TlaModule(paramNormModule.name, newDecls)
   }
 }
 
 object Unroller {
-  val UNROLL_TIMES_PREFIX   : String = "UNROLL_TIMES_"
-  val UNROLL_DEFAULT_PREFIX : String = "UNROLL_DEFAULT_"
-  val MANUAL_LINK           : String = "https://apalache.informal.systems/docs/apalache/principles.html#recursion"
+  val UNROLL_TIMES_PREFIX: String = "UNROLL_TIMES_"
+  val UNROLL_DEFAULT_PREFIX: String = "UNROLL_DEFAULT_"
+  val MANUAL_LINK: String = "https://apalache.informal.systems/docs/apalache/principles.html#recursion"
 
-  def apply( nameGenerator : UniqueNameGenerator, tracker : TransformationTracker, renaming: IncrementalRenaming ) : Unroller = {
-    new Unroller( nameGenerator, tracker, renaming )
+  def apply(nameGenerator: UniqueNameGenerator, tracker: TransformationTracker,
+      renaming: IncrementalRenaming): Unroller = {
+    new Unroller(nameGenerator, tracker, renaming)
   }
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -3,60 +3,49 @@ package at.forsyte.apalache.tla.pp.passes
 import java.io.{File, FileNotFoundException, FileReader}
 import java.nio.file.Path
 
-import at.forsyte.apalache.infra.passes.{
-  Pass,
-  PassOptions,
-  TlaModuleMixin,
-  WriteablePassOptions
-}
+import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin, WriteablePassOptions}
 import at.forsyte.apalache.io.tlc.TlcConfigParserApalache
 import at.forsyte.apalache.io.tlc.config._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
-import at.forsyte.apalache.tla.lir.oper.{
-  TlaActionOper,
-  TlaBoolOper,
-  TlaOper,
-  TlaTempOper
-}
+import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaBoolOper, TlaOper, TlaTempOper}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.pp._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FilenameUtils
 
 /**
-  * The pass that collects the configuration parameters and overrides constants and definitions.
-  * This pass also overrides attributes in the PassOptions object:
-  * checker.init, checker.next, checker.cinit, checker.inv. In general, passes should not override options.
-  * This is a reasonable exception to this rule, as this pass configures the options based on the user input.
-  *
-  * @param options pass options
-  * @param nextPass next pass to call
-  */
+ * The pass that collects the configuration parameters and overrides constants and definitions.
+ * This pass also overrides attributes in the PassOptions object:
+ * checker.init, checker.next, checker.cinit, checker.inv. In general, passes should not override options.
+ * This is a reasonable exception to this rule, as this pass configures the options based on the user input.
+ *
+ * @param options  pass options
+ * @param nextPass next pass to call
+ */
 class ConfigurationPassImpl @Inject() (
-    val options: WriteablePassOptions,
-    tracker: TransformationTracker,
+    val options: WriteablePassOptions, tracker: TransformationTracker,
     @Named("AfterConfiguration") nextPass: Pass with TlaModuleMixin
-) extends ConfigurationPass
-    with LazyLogging {
+) extends ConfigurationPass with LazyLogging {
 
   private var outputTlaModule: Option[TlaModule] = None
 
   /**
-    * The pass name.
-    *
-    * @return the name associated with the pass
-    */
+   * The pass name.
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "ConfigurationPass"
 
   /**
-    * Run the pass.
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass.
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     // this pass is hard to read, too many things are happening here...
     val currentModule = tlaModule.get
@@ -82,8 +71,8 @@ class ConfigurationPassImpl @Inject() (
     // dump the configuration result
     val outdir = options.getOrError("io", "outdir").asInstanceOf[Path]
     PrettyWriter.write(
-      configuredModule,
-      new File(outdir.toFile, "out-config.tla")
+        configuredModule,
+        new File(outdir.toFile, "out-config.tla")
     )
 
     outputTlaModule = Some(configuredModule)
@@ -106,8 +95,7 @@ class ConfigurationPassImpl @Inject() (
 
   // copy the relevant options
   private def copyRelevantOptions(
-      from: PassOptions,
-      to: WriteablePassOptions
+      from: PassOptions, to: WriteablePassOptions
   ): Unit = {
     for (name <- NormalizedNames.STANDARD_OPTION_NAMES) {
       from
@@ -117,14 +105,14 @@ class ConfigurationPassImpl @Inject() (
   }
 
   /**
-    * Produce the configuration options from a TLC config, if it is present.
-    * @param module the input module
-    * @param outOptions the pass options to update from the configuration file
-    * @return additional declarations, which originate from assignments and replacements
-    */
+   * Produce the configuration options from a TLC config, if it is present.
+   *
+   * @param module     the input module
+   * @param outOptions the pass options to update from the configuration file
+   * @return additional declarations, which originate from assignments and replacements
+   */
   private def loadOptionsFromTlcConfig(
-      module: TlaModule,
-      outOptions: WriteablePassOptions
+      module: TlaModule, outOptions: WriteablePassOptions
   ): Seq[TlaDecl] = {
     var configuredModule = module
     // read TLC config if present
@@ -149,7 +137,7 @@ class ConfigurationPassImpl @Inject() (
 
         case Some(cmdInit) =>
           logger.warn(
-            s"  > $basename: Init operator is set in TLC config but overridden via --init command line option; using $cmdInit"
+              s"  > $basename: Init operator is set in TLC config but overridden via --init command line option; using $cmdInit"
           )
           outOptions.set("checker.init", cmdInit)
       }
@@ -172,7 +160,7 @@ class ConfigurationPassImpl @Inject() (
     try {
       val config = TlcConfigParserApalache.apply(new FileReader(filename))
       configuredModule = new TlcConfigImporter(config, new IdleTracker())(
-        module
+          module
       )
       config.behaviorSpec match {
         case InitNextSpec(init, next) =>
@@ -190,10 +178,10 @@ class ConfigurationPassImpl @Inject() (
       }
       if (config.invariants.nonEmpty) {
         logger.info(
-          s"  > $basename: found INVARIANTS: " + String.join(
-            ", ",
-            config.invariants: _*
-          )
+            s"  > $basename: found INVARIANTS: " + String.join(
+                ", ",
+                config.invariants: _*
+            )
         )
 
         outOptions.get[List[String]]("checker", "inv") match {
@@ -203,10 +191,10 @@ class ConfigurationPassImpl @Inject() (
           case Some(cmdInvariants) =>
             val cmdInvariantsStr = cmdInvariants.map(s => "--inv " + s)
             logger.warn(
-              s"  > Overriding with command line arguments: " + String.join(
-                " ",
-                cmdInvariantsStr: _*
-              )
+                s"  > Overriding with command line arguments: " + String.join(
+                    " ",
+                    cmdInvariantsStr: _*
+                )
             )
             outOptions.set("checker.inv", cmdInvariants)
         }
@@ -217,7 +205,7 @@ class ConfigurationPassImpl @Inject() (
         outOptions.set("checker.temporalProps", config.temporalProps)
         for (prop <- config.temporalProps) {
           logger.warn(
-            s"  > $basename: PROPERTY $prop is ignored. Only INVARIANTS are supported."
+              s"  > $basename: PROPERTY $prop is ignored. Only INVARIANTS are supported."
           )
         }
       }
@@ -225,9 +213,7 @@ class ConfigurationPassImpl @Inject() (
       val namesOfOverrides =
         (config.constAssignments.keySet ++ config.constReplacements.keySet)
           .map(ConstAndDefRewriter.OVERRIDE_PREFIX + _)
-      configuredModule.declarations.filter(d =>
-        namesOfOverrides.contains(d.name)
-      )
+      configuredModule.declarations.filter(d => namesOfOverrides.contains(d.name))
     } catch {
       case _: FileNotFoundException =>
         if (configFilename.isEmpty) {
@@ -235,27 +221,26 @@ class ConfigurationPassImpl @Inject() (
           List()
         } else {
           throw new TLCConfigurationError(
-            s"  > $basename: TLC config is provided with --config, but not found"
+              s"  > $basename: TLC config is provided with --config, but not found"
           )
         }
 
       case e: TlcConfigParseError =>
         throw new TLCConfigurationError(
-          s"  > $basename:${e.pos}:  Error parsing the TLC config file: " + e.msg
+            s"  > $basename:${e.pos}:  Error parsing the TLC config file: " + e.msg
         )
     }
   }
 
   // Make sure that all operators passed via --init, --cinit, --next, --inv are present.
   private def ensureDeclarationsArePresent(
-      mod: TlaModule,
-      configOptions: PassOptions
+      mod: TlaModule, configOptions: PassOptions
   ): Unit = {
     def assertDecl(role: String, name: String): Unit = {
       logger.info(s"  > Set $role to $name")
       if (mod.operDeclarations.forall(_.name != name)) {
         throw new ConfigurationError(
-          s"Operator $name not found (used as $role)"
+            s"Operator $name not found (used as $role)"
         )
       }
     }
@@ -300,15 +285,14 @@ class ConfigurationPassImpl @Inject() (
   }
 
   /**
-    * Extract Init and Next from the spec definition that has the canonical form Init /\ [Next]_vars /\ ...
-    * @param module TLA+ module
-    * @param specName the name of the specification definition
-    * @return the pair (Init, Next)
-    */
+   * Extract Init and Next from the spec definition that has the canonical form Init /\ [Next]_vars /\ ...
+   *
+   * @param module   TLA+ module
+   * @param specName the name of the specification definition
+   * @return the pair (Init, Next)
+   */
   private def extractFromSpec(
-      module: TlaModule,
-      contextName: String,
-      specName: String
+      module: TlaModule, contextName: String, specName: String
   ): (String, String) = {
     // flatten nested conjunctions into a single one
     def flattenAnds: TlaEx => TlaEx = {
@@ -318,8 +302,8 @@ class ConfigurationPassImpl @Inject() (
           case OperEx(TlaBoolOper.and, _*) => true
           case _                           => false
         }
-        val propagated = ands.collect {
-          case OperEx(TlaBoolOper.and, as @ _*) => as
+        val propagated = ands.collect { case OperEx(TlaBoolOper.and, as @ _*) =>
+          as
         }.flatten
         OperEx(TlaBoolOper.and, propagated ++ nonAnds: _*)
 
@@ -328,7 +312,7 @@ class ConfigurationPassImpl @Inject() (
 
     def throwError(d: TlaOperDecl): Nothing = {
       logger.error(
-        s"Operator $specName of ${d.formalParams.length} arguments is defined as: " + d.body
+          s"Operator $specName of ${d.formalParams.length} arguments is defined as: " + d.body
       )
       val msg =
         s"$contextName: Expected $specName to be in the canonical form Init /\\ [][Next]_vars /\\ ..."
@@ -338,7 +322,7 @@ class ConfigurationPassImpl @Inject() (
     module.operDeclarations.find(_.name == specName) match {
       case None =>
         throw new ConfigurationError(
-          s"$contextName: Operator $specName not found (used as SPECIFICATION)"
+            s"$contextName: Operator $specName not found (used as SPECIFICATION)"
         )
 
       // the canonical form: Init /\ [][Next]_vars /\ ...
@@ -353,28 +337,28 @@ class ConfigurationPassImpl @Inject() (
             val (init, next) =
               nonFairness match {
                 case Seq(
-                      OperEx(TlaOper.apply, NameEx(init)), // Init
-                      OperEx(
-                        TlaTempOper.box,
+                        OperEx(TlaOper.apply, NameEx(init)), // Init
                         OperEx(
-                          TlaActionOper.stutter,
-                          OperEx(TlaOper.apply, NameEx(next)),
-                          _*
-                        )
-                      ) // [][Next]_vars
+                            TlaTempOper.box,
+                            OperEx(
+                                TlaActionOper.stutter,
+                                OperEx(TlaOper.apply, NameEx(next)),
+                                _*
+                            )
+                        ) // [][Next]_vars
                     ) =>
                   (init, next)
 
                 case Seq(
-                      OperEx(
-                        TlaTempOper.box,
                         OperEx(
-                          TlaActionOper.stutter,
-                          OperEx(TlaOper.apply, NameEx(next)),
-                          _*
-                        )
-                      ),
-                      OperEx(TlaOper.apply, NameEx(init)) // Init
+                            TlaTempOper.box,
+                            OperEx(
+                                TlaActionOper.stutter,
+                                OperEx(TlaOper.apply, NameEx(next)),
+                                _*
+                            )
+                        ),
+                        OperEx(TlaOper.apply, NameEx(init)) // Init
                     ) =>
                   (init, next)
 
@@ -396,11 +380,11 @@ class ConfigurationPassImpl @Inject() (
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     outputTlaModule map { m =>
       nextPass.setModule(m)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
-import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.lir.TlaModule
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
-import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
+import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{TlaDecl, TlaModule, TlaOperDecl}
-import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.pp.Desugarer
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -1,69 +1,68 @@
 package at.forsyte.apalache.tla.pp.passes
 
-import java.io.File
-import java.nio.file.Path
-
 import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.{TlaModule, TlaOperDecl}
-import at.forsyte.apalache.tla.pp.{OperAppToLetInDef, NormalizedNames, ParameterNormalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.pp.{NormalizedNames, OperAppToLetInDef, UniqueNameGenerator}
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
+import java.io.File
+import java.nio.file.Path
+
 /**
-  * A pass that expands operators and let-in definitions.
-  *
-  * @param options pass options
-  * @param gen name generator
-  * @param tracker transformation tracker
-  * @param nextPass next pass to call
-  */
-class InlinePassImpl @Inject()(val options: PassOptions,
-                               gen: UniqueNameGenerator,
-                               renaming: IncrementalRenaming,
-                               tracker: TransformationTracker,
-                               @Named("AfterInline") nextPass: Pass with TlaModuleMixin)
+ * A pass that expands operators and let-in definitions.
+ *
+ * @param options  pass options
+ * @param gen      name generator
+ * @param tracker  transformation tracker
+ * @param nextPass next pass to call
+ */
+class InlinePassImpl @Inject() (val options: PassOptions, gen: UniqueNameGenerator, renaming: IncrementalRenaming,
+    tracker: TransformationTracker, @Named("AfterInline") nextPass: Pass with TlaModuleMixin)
     extends InlinePass with LazyLogging {
 
   private var outputTlaModule: Option[TlaModule] = None
 
   /**
-    * The pass name.
-    *
-    * @return the name associated with the pass
-    */
+   * The pass name.
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "InlinePass"
 
   /**
-    * Run the pass.
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass.
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     val baseModule = tlaModule.get
 
-    val appWrap = OperAppToLetInDef( gen, tracker )
-    val operNames = (baseModule.operDeclarations map {_.name}).toSet
-    val module = appWrap.moduleTransform( operNames )( baseModule )
+    val appWrap = OperAppToLetInDef(gen, tracker)
+    val operNames = (baseModule.operDeclarations map {
+      _.name
+    }).toSet
+    val module = appWrap.moduleTransform(operNames)(baseModule)
 
     val defBodyMap = BodyMapFactory.makeFromDecls(module.operDeclarations)
 
     val transformationSequence =
       List(
-        InlinerOfUserOper(defBodyMap, tracker),
-        LetInExpander(tracker, keepNullary = true),
-        // the second pass of Inliner may be needed, when the higher-order operators were inlined by LetInExpander
-        InlinerOfUserOper(defBodyMap, tracker)
+          InlinerOfUserOper(defBodyMap, tracker),
+          LetInExpander(tracker, keepNullary = true),
+          // the second pass of Inliner may be needed, when the higher-order operators were inlined by LetInExpander
+          InlinerOfUserOper(defBodyMap, tracker)
       ) ///
 
-    val inlined = transformationSequence.foldLeft(module){
-      case (m, tr) =>
-        logger.info("  > %s".format(tr.getClass.getSimpleName))
-        ModuleByExTransformer(tr) (m)
+    val inlined = transformationSequence.foldLeft(module) { case (m, tr) =>
+      logger.info("  > %s".format(tr.getClass.getSimpleName))
+      ModuleByExTransformer(tr)(m)
     }
 
     // Fixing issue 283: https://github.com/informalsystems/apalache/issues/283
@@ -95,14 +94,14 @@ class InlinePassImpl @Inject()(val options: PassOptions,
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     outputTlaModule map { m =>
-      nextPass.setModule( m )
+      nextPass.setModule(m)
       nextPass
     }
   }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
@@ -8,54 +8,52 @@ import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{ConstSimplifier, ExprOptimizer, UniqueNameGenerator}
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * A preprocessing pass that simplifies TLA+ expression by running multiple transformation.
-  * @param options pass options
-  * @param gen name generator
-  * @param tracker transformation tracker
-  * @param nextPass next pass to call
-  */
-class OptPassImpl @Inject()(val options: PassOptions,
-                            gen: UniqueNameGenerator,
-                            renaming: IncrementalRenaming,
-                            tracker: TransformationTracker,
-                            @Named("AfterOpt") nextPass: Pass with TlaModuleMixin)
+ * A preprocessing pass that simplifies TLA+ expression by running multiple transformation.
+ *
+ * @param options  pass options
+ * @param gen      name generator
+ * @param tracker  transformation tracker
+ * @param nextPass next pass to call
+ */
+class OptPassImpl @Inject() (val options: PassOptions, gen: UniqueNameGenerator, renaming: IncrementalRenaming,
+    tracker: TransformationTracker, @Named("AfterOpt") nextPass: Pass with TlaModuleMixin)
     extends OptPass with LazyLogging {
 
   private var outputTlaModule: Option[TlaModule] = None
 
   /**
-    * The pass name.
-    *
-    * @return the name associated with the pass
-    */
+   * The pass name.
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "OptimizationPass"
 
   /**
-    * Run the pass.
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass.
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     val module = tlaModule.get
 
     val transformationSequence =
       List(
-        ConstSimplifier(tracker),
-        ExprOptimizer(gen, tracker),
-        ConstSimplifier(tracker)
+          ConstSimplifier(tracker),
+          ExprOptimizer(gen, tracker),
+          ConstSimplifier(tracker)
       ) ///
 
     logger.info(" > Applying optimizations:")
-    val optimized = transformationSequence.foldLeft(module) {
-      case (m, tr) =>
-        logger.info("  > %s".format(tr.getClass.getSimpleName))
-        ModuleByExTransformer(tr).apply(m)
+    val optimized = transformationSequence.foldLeft(module) { case (m, tr) =>
+      logger.info("  > %s".format(tr.getClass.getSimpleName))
+      ModuleByExTransformer(tr).apply(m)
     }
 
     // dump the result of preprocessing
@@ -67,14 +65,14 @@ class OptPassImpl @Inject()(val options: PassOptions,
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     outputTlaModule map { m =>
-      nextPass.setModule( m )
+      nextPass.setModule(m)
       nextPass
     }
   }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
 import com.google.inject.Inject
 import com.google.inject.name.Named

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
@@ -8,40 +8,38 @@ import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{UniqueNameGenerator, Unroller}
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**
-  * An unrolling pass that
-  *
-  * @param options pass options
-  * @param tracker transformation tracker
-  * @param nextPass next pass to call
-  */
-class UnrollPassImpl @Inject()( val options : PassOptions,
-                                nameGenerator : UniqueNameGenerator,
-                                tracker : TransformationTracker,
-                                renaming: IncrementalRenaming,
-                                @Named( "AfterUnroll" ) nextPass : Pass with TlaModuleMixin
-                              )
-  extends UnrollPass with LazyLogging {
+ * An unrolling pass that
+ *
+ * @param options  pass options
+ * @param tracker  transformation tracker
+ * @param nextPass next pass to call
+ */
+class UnrollPassImpl @Inject() (val options: PassOptions, nameGenerator: UniqueNameGenerator,
+    tracker: TransformationTracker, renaming: IncrementalRenaming,
+    @Named("AfterUnroll") nextPass: Pass with TlaModuleMixin)
+    extends UnrollPass with LazyLogging {
 
   private var outputTlaModule: Option[TlaModule] = None
 
   /**
-    * The pass name.
-    *
-    * @return the name associated with the pass
-    */
+   * The pass name.
+   *
+   * @return the name associated with the pass
+   */
   override def name: String = "UnrollPass"
 
   /**
-    * Run the pass.
-    *
-    * @return true, if the pass was successful
-    */
+   * Run the pass.
+   *
+   * @return true, if the pass was successful
+   */
   override def execute(): Boolean = {
     val module = tlaModule.get
 
@@ -57,11 +55,11 @@ class UnrollPassImpl @Inject()( val options : PassOptions,
     //
     val renamedModule = renaming.renameInModule(module)
 
-    val unroller = Unroller( nameGenerator, tracker, renaming )
+    val unroller = Unroller(nameGenerator, tracker, renaming)
     logger.info("  > %s".format(unroller.getClass.getSimpleName))
 
     // TODO: re-enable cacher once caching is reworked (see #276 for context)
-    val newModule = unroller( renamedModule )
+    val newModule = unroller(renamedModule)
 
     // dump the result of preprocessing
     val outdir = options.getOrError("io", "outdir").asInstanceOf[Path]
@@ -72,14 +70,14 @@ class UnrollPassImpl @Inject()( val options : PassOptions,
   }
 
   /**
-    * Get the next pass in the chain. What is the next pass is up
-    * to the module configuration and the pass outcome.
-    *
-    * @return the next pass, if exists, or None otherwise
-    */
+   * Get the next pass in the chain. What is the next pass is up
+   * to the module configuration and the pass outcome.
+   *
+   * @return the next pass, if exists, or None otherwise
+   */
   override def next(): Option[Pass] = {
     outputTlaModule map { m =>
-      nextPass.setModule( m )
+      nextPass.setModule(m)
       nextPass
     }
   }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestParameterNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestParameterNormalizer.scala
@@ -1,80 +1,79 @@
 package at.forsyte.apalache.tla.pp
 
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, OperFormalParam, SimpleFormalParam, TestingPredefs, TlaOperDecl, Builder => tla}
+import at.forsyte.apalache.tla.lir.{
+  LetInEx, NameEx, OperEx, OperFormalParam, SimpleFormalParam, TestingPredefs, TlaOperDecl, Builder => tla
+}
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestParameterNormalizer extends FunSuite with BeforeAndAfterEach with TestingPredefs {
 
-  val noTracker                           = TrackerWithListeners()
-  val decisionFn : TlaOperDecl => Boolean = { _ => true }
-  var parNorm                             = new ParameterNormalizer( new UniqueNameGenerator, noTracker, decisionFn )
+  val noTracker = TrackerWithListeners()
+  val decisionFn: TlaOperDecl => Boolean = { _ => true }
+  var parNorm = new ParameterNormalizer(new UniqueNameGenerator, noTracker, decisionFn)
 
-  override def beforeEach( ) : Unit = {
-    parNorm = new ParameterNormalizer( new UniqueNameGenerator, noTracker, decisionFn )
+  override def beforeEach(): Unit = {
+    parNorm = new ParameterNormalizer(new UniqueNameGenerator, noTracker, decisionFn)
   }
 
   test("Nullary: No-op") {
 
     // A == 1
-    val decl = tla.declOp( "A", 1 )
+    val decl = tla.declOp("A", 1)
 
-    val pnf = parNorm.normalizeDeclaration( decl )
+    val pnf = parNorm.normalizeDeclaration(decl)
 
-    assert( pnf == decl )
+    assert(pnf == decl)
 
   }
 
   test("Simple parameter") {
 
     // A(p) == p
-    val decl = tla.declOp( "A", n_p, "p" )
+    val decl = tla.declOp("A", n_p, "p")
 
-    val pnf = parNorm.normalizeDeclaration( decl )
+    val pnf = parNorm.normalizeDeclaration(decl)
 
     val assertCond = pnf match {
-      case TlaOperDecl( name, SimpleFormalParam( p ) :: Nil, body ) =>
+      case TlaOperDecl(name, SimpleFormalParam(p) :: Nil, body) =>
         body match {
-          case LetInEx( letInBody, TlaOperDecl( newName, Nil, NameEx( `p` ) ) ) =>
-            name != newName && letInBody == OperEx( TlaOper.apply, NameEx( newName ) )
+          case LetInEx(letInBody, TlaOperDecl(newName, Nil, NameEx(`p`))) =>
+            name != newName && letInBody == OperEx(TlaOper.apply, NameEx(newName))
           case _ => false
         }
       case _ => false
     }
 
-    assert( assertCond )
+    assert(assertCond)
 
   }
 
   test("HO parameter") {
 
     // A(T(_)) == T(0)
-    val decl = tla.declOp( "A", tla.appOp( n_T, 0 ) , ("T", 1) )
+    val decl = tla.declOp("A", tla.appOp(n_T, 0), ("T", 1))
 
-    val pnf = parNorm.normalizeDeclaration( decl )
+    val pnf = parNorm.normalizeDeclaration(decl)
 
     val assertCond = pnf match {
-      case TlaOperDecl( name, OperFormalParam( opName, 1 ) :: Nil, body ) =>
+      case TlaOperDecl(name, OperFormalParam(opName, 1) :: Nil, body) =>
         body match {
-          case LetInEx( letInBody,
-          TlaOperDecl(
-            newName,
-            SimpleFormalParam( fakeArg ) :: Nil,
-            OperEx( TlaOper.apply, NameEx( `opName` ), NameEx( arg ) ) )
-          ) =>
+          case LetInEx(letInBody, TlaOperDecl(newName, SimpleFormalParam(fakeArg) :: Nil, OperEx(TlaOper.apply, NameEx(
+                              `opName`), NameEx(arg)))) =>
             arg == fakeArg &&
-            name != newName &&
-            letInBody == OperEx( TlaOper.apply, NameEx( newName ), 0 )
+              name != newName &&
+              letInBody == OperEx(TlaOper.apply, NameEx(newName), 0)
           case _ => false
         }
       case _ => false
     }
 
-    assert( assertCond )
+    assert(assertCond)
 
   }
 

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.imp.SanyImporter
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUnroller.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUnroller.scala
@@ -6,163 +6,162 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner
 
 import scala.math.BigInt
 
-
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestUnroller extends FunSuite with BeforeAndAfterEach with TestingPredefs {
 
   val noTracker = TrackerWithListeners()
-  private var unroller = new Unroller( new UniqueNameGenerator, noTracker, new IncrementalRenaming(noTracker) )
+  private var unroller = new Unroller(new UniqueNameGenerator, noTracker, new IncrementalRenaming(noTracker))
 
-  override def beforeEach( ) : Unit = {
-    unroller = new Unroller( new UniqueNameGenerator, noTracker, new IncrementalRenaming(noTracker) )
+  override def beforeEach(): Unit = {
+    unroller = new Unroller(new UniqueNameGenerator, noTracker, new IncrementalRenaming(noTracker))
   }
 
-  def exAsDecl(pa: (String, TlaEx)): TlaOperDecl = TlaOperDecl( pa._1, List.empty, pa._2 )
+  def exAsDecl(pa: (String, TlaEx)): TlaOperDecl = TlaOperDecl(pa._1, List.empty, pa._2)
 
-  test("No-op"){
+  test("No-op") {
     val decls = Seq[(String, TlaEx)](
-      ("A", "1"),
-      ("B", 0),
-      ("C", tla.and( n_x, n_P )),
-      ("D", tla.letIn( n_T, tla.declOp( "T", "p", "p" ) ) )
+        ("A", "1"),
+        ("B", 0),
+        ("C", tla.and(n_x, n_P)),
+        ("D", tla.letIn(n_T, tla.declOp("T", "p", "p")))
     ) map exAsDecl
 
     val module = new TlaModule("M", decls)
 
     val unrolled = unroller(module)
 
-    assert( module.declarations == unrolled.declarations )
+    assert(module.declarations == unrolled.declarations)
   }
 
-  test("0 step: ParamNormalForm"){
+  test("0 step: ParamNormalForm") {
     val name = "A"
 
     // A(p) == A(p)
-    val recDecl = tla.declOp( name, tla.appOp( n_A, n_p ), "p")
+    val recDecl = tla.declOp(name, tla.appOp(n_A, n_p), "p")
     recDecl.isRecursive = true
 
-    val defaultVal : BigInt = 42
+    val defaultVal: BigInt = 42
 
-    val decls = recDecl +: (Seq[(String,TlaEx)](
-      (Unroller.UNROLL_TIMES_PREFIX + name, 0),
-      (Unroller.UNROLL_DEFAULT_PREFIX + name, defaultVal.intValue)
-    ) map exAsDecl )
+    val decls = recDecl +: (Seq[(String, TlaEx)](
+        (Unroller.UNROLL_TIMES_PREFIX + name, 0),
+        (Unroller.UNROLL_DEFAULT_PREFIX + name, defaultVal.intValue)
+    ) map exAsDecl)
 
     val module = new TlaModule("M", decls)
 
     val unrolled = unroller(module)
 
-    val newAOpt = unrolled.operDeclarations.find( _.name == name )
+    val newAOpt = unrolled.operDeclarations.find(_.name == name)
 
-    val assertCond = newAOpt.exists{
-      case d@TlaOperDecl( _, _, body ) => !d.isRecursive &&
-        ( body match {
-          case LetInEx( ValEx( TlaInt( `defaultVal` ) ), TlaOperDecl( _, Nil, NameEx( "p" ) ) ) =>
+    val assertCond = newAOpt.exists { case d @ TlaOperDecl(_, _, body) =>
+      !d.isRecursive &&
+        (body match {
+          case LetInEx(ValEx(TlaInt(`defaultVal`)), TlaOperDecl(_, Nil, NameEx("p"))) =>
             true
           case _ => false
-        } )
+        })
     }
 
-    assert( assertCond )
+    assert(assertCond)
   }
 
   test("1 step: Nontrivial inlining") {
     val name = "A"
 
     // A(p) == A(p)
-    val recDecl = tla.declOp( name, tla.appOp( n_A, n_p ), "p" )
+    val recDecl = tla.declOp(name, tla.appOp(n_A, n_p), "p")
     recDecl.isRecursive = true
 
-    val defaultVal : BigInt = 42
+    val defaultVal: BigInt = 42
 
-    val decls = recDecl +: ( Seq[(String, TlaEx)](
-      (Unroller.UNROLL_TIMES_PREFIX + name, 1),
-      (Unroller.UNROLL_DEFAULT_PREFIX + name, defaultVal.intValue)
-    ) map exAsDecl )
+    val decls = recDecl +: (Seq[(String, TlaEx)](
+        (Unroller.UNROLL_TIMES_PREFIX + name, 1),
+        (Unroller.UNROLL_DEFAULT_PREFIX + name, defaultVal.intValue)
+    ) map exAsDecl)
 
-    val module = new TlaModule( "M", decls )
+    val module = new TlaModule("M", decls)
 
-    val unrolled = unroller( module )
+    val unrolled = unroller(module)
 
-    val newAOpt = unrolled.operDeclarations.find( _.name == name )
+    val newAOpt = unrolled.operDeclarations.find(_.name == name)
 
-    val assertCond = newAOpt.exists {
-      case d@TlaOperDecl( _, _, body ) => !d.isRecursive &&
-        ( body match {
-          case LetInEx( paramNormalBody, TlaOperDecl( uniqueName, Nil, NameEx( "p" ) ) ) =>
+    val assertCond = newAOpt.exists { case d @ TlaOperDecl(_, _, body) =>
+      !d.isRecursive &&
+        (body match {
+          case LetInEx(paramNormalBody, TlaOperDecl(uniqueName, Nil, NameEx("p"))) =>
             paramNormalBody match {
-              case LetInEx(
-              ValEx( TlaInt( `defaultVal` ) ),
-              TlaOperDecl( _, Nil, OperEx( TlaOper.apply, NameEx( `uniqueName` ) ) ) ) =>
+              case LetInEx(ValEx(TlaInt(`defaultVal`)), TlaOperDecl(_, Nil, OperEx(TlaOper.apply, NameEx(
+                                  `uniqueName`)))) =>
                 true
               case _ => false
             }
           case _ => false
-        } )
+        })
     }
 
-    assert( assertCond )
+    assert(assertCond)
 
   }
 
-  test( "Recursive LET-IN inside non-recursive operator" ){
+  test("Recursive LET-IN inside non-recursive operator") {
     val letInOpName = "A"
 
     // A(p) == A(p)
-    val recDecl = tla.declOp( letInOpName, tla.appOp( n_A, n_p ), "p" )
+    val recDecl = tla.declOp(letInOpName, tla.appOp(n_A, n_p), "p")
     recDecl.isRecursive = true
 
-    val appEx = tla.appDecl( recDecl, 99 )
+    val appEx = tla.appDecl(recDecl, 99)
     // X == LET A(p) == A(p) IN A(99)
-    val nonRecDecl = tla.declOp( "X", tla.letIn( appEx, recDecl ) )
+    val nonRecDecl = tla.declOp("X", tla.letIn(appEx, recDecl))
 
-    val defaultVal : BigInt = 42
+    val defaultVal: BigInt = 42
 
-    val decls = nonRecDecl +: ( Seq[(String, TlaEx)](
-      (Unroller.UNROLL_TIMES_PREFIX + letInOpName, 1),
-      (Unroller.UNROLL_DEFAULT_PREFIX + letInOpName, defaultVal.intValue)
-    ) map exAsDecl )
+    val decls = nonRecDecl +: (Seq[(String, TlaEx)](
+        (Unroller.UNROLL_TIMES_PREFIX + letInOpName, 1),
+        (Unroller.UNROLL_DEFAULT_PREFIX + letInOpName, defaultVal.intValue)
+    ) map exAsDecl)
 
-    val module = new TlaModule( "M", decls )
+    val module = new TlaModule("M", decls)
 
-    val unrolled = unroller( module )
+    val unrolled = unroller(module)
 
-    val newXOpt = unrolled.operDeclarations.find( _.name == "X" )
+    val newXOpt = unrolled.operDeclarations.find(_.name == "X")
 
     // The test is: Does an embedded LET-IN get unrolled in the same way as a top-level declaration
 
     // reset Renaming
-    unroller = new Unroller( new UniqueNameGenerator, noTracker, new IncrementalRenaming(noTracker) )
+    unroller = new Unroller(new UniqueNameGenerator, noTracker, new IncrementalRenaming(noTracker))
 
-    val altDecls = recDecl +: ( Seq[(String, TlaEx)](
-      (Unroller.UNROLL_TIMES_PREFIX + letInOpName, 1),
-      (Unroller.UNROLL_DEFAULT_PREFIX + letInOpName, defaultVal.intValue)
-    ) map exAsDecl )
+    val altDecls = recDecl +: (Seq[(String, TlaEx)](
+        (Unroller.UNROLL_TIMES_PREFIX + letInOpName, 1),
+        (Unroller.UNROLL_DEFAULT_PREFIX + letInOpName, defaultVal.intValue)
+    ) map exAsDecl)
 
     val altModule = new TlaModule("N", altDecls)
-    val altUnrolled = unroller( altModule )
+    val altUnrolled = unroller(altModule)
 
-    val aUnrolledOpt =  altUnrolled.operDeclarations.find( _.name == letInOpName )
+    val aUnrolledOpt = altUnrolled.operDeclarations.find(_.name == letInOpName)
 
-    assert( aUnrolledOpt.nonEmpty )
+    assert(aUnrolledOpt.nonEmpty)
 
     val aUnrolledBody = aUnrolledOpt.get.body
 
-    val assertCond = newXOpt.exists {
-      case d@TlaOperDecl( _, _, body ) => body match {
-        case LetInEx( `appEx`, TlaOperDecl( `letInOpName`, List(SimpleFormalParam("p")), `aUnrolledBody` ) ) =>
-            true
-          case _ => false
-        }
+    val assertCond = newXOpt.exists { case d @ TlaOperDecl(_, _, body) =>
+      body match {
+        case LetInEx(`appEx`, TlaOperDecl(`letInOpName`, List(SimpleFormalParam("p")), `aUnrolledBody`)) =>
+          true
+        case _ => false
+      }
     }
 
-    assert( assertCond )
+    assert(assertCond)
 
   }
 

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TypingOper}
 import at.forsyte.apalache.tla.lir.values.TlaReal
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.typecheck._
 import at.forsyte.apalache.tla.typecheck.parser.DefaultType1Parser
 import org.junit.runner.RunWith

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprDecls.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprDecls.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.io.annotations.store.{AnnotationStore, createAnnotati
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TypingOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.typecheck._
 import at.forsyte.apalache.tla.typecheck.parser.DefaultType1Parser
 import org.junit.runner.RunWith

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -3,427 +3,301 @@ package at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaBoolSet
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
-  * A builder for TLA expressions.
-  *
-  * Contains methods for constructing various types of [[TlaEx]] expressions, guaranteeing
-  * correct arity where the arity of the associated [[oper.TlaOper TlaOper]] is fixed.
-  *
-  * @author jkukovec
-  */
+ * A builder for TLA expressions.
+ *
+ * Contains methods for constructing various types of [[TlaEx]] expressions, guaranteeing
+ * correct arity where the arity of the associated [[oper.TlaOper TlaOper]] is fixed.
+ *
+ * @author jkukovec
+ */
 object Builder {
 
   /** Names and values */
-  implicit def name( p_name : String ) : NameEx = NameEx( p_name )
+  implicit def name(p_name: String): NameEx = NameEx(p_name)
 
-  def bigInt( p_val : BigInt ) : ValEx = ValEx( TlaInt( p_val ) )
+  def bigInt(p_val: BigInt): ValEx = ValEx(TlaInt(p_val))
 
-  def decimal( p_val : BigDecimal ) : ValEx = ValEx( TlaDecimal( p_val ) )
+  def decimal(p_val: BigDecimal): ValEx = ValEx(TlaDecimal(p_val))
 
-  implicit def int( p_val : Int ) : ValEx = ValEx( TlaInt( p_val ) )
+  implicit def int(p_val: Int): ValEx = ValEx(TlaInt(p_val))
 
-  implicit def bool( p_val : Boolean ) : ValEx = ValEx( TlaBool( p_val ) )
+  implicit def bool(p_val: Boolean): ValEx = ValEx(TlaBool(p_val))
 
-  def str( p_val : String ) : ValEx = ValEx( TlaStr( p_val ) )
+  def str(p_val: String): ValEx = ValEx(TlaStr(p_val))
 
   /**
-    * The set BOOLEAN.
-    *
-    * @return the value expression that corresponds to BOOLEAN.
-    */
+   * The set BOOLEAN.
+   *
+   * @return the value expression that corresponds to BOOLEAN.
+   */
   def booleanSet(): ValEx = ValEx(TlaBoolSet)
 
   /**
-    * The set Int of all integers.
-    *
-    * @return the value expression that corresponds to Int.
-    */
+   * The set Int of all integers.
+   *
+   * @return the value expression that corresponds to Int.
+   */
   def intSet(): ValEx = ValEx(TlaIntSet)
 
   /**
-    * The set Nat of all natural numbers.
-    *
-    * @return the value expression that corresponds to Nat.
-    */
+   * The set Nat of all natural numbers.
+   *
+   * @return the value expression that corresponds to Nat.
+   */
   def natSet(): ValEx = ValEx(TlaNatSet)
 
   /** Declarations */
 
-  def declOp( p_name : String,
-              p_body : TlaEx,
-              p_args : FormalParam*
-            ) : TlaOperDecl = TlaOperDecl( p_name, p_args.toList, p_body )
+  def declOp(p_name: String, p_body: TlaEx, p_args: FormalParam*): TlaOperDecl =
+    TlaOperDecl(p_name, p_args.toList, p_body)
 
-  def appDecl( p_decl : TlaOperDecl,
-               p_args : TlaEx*
-             ) : OperEx = {
-    if ( p_args.length == p_decl.formalParams.length )
-      OperEx( TlaOper.apply, name( p_decl.name ) +: p_args : _* )
+  def appDecl(p_decl: TlaOperDecl, p_args: TlaEx*): OperEx = {
+    if (p_args.length == p_decl.formalParams.length)
+      OperEx(TlaOper.apply, name(p_decl.name) +: p_args: _*)
     else
       throw new IllegalArgumentException
   }
 
   /** TlaOper */
-  def eql( p_lhs : TlaEx,
-           p_rhs : TlaEx
-         ) : OperEx = OperEx( TlaOper.eq, p_lhs, p_rhs )
+  def eql(p_lhs: TlaEx, p_rhs: TlaEx): OperEx = OperEx(TlaOper.eq, p_lhs, p_rhs)
 
-  def neql( p_lhs : TlaEx,
-            p_rhs : TlaEx
-          ) : OperEx = OperEx( TlaOper.ne, p_lhs, p_rhs )
+  def neql(p_lhs: TlaEx, p_rhs: TlaEx): OperEx = OperEx(TlaOper.ne, p_lhs, p_rhs)
 
-  def appOp( p_Op : TlaEx,
-             p_args : TlaEx*
-           ) : OperEx = OperEx( TlaOper.apply, p_Op +: p_args : _* )
+  def appOp(p_Op: TlaEx, p_args: TlaEx*): OperEx = OperEx(TlaOper.apply, p_Op +: p_args: _*)
 
-  def choose( p_x : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaOper.chooseUnbounded, p_x, p_p )
+  def choose(p_x: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaOper.chooseUnbounded, p_x, p_p)
 
-  def choose( p_x : TlaEx,
-              p_S : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaOper.chooseBounded, p_x, p_S, p_p )
+  def choose(p_x: TlaEx, p_S: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaOper.chooseBounded, p_x, p_S, p_p)
 
   /**
-    * Decorate a TLA+ expression with a label (a TLA+2 feature), e.g.,
-    * lab(a, b) :: e decorates e with the label "lab" whose arguments are "a" and "b".
-    * @param ex a TLA+ expression to decorate
-    * @param name label identifier
-    * @param args label arguments (also identifiers)
-    * @return OperEx(TlaOper.label, ex, name as ValEx(TlaStr(_)), args as ValEx(TlaStr(_)))
-    */
+   * Decorate a TLA+ expression with a label (a TLA+2 feature), e.g.,
+   * lab(a, b) :: e decorates e with the label "lab" whose arguments are "a" and "b".
+   *
+   * @param ex   a TLA+ expression to decorate
+   * @param name label identifier
+   * @param args label arguments (also identifiers)
+   * @return OperEx(TlaOper.label, ex, name as ValEx(TlaStr(_)), args as ValEx(TlaStr(_)))
+   */
   def label(ex: TlaEx, name: String, args: String*): OperEx = {
-    OperEx(TlaOper.label, ex +: ValEx(TlaStr(name)) +: args.map(s => ValEx(TlaStr(s))) :_*)
+    OperEx(TlaOper.label, ex +: ValEx(TlaStr(name)) +: args.map(s => ValEx(TlaStr(s))): _*)
   }
-
 
   /** TlaBoolOper */
-  def and( p_args : TlaEx* ) : OperEx = OperEx( TlaBoolOper.and, p_args : _* )
+  def and(p_args: TlaEx*): OperEx = OperEx(TlaBoolOper.and, p_args: _*)
 
-  def or( p_args : TlaEx* ) : OperEx = OperEx( TlaBoolOper.or, p_args : _* )
+  def or(p_args: TlaEx*): OperEx = OperEx(TlaBoolOper.or, p_args: _*)
 
-  def not( p_P : TlaEx ) : OperEx = OperEx( TlaBoolOper.not, p_P )
+  def not(p_P: TlaEx): OperEx = OperEx(TlaBoolOper.not, p_P)
 
-  def impl( p_P : TlaEx,
-            p_Q : TlaEx
-          ) : OperEx = OperEx( TlaBoolOper.implies, p_P, p_Q )
+  def impl(p_P: TlaEx, p_Q: TlaEx): OperEx = OperEx(TlaBoolOper.implies, p_P, p_Q)
 
-  def equiv( p_P : TlaEx,
-             p_Q : TlaEx
-           ) : OperEx = OperEx( TlaBoolOper.equiv, p_P, p_Q )
+  def equiv(p_P: TlaEx, p_Q: TlaEx): OperEx = OperEx(TlaBoolOper.equiv, p_P, p_Q)
 
-  def forall( p_x : TlaEx,
-              p_S : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaBoolOper.forall, p_x, p_S, p_p )
+  def forall(p_x: TlaEx, p_S: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaBoolOper.forall, p_x, p_S, p_p)
 
-  def forall( p_x : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaBoolOper.forallUnbounded, p_x, p_p )
+  def forall(p_x: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaBoolOper.forallUnbounded, p_x, p_p)
 
-  def exists( p_x : TlaEx,
-              p_S : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaBoolOper.exists, p_x, p_S, p_p )
+  def exists(p_x: TlaEx, p_S: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaBoolOper.exists, p_x, p_S, p_p)
 
-  def exists( p_x : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaBoolOper.existsUnbounded, p_x, p_p )
+  def exists(p_x: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaBoolOper.existsUnbounded, p_x, p_p)
 
   /** TlaActionOper */
-  def prime( p_name : TlaEx ) : OperEx = OperEx( TlaActionOper.prime, p_name )
+  def prime(p_name: TlaEx): OperEx = OperEx(TlaActionOper.prime, p_name)
 
-  def primeEq( p_name : TlaEx,
-               p_rhs : TlaEx
-             ) : OperEx = eql( prime( p_name ), p_rhs )
+  def primeEq(p_name: TlaEx, p_rhs: TlaEx): OperEx = eql(prime(p_name), p_rhs)
 
-  def stutt( p_A : TlaEx,
-             p_e : TlaEx
-           ) : OperEx = OperEx( TlaActionOper.stutter, p_A, p_e )
+  def stutt(p_A: TlaEx, p_e: TlaEx): OperEx = OperEx(TlaActionOper.stutter, p_A, p_e)
 
-  def nostutt( p_A : TlaEx,
-               p_e : TlaEx
-             ) : OperEx = OperEx( TlaActionOper.nostutter, p_A, p_e )
+  def nostutt(p_A: TlaEx, p_e: TlaEx): OperEx = OperEx(TlaActionOper.nostutter, p_A, p_e)
 
-  def enabled( p_A : TlaEx ) : OperEx = OperEx( TlaActionOper.enabled, p_A )
+  def enabled(p_A: TlaEx): OperEx = OperEx(TlaActionOper.enabled, p_A)
 
-  def unchanged( p_v : TlaEx ) : OperEx = OperEx( TlaActionOper.unchanged, p_v )
+  def unchanged(p_v: TlaEx): OperEx = OperEx(TlaActionOper.unchanged, p_v)
 
   /** UNTESTED */
-  def unchangedTup( p_args : TlaEx* ) : OperEx = unchanged( tuple( p_args : _* ) )
+  def unchangedTup(p_args: TlaEx*): OperEx = unchanged(tuple(p_args: _*))
 
-  def comp( p_A : TlaEx
-            , p_B : TlaEx
-          ) : OperEx = OperEx( TlaActionOper.composition, p_A, p_B )
+  def comp(p_A: TlaEx, p_B: TlaEx): OperEx = OperEx(TlaActionOper.composition, p_A, p_B)
 
   /** TlaControlOper */
-  def caseAny( p_arg1 : TlaEx,
-               p_arg2 : TlaEx,
-               p_args : TlaEx*
-             ) : OperEx =
-    if ( p_args.size % 2 == 0 )
-      caseSplit( p_arg1, p_arg2, p_args : _* )
+  def caseAny(p_arg1: TlaEx, p_arg2: TlaEx, p_args: TlaEx*): OperEx =
+    if (p_args.size % 2 == 0)
+      caseSplit(p_arg1, p_arg2, p_args: _*)
     else
-      caseOther( p_arg1, p_arg2, p_args.head, p_args.tail : _* )
+      caseOther(p_arg1, p_arg2, p_args.head, p_args.tail: _*)
 
-  def caseSplit( p_p1 : TlaEx,
-                 p_e1 : TlaEx,
-                 p_args : TlaEx* /* Expected even size */
-               ) : OperEx = OperEx( TlaControlOper.caseNoOther, p_p1 +: p_e1 +: p_args : _* )
+  def caseSplit(p_p1: TlaEx, p_e1: TlaEx, p_args: TlaEx* /* Expected even size */
+  ): OperEx = OperEx(TlaControlOper.caseNoOther, p_p1 +: p_e1 +: p_args: _*)
 
-  def caseOther(p_other : TlaEx,
-                p_p1 : TlaEx,
-                p_e1 : TlaEx,
-                p_args : TlaEx* /* Expected even size */
-               ) : OperEx =
-    OperEx( TlaControlOper.caseWithOther, p_other +: p_p1 +: p_e1 +: p_args : _* )
+  def caseOther(p_other: TlaEx, p_p1: TlaEx, p_e1: TlaEx, p_args: TlaEx* /* Expected even size */
+  ): OperEx =
+    OperEx(TlaControlOper.caseWithOther, p_other +: p_p1 +: p_e1 +: p_args: _*)
 
-  def ite( p_cond : TlaEx,
-           p_then : TlaEx,
-           p_else : TlaEx
-         ) : OperEx = OperEx( TlaControlOper.ifThenElse, p_cond, p_then, p_else )
+  def ite(p_cond: TlaEx, p_then: TlaEx, p_else: TlaEx): OperEx =
+    OperEx(TlaControlOper.ifThenElse, p_cond, p_then, p_else)
 
   // [[LetIn]]
-  def letIn( p_ex : TlaEx,
-             p_defs : TlaOperDecl*
-           ) : LetInEx = LetInEx( p_ex, p_defs : _* )
+  def letIn(p_ex: TlaEx, p_defs: TlaOperDecl*): LetInEx = LetInEx(p_ex, p_defs: _*)
 
   /** TlaTempOper */
-  def AA( p_x : TlaEx,
-          p_F : TlaEx
-        ) : OperEx = OperEx( TlaTempOper.AA, p_x, p_F )
+  def AA(p_x: TlaEx, p_F: TlaEx): OperEx = OperEx(TlaTempOper.AA, p_x, p_F)
 
-  def EE( p_x : TlaEx,
-          p_F : TlaEx
-        ) : OperEx = OperEx( TlaTempOper.EE, p_x, p_F )
+  def EE(p_x: TlaEx, p_F: TlaEx): OperEx = OperEx(TlaTempOper.EE, p_x, p_F)
 
-  def box( p_F : TlaEx ) : OperEx = OperEx( TlaTempOper.box, p_F )
+  def box(p_F: TlaEx): OperEx = OperEx(TlaTempOper.box, p_F)
 
-  def diamond( p_F : TlaEx ) : OperEx = OperEx( TlaTempOper.diamond, p_F )
+  def diamond(p_F: TlaEx): OperEx = OperEx(TlaTempOper.diamond, p_F)
 
-  def guarantees( p_F : TlaEx,
-                  p_G : TlaEx
-                ) : OperEx = OperEx( TlaTempOper.guarantees, p_F, p_G )
+  def guarantees(p_F: TlaEx, p_G: TlaEx): OperEx = OperEx(TlaTempOper.guarantees, p_F, p_G)
 
-  def leadsTo( p_F : TlaEx,
-               p_G : TlaEx
-             ) : OperEx = OperEx( TlaTempOper.leadsTo, p_F, p_G )
+  def leadsTo(p_F: TlaEx, p_G: TlaEx): OperEx = OperEx(TlaTempOper.leadsTo, p_F, p_G)
 
-  def SF( p_e : TlaEx,
-          p_A : TlaEx
-        ) : OperEx = OperEx( TlaTempOper.strongFairness, p_e, p_A )
+  def SF(p_e: TlaEx, p_A: TlaEx): OperEx = OperEx(TlaTempOper.strongFairness, p_e, p_A)
 
-  def WF( p_e : TlaEx,
-          p_A : TlaEx
-        ) : OperEx = OperEx( TlaTempOper.weakFairness, p_e, p_A )
+  def WF(p_e: TlaEx, p_A: TlaEx): OperEx = OperEx(TlaTempOper.weakFairness, p_e, p_A)
 
   /** TlaArithOper */
-  def sum( p_args : TlaEx* ) : OperEx = OperEx( TlaArithOper.sum, p_args : _* )
+  def sum(p_args: TlaEx*): OperEx = OperEx(TlaArithOper.sum, p_args: _*)
 
-  def plus( p_a : TlaEx,
-            p_b : TlaEx
-          ) : OperEx = OperEx( TlaArithOper.plus, p_a, p_b )
+  def plus(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.plus, p_a, p_b)
 
-  def minus( p_a : TlaEx,
-             p_b : TlaEx
-           ) : OperEx = OperEx( TlaArithOper.minus, p_a, p_b )
+  def minus(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.minus, p_a, p_b)
 
-  def uminus( p_a : TlaEx ) : OperEx = OperEx( TlaArithOper.uminus, p_a )
+  def uminus(p_a: TlaEx): OperEx = OperEx(TlaArithOper.uminus, p_a)
 
-  def prod( p_args : TlaEx* ) : OperEx = OperEx( TlaArithOper.prod, p_args : _* )
+  def prod(p_args: TlaEx*): OperEx = OperEx(TlaArithOper.prod, p_args: _*)
 
-  def mult( p_a : TlaEx,
-            p_b : TlaEx
-          ) : OperEx = OperEx( TlaArithOper.mult, p_a, p_b )
+  def mult(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.mult, p_a, p_b)
 
-  def div( p_a : TlaEx,
-           p_b : TlaEx
-         ) : OperEx = OperEx( TlaArithOper.div, p_a, p_b )
+  def div(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.div, p_a, p_b)
 
+  def mod(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.mod, p_a, p_b)
 
-  def mod( p_a : TlaEx,
-           p_b : TlaEx
-         ) : OperEx = OperEx( TlaArithOper.mod, p_a, p_b )
+  def rDiv(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.realDiv, p_a, p_b)
 
+  def exp(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.exp, p_a, p_b)
 
-  def rDiv( p_a : TlaEx,
-            p_b : TlaEx
-          ) : OperEx = OperEx( TlaArithOper.realDiv, p_a, p_b )
+  def dotdot(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.dotdot, p_a, p_b)
 
-  def exp( p_a : TlaEx,
-           p_b : TlaEx
-         ) : OperEx = OperEx( TlaArithOper.exp, p_a, p_b )
+  def lt(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.lt, p_a, p_b)
 
-  def dotdot( p_a : TlaEx,
-              p_b : TlaEx
-            ) : OperEx = OperEx( TlaArithOper.dotdot, p_a, p_b )
+  def gt(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.gt, p_a, p_b)
 
-  def lt( p_a : TlaEx,
-          p_b : TlaEx
-        ) : OperEx = OperEx( TlaArithOper.lt, p_a, p_b )
+  def le(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.le, p_a, p_b)
 
-  def gt( p_a : TlaEx,
-          p_b : TlaEx
-        ) : OperEx = OperEx( TlaArithOper.gt, p_a, p_b )
-
-  def le( p_a : TlaEx,
-          p_b : TlaEx
-        ) : OperEx = OperEx( TlaArithOper.le, p_a, p_b )
-
-  def ge( p_a : TlaEx,
-          p_b : TlaEx
-        ) : OperEx = OperEx( TlaArithOper.ge, p_a, p_b )
+  def ge(p_a: TlaEx, p_b: TlaEx): OperEx = OperEx(TlaArithOper.ge, p_a, p_b)
 
   /** TlaFiniteSetOper */
-  def card( p_S : TlaEx ) : OperEx = OperEx( TlaFiniteSetOper.cardinality, p_S )
+  def card(p_S: TlaEx): OperEx = OperEx(TlaFiniteSetOper.cardinality, p_S)
 
-  def isFin( p_S : TlaEx ) : OperEx = OperEx( TlaFiniteSetOper.isFiniteSet, p_S )
+  def isFin(p_S: TlaEx): OperEx = OperEx(TlaFiniteSetOper.isFiniteSet, p_S)
 
   /** TlaFunOper */
-  def appFun( p_f : TlaEx,
-              p_e : TlaEx
-            ) : OperEx = OperEx( TlaFunOper.app, p_f, p_e )
+  def appFun(p_f: TlaEx, p_e: TlaEx): OperEx = OperEx(TlaFunOper.app, p_f, p_e)
 
-  def dom( p_f : TlaEx ) : OperEx = OperEx( TlaFunOper.domain, p_f )
+  def dom(p_f: TlaEx): OperEx = OperEx(TlaFunOper.domain, p_f)
 
-  def enumFun( p_k1 : TlaEx,
-               p_v1 : TlaEx,
-               p_args : TlaEx* /* Expected even size */
-             ) : OperEx = OperEx( TlaFunOper.enum, p_k1 +: p_v1 +: p_args : _* )
+  def enumFun(p_k1: TlaEx, p_v1: TlaEx, p_args: TlaEx* /* Expected even size */
+  ): OperEx = OperEx(TlaFunOper.enum, p_k1 +: p_v1 +: p_args: _*)
 
-  def except( p_f : TlaEx,
-              p_k1 : TlaEx,
-              p_v1 : TlaEx,
-              p_args : TlaEx* /* Expected even size */
-            ) : OperEx = {
-    OperEx( TlaFunOper.except, p_f +: p_k1 +: p_v1 +: p_args : _* )
+  def except(p_f: TlaEx, p_k1: TlaEx, p_v1: TlaEx, p_args: TlaEx* /* Expected even size */
+  ): OperEx = {
+    OperEx(TlaFunOper.except, p_f +: p_k1 +: p_v1 +: p_args: _*)
   }
 
-  def funDef( p_e : TlaEx,
-              p_x : TlaEx,
-              p_S : TlaEx,
-              p_args : TlaEx* /* Expected even size */
-            ) : OperEx = OperEx( TlaFunOper.funDef, p_e +: p_x +: p_S +: p_args : _* )
+  def funDef(p_e: TlaEx, p_x: TlaEx, p_S: TlaEx, p_args: TlaEx* /* Expected even size */
+  ): OperEx = OperEx(TlaFunOper.funDef, p_e +: p_x +: p_S +: p_args: _*)
 
-  def recFunDef(body : TlaEx, boundVar : TlaEx, set : TlaEx, otherArgs: TlaEx*): OperEx = {
-    OperEx(TlaFunOper.recFunDef, body +: boundVar +: set +: otherArgs :_*)
+  def recFunDef(body: TlaEx, boundVar: TlaEx, set: TlaEx, otherArgs: TlaEx*): OperEx = {
+    OperEx(TlaFunOper.recFunDef, body +: boundVar +: set +: otherArgs: _*)
   }
 
   def recFunRef(): OperEx = {
     OperEx(TlaFunOper.recFunRef)
   }
 
-  def tuple( p_args : TlaEx* ) : OperEx = OperEx( TlaFunOper.tuple, p_args : _* )
+  def tuple(p_args: TlaEx*): OperEx = OperEx(TlaFunOper.tuple, p_args: _*)
 
   /** TlaSeqOper */
-  def append( p_s : TlaEx,
-              p_e : TlaEx
-            ) : OperEx = OperEx( TlaSeqOper.append, p_s, p_e )
+  def append(p_s: TlaEx, p_e: TlaEx): OperEx = OperEx(TlaSeqOper.append, p_s, p_e)
 
-  def concat( p_s1 : TlaEx,
-              p_s2 : TlaEx
-            ) : OperEx = OperEx( TlaSeqOper.concat, p_s1, p_s2 )
+  def concat(p_s1: TlaEx, p_s2: TlaEx): OperEx = OperEx(TlaSeqOper.concat, p_s1, p_s2)
 
-  def head( p_s : TlaEx ) : OperEx = OperEx( TlaSeqOper.head, p_s )
+  def head(p_s: TlaEx): OperEx = OperEx(TlaSeqOper.head, p_s)
 
-  def tail( p_s : TlaEx ) : OperEx = OperEx( TlaSeqOper.tail, p_s )
+  def tail(p_s: TlaEx): OperEx = OperEx(TlaSeqOper.tail, p_s)
 
-  def len( p_s : TlaEx ) : OperEx = OperEx( TlaSeqOper.len, p_s )
+  def len(p_s: TlaEx): OperEx = OperEx(TlaSeqOper.len, p_s)
 
   /**
-    * Get a subsequence of S, that is, SubSeq(S, from, to)
-    * @param seq a sequence, e.g., constructed with tla.tuple
-    * @param from the first index of the subsequene, greater or equal to 1
-    * @param to the last index of the subsequence, not greater than Len(S)
-    * @return the expression that corresponds to SubSeq(S, from, to)
-    */
+   * Get a subsequence of S, that is, SubSeq(S, from, to)
+   *
+   * @param seq  a sequence, e.g., constructed with tla.tuple
+   * @param from the first index of the subsequene, greater or equal to 1
+   * @param to   the last index of the subsequence, not greater than Len(S)
+   * @return the expression that corresponds to SubSeq(S, from, to)
+   */
   def subseq(seq: TlaEx, from: TlaEx, to: TlaEx): TlaEx =
     OperEx(TlaSeqOper.subseq, seq, from, to)
 
   /**
-    * Get the subsequence of S that consists of the elements matching a predicate.
-    * @param seq a sequence
-    * @param test a predicate, it should be an action name
-    * @return the expression that corresponds to SelectSeq(S, test)
-    */
+   * Get the subsequence of S that consists of the elements matching a predicate.
+   *
+   * @param seq  a sequence
+   * @param test a predicate, it should be an action name
+   * @return the expression that corresponds to SelectSeq(S, test)
+   */
   def selectseq(seq: TlaEx, test: TlaEx): TlaEx =
     OperEx(TlaSeqOper.selectseq, seq, test)
 
   /** TlaSetOper */
-  def enumSet( p_args : TlaEx* ) : OperEx = OperEx( TlaSetOper.enumSet, p_args : _* )
+  def enumSet(p_args: TlaEx*): OperEx = OperEx(TlaSetOper.enumSet, p_args: _*)
 
-  def emptySet() : OperEx = enumSet()
+  def emptySet(): OperEx = enumSet()
 
-  def in( p_x : TlaEx,
-          p_S : TlaEx
-        ) : OperEx = OperEx( TlaSetOper.in, p_x, p_S )
+  def in(p_x: TlaEx, p_S: TlaEx): OperEx = OperEx(TlaSetOper.in, p_x, p_S)
 
-  def notin( p_x : TlaEx,
-             p_S : TlaEx
-           ) : OperEx = OperEx( TlaSetOper.notin, p_x, p_S )
+  def notin(p_x: TlaEx, p_S: TlaEx): OperEx = OperEx(TlaSetOper.notin, p_x, p_S)
 
-  def cap( p_S1 : TlaEx,
-           p_S2 : TlaEx
-         ) : OperEx = OperEx( TlaSetOper.cap, p_S1, p_S2 )
+  def cap(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.cap, p_S1, p_S2)
 
-  def cup( p_S1 : TlaEx,
-           p_S2 : TlaEx
-         ) : OperEx = OperEx( TlaSetOper.cup, p_S1, p_S2 )
+  def cup(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.cup, p_S1, p_S2)
 
-  def union( p_S : TlaEx ) : OperEx = OperEx( TlaSetOper.union, p_S )
+  def union(p_S: TlaEx): OperEx = OperEx(TlaSetOper.union, p_S)
 
-  def filter( p_x : TlaEx,
-              p_S : TlaEx,
-              p_p : TlaEx
-            ) : OperEx = OperEx( TlaSetOper.filter, p_x, p_S, p_p )
+  def filter(p_x: TlaEx, p_S: TlaEx, p_p: TlaEx): OperEx = OperEx(TlaSetOper.filter, p_x, p_S, p_p)
 
-  def map( p_e : TlaEx,
-           p_x : TlaEx,
-           p_S : TlaEx,
-           p_args : TlaEx* /* Expected even size */
-         ) : OperEx = OperEx( TlaSetOper.map, p_e +: p_x +: p_S +: p_args : _* )
+  def map(p_e: TlaEx, p_x: TlaEx, p_S: TlaEx, p_args: TlaEx* /* Expected even size */
+  ): OperEx = OperEx(TlaSetOper.map, p_e +: p_x +: p_S +: p_args: _*)
 
-  def funSet( p_S : TlaEx,
-              p_T : TlaEx
-            ) : OperEx = OperEx( TlaSetOper.funSet, p_S, p_T )
+  def funSet(p_S: TlaEx, p_T: TlaEx): OperEx = OperEx(TlaSetOper.funSet, p_S, p_T)
 
-  def recSet( p_args : TlaEx* /* Expected even size */
-            ) : OperEx = OperEx( TlaSetOper.recSet, p_args : _* )
+  def recSet(p_args: TlaEx* /* Expected even size */
+  ): OperEx = OperEx(TlaSetOper.recSet, p_args: _*)
 
-  def seqSet( p_S : TlaEx ) : OperEx = OperEx( TlaSetOper.seqSet, p_S )
+  def seqSet(p_S: TlaEx): OperEx = OperEx(TlaSetOper.seqSet, p_S)
 
-  def subset( p_S1 : TlaEx,
-              p_S2 : TlaEx
-            ) : OperEx = OperEx( TlaSetOper.subsetProper, p_S1, p_S2 )
+  def subset(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.subsetProper, p_S1, p_S2)
 
-  def subseteq( p_S1 : TlaEx,
-                p_S2 : TlaEx
-              ) : OperEx = OperEx( TlaSetOper.subseteq, p_S1, p_S2 )
+  def subseteq(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.subseteq, p_S1, p_S2)
 
-  def supset( p_S1 : TlaEx,
-              p_S2 : TlaEx
-            ) : OperEx = OperEx( TlaSetOper.supsetProper, p_S1, p_S2 )
+  def supset(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.supsetProper, p_S1, p_S2)
 
-  def supseteq( p_S1 : TlaEx,
-                p_S2 : TlaEx
-              ) : OperEx = OperEx( TlaSetOper.supseteq, p_S1, p_S2 )
+  def supseteq(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.supseteq, p_S1, p_S2)
 
-  def setminus( p_S1 : TlaEx,
-                p_S2 : TlaEx
-              ) : OperEx = OperEx( TlaSetOper.setminus, p_S1, p_S2 )
+  def setminus(p_S1: TlaEx, p_S2: TlaEx): OperEx = OperEx(TlaSetOper.setminus, p_S1, p_S2)
 
-  def times( p_args : TlaEx* ) : OperEx = OperEx( TlaSetOper.times, p_args : _* )
+  def times(p_args: TlaEx*): OperEx = OperEx(TlaSetOper.times, p_args: _*)
 
-  def powSet( p_S : TlaEx ) : OperEx = OperEx( TlaSetOper.powerset, p_S )
+  def powSet(p_S: TlaEx): OperEx = OperEx(TlaSetOper.powerset, p_S)
 
   // tlc
-  def tlcAssert( e: TlaEx, msg: String ): OperEx = OperEx(TlcOper.assert, e, ValEx(TlaStr(msg)))
+  def tlcAssert(e: TlaEx, msg: String): OperEx = OperEx(TlcOper.assert, e, ValEx(TlaStr(msg)))
 
-  def primeInSingleton( p_x : TlaEx,
-                        p_y : TlaEx
-                      ) : OperEx = in( prime( p_x ), enumSet( p_y ) )
+  def primeInSingleton(p_x: TlaEx, p_y: TlaEx): OperEx = in(prime(p_x), enumSet(p_y))
 
   // d_1 :> e_1 @@ ... @@ d_k :> e_k
   def atat(args: TlaEx*): OperEx = {
@@ -432,7 +306,7 @@ object Builder {
     } else {
       val kvs = args.sliding(2, 2).toList
       val pairs = kvs.map(p => OperEx(TlcOper.colonGreater, p.head, p(1)))
-      OperEx(TlcOper.atat, pairs :_*)
+      OperEx(TlcOper.atat, pairs: _*)
     }
   }
 
@@ -440,113 +314,103 @@ object Builder {
   def withType(expr: TlaEx, typeAnnot: TlaEx): OperEx =
     OperEx(BmcOper.withType, expr, typeAnnot)
 
-  def assign( lhs: TlaEx, rhs: TlaEx ) =
-    OperEx( BmcOper.assign, lhs, rhs )
-  def assignPrime( n: NameEx, rhs: TlaEx ): OperEx =
-    OperEx( BmcOper.assign, prime( n ), rhs )
+  def assign(lhs: TlaEx, rhs: TlaEx) =
+    OperEx(BmcOper.assign, lhs, rhs)
 
+  def assignPrime(n: NameEx, rhs: TlaEx): OperEx =
+    OperEx(BmcOper.assign, prime(n), rhs)
 
-  private val m_nameMap : Map[String, TlaOper] =
+  private val m_nameMap: Map[String, TlaOper] =
     scala.collection.immutable.Map(
-      TlaOper.eq.name -> TlaOper.eq,
-      TlaOper.ne.name -> TlaOper.ne,
-      TlaOper.apply.name -> TlaOper.apply,
-      TlaOper.chooseBounded.name -> TlaOper.chooseBounded,
-      TlaOper.chooseUnbounded.name -> TlaOper.chooseUnbounded,
-
-      TlaBoolOper.and.name -> TlaBoolOper.and,
-      TlaBoolOper.or.name -> TlaBoolOper.or,
-      TlaBoolOper.not.name -> TlaBoolOper.not,
-      TlaBoolOper.implies.name -> TlaBoolOper.implies,
-      TlaBoolOper.equiv.name -> TlaBoolOper.equiv,
-      TlaBoolOper.forall.name -> TlaBoolOper.forall,
-      TlaBoolOper.exists.name -> TlaBoolOper.exists,
-      TlaBoolOper.forallUnbounded.name -> TlaBoolOper.forallUnbounded,
-      TlaBoolOper.existsUnbounded.name -> TlaBoolOper.existsUnbounded,
-
-      TlaActionOper.prime.name -> TlaActionOper.prime,
-      TlaActionOper.stutter.name -> TlaActionOper.stutter,
-      TlaActionOper.nostutter.name -> TlaActionOper.nostutter,
-      TlaActionOper.enabled.name -> TlaActionOper.enabled,
-      TlaActionOper.unchanged.name -> TlaActionOper.unchanged,
-      TlaActionOper.composition.name -> TlaActionOper.composition,
-
-      TlaControlOper.caseNoOther.name -> TlaControlOper.caseNoOther,
-      TlaControlOper.caseWithOther.name -> TlaControlOper.caseWithOther,
-      TlaControlOper.ifThenElse.name -> TlaControlOper.ifThenElse,
-
-      TlaTempOper.AA.name -> TlaTempOper.AA,
-      TlaTempOper.box.name -> TlaTempOper.box,
-      TlaTempOper.diamond.name -> TlaTempOper.diamond,
-      TlaTempOper.EE.name -> TlaTempOper.EE,
-      TlaTempOper.guarantees.name -> TlaTempOper.guarantees,
-      TlaTempOper.leadsTo.name -> TlaTempOper.leadsTo,
-      TlaTempOper.strongFairness.name -> TlaTempOper.strongFairness,
-      TlaTempOper.weakFairness.name -> TlaTempOper.weakFairness,
-
-      TlaArithOper.sum.name -> TlaArithOper.sum,
-      TlaArithOper.plus.name -> TlaArithOper.plus,
-      TlaArithOper.uminus.name -> TlaArithOper.uminus,
-      TlaArithOper.minus.name -> TlaArithOper.minus,
-      TlaArithOper.prod.name -> TlaArithOper.prod,
-      TlaArithOper.mult.name -> TlaArithOper.mult,
-      TlaArithOper.div.name -> TlaArithOper.div,
-      TlaArithOper.mod.name -> TlaArithOper.mod,
-      TlaArithOper.realDiv.name -> TlaArithOper.realDiv,
-      TlaArithOper.exp.name -> TlaArithOper.exp,
-      TlaArithOper.dotdot.name -> TlaArithOper.dotdot,
-      TlaArithOper.lt.name -> TlaArithOper.lt,
-      TlaArithOper.gt.name -> TlaArithOper.gt,
-      TlaArithOper.le.name -> TlaArithOper.le,
-      TlaArithOper.ge.name -> TlaArithOper.ge,
-
-      TlaFiniteSetOper.cardinality.name -> TlaFiniteSetOper.cardinality,
-      TlaFiniteSetOper.isFiniteSet.name -> TlaFiniteSetOper.isFiniteSet,
-
-      TlaFunOper.app.name -> TlaFunOper.app,
-      TlaFunOper.domain.name -> TlaFunOper.domain,
-      TlaFunOper.enum.name -> TlaFunOper.enum,
-      TlaFunOper.except.name -> TlaFunOper.except,
-      TlaFunOper.funDef.name -> TlaFunOper.funDef,
-      TlaFunOper.tuple.name -> TlaFunOper.tuple,
-
-      TlaSeqOper.append.name -> TlaSeqOper.append,
-      TlaSeqOper.concat.name -> TlaSeqOper.concat,
-      TlaSeqOper.head.name -> TlaSeqOper.head,
-      TlaSeqOper.tail.name -> TlaSeqOper.tail,
-      TlaSeqOper.len.name -> TlaSeqOper.len,
-
-      TlaSetOper.enumSet.name -> TlaSetOper.enumSet,
-      TlaSetOper.in.name -> TlaSetOper.in,
-      TlaSetOper.notin.name -> TlaSetOper.notin,
-      TlaSetOper.cap.name -> TlaSetOper.cap,
-      TlaSetOper.cup.name -> TlaSetOper.cup,
-      TlaSetOper.filter.name -> TlaSetOper.filter,
-      TlaSetOper.funSet.name -> TlaSetOper.funSet,
-      TlaSetOper.map.name -> TlaSetOper.map,
-      TlaSetOper.powerset.name -> TlaSetOper.powerset,
-      TlaSetOper.recSet.name -> TlaSetOper.recSet,
-      TlaSetOper.seqSet.name -> TlaSetOper.seqSet,
-      TlaSetOper.setminus.name -> TlaSetOper.setminus,
-      TlaSetOper.subseteq.name -> TlaSetOper.subseteq,
-      TlaSetOper.subsetProper.name -> TlaSetOper.subsetProper,
-      TlaSetOper.supseteq.name -> TlaSetOper.supseteq,
-      TlaSetOper.supsetProper.name -> TlaSetOper.supsetProper,
-      TlaSetOper.times.name -> TlaSetOper.times,
-      TlaSetOper.union.name -> TlaSetOper.union
+        TlaOper.eq.name -> TlaOper.eq,
+        TlaOper.ne.name -> TlaOper.ne,
+        TlaOper.apply.name -> TlaOper.apply,
+        TlaOper.chooseBounded.name -> TlaOper.chooseBounded,
+        TlaOper.chooseUnbounded.name -> TlaOper.chooseUnbounded,
+        TlaBoolOper.and.name -> TlaBoolOper.and,
+        TlaBoolOper.or.name -> TlaBoolOper.or,
+        TlaBoolOper.not.name -> TlaBoolOper.not,
+        TlaBoolOper.implies.name -> TlaBoolOper.implies,
+        TlaBoolOper.equiv.name -> TlaBoolOper.equiv,
+        TlaBoolOper.forall.name -> TlaBoolOper.forall,
+        TlaBoolOper.exists.name -> TlaBoolOper.exists,
+        TlaBoolOper.forallUnbounded.name -> TlaBoolOper.forallUnbounded,
+        TlaBoolOper.existsUnbounded.name -> TlaBoolOper.existsUnbounded,
+        TlaActionOper.prime.name -> TlaActionOper.prime,
+        TlaActionOper.stutter.name -> TlaActionOper.stutter,
+        TlaActionOper.nostutter.name -> TlaActionOper.nostutter,
+        TlaActionOper.enabled.name -> TlaActionOper.enabled,
+        TlaActionOper.unchanged.name -> TlaActionOper.unchanged,
+        TlaActionOper.composition.name -> TlaActionOper.composition,
+        TlaControlOper.caseNoOther.name -> TlaControlOper.caseNoOther,
+        TlaControlOper.caseWithOther.name -> TlaControlOper.caseWithOther,
+        TlaControlOper.ifThenElse.name -> TlaControlOper.ifThenElse,
+        TlaTempOper.AA.name -> TlaTempOper.AA,
+        TlaTempOper.box.name -> TlaTempOper.box,
+        TlaTempOper.diamond.name -> TlaTempOper.diamond,
+        TlaTempOper.EE.name -> TlaTempOper.EE,
+        TlaTempOper.guarantees.name -> TlaTempOper.guarantees,
+        TlaTempOper.leadsTo.name -> TlaTempOper.leadsTo,
+        TlaTempOper.strongFairness.name -> TlaTempOper.strongFairness,
+        TlaTempOper.weakFairness.name -> TlaTempOper.weakFairness,
+        TlaArithOper.sum.name -> TlaArithOper.sum,
+        TlaArithOper.plus.name -> TlaArithOper.plus,
+        TlaArithOper.uminus.name -> TlaArithOper.uminus,
+        TlaArithOper.minus.name -> TlaArithOper.minus,
+        TlaArithOper.prod.name -> TlaArithOper.prod,
+        TlaArithOper.mult.name -> TlaArithOper.mult,
+        TlaArithOper.div.name -> TlaArithOper.div,
+        TlaArithOper.mod.name -> TlaArithOper.mod,
+        TlaArithOper.realDiv.name -> TlaArithOper.realDiv,
+        TlaArithOper.exp.name -> TlaArithOper.exp,
+        TlaArithOper.dotdot.name -> TlaArithOper.dotdot,
+        TlaArithOper.lt.name -> TlaArithOper.lt,
+        TlaArithOper.gt.name -> TlaArithOper.gt,
+        TlaArithOper.le.name -> TlaArithOper.le,
+        TlaArithOper.ge.name -> TlaArithOper.ge,
+        TlaFiniteSetOper.cardinality.name -> TlaFiniteSetOper.cardinality,
+        TlaFiniteSetOper.isFiniteSet.name -> TlaFiniteSetOper.isFiniteSet,
+        TlaFunOper.app.name -> TlaFunOper.app,
+        TlaFunOper.domain.name -> TlaFunOper.domain,
+        TlaFunOper.enum.name -> TlaFunOper.enum,
+        TlaFunOper.except.name -> TlaFunOper.except,
+        TlaFunOper.funDef.name -> TlaFunOper.funDef,
+        TlaFunOper.tuple.name -> TlaFunOper.tuple,
+        TlaSeqOper.append.name -> TlaSeqOper.append,
+        TlaSeqOper.concat.name -> TlaSeqOper.concat,
+        TlaSeqOper.head.name -> TlaSeqOper.head,
+        TlaSeqOper.tail.name -> TlaSeqOper.tail,
+        TlaSeqOper.len.name -> TlaSeqOper.len,
+        TlaSetOper.enumSet.name -> TlaSetOper.enumSet,
+        TlaSetOper.in.name -> TlaSetOper.in,
+        TlaSetOper.notin.name -> TlaSetOper.notin,
+        TlaSetOper.cap.name -> TlaSetOper.cap,
+        TlaSetOper.cup.name -> TlaSetOper.cup,
+        TlaSetOper.filter.name -> TlaSetOper.filter,
+        TlaSetOper.funSet.name -> TlaSetOper.funSet,
+        TlaSetOper.map.name -> TlaSetOper.map,
+        TlaSetOper.powerset.name -> TlaSetOper.powerset,
+        TlaSetOper.recSet.name -> TlaSetOper.recSet,
+        TlaSetOper.seqSet.name -> TlaSetOper.seqSet,
+        TlaSetOper.setminus.name -> TlaSetOper.setminus,
+        TlaSetOper.subseteq.name -> TlaSetOper.subseteq,
+        TlaSetOper.subsetProper.name -> TlaSetOper.subsetProper,
+        TlaSetOper.supseteq.name -> TlaSetOper.supseteq,
+        TlaSetOper.supsetProper.name -> TlaSetOper.supsetProper,
+        TlaSetOper.times.name -> TlaSetOper.times,
+        TlaSetOper.union.name -> TlaSetOper.union
     )
 
-  def byName( p_operName : String,
-              p_args : TlaEx* /* Expected to match operator arity */
-            ) : TlaEx = OperEx( m_nameMap( p_operName ), p_args : _* )
+  def byName(p_operName: String, p_args: TlaEx* /* Expected to match operator arity */
+  ): TlaEx = OperEx(m_nameMap(p_operName), p_args: _*)
 
-  def byNameOrNull( p_operName : String,
-                    p_args : TlaEx*
-                  ) : TlaEx =
-    m_nameMap.get( p_operName ).map(
-      op =>
-        if ( op.isCorrectArity( p_args.size ) )
-          OperEx( op, p_args : _* )
+  def byNameOrNull(p_operName: String, p_args: TlaEx*): TlaEx =
+    m_nameMap
+      .get(p_operName)
+      .map(op =>
+        if (op.isCorrectArity(p_args.size))
+          OperEx(op, p_args: _*)
         else NullEx
-    ).getOrElse( NullEx )
+      )
+      .getOrElse(NullEx)
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TestingPredefs.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TestingPredefs.scala
@@ -1,60 +1,82 @@
 package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 // Igor@02.11.2019: why are TestingPredefs located in src/main?
 // TODO: move TestingPredefs into src/test
 trait TestingPredefs {
-  implicit def name( p_s : String ) : NameEx = NameEx( p_s )
-  implicit def value( p_n : Int  ) : ValEx = ValEx( TlaInt( p_n ) )
-  implicit def sfp( p_s : String ) : SimpleFormalParam = SimpleFormalParam( p_s )
-  implicit def ofp( p_pair : (String, Int) ) : OperFormalParam =
-    OperFormalParam( p_pair._1, p_pair._2 )
+  implicit def name(p_s: String): NameEx = NameEx(p_s)
 
-  def n_a : NameEx = "a"
-  def n_b : NameEx = "b"
-  def n_c : NameEx = "c"
-  def n_d : NameEx = "d"
-  def n_e : NameEx = "e"
-  def n_f : NameEx = "f"
-  def n_g : NameEx = "g"
+  implicit def value(p_n: Int): ValEx = ValEx(TlaInt(p_n))
 
-  def n_p : NameEx = "p"
-  def n_q : NameEx = "q"
-  def n_r : NameEx = "r"
-  def n_s : NameEx = "s"
-  def n_t : NameEx = "t"
+  implicit def sfp(p_s: String): SimpleFormalParam = SimpleFormalParam(p_s)
 
-  def n_A : NameEx = "A"
-  def n_B : NameEx = "B"
-  def n_S : NameEx = "S"
-  def n_T : NameEx = "T"
-  def n_P : NameEx = "P"
-  def n_Q : NameEx = "Q"
+  implicit def ofp(p_pair: (String, Int)): OperFormalParam =
+    OperFormalParam(p_pair._1, p_pair._2)
 
-  def n_x : NameEx = "x"
-  def n_y : NameEx = "y"
-  def n_z : NameEx = "z"
+  def n_a: NameEx = "a"
 
-  def trueEx  : ValEx = ValEx(TlaBool(true))
-  def falseEx : ValEx = ValEx(TlaBool(false))
+  def n_b: NameEx = "b"
 
-  def arr   : Array[TlaEx] = Array( n_a, n_b, n_c, n_d, n_e, n_f, n_g )
-  def arr_s : Seq[TlaEx]   = arr.toSeq
+  def n_c: NameEx = "c"
 
-  def seq( n : Int, nSkip : Int = 0 ) : Seq[TlaEx] = arr.slice( nSkip, n + nSkip ).toSeq ++ Seq.fill( n - arr.length )( n_x )
+  def n_d: NameEx = "d"
 
-  def x_in_S : OperEx = Builder.in( "x", "S" )
+  def n_e: NameEx = "e"
 
-  def printlns( p_ss : String* )
-              ( implicit p_surround : Boolean = true ) : Unit =
-    println( (if ( p_surround ) p_ss.map( "\"%s\"".format( _ ) ) else p_ss).mkString( "\n" ) )
+  def n_f: NameEx = "f"
 
-  def printsep() : Unit = println( "\n%s\n".format( Seq.fill( 20 )( "-" ).mkString ) )
+  def n_g: NameEx = "g"
 
-  def noOp() : Unit = {}
+  def n_p: NameEx = "p"
 
-  def prePostTest( f: => Unit, pre : () => Unit = noOp, post: () => Unit = noOp ) : Unit = {
+  def n_q: NameEx = "q"
+
+  def n_r: NameEx = "r"
+
+  def n_s: NameEx = "s"
+
+  def n_t: NameEx = "t"
+
+  def n_A: NameEx = "A"
+
+  def n_B: NameEx = "B"
+
+  def n_S: NameEx = "S"
+
+  def n_T: NameEx = "T"
+
+  def n_P: NameEx = "P"
+
+  def n_Q: NameEx = "Q"
+
+  def n_x: NameEx = "x"
+
+  def n_y: NameEx = "y"
+
+  def n_z: NameEx = "z"
+
+  def trueEx: ValEx = ValEx(TlaBool(true))
+
+  def falseEx: ValEx = ValEx(TlaBool(false))
+
+  def arr: Array[TlaEx] = Array(n_a, n_b, n_c, n_d, n_e, n_f, n_g)
+
+  def arr_s: Seq[TlaEx] = arr.toSeq
+
+  def seq(n: Int, nSkip: Int = 0): Seq[TlaEx] = arr.slice(nSkip, n + nSkip).toSeq ++ Seq.fill(n - arr.length)(n_x)
+
+  def x_in_S: OperEx = Builder.in("x", "S")
+
+  def printlns(p_ss: String*)(implicit p_surround: Boolean = true): Unit =
+    println((if (p_surround) p_ss.map("\"%s\"".format(_)) else p_ss).mkString("\n"))
+
+  def printsep(): Unit = println("\n%s\n".format(Seq.fill(20)("-").mkString))
+
+  def noOp(): Unit = {}
+
+  def prePostTest(f: => Unit, pre: () => Unit = noOp, post: () => Unit = noOp): Unit = {
     pre()
     f
     post()

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
@@ -8,119 +8,122 @@ package object aux {
   type EoV[T] = ExceptionOrValue[T]
 
   def aggregate[T](
-                    join : (T, T) => T,
-                    base : TlaEx => T
-                  )
-                  ( ex : TlaEx ) : T = {
-    val self = aggregate[T]( join, base )( _ )
+      join: (T, T) => T, base: TlaEx => T
+  )(ex: TlaEx): T = {
+    val self = aggregate[T](join, base)(_)
     ex match {
-      case LetInEx( body, defs@_* ) =>
+      case LetInEx(body, defs @ _*) =>
         join(
-          self( body ),
-          defs.map( _.body ).map( self ).foldLeft( base( ex ) ) {
-            join
-          }
+            self(body),
+            defs.map(_.body).map(self).foldLeft(base(ex)) {
+              join
+            }
         )
 
-      case OperEx( _, args@_* ) => args.map( self ).foldLeft( base( ex ) ) {
-        join
-      }
-      case _ => base( ex )
+      case OperEx(_, args @ _*) =>
+        args.map(self).foldLeft(base(ex)) {
+          join
+        }
+      case _ => base(ex)
     }
   }
 
-  def allUidsBelow : TlaEx => Set[UID] = aggregate[Set[UID]](
-    _ ++ _,
-    ex => Set( ex.ID )
+  def allUidsBelow: TlaEx => Set[UID] = aggregate[Set[UID]](
+      _ ++ _,
+      ex => Set(ex.ID)
   )
 
-  def uidToExMap : TlaEx => Map[UID, TlaEx] = aggregate[Map[UID, TlaEx]](
-    _ ++ _,
-    ex => Map( ex.ID -> ex )
+  def uidToExMap: TlaEx => Map[UID, TlaEx] = aggregate[Map[UID, TlaEx]](
+      _ ++ _,
+      ex => Map(ex.ID -> ex)
   )
 
-  def joinMaps( a : Map[String, Int], b : Map[String, Int] ) : Map[String, Int] = ( for {
-    x <- a.keySet.union( b.keySet )
-  } yield x -> ( a.getOrElse( x, 0 ) + b.getOrElse( x, 0 ) ) ).toMap[String, Int]
+  def joinMaps(a: Map[String, Int], b: Map[String, Int]): Map[String, Int] = (for {
+    x <- a.keySet.union(b.keySet)
+  } yield x -> (a.getOrElse(x, 0) + b.getOrElse(x, 0))).toMap[String, Int]
 
-  def countCandidates( vars : Set[String], ex : TlaEx ) : Map[String, Int] = ex match {
-    case OperEx( TlaSetOper.in, OperEx( TlaActionOper.prime, NameEx( s ) ), _ )
-      if vars.contains( s ) => Map( s -> 1 )
+  def countCandidates(vars: Set[String], ex: TlaEx): Map[String, Int] = ex match {
+    case OperEx(TlaSetOper.in, OperEx(TlaActionOper.prime, NameEx(s)), _) if vars.contains(s) => Map(s -> 1)
 
-    case LetInEx( body, defs@_* ) =>
-      val opMaps = defs.map {
-        decl => countCandidates( vars, decl.body )
+    case LetInEx(body, defs @ _*) =>
+      val opMaps = defs.map { decl =>
+        countCandidates(vars, decl.body)
       }
-      val bodyMap = countCandidates( vars, body )
-      opMaps.foldLeft( bodyMap )( joinMaps )
+      val bodyMap = countCandidates(vars, body)
+      opMaps.foldLeft(bodyMap)(joinMaps)
 
-    case OperEx( _, args@_* ) =>
+    case OperEx(_, args @ _*) =>
       val argMaps = args map {
-        countCandidates( vars, _ )
+        countCandidates(vars, _)
       }
-      argMaps.foldLeft( Map.empty[String, Int] ) {
+      argMaps.foldLeft(Map.empty[String, Int]) {
         joinMaps
       }
     case _ => Map.empty[String, Int]
   }
 
-  def hasPositiveArity( decl: TlaOperDecl ) : Boolean = decl.formalParams.nonEmpty
+  def hasPositiveArity(decl: TlaOperDecl): Boolean = decl.formalParams.nonEmpty
 
-  /** We may need to split an ordered collection of OperDecls (from a LET-IN operator),
-    * into segments of 0 arity and >0 ariry operators
-    */
-  def collectSegments( decls : Traversable[TlaOperDecl] ) : List[List[TlaOperDecl]] = decls match {
+  /**
+   * We may need to split an ordered collection of OperDecls (from a LET-IN operator),
+   * into segments of 0 arity and >0 ariry operators
+   */
+  def collectSegments(decls: Traversable[TlaOperDecl]): List[List[TlaOperDecl]] = decls match {
     case d if d.isEmpty => List.empty
     case head :: tail =>
-      val headPosArity = hasPositiveArity( head )
-      val rec = collectSegments( tail )
-      val recHeadOrEmpty = rec.headOption.getOrElse( List.empty )
+      val headPosArity = hasPositiveArity(head)
+      val rec = collectSegments(tail)
+      val recHeadOrEmpty = rec.headOption.getOrElse(List.empty)
       // We merge to previous, if they have the same arity category (0 or >0)
       // if headOption returns None, the condition vacuously holds for the empty seq
-      if ( recHeadOrEmpty.forall( d => hasPositiveArity( d ) == headPosArity ) )
-        ( head +: recHeadOrEmpty ) +: rec.drop( 1 ) // Nil.tail throws, but Nil.drop(1) doesn't
+      if (recHeadOrEmpty.forall(d => hasPositiveArity(d) == headPosArity))
+        (head +: recHeadOrEmpty) +: rec.drop(1) // Nil.tail throws, but Nil.drop(1) doesn't
       else
-        List( head ) +: rec
+        List(head) +: rec
   }
 
-  def diff( ex1 : TlaEx, ex2: TlaEx ) : TlaEx = (ex1, ex2) match {
-    case (OperEx( op1, args1@_* ), OperEx(op2, args2@_*)) if op1 == op2 =>
-        val argDiff = args1.zipAll( args2, NullEx, NullEx ) map { case (x, y) => diff( x, y ) }
-        OperEx( op1, argDiff: _* )
-    case (ValEx(v1), ValEx(v2)) if v1 == v2 => ex1
+  def diff(ex1: TlaEx, ex2: TlaEx)(implicit typeTag: TypeTag): TlaEx = (ex1, ex2) match {
+    case (OperEx(op1, args1 @ _*), OperEx(op2, args2 @ _*)) if op1 == op2 =>
+      val argDiff = args1.zipAll(args2, NullEx, NullEx) map { case (x, y) => diff(x, y) }
+      OperEx(op1, argDiff: _*)
+    case (ValEx(v1), ValEx(v2)) if v1 == v2   => ex1
     case (NameEx(n1), NameEx(n2)) if n1 == n2 => ex1
-    case (LetInEx(b1, decls1@_*), LetInEx(b2, decls2@_*) ) =>
+    case (LetInEx(b1, decls1 @ _*), LetInEx(b2, decls2 @ _*)) =>
       val defaultDecl = TlaOperDecl("Null", List.empty, NullEx)
       val defaultParam = SimpleFormalParam("diffParam")
-      val declDiff = decls1.zipAll( decls2, defaultDecl, defaultDecl ) map { case (d1, d2) =>
-        if ( d1.name == d2.name && d1.formalParams == d2.formalParams )
-          d1.copy( body = diff( d1.body, d2.body ) )
+      val declDiff = decls1.zipAll(decls2, defaultDecl, defaultDecl) map { case (d1, d2) =>
+        if (d1.name == d2.name && d1.formalParams == d2.formalParams)
+          d1.copy(body = diff(d1.body, d2.body))
         else {
           val name = s"DiffDecl_${d1.name}_${d2.name}"
-          val params = d1.formalParams.zipAll( d2.formalParams, defaultParam, defaultParam ) map {
-            case (par1@SimpleFormalParam( p1 ), SimpleFormalParam( p2 )) if p1 == p2 =>
+          val params = d1.formalParams.zipAll(d2.formalParams, defaultParam, defaultParam) map {
+            case (par1 @ SimpleFormalParam(p1), SimpleFormalParam(p2)) if p1 == p2 =>
               par1
-            case (par1@OperFormalParam( p1, n1), OperFormalParam( p2, n2)) if p1 == p2 && n1 == n2 =>
+            case (par1 @ OperFormalParam(p1, n1), OperFormalParam(p2, n2)) if p1 == p2 && n1 == n2 =>
               par1
             case (par1, par2) =>
-              SimpleFormalParam( s"DiffParam_${par1.name}_${par2.name}" )
+              SimpleFormalParam(s"DiffParam_${par1.name}_${par2.name}")
           }
-          TlaOperDecl( name, params, diff( d1.body, d2.body ) )
+          TlaOperDecl(name, params, diff(d1.body, d2.body))
         }
       }
-      LetInEx( diff( b1, b2 ), declDiff : _* )
+      LetInEx(diff(b1, b2), declDiff: _*)
     case _ =>
-      OperEx( TlaOper.apply, NameEx("Diff"), ex1, ex2 )
+      OperEx(TlaOper.apply, NameEx("Diff"), ex1, ex2)
   }
 
-  def allDiffs( ex : TlaEx ) : Seq[TlaEx] = ex match {
-      case OperEx( TlaOper.apply, NameEx( "Diff" ), ex1, ex2 ) =>
-        Seq(ex)
-      case OperEx( _, args@_* ) =>
-        args flatMap { allDiffs }
-      case LetInEx( body, defs@_*) =>
-        ( body +: (defs map {_.body}) ) flatMap allDiffs
-      case _ =>
-        Seq.empty
-    }
+  def allDiffs(ex: TlaEx): Seq[TlaEx] = ex match {
+    case OperEx(TlaOper.apply, NameEx("Diff"), ex1, ex2) =>
+      Seq(ex)
+    case OperEx(_, args @ _*) =>
+      args flatMap {
+        allDiffs
+      }
+    case LetInEx(body, defs @ _*) =>
+      (body +: (defs map {
+        _.body
+      })) flatMap allDiffs
+    case _ =>
+      Seq.empty
+  }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/CounterexampleWriter.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/CounterexampleWriter.scala
@@ -6,6 +6,8 @@ import java.util.Calendar
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
+
 /**
  * A printer for counterexamples, in various formats: TLA+ , as TLC output, ...
  *
@@ -13,29 +15,28 @@ import at.forsyte.apalache.tla.lir.values._
  */
 trait CounterexampleWriter {
   // Print out invariant violation
-  def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]) : Unit
+  def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): Unit
 }
 
 object CounterexampleWriter {
   // default implementation -- write in all formats, and return the list of files written
-  def writeAllFormats(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState] ): List[String] = {
+  def writeAllFormats(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): List[String] = {
     val fileNames = Map(
-      "tla" -> "counterexample.tla",
-      "tlc" -> "MC.out",
-      "json" -> "counterexample.json"
+        "tla" -> "counterexample.tla",
+        "tlc" -> "MC.out",
+        "json" -> "counterexample.json"
     )
-    val files = fileNames.map {
-      case (kind, name) => (kind, new PrintWriter(new FileWriter(name)))
+    val files = fileNames.map { case (kind, name) =>
+      (kind, new PrintWriter(new FileWriter(name)))
     }
     try {
-      files.foreach {
-        case (kind, writer) => apply(kind, writer).write(rootModule, notInvariant, states)
+      files.foreach { case (kind, writer) =>
+        apply(kind, writer).write(rootModule, notInvariant, states)
       }
       fileNames.values.toList
-    }
-    finally {
-      files.foreach {
-        case (_, writer) => writer.close()
+    } finally {
+      files.foreach { case (_, writer) =>
+        writer.close()
       }
     }
   }
@@ -43,10 +44,10 @@ object CounterexampleWriter {
   // factory method to get the desired CE writer
   def apply(kind: String, writer: PrintWriter): CounterexampleWriter = {
     kind match {
-      case "tla" => new TlaCounterexampleWriter(writer)
-      case "tlc" => new TlcCounterexampleWriter(writer)
+      case "tla"  => new TlaCounterexampleWriter(writer)
+      case "tlc"  => new TlcCounterexampleWriter(writer)
       case "json" => new JsonCounterexampleWriter(writer)
-      case _ => throw new Exception("unknown couterexample writer requested")
+      case _      => throw new Exception("unknown couterexample writer requested")
     }
   }
 }
@@ -57,36 +58,32 @@ class TlaCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
     if (state.isEmpty) {
       pretty.write(ValEx(TlaBool(true)))
     } else {
-      state.toList.sortBy(_._1).foreach{
-        case (name,value) =>
-          writer.print(s"/\\ $name = " )
-          pretty.write(value)
-          writer.println
+      state.toList.sortBy(_._1).foreach { case (name, value) =>
+        writer.print(s"/\\ $name = ")
+        pretty.write(value)
+        writer.println
       }
     }
   }
 
-  override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState] ) : Unit = {
+  override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): Unit = {
     val pretty = new PrettyWriter(writer)
 
     writer.println("%s MODULE counterexample %s\n".format("-" * 25, "-" * 25))
     writer.println("EXTENDS %s\n".format(rootModule.name))
 
-    states.zipWithIndex.foreach {
-      case (state, j) =>
-        val i = j+1 // start counting from 1, for compatibility with TLC counterexamples
-        if(i == 1) {
-          writer.println("(* Initial state *)")
-        }
-        else {
-          writer.println(s"(* Transition ${state._1} to State$i *)")
-        }
-        writer.println(s"\nState$i ==")
-        printStateFormula(pretty, state._2)
-        writer.println
+    states.zipWithIndex.foreach { case (state, j) =>
+      val i = j + 1 // start counting from 1, for compatibility with TLC counterexamples
+      if (i == 1) {
+        writer.println("(* Initial state *)")
+      } else {
+        writer.println(s"(* Transition ${state._1} to State$i *)")
+      }
+      writer.println(s"\nState$i ==")
+      printStateFormula(pretty, state._2)
+      writer.println
     }
-    writer.print(
-      s"""(* The following formula holds true in the last state and violates the invariant *)
+    writer.print(s"""(* The following formula holds true in the last state and violates the invariant *)
          |
          |""".stripMargin)
     pretty.write(TlaOperDecl("InvariantViolation", List(), notInvariant))
@@ -98,12 +95,10 @@ class TlaCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
   }
 }
 
-
 class TlcCounterexampleWriter(writer: PrintWriter) extends TlaCounterexampleWriter(writer) {
 
   override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): Unit = {
-    writer.print(
-      s"""@!@!@STARTMSG 2262:0 @!@!@
+    writer.print(s"""@!@!@STARTMSG 2262:0 @!@!@
          |Created by Apalache on ${Calendar.getInstance().getTime}
          |@!@!@ENDMSG 2262 @!@!@
          |@!@!@STARTMSG 2110:1 @!@!@
@@ -114,17 +109,14 @@ class TlcCounterexampleWriter(writer: PrintWriter) extends TlaCounterexampleWrit
          |@!@!@ENDMSG 2121 @!@!@
          |""".stripMargin)
 
-    states.zipWithIndex.foreach {
-      case (state, j) =>
-        val i = j + 1 // start counting from 1, for compatibility with TLC counterexamples
-        val prefix = if(i==1) s"$i: <Initial predicate>" else s"$i: <Next>"
+    states.zipWithIndex.foreach { case (state, j) =>
+      val i = j + 1 // start counting from 1, for compatibility with TLC counterexamples
+      val prefix = if (i == 1) s"$i: <Initial predicate>" else s"$i: <Next>"
 
-        writer.println(
-          s"""@!@!@STARTMSG 2217:4 @!@!@
-             |$prefix""".stripMargin)
-        printStateFormula(new PrettyWriter(writer), state._2)
-        writer.println(
-          """|
+      writer.println(s"""@!@!@STARTMSG 2217:4 @!@!@
+           |$prefix""".stripMargin)
+      printStateFormula(new PrettyWriter(writer), state._2)
+      writer.println("""|
              |@!@!@ENDMSG 2217 @!@!@""".stripMargin)
     }
     writer.close()
@@ -132,21 +124,19 @@ class TlcCounterexampleWriter(writer: PrintWriter) extends TlaCounterexampleWrit
 }
 
 class JsonCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter {
-  override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState] ) : Unit = {
+  override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): Unit = {
     val json = new JsonWriter(writer)
 
-    val tlaStates = states.zipWithIndex.collect{
-      case ((tran,vars), i) =>
-        val state = vars.collect{
-          case (name,value) => OperEx(TlaOper.eq, NameEx(name), value)
-        }
-        TlaOperDecl(s"State${i+1}", List(), OperEx(TlaBoolOper.and, state.toList: _*))
+    val tlaStates = states.zipWithIndex.collect { case ((tran, vars), i) =>
+      val state = vars.collect { case (name, value) =>
+        OperEx(TlaOper.eq, NameEx(name), value)
+      }
+      TlaOperDecl(s"State${i + 1}", List(), OperEx(TlaBoolOper.and, state.toList: _*))
 
     }
 
-    val mod = new TlaModule(
-      "counterexample",
-      tlaStates ++ List(TlaOperDecl(s"InvariantViolation", List(), notInvariant)))
+    val mod =
+      new TlaModule("counterexample", tlaStates ++ List(TlaOperDecl(s"InvariantViolation", List(), notInvariant)))
     json.write(mod)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/JsonReader.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/JsonReader.scala
@@ -7,11 +7,13 @@ import at.forsyte.apalache.tla.lir.values._
 import java.lang.NumberFormatException
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.LinkedHashMap
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * <p>A reader of TlaEx and TlaModule from JSON, for interoperability with external tools.</p>
+ *
  * @author Andrey Kuprianov
- **/
+ */
 
 object JsonReader {
 
@@ -28,9 +30,9 @@ object JsonReader {
     // it should be a JSON object
     val m = v.objOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting a module object")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting a module object")
     }
-    if(!m.contains("module") || !m.contains("declarations"))
+    if (!m.contains("module") || !m.contains("declarations"))
       throw new Exception("incorrect TLA+ JSON: malformed module object")
     new TlaModule(parseStr(m("module")), parseDecls(m("declarations")))
   }
@@ -47,11 +49,11 @@ object JsonReader {
   val otherOps = Set("id", "str", "int", "set", "applyFun", "applyOp", "if", "case", "let")
 
   val sets = HashMap(
-    "BOOLEAN" -> TlaBoolSet,
-    "Int" -> TlaIntSet,
-    "Nat" -> TlaNatSet,
-    "Real" -> TlaRealSet,
-    "STRING" -> TlaStrSet
+      "BOOLEAN" -> TlaBoolSet,
+      "Int" -> TlaIntSet,
+      "Nat" -> TlaNatSet,
+      "Real" -> TlaRealSet,
+      "STRING" -> TlaStrSet
   )
 
   // parse arbitrary ujson.Value
@@ -68,8 +70,8 @@ object JsonReader {
             throw new Exception("incorrect TLA+ JSON: " + e.getMessage)
         }
       case ujson.Bool(value) => ValEx(TlaBool(value))
-      case ujson.Obj(value) => parseExpr(value)
-      case _ => throw new Exception("incorrect TLA+ JSON: unexpected input")
+      case ujson.Obj(value)  => parseExpr(value)
+      case _                 => throw new Exception("incorrect TLA+ JSON: unexpected input")
     }
   }
 
@@ -86,106 +88,97 @@ object JsonReader {
     val fairness = m.keySet & fairnessOps.keySet
     val other = m.keySet & otherOps
     val ourKeys = unary.size + binary.size + nary.size + naryPair.size + functional.size +
-      + boundedPred.size + unboundedPred.size + stutter.size + fairness.size + other.size
+      +boundedPred.size + unboundedPred.size + stutter.size + fairness.size + other.size
     val expr =
-    if(ourKeys < 1)
-      throw new Exception("incorrect TLA+ JSON: expected expression, but none found")
-    else if(ourKeys > 1)
-      throw new Exception("incorrect TLA+ JSON: multiple matching expressions")
-    else if(unary.nonEmpty)
-      OperEx(unaryOps(unary.head), parseJson(m(unary.head)))
-    else if(binary.nonEmpty) {
-      if(!m.contains("arg"))
-        throw new Exception("incorrect TLA+ JSON: expecting 'arg'")
-      OperEx(binaryOps(binary.head), parseJson(m(binary.head)), parseJson(m("arg")))
-    } else if(nary.nonEmpty)
-      OperEx(naryOps(nary.head), parseArray(m(nary.head)):_*)
-    else if(naryPair.nonEmpty) {
-      OperEx(naryPairOps(naryPair.head), parsePairs(m(naryPair.head)) :_*)
-    }
-    else if(functional.nonEmpty) {
-      if(!m.contains("where"))
-        throw new Exception("incorrect TLA+ JSON: expecting 'where'")
-      OperEx(functionalOps(functional.head), parseJson(m(functional.head)) +: parsePairs(m("where")) :_*)
-    }
-    else if(unboundedPred.nonEmpty) {
-      if(!m.contains("that"))
-        throw new Exception("incorrect TLA+ JSON: expecting 'that'")
-      OperEx(unboundedPredOps(unboundedPred.head), parseJson(m(unboundedPred.head)), parseJson(m("that")))
-    }
-    else if(boundedPred.nonEmpty) {
-      val nameSet = parsePair(m(boundedPred.head))
-      if(!m.contains("that"))
-        throw new Exception("incorrect TLA+ JSON: expecting 'that'")
-      OperEx(boundedPredOps(boundedPred.head), nameSet(0), nameSet(1), parseJson(m("that")))
-    }
-    else if(stutter.nonEmpty) {
-      if(!m.contains("vars"))
-        throw new Exception("incorrect TLA+ JSON: expecting 'vars'")
-      OperEx(stutterOps(stutter.head), parseJson(m(stutter.head)), parseJson(m("vars")))
-    }
-    else if(fairness.nonEmpty) {
-      if(!m.contains("vars"))
-        throw new Exception("incorrect TLA+ JSON: expecting 'vars'")
-      OperEx(fairnessOps(fairness.head), parseJson(m("vars")), parseJson(m(fairness.head)))
-    }
-    else if(other.nonEmpty) {
-      other.head match {
-        case "id" => NameEx(parseStr(m("id")))
-        case "str" => ValEx(TlaStr(parseStr(m("str"))))
-        case "int" => ValEx(TlaInt(BigInt(parseStr(m("int")))))
-        case "set" => {
-          val set = parseStr(m("set"))
-          if(sets.contains(set))
-            ValEx(sets(set))
-          else
-            throw new Exception("can't parse TLA+ JSON: reference to unknown set")
-        }
-        case "applyFun" => {
-          if(!m.contains("arg"))
-            throw new Exception("incorrect TLA+ JSON: expecting 'arg'")
-          OperEx(TlaFunOper.app, parseJson(m("applyFun")), parseJson(m("arg")))
-        }
-        case "applyOp" => {
-          if(!m.contains("args"))
-            throw new Exception("incorrect TLA+ JSON: expecting 'args'")
-          val name = parseStr(m("applyOp"))
-          val args = parseArray(m("args"))
-          if(name == "recFunRef") {
-            if(args.nonEmpty)
-              throw new Exception("incorrect TLA+ JSON: found arguments for 'recFunRef'")
-            OperEx(TlaFunOper.recFunRef)
+      if (ourKeys < 1)
+        throw new Exception("incorrect TLA+ JSON: expected expression, but none found")
+      else if (ourKeys > 1)
+        throw new Exception("incorrect TLA+ JSON: multiple matching expressions")
+      else if (unary.nonEmpty)
+        OperEx(unaryOps(unary.head), parseJson(m(unary.head)))
+      else if (binary.nonEmpty) {
+        if (!m.contains("arg"))
+          throw new Exception("incorrect TLA+ JSON: expecting 'arg'")
+        OperEx(binaryOps(binary.head), parseJson(m(binary.head)), parseJson(m("arg")))
+      } else if (nary.nonEmpty)
+        OperEx(naryOps(nary.head), parseArray(m(nary.head)): _*)
+      else if (naryPair.nonEmpty) {
+        OperEx(naryPairOps(naryPair.head), parsePairs(m(naryPair.head)): _*)
+      } else if (functional.nonEmpty) {
+        if (!m.contains("where"))
+          throw new Exception("incorrect TLA+ JSON: expecting 'where'")
+        OperEx(functionalOps(functional.head), parseJson(m(functional.head)) +: parsePairs(m("where")): _*)
+      } else if (unboundedPred.nonEmpty) {
+        if (!m.contains("that"))
+          throw new Exception("incorrect TLA+ JSON: expecting 'that'")
+        OperEx(unboundedPredOps(unboundedPred.head), parseJson(m(unboundedPred.head)), parseJson(m("that")))
+      } else if (boundedPred.nonEmpty) {
+        val nameSet = parsePair(m(boundedPred.head))
+        if (!m.contains("that"))
+          throw new Exception("incorrect TLA+ JSON: expecting 'that'")
+        OperEx(boundedPredOps(boundedPred.head), nameSet(0), nameSet(1), parseJson(m("that")))
+      } else if (stutter.nonEmpty) {
+        if (!m.contains("vars"))
+          throw new Exception("incorrect TLA+ JSON: expecting 'vars'")
+        OperEx(stutterOps(stutter.head), parseJson(m(stutter.head)), parseJson(m("vars")))
+      } else if (fairness.nonEmpty) {
+        if (!m.contains("vars"))
+          throw new Exception("incorrect TLA+ JSON: expecting 'vars'")
+        OperEx(fairnessOps(fairness.head), parseJson(m("vars")), parseJson(m(fairness.head)))
+      } else if (other.nonEmpty) {
+        other.head match {
+          case "id"  => NameEx(parseStr(m("id")))
+          case "str" => ValEx(TlaStr(parseStr(m("str"))))
+          case "int" => ValEx(TlaInt(BigInt(parseStr(m("int")))))
+          case "set" => {
+            val set = parseStr(m("set"))
+            if (sets.contains(set))
+              ValEx(sets(set))
+            else
+              throw new Exception("can't parse TLA+ JSON: reference to unknown set")
           }
-          else
-            OperEx(TlaOper.apply, NameEx(name) +: args:_*)
+          case "applyFun" => {
+            if (!m.contains("arg"))
+              throw new Exception("incorrect TLA+ JSON: expecting 'arg'")
+            OperEx(TlaFunOper.app, parseJson(m("applyFun")), parseJson(m("arg")))
+          }
+          case "applyOp" => {
+            if (!m.contains("args"))
+              throw new Exception("incorrect TLA+ JSON: expecting 'args'")
+            val name = parseStr(m("applyOp"))
+            val args = parseArray(m("args"))
+            if (name == "recFunRef") {
+              if (args.nonEmpty)
+                throw new Exception("incorrect TLA+ JSON: found arguments for 'recFunRef'")
+              OperEx(TlaFunOper.recFunRef)
+            } else
+              OperEx(TlaOper.apply, NameEx(name) +: args: _*)
+          }
+          case "if" => {
+            if (!m.contains("then") || !m.contains("else"))
+              throw new Exception("incorrect TLA+ JSON: malformed 'if'")
+            OperEx(TlaControlOper.ifThenElse, parseJson(m("if")), parseJson(m("then")), parseJson(m("else")))
+          }
+          case "case" => {
+            if (m.contains("other"))
+              OperEx(TlaControlOper.caseWithOther, parseJson(m("other")) +: parsePairs(m("case")): _*)
+            else
+              OperEx(TlaControlOper.caseNoOther, parsePairs(m("case")): _*)
+          }
+          case "let" => {
+            if (!m.contains("body"))
+              throw new Exception("incorrect TLA+ JSON: malformed 'let'")
+            LetInEx(parseJson(m("body")), parseOperDecls(m("let")): _*)
+          }
+          case _ =>
+            throw new Exception("can't parse TLA+ JSON: unknown JSON key")
         }
-        case "if" => {
-          if(!m.contains("then") || !m.contains("else"))
-            throw new Exception("incorrect TLA+ JSON: malformed 'if'")
-          OperEx(TlaControlOper.ifThenElse, parseJson(m("if")), parseJson(m("then")), parseJson(m("else")))
-        }
-        case "case" => {
-          if(m.contains("other"))
-            OperEx(TlaControlOper.caseWithOther, parseJson(m("other")) +: parsePairs(m("case")) :_*)
-          else
-            OperEx(TlaControlOper.caseNoOther, parsePairs(m("case")):_*)
-        }
-        case "let" => {
-          if(!m.contains("body"))
-            throw new Exception("incorrect TLA+ JSON: malformed 'let'")
-          LetInEx(parseJson(m("body")), parseOperDecls(m("let")):_*)
-        }
-        case _ =>
-          throw new Exception("can't parse TLA+ JSON: unknown JSON key")
-      }
-    }
-    else
-      throw new Exception("can't parse TLA+ JSON: cannot find a known JSON key")
-    if(m.contains("label")) {
+      } else
+        throw new Exception("can't parse TLA+ JSON: cannot find a known JSON key")
+    if (m.contains("label")) {
       val (name, args) = parseLabel(m("label"))
-      OperEx(TlaOper.label, (expr +: ValEx(TlaStr(name)) +: args) :_*)
-    }
-    else
+      OperEx(TlaOper.label, (expr +: ValEx(TlaStr(name)) +: args): _*)
+    } else
       expr
   }
 
@@ -194,7 +187,7 @@ object JsonReader {
     // it should be a JSON string
     v.strOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting string")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting string")
     }
   }
 
@@ -203,7 +196,7 @@ object JsonReader {
     // it should be a JSON array
     val arr = v.arrOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting expression array")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting expression array")
     }
     arr.map(parseJson)
   }
@@ -213,7 +206,7 @@ object JsonReader {
     // it should be a JSON array
     val arr = v.arrOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting array of pairs")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting array of pairs")
     }
     arr.map(parsePair).flatten
   }
@@ -222,9 +215,9 @@ object JsonReader {
   def parsePair(v: ujson.Value): Seq[TlaEx] = {
     val m = v.objOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting a key-value object")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting a key-value object")
     }
-    if(!m.contains("key") || !m.contains("value"))
+    if (!m.contains("key") || !m.contains("value"))
       throw new Exception("incorrect TLA+ JSON: malformed key-value object")
     val key = parseJson(m("key"))
     val value = parseJson(m("value"))
@@ -236,15 +229,16 @@ object JsonReader {
     // it should be a JSON object
     val m = v.objOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting a label object")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting a label object")
     }
-    if(!m.contains("name") || !m.contains("args"))
+    if (!m.contains("name") || !m.contains("args"))
       throw new Exception("incorrect TLA+ JSON: malformed label")
     val name = parseStr(m("name"))
     val args = parseArray(m("args"))
-    (name, args.map {
+    (name,
+        args.map {
       case NameEx(str) => ValEx(TlaStr(str)) // change back from NameEx to ValEx
-      case _ => throw new Exception("incorrect TLA+ JSON: malformed label")
+      case _           => throw new Exception("incorrect TLA+ JSON: malformed label")
     })
   }
 
@@ -253,7 +247,7 @@ object JsonReader {
     // it should be a JSON array
     val arr = v.arrOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting declaration array")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting declaration array")
     }
     arr.map(parseDecl)
   }
@@ -261,20 +255,19 @@ object JsonReader {
   def parseDecl(v: ujson.Value): TlaDecl = {
     val m = v.objOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting a declaration object")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting a declaration object")
     }
-    if(m.contains("constant"))
+    if (m.contains("constant"))
       TlaConstDecl(parseStr(m("constant")))
-    else if(m.contains("variable"))
+    else if (m.contains("variable"))
       TlaVarDecl(parseStr(m("variable")))
-    else if(m.contains("assume"))
+    else if (m.contains("assume"))
       TlaAssumeDecl(parseJson(m("assume")))
-    else if(m.contains("operator")) {
-      if(!m.contains("body") || !m.contains("params"))
+    else if (m.contains("operator")) {
+      if (!m.contains("body") || !m.contains("params"))
         throw new Exception("incorrect TLA+ JSON: malformed operator declaration")
       TlaOperDecl(parseStr(m("operator")), parseParams(m("params")).toList, parseJson(m("body")))
-    }
-    else
+    } else
       throw new Exception("incorrect TLA+ JSON: malformed declaration object")
   }
 
@@ -283,7 +276,7 @@ object JsonReader {
     // it should be a JSON array
     val arr = v.arrOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting declaration array")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting declaration array")
     }
     arr.map(parseOperDecl)
   }
@@ -291,10 +284,10 @@ object JsonReader {
   def parseOperDecl(v: ujson.Value): TlaOperDecl = {
     val m = v.objOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting a declaration object")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting a declaration object")
     }
-    if(!m.contains("operator") || !m.contains("body") || !m.contains("params"))
-        throw new Exception("incorrect TLA+ JSON: malformed operator declaration")
+    if (!m.contains("operator") || !m.contains("body") || !m.contains("params"))
+      throw new Exception("incorrect TLA+ JSON: malformed operator declaration")
     TlaOperDecl(parseStr(m("operator")), parseParams(m("params")).toList, parseJson(m("body")))
   }
 
@@ -303,7 +296,7 @@ object JsonReader {
     // it should be a JSON array
     val arr = v.arrOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting parameter array")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting parameter array")
     }
     arr.map(parseParam)
   }
@@ -313,16 +306,17 @@ object JsonReader {
     // it should be a JSON object
     val m = v.objOpt match {
       case Some(value) => value
-      case None => throw new Exception("incorrect TLA+ JSON: expecting a parameter object")
+      case None        => throw new Exception("incorrect TLA+ JSON: expecting a parameter object")
     }
-    if(!m.contains("name") || m("name").strOpt == None
-    || !m.contains("arity") || m("arity").numOpt == None || !m("arity").num.isValidInt)
+    if (
+        !m.contains("name") || m("name").strOpt == None
+        || !m.contains("arity") || m("arity").numOpt == None || !m("arity").num.isValidInt
+    )
       throw new Exception("incorrect TLA+ JSON: malformed parameter")
     val arity = m("arity").num.toInt
-    if(arity == 0)
+    if (arity == 0)
       SimpleFormalParam(m("name").str)
     else
       OperFormalParam(m("name").str, arity)
   }
 }
-

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/PrettyWriter.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/PrettyWriter.scala
@@ -11,19 +11,20 @@ import org.bitbucket.inkytonik.kiama.output.PrettyPrinter
 import scala.collection.immutable.HashMap
 
 /**
-  * <p>A pretty printer to a file that formats a TLA+ expression to a given text width (normally, 80 characters).
-  * As pretty-printing is hard, we are using the kiama library for finding an optimal layout.
-  * Note that this printer is not using UTF8 characters, as its output should be readable by TLA+ Tools.</p>
-  *
-  * <p>Finding a nice code layout is hard. In many cases, it is also a matter of taste. To see the examples
-  * of formatting, check TestPrettyWriter.</p>
-  *
-  * <p>TODO: Parameterize PrettyWriter by a Printer that would give us access to different graphical representations
-  * of TLA+ expressions, e.g., UTFPrinter. </p>
-  *
-  * @author Igor Konnov
-  */
-class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) extends PrettyPrinter {
+ * <p>A pretty printer to a file that formats a TLA+ expression to a given text width (normally, 80 characters).
+ * As pretty-printing is hard, we are using the kiama library for finding an optimal layout.
+ * Note that this printer is not using UTF8 characters, as its output should be readable by TLA+ Tools.</p>
+ *
+ * <p>Finding a nice code layout is hard. In many cases, it is also a matter of taste. To see the examples
+ * of formatting, check TestPrettyWriter.</p>
+ *
+ * <p>TODO: Parameterize PrettyWriter by a Printer that would give us access to different graphical representations
+ * of TLA+ expressions, e.g., UTFPrinter. </p>
+ *
+ * @author Igor Konnov
+ */
+class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2)(implicit typeTag: TypeTag)
+    extends PrettyPrinter {
   override val defaultIndent: Int = indent
 
   val REC_FUN_UNDEFINED = "recFunNameUndefined"
@@ -50,7 +51,6 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
       "===============" <> line
   }
 
-
   def toDoc(parentPrecedence: (Int, Int), expr: TlaEx): Doc = {
     expr match {
       case NameEx(x) if x == "LAMBDA" =>
@@ -66,48 +66,49 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
               else
                 ssep(top.formalParams map toDoc, "," <> softline)
 
-            group("LAMBDA" <> space <> paramsDoc <> text(":") <> space <>
-              toDoc((0, 0), top.body))
+            group(
+                "LAMBDA" <> space <> paramsDoc <> text(":") <> space <>
+                  toDoc((0, 0), top.body))
         }
 
       case NameEx(x) =>
         text(x)
 
-      case ValEx(TlaStr(str)) => text("\"%s\"".format(str))
+      case ValEx(TlaStr(str))   => text("\"%s\"".format(str))
       case ValEx(TlaInt(value)) => text(value.toString)
-      case ValEx(TlaBool(b)) => text(if (b) "TRUE" else "FALSE")
-      case ValEx(TlaBoolSet) => text("BOOLEAN")
-      case ValEx(TlaIntSet) => text("Int")
-      case ValEx(TlaNatSet) => text("Nat")
-      case ValEx(TlaRealSet) => text("Real")
-      case ValEx(TlaStrSet) => text("STRING")
+      case ValEx(TlaBool(b))    => text(if (b) "TRUE" else "FALSE")
+      case ValEx(TlaBoolSet)    => text("BOOLEAN")
+      case ValEx(TlaIntSet)     => text("Int")
+      case ValEx(TlaNatSet)     => text("Nat")
+      case ValEx(TlaRealSet)    => text("Real")
+      case ValEx(TlaStrSet)     => text("STRING")
 
       case NullEx => text("\"NOP\"")
 
-      case OperEx(op@TlaActionOper.prime, e) =>
+      case OperEx(op @ TlaActionOper.prime, e) =>
         toDoc(op.precedence, e) <> "'"
 
       case OperEx(TlaSetOper.enumSet) =>
         // an empty set
         text("{}")
 
-      case OperEx(op@TlaSetOper.enumSet, arg) =>
+      case OperEx(op @ TlaSetOper.enumSet, arg) =>
         // a singleton set
         group("{" <> toDoc(op.precedence, arg) <> "}")
 
-      case OperEx(op@TlaSetOper.enumSet, args@_*) =>
+      case OperEx(op @ TlaSetOper.enumSet, args @ _*) =>
         // a set enumeration, e.g., { 1, 2, 3 }
         val argDocs = args.map(toDoc(op.precedence, _))
         val commaSeparated = folddoc(argDocs.toList, _ <> text(",") <@> _)
         group(braces(group(softline <> nest(commaSeparated, indent)) <> softline))
 
-      case OperEx(op@TlaFunOper.tuple, args@_*) =>
+      case OperEx(op @ TlaFunOper.tuple, args @ _*) =>
         // a tuple, e.g., <<1, 2, 3>>
         val argDocs = args.map(toDoc(op.precedence, _))
         val commaSeparated = ssep(argDocs.toList, text(",") <> softline)
         group(text("<<") <> nest(linebreak <> commaSeparated, indent) <> linebreak <> ">>")
 
-      case OperEx(op, args@_*) if op == TlaBoolOper.and || op == TlaBoolOper.or =>
+      case OperEx(op, args @ _*) if op == TlaBoolOper.and || op == TlaBoolOper.or =>
         // we are not using indented /\ and \/, as they are hard to get automatically
         val sign = if (op == TlaBoolOper.and) "/\\" else "\\/"
 
@@ -128,80 +129,77 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
         }
 
       case OperEx(op, x, set, pred)
-        if op == TlaBoolOper.exists || op == TlaBoolOper.forall || op == TlaOper.chooseBounded =>
+          if op == TlaBoolOper.exists || op == TlaBoolOper.forall || op == TlaOper.chooseBounded =>
         val sign = PrettyWriter.bindingOps(op)
         val doc =
           group(
-            group(text(sign) <> space <> text(x.toString) <> space <>
-              text(PrettyWriter.binaryOps(TlaSetOper.in)) <> softline <>
-              toDoc(op.precedence, set) <> text(":")
-            ) <>
-              nest(line <> toDoc(op.precedence, pred))
+              group(
+                  text(sign) <> space <> text(x.toString) <> space <>
+                    text(PrettyWriter.binaryOps(TlaSetOper.in)) <> softline <>
+                    toDoc(op.precedence, set) <> text(":")) <>
+                nest(line <> toDoc(op.precedence, pred))
           ) ///
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
-      case OperEx(op, x, pred)
-        if op == TlaTempOper.EE || op == TlaTempOper.AA =>
+      case OperEx(op, x, pred) if op == TlaTempOper.EE || op == TlaTempOper.AA =>
         val sign = PrettyWriter.bindingOps(op)
         val doc =
           group(
-            group(text(sign) <> space <> text(x.toString) <> ":") <>
-              nest(line <> toDoc(op.precedence, pred))
+              group(text(sign) <> space <> text(x.toString) <> ":") <>
+                nest(line <> toDoc(op.precedence, pred))
           ) ///
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
-      case OperEx(TlaFunOper.enum, keysAndValues@_*) =>
+      case OperEx(TlaFunOper.enum, keysAndValues @ _*) =>
         // a record, e.g., [ x |-> 1, y |-> 2 ]
         val (ks, vs) = keysAndValues.zipWithIndex partition (_._2 % 2 == 0)
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k |-> v
         val boxes =
-          keys.zip(values).map(p =>
-            group(strNoQuotes(p._1) <> space <> "|->" <> nest(line <> toDoc((0, 0), p._2)))
-          ) ///
+          keys.zip(values).map(p => group(strNoQuotes(p._1) <> space <> "|->" <> nest(line <> toDoc((0, 0), p._2)))) ///
 
         group(brackets(nest(ssep(boxes.toList, comma <> line))))
 
-      case OperEx(TlaSetOper.recSet, keysAndValues@_*) =>
+      case OperEx(TlaSetOper.recSet, keysAndValues @ _*) =>
         // a record, e.g., [ x: S, y: T ]
         val (ks, vs) = keysAndValues.zipWithIndex partition (_._2 % 2 == 0)
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k: v
         val boxes =
-          keys.zip(values).map(p =>
-            group(strNoQuotes(p._1) <> ":" <> nest(line <> toDoc((0, 0), p._2)))
-          ) ///
+          keys.zip(values).map(p => group(strNoQuotes(p._1) <> ":" <> nest(line <> toDoc((0, 0), p._2)))) ///
 
         group(brackets(nest(ssep(boxes.toList, comma <> line))))
 
-      case OperEx(TlaFunOper.funDef, body, keysAndValues@_*) =>
+      case OperEx(TlaFunOper.funDef, body, keysAndValues @ _*) =>
         val (ks, vs) = keysAndValues.zipWithIndex partition (_._2 % 2 == 0)
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k \in v
         val boxes =
-          keys.zip(values).map(p =>
-            group(toDoc((0, 0), p._1) <> space <> "\\in" <> nest(line <> toDoc((0, 0), p._2)))
-          ) ///
+          keys
+            .zip(values)
+            .map(p => group(toDoc((0, 0), p._1) <> space <> "\\in" <> nest(line <> toDoc((0, 0), p._2)))) ///
 
         val binders = ssep(boxes.toList, comma <> line)
         val bodyDoc = toDoc((0, 0), body)
         group(
-          text("[") <>
-            nest(line <> binders <> space <> "|->" <> nest(line <> bodyDoc)) <> line <>
-            text("]")
+            text("[") <>
+              nest(line <> binders <> space <> "|->" <> nest(line <> bodyDoc)) <> line <>
+              text("]")
         ) ////
 
-      case OperEx(TlaSetOper.map, body, keysAndValues@_*) =>
+      case OperEx(TlaSetOper.map, body, keysAndValues @ _*) =>
         val (ks, vs) = keysAndValues.zipWithIndex partition (_._2 % 2 == 0)
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k |-> v
         val boxes =
-          keys.zip(values).map(p =>
-            group(toDoc(TlaSetOper.in.precedence, p._1) <> space <>
-              "\\in" <> nest(line <> toDoc(TlaSetOper.in.precedence, p._2)))
-          ) ///
+          keys
+            .zip(values)
+            .map(p =>
+              group(toDoc(TlaSetOper.in.precedence, p._1) <> space <>
+                    "\\in" <> nest(line <> toDoc(TlaSetOper.in.precedence, p._2)))
+            ) ///
 
         val binders = ssep(boxes.toList, comma <> line)
         val bodyDoc = toDoc((0, 0), body)
@@ -209,52 +207,53 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
 
       case OperEx(TlaSetOper.filter, name, set, pred) =>
         val binding = group(
-          toDoc(TlaSetOper.in.precedence, name) <> softline <> "\\in" <>
-            nest(line <> toDoc(TlaSetOper.in.precedence, set))
+            toDoc(TlaSetOper.in.precedence, name) <> softline <> "\\in" <>
+              nest(line <> toDoc(TlaSetOper.in.precedence, set))
         ) ///
-      // use the precedence (0, 0), as there is no need for parentheses around the predicate
-      val filter = toDoc((0, 0), pred)
+        // use the precedence (0, 0), as there is no need for parentheses around the predicate
+        val filter = toDoc((0, 0), pred)
         group(
-          text("{") <> nest(line <> binding <> ":" <> nest(line <> filter)) <> line <> text("}")
+            text("{") <> nest(line <> binding <> ":" <> nest(line <> filter)) <> line <> text("}")
         ) ///
 
-        // a function of multiple arguments that are packed into a tuple: don't print the angular brackets <<...>>
+      // a function of multiple arguments that are packed into a tuple: don't print the angular brackets <<...>>
       case OperEx(op @ TlaFunOper.app, funEx, OperEx(TlaFunOper.tuple, args @ _*)) =>
         val argDocs = args.map(toDoc(op.precedence, _))
         val commaSeparatedArgs = folddoc(argDocs.toList, _ <> text(",") <@> _)
         group(
-          toDoc(TlaFunOper.app.precedence, funEx) <> brackets(commaSeparatedArgs)
+            toDoc(TlaFunOper.app.precedence, funEx) <> brackets(commaSeparatedArgs)
         ) ///
 
-        // a function of a single argument
+      // a function of a single argument
       case OperEx(TlaFunOper.app, funEx, argEx) =>
         group(
-          toDoc(TlaFunOper.app.precedence, funEx) <>
-            text("[") <> nest(linebreak <> toDoc(TlaFunOper.app.precedence, argEx)) <> linebreak <> text("]")
+            toDoc(TlaFunOper.app.precedence, funEx) <>
+              text("[") <> nest(linebreak <> toDoc(TlaFunOper.app.precedence, argEx)) <> linebreak <> text("]")
         ) ///
 
       case OperEx(TlaControlOper.ifThenElse, pred, thenEx, elseEx) =>
         val prec = TlaControlOper.ifThenElse.precedence
         val doc =
           group(
-            text("IF") <> space <> toDoc(prec, pred) <> line <>
-              text("THEN") <> space <> toDoc(prec, thenEx) <> line <>
-              text("ELSE") <> space <> toDoc(prec, elseEx)
+              text("IF") <> space <> toDoc(prec, pred) <> line <>
+                text("THEN") <> space <> toDoc(prec, thenEx) <> line <>
+                text("ELSE") <> space <> toDoc(prec, elseEx)
           ) ///
 
         wrapWithParen(parentPrecedence, prec, doc)
 
-
-      case OperEx(TlaControlOper.caseWithOther, otherEx, guardsAndUpdates@_*) =>
+      case OperEx(TlaControlOper.caseWithOther, otherEx, guardsAndUpdates @ _*) =>
         val prec = TlaControlOper.caseWithOther.precedence
         val (gs, us) = guardsAndUpdates.zipWithIndex partition (_._2 % 2 == 0)
         val (guards, updates) = (gs.map(_._1), us.map(_._1))
         // format each guard-update pair (g, u) into ![g] = u
         val pairs =
-          guards.zip(updates).map(p =>
-            group(toDoc(prec, p._1) <>
-              nest(line <> text("->") <> space <> toDoc(prec, p._2)))
-          ) ///
+          guards
+            .zip(updates)
+            .map(p =>
+              group(toDoc(prec, p._1) <>
+                    nest(line <> text("->") <> space <> toDoc(prec, p._2)))
+            ) ///
 
         val pairsWithOther =
           if (otherEx == NullEx) {
@@ -266,43 +265,46 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
         val doc = group(text("CASE") <> nest(space <> folddoc(pairsWithOther.toList, _ <> line <> "[]" <> space <> _)))
         wrapWithParen(parentPrecedence, prec, doc)
 
-      case OperEx(TlaControlOper.caseNoOther, guardsAndUpdates@_*) =>
+      case OperEx(TlaControlOper.caseNoOther, guardsAndUpdates @ _*) =>
         // delegate this case to CASE with OTHER by passing NullEx
         toDoc(parentPrecedence, OperEx(TlaControlOper.caseWithOther, NullEx +: guardsAndUpdates: _*))
 
-      case OperEx(TlaFunOper.except, funEx, keysAndValues@_*) =>
+      case OperEx(TlaFunOper.except, funEx, keysAndValues @ _*) =>
         val (ks, vs) = keysAndValues.zipWithIndex partition (_._2 % 2 == 0)
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into ![k] = v
         val boxes =
-          keys.zip(values).map(p =>
-            group(text("!") <> brackets(toDoc((0, 0), p._1)) <> space <> text("=") <>
-              nest(line <> toDoc((0, 0), p._2)))
-          ) ///
+          keys
+            .zip(values)
+            .map(p =>
+              group(text("!") <> brackets(toDoc((0, 0), p._1)) <> space <> text("=") <>
+                    nest(line <> toDoc((0, 0), p._2)))
+            ) ///
 
         val updates = ssep(boxes.toList, comma <> line)
 
         val doc =
           text("[") <> nest(line <> toDoc(TlaFunOper.except.precedence, funEx) <>
-            nest(softline <> text("EXCEPT") <> line <> updates)) <> line <>
+                nest(softline <> text("EXCEPT") <> line <> updates)) <> line <>
             text("]")
 
         group(doc)
 
-        // a set of functions [S -> T]
+      // a set of functions [S -> T]
       case OperEx(TlaSetOper.funSet, domain, coDomain) =>
         val doc =
           toDoc(TlaSetOper.funSet.precedence, domain) <>
-            nest(line <>
-              text("->") <> space <>
-              toDoc(TlaSetOper.funSet.precedence, coDomain))
+            nest(
+                line <>
+                  text("->") <> space <>
+                  toDoc(TlaSetOper.funSet.precedence, coDomain))
         group(brackets(doc))
 
-        // a labelled expression L3(a, b) :: 42
+      // a labelled expression L3(a, b) :: 42
       case expr @ OperEx(oper @ TlaOper.label, decoratedExpr, ValEx(TlaStr(name)), args @ _*) =>
         val argDocs = args map {
           case ValEx(TlaStr(str)) => text(str)
-          case _ => throw new MalformedTlaError("Malformed expression", expr)
+          case _                  => throw new MalformedTlaError("Malformed expression", expr)
         }
         val optionalArgs =
           if (args.isEmpty)
@@ -312,12 +314,11 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
 
         val doc =
           text(name) <> optionalArgs <> space <> "::" <>
-            nest(line <>toDoc(oper.precedence, decoratedExpr))
+            nest(line <> toDoc(oper.precedence, decoratedExpr))
         group(wrapWithParen(parentPrecedence, oper.precedence, doc))
 
       // [A]_vars or <A>_vars
-      case OperEx(op, action, vars)
-        if op == TlaActionOper.stutter || op == TlaActionOper.nostutter =>
+      case OperEx(op, action, vars) if op == TlaActionOper.stutter || op == TlaActionOper.nostutter =>
         def wrapper = if (op == TlaActionOper.stutter) brackets _ else angles _
 
         val doc =
@@ -325,8 +326,7 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
             "_" <> toDoc(op.precedence, vars)
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
-      case OperEx(op, vars, action)
-        if op == TlaTempOper.weakFairness || op == TlaTempOper.strongFairness =>
+      case OperEx(op, vars, action) if op == TlaTempOper.weakFairness || op == TlaTempOper.strongFairness =>
         val sign = if (op == TlaTempOper.weakFairness) "WF" else "SF"
         val doc =
           sign <> "_" <> toDoc(op.precedence, vars) <>
@@ -357,18 +357,19 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
       case OperEx(op, lhs, rhs) if PrettyWriter.binaryOps.contains(op) =>
         val doc =
           toDoc(op.precedence, lhs) <>
-            nest(line <>
-              text(PrettyWriter.binaryOps(op)) <> space <>
-              toDoc(op.precedence, rhs))
+            nest(
+                line <>
+                  text(PrettyWriter.binaryOps(op)) <> space <>
+                  toDoc(op.precedence, rhs))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
-      case OperEx(op, args@_*) if PrettyWriter.naryOps.contains(op) =>
+      case OperEx(op, args @ _*) if PrettyWriter.naryOps.contains(op) =>
         val sign = PrettyWriter.naryOps(op)
         val argDocs = args.map(toDoc(op.precedence, _)).toList
         val doc = nest(folddoc(argDocs, _ <> line <> sign <> space <> _))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
-      case OperEx(op@TlaOper.apply, NameEx(name), args@_*) =>
+      case OperEx(op @ TlaOper.apply, NameEx(name), args @ _*) =>
         // apply an operator by its name, e.g., F(x)
         val argDocs = args.map(toDoc(op.precedence, _)).toList
         val commaSeparated = ssep(argDocs, "," <> softline)
@@ -381,7 +382,7 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
-      case OperEx(op@TlaOper.apply, operEx, args@_*) =>
+      case OperEx(op @ TlaOper.apply, operEx, args @ _*) =>
         // apply an operator by its definition, e.g., (LAMBDA x: x)(y)
         val argDocs = args.map(toDoc(op.precedence, _)).toList
         val commaSeparated = ssep(argDocs, "," <> softline)
@@ -389,8 +390,8 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
-        // TODO: fix funSet
-      case OperEx(op, args@_*) =>
+      // TODO: fix funSet
+      case OperEx(op, args @ _*) =>
         val argDocs = args.map(toDoc(op.precedence, _)).toList
         val commaSeparated = ssep(argDocs, "," <> softline)
         val doc =
@@ -409,13 +410,13 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
         lambdaStack = lambdaStack.tail // pop the lambda definition
         doc
 
-      case LetInEx(body, decls@_*) =>
+      case LetInEx(body, decls @ _*) =>
         def eachDecl(d: TlaOperDecl) = {
           group("LET" <> space <> toDoc(d) <> line <> "IN")
         }
 
         group(ssep(decls.map(eachDecl).toList, line) <>
-          line <> toDoc((0, 0), body))
+              line <> toDoc((0, 0), body))
     }
   }
 
@@ -430,15 +431,15 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
       case TlaAssumeDecl(body) =>
         group("ASSUME" <> parens(toDoc((0, 0), body)))
 
-        // a declaration of a recursive function
+      // a declaration of a recursive function
       case TlaOperDecl(name, List(), OperEx(TlaFunOper.recFunDef, body, keysAndValues @ _*)) =>
         val (ks, vs) = keysAndValues.zipWithIndex partition (_._2 % 2 == 0)
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k \in v
         val boxes =
-          keys.zip(values).map(p =>
-            group(toDoc((0, 0), p._1) <> space <> "\\in" <> nest(line <> toDoc((0, 0), p._2)))
-          ) ///
+          keys
+            .zip(values)
+            .map(p => group(toDoc((0, 0), p._1) <> space <> "\\in" <> nest(line <> toDoc((0, 0), p._2)))) ///
 
         val binders = ssep(boxes.toList, comma <> line)
 
@@ -451,7 +452,7 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
         recFunName = REC_FUN_UNDEFINED
         doc
 
-        // an operator declaration (may be recursive)
+      // an operator declaration (may be recursive)
       case tod @ TlaOperDecl(name, params, body) =>
         val recPreambule =
           if (!tod.isRecursive)
@@ -493,19 +494,20 @@ class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) ex
   private def strNoQuotes(ex: TlaEx): String = {
     ex match {
       case ValEx(TlaStr(s)) => s
-      case _ => throw new IllegalStateException("Expected a string as a record key, found: " + ex)
+      case _                => throw new IllegalStateException("Expected a string as a record key, found: " + ex)
     }
   }
 }
 
 object PrettyWriter {
+
   /**
-    * Write a module to a file (without appending).
-    *
-    * @param module a TLA module
-    * @param outputFile an output file that will be created or overwritten
-    */
-  def write(module: TlaModule, outputFile: File): Unit = {
+   * Write a module to a file (without appending).
+   *
+   * @param module     a TLA module
+   * @param outputFile an output file that will be created or overwritten
+   */
+  def write(module: TlaModule, outputFile: File)(implicit typeTag: TypeTag): Unit = {
     val writer = new PrintWriter(new FileWriter(outputFile, false))
     try {
       new PrettyWriter(writer).write(module)
@@ -515,64 +517,65 @@ object PrettyWriter {
   }
 
   protected val unaryOps = HashMap(
-    TlaBoolOper.not -> "~",
-    TlaArithOper.uminus -> "-",
-    TlaSetOper.union -> "UNION ",
-    TlaSetOper.powerset -> "SUBSET ",
-    TlaActionOper.enabled -> "ENABLED ",
-    TlaActionOper.unchanged -> "UNCHANGED ",
-    TlaFunOper.domain -> "DOMAIN ",
-    TlaTempOper.box -> "[]",
-    TlaTempOper.diamond -> "<>"
+      TlaBoolOper.not -> "~",
+      TlaArithOper.uminus -> "-",
+      TlaSetOper.union -> "UNION ",
+      TlaSetOper.powerset -> "SUBSET ",
+      TlaActionOper.enabled -> "ENABLED ",
+      TlaActionOper.unchanged -> "UNCHANGED ",
+      TlaFunOper.domain -> "DOMAIN ",
+      TlaTempOper.box -> "[]",
+      TlaTempOper.diamond -> "<>"
   ) ////
 
   protected val binaryOps =
-    HashMap(TlaOper.eq -> "=",
-      TlaOper.ne -> "/=",
-      TlaBoolOper.implies -> "=>",
-      TlaBoolOper.equiv -> "<=>",
-      TlaArithOper.plus -> "+",
-      TlaArithOper.minus -> "-",
-      TlaArithOper.mult -> "*",
-      TlaArithOper.div -> "/",
-      TlaArithOper.mod -> "%",
-      TlaArithOper.realDiv -> "/.",
-      TlaArithOper.exp -> "^",
-      TlaArithOper.dotdot -> "..",
-      TlaArithOper.lt -> "<",
-      TlaArithOper.gt -> ">",
-      TlaArithOper.le -> "<=",
-      TlaArithOper.ge -> ">=",
-      TlaSetOper.in -> "\\in",
-      TlaSetOper.notin -> "\\notin",
-      TlaSetOper.cap -> "\\intersect",
-      TlaSetOper.cup -> "\\union",
-      TlaSetOper.setminus -> "\\",
-      TlaSetOper.subseteq -> "\\subseteq",
-      TlaSetOper.subsetProper -> "\\subset",
-      TlaSetOper.supseteq -> "\\supseteq",
-      TlaSetOper.supsetProper -> "\\supset",
-      TlaActionOper.composition -> "\\cdot",
-      TlaTempOper.leadsTo -> "~>",
-      TlaTempOper.guarantees -> "-+->",
-      TlaSeqOper.concat -> "\\o",
-      TlcOper.colonGreater -> ":>",
-      BmcOper.assign -> ":=",
-      BmcOper.withType -> "<:"
+    HashMap(
+        TlaOper.eq -> "=",
+        TlaOper.ne -> "/=",
+        TlaBoolOper.implies -> "=>",
+        TlaBoolOper.equiv -> "<=>",
+        TlaArithOper.plus -> "+",
+        TlaArithOper.minus -> "-",
+        TlaArithOper.mult -> "*",
+        TlaArithOper.div -> "/",
+        TlaArithOper.mod -> "%",
+        TlaArithOper.realDiv -> "/.",
+        TlaArithOper.exp -> "^",
+        TlaArithOper.dotdot -> "..",
+        TlaArithOper.lt -> "<",
+        TlaArithOper.gt -> ">",
+        TlaArithOper.le -> "<=",
+        TlaArithOper.ge -> ">=",
+        TlaSetOper.in -> "\\in",
+        TlaSetOper.notin -> "\\notin",
+        TlaSetOper.cap -> "\\intersect",
+        TlaSetOper.cup -> "\\union",
+        TlaSetOper.setminus -> "\\",
+        TlaSetOper.subseteq -> "\\subseteq",
+        TlaSetOper.subsetProper -> "\\subset",
+        TlaSetOper.supseteq -> "\\supseteq",
+        TlaSetOper.supsetProper -> "\\supset",
+        TlaActionOper.composition -> "\\cdot",
+        TlaTempOper.leadsTo -> "~>",
+        TlaTempOper.guarantees -> "-+->",
+        TlaSeqOper.concat -> "\\o",
+        TlcOper.colonGreater -> ":>",
+        BmcOper.assign -> ":=",
+        BmcOper.withType -> "<:"
     ) ////
 
   protected val naryOps: Map[TlaOper, String] = HashMap(
-    TlaSetOper.times -> "\\X",
-    TlaArithOper.sum -> "+",
-    TlaArithOper.prod -> "*",
-    TlcOper.atat -> "@@"
+      TlaSetOper.times -> "\\X",
+      TlaArithOper.sum -> "+",
+      TlaArithOper.prod -> "*",
+      TlcOper.atat -> "@@"
   ) ////
 
   protected val bindingOps = HashMap(
-    TlaBoolOper.exists -> "\\E",
-    TlaBoolOper.forall -> "\\A",
-    TlaOper.chooseBounded -> "CHOOSE",
-    TlaTempOper.EE -> "\\EE",
-    TlaTempOper.AA -> "\\AA"
+      TlaBoolOper.exists -> "\\E",
+      TlaBoolOper.forall -> "\\A",
+      TlaOper.chooseBounded -> "CHOOSE",
+      TlaTempOper.EE -> "\\EE",
+      TlaTempOper.AA -> "\\AA"
   ) ////
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -1,10 +1,10 @@
 package at.forsyte.apalache.tla.lir.oper
 
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, TypeTag}
 
 /**
-  * Function operators.
-  */
+ * Function operators.
+ */
 abstract class TlaFunOper extends TlaOper {
   override def interpretation: Interpretation.Value = Interpretation.Predefined
 }
@@ -12,20 +12,20 @@ abstract class TlaFunOper extends TlaOper {
 object TlaFunOper {
 
   /**
-    * A function constructor like the one for the records: [ k_1 |-> v_1, ..., k_n |-> v_n ].
-    * The order of the arguments is: (k_1, v_1, ..., k_n, v_n).
-    * Note that in case of records, k_1, ..., k_n are strings, that is, ValEx(TlaStr(...)), not NameEx.
-    */
+   * A function constructor like the one for the records: [ k_1 |-> v_1, ..., k_n |-> v_n ].
+   * The order of the arguments is: (k_1, v_1, ..., k_n, v_n).
+   * Note that in case of records, k_1, ..., k_n are strings, that is, ValEx(TlaStr(...)), not NameEx.
+   */
   object enum extends TlaFunOper {
-    override def arity: OperArity = new OperArity( k => k >= 2 && k % 2 == 0 )
+    override def arity: OperArity = new OperArity(k => k >= 2 && k % 2 == 0)
     override val name: String = "fun-enum"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
   /**
-    * Define a tuple by listing its elements, i.e., < e_1, ..., e_k >.
-    * One can use enum to achieve the same effect.
-    */
+   * Define a tuple by listing its elements, i.e., < e_1, ..., e_k >.
+   * One can use enum to achieve the same effect.
+   */
   object tuple extends TlaFunOper {
     override val arity = AnyArity()
     override val name = "<<...>>"
@@ -33,20 +33,20 @@ object TlaFunOper {
   }
 
   /**
-    * A short-hand constructor for tuples.
-    *
-    * TODO: remove, as we have the TLA builder
-    *
-    * @param elems tuple elements
-    * @return a new OperEx(tuple, elems: _*)
-    */
-  def mkTuple(elems: TlaEx*): OperEx =
+   * A short-hand constructor for tuples.
+   *
+   * TODO: remove, as we have the TLA builder
+   *
+   * @param elems tuple elements
+   * @return a new OperEx(tuple, elems: _*)
+   */
+  def mkTuple(elems: TlaEx*)(implicit typeTag: TypeTag): OperEx =
     OperEx(tuple, elems: _*)
 
   /**
-    * A function application, e.g., f[e].
-    * The order of the arguments is: (f, e).
-    */
+   * A function application, e.g., f[e].
+   * The order of the arguments is: (f, e).
+   */
   object app extends TlaFunOper {
     override val arity: OperArity = FixedArity(2)
     override val name: String = "fun-app"
@@ -61,70 +61,70 @@ object TlaFunOper {
   }
 
   /**
-    * A function constructor: [ x \in S |-> e ]. In fact, it is a lambda function (NOT the TLA+ LAMBDA!)
-    * Similar to \E and \A, one can use many combinations of variables and tuples, e.g.,
-    * [ x, y \in S, <<a, b>> \in S |-> e ]. We translate function constructors
-    * in a list of fixed structure, where the defining expression comes first and every variables (or a tuple)
-    * comes with its bounding set, e.g., (e, x, S, y, S, <<a, b>>, S).
-    *
-    * The arguments are always an odd-length list
-    * of the following structure: body, x_1, S_1, ..., x_k, S_k.
-    */
+   * A function constructor: [ x \in S |-> e ]. In fact, it is a lambda function (NOT the TLA+ LAMBDA!)
+   * Similar to \E and \A, one can use many combinations of variables and tuples, e.g.,
+   * [ x, y \in S, <<a, b>> \in S |-> e ]. We translate function constructors
+   * in a list of fixed structure, where the defining expression comes first and every variables (or a tuple)
+   * comes with its bounding set, e.g., (e, x, S, y, S, <<a, b>>, S).
+   *
+   * The arguments are always an odd-length list
+   * of the following structure: body, x_1, S_1, ..., x_k, S_k.
+   */
   object funDef extends TlaFunOper {
-    override def arity: OperArity = new OperArity( k => k >= 3 && k % 2 == 1 )
+    override def arity: OperArity = new OperArity(k => k >= 3 && k % 2 == 1)
     override val name: String = "fun-def"
     override val precedence: (Int, Int) = (16, 16) // as the function application
   }
 
   /**
-    * <p>A constructor of a recursive function, which is defined in TLA+ as: `f[x \in S] == ... f[y] ...`.
-    * We introduce an operator that have at least 3 arguments, whose meaning is as follows:</p>
-    *
-    * <ul>
-    *   <li>function body of type TlaEx that may refer to the function via recFunRef,</li>
-    *   <li>NameEx(variableName1),</li>
-    *   <li>variable1 domain of type TlaEx.</li>
-    *   <li>...</li>
-    *   <li>NameEx(variableName_k),</li>
-    *   <li>variable_k domain of type TlaEx.</li>
-    * </ul>
-    *
-    * <p>Hence, a declaration of a recursive operator looks like a nullary operator declaration,
-    *    whose body contains the constructor of a recursive function. The body of a recursive function may
-    *    refer to the function itself by using the operator recFunRef (see below).
-    *    Note that the output methods should convert this intermediate representation to the standard TLA+ form.</p>
-    *
-    * <p>There is a reason for defining a recursive function with two operators, rather than by introducing
-    * a special case of `TlaDecl`. In TLA+, the operator bodies (as well as function bodies) may refer only to
-    * the names that have been defined before. That is why we keep function definitions intermingled with
-    * operator definitions. Moreover, we do not refer to the function name in its body, as otherwise, we would
-    * run in two problems: (1) the operator name would clash with the function name, an
-    * (2) the renaming transformations would try to rename the function. TLA+ forbids mutually recursive functions,
-    * so it is sound to refer to the function with the operator `recFunDef`.</p>
-    *
-    * <p><b>Example.</b>
-    * `Fact[n \in Int] == IF n <= 1 THEN 1 ELSE n * Fact[n - 1]` is translated into:</p>
-    *
-    * <p>
-    * `TlaOperDecl("Fact", List(),
-    *   OperEx(recFunDef,
-    *     OperEx(TlaControlOper.ifThenElse,
-    *       (* n <= 1 *),
-    *       (* 1 *),
-    *       OperEx(Tla.ArithOper.mult,
-    *         NameEx("n"),
-    *         OperEx(TlaFunOper.app,
-    *           OperEx(recFunRef),
-    *           OperEx(TlaArithOper.minus, NameEx(n), ValEx(TlaInt(1)))
-    *         )
-    *       )
-    *     ),
-    *     NameEx("n"),
-    *     TlaIntSet
-    *   )
-    * )`
-    * </p>
-    */
+   * <p>A constructor of a recursive function, which is defined in TLA+ as: `f[x \in S] == ... f[y] ...`.
+   * We introduce an operator that have at least 3 arguments, whose meaning is as follows:</p>
+   *
+   * <ul>
+   * <li>function body of type TlaEx that may refer to the function via recFunRef,</li>
+   * <li>NameEx(variableName1),</li>
+   * <li>variable1 domain of type TlaEx.</li>
+   * <li>...</li>
+   * <li>NameEx(variableName_k),</li>
+   * <li>variable_k domain of type TlaEx.</li>
+   * </ul>
+   *
+   * <p>Hence, a declaration of a recursive operator looks like a nullary operator declaration,
+   * whose body contains the constructor of a recursive function. The body of a recursive function may
+   * refer to the function itself by using the operator recFunRef (see below).
+   * Note that the output methods should convert this intermediate representation to the standard TLA+ form.</p>
+   *
+   * <p>There is a reason for defining a recursive function with two operators, rather than by introducing
+   * a special case of `TlaDecl`. In TLA+, the operator bodies (as well as function bodies) may refer only to
+   * the names that have been defined before. That is why we keep function definitions intermingled with
+   * operator definitions. Moreover, we do not refer to the function name in its body, as otherwise, we would
+   * run in two problems: (1) the operator name would clash with the function name, an
+   * (2) the renaming transformations would try to rename the function. TLA+ forbids mutually recursive functions,
+   * so it is sound to refer to the function with the operator `recFunDef`.</p>
+   *
+   * <p><b>Example.</b>
+   * `Fact[n \in Int] == IF n <= 1 THEN 1 ELSE n * Fact[n - 1]` is translated into:</p>
+   *
+   * <p>
+   * `TlaOperDecl("Fact", List(),
+   * OperEx(recFunDef,
+   * OperEx(TlaControlOper.ifThenElse,
+   * (* n <= 1 *),
+   * (* 1 *),
+   * OperEx(Tla.ArithOper.mult,
+   * NameEx("n"),
+   * OperEx(TlaFunOper.app,
+   * OperEx(recFunRef),
+   * OperEx(TlaArithOper.minus, NameEx(n), ValEx(TlaInt(1)))
+   * )
+   * )
+   * ),
+   * NameEx("n"),
+   * TlaIntSet
+   * )
+   * )`
+   * </p>
+   */
   object recFunDef extends TlaFunOper {
     override def arity: OperArity = new OperArity(_ >= 3)
     override def name: String = "rec-fun-def"
@@ -132,14 +132,15 @@ object TlaFunOper {
   }
 
   /**
-    * A reference to a recursive function inside its definition.
-    *
-    * @see TlaFunOper.recFunDef
-    */
+   * A reference to a recursive function inside its definition.
+   *
+   * @see TlaFunOper.recFunDef
+   */
   object recFunRef extends TlaFunOper {
+
     /**
-      * A unique name that can be used to refer to a recursive function inside its body.
-      */
+     * A unique name that can be used to refer to a recursive function inside its body.
+     */
     val uniqueName = "$recFun"
     override def name: String = "rec-fun-ref"
     override def arity: OperArity = FixedArity(0)
@@ -147,28 +148,28 @@ object TlaFunOper {
   }
 
   /**
-    * <p>A function update, e.g., [f EXCEPT ![i_1] = e_1, ![i_2] = e_2, ..., ![i_k] = e_k].
-    * The order of the arguments is as follows: (f, i_1, e_1, ..., i_k, e_k).</p>
-    *
-    * <p>Note that all indices i_1, ..., i_k are tuples. For one-dimensional functions,
-    * they are singleton tuples, whereas for multidimensional functions the indices are
-    * tuples of arbitrary length. This is the design choice that comes from SANY.
-    * When you write f[<<1>>] in TLA+, expect to deal with (except (tuple (tuple 1))) here.
-    * The method `unpackIndex` maps singleton tuples to their contents.
-    * </p>
-    */
+   * <p>A function update, e.g., [f EXCEPT ![i_1] = e_1, ![i_2] = e_2, ..., ![i_k] = e_k].
+   * The order of the arguments is as follows: (f, i_1, e_1, ..., i_k, e_k).</p>
+   *
+   * <p>Note that all indices i_1, ..., i_k are tuples. For one-dimensional functions,
+   * they are singleton tuples, whereas for multidimensional functions the indices are
+   * tuples of arbitrary length. This is the design choice that comes from SANY.
+   * When you write f[<<1>>] in TLA+, expect to deal with (except (tuple (tuple 1))) here.
+   * The method `unpackIndex` maps singleton tuples to their contents.
+   * </p>
+   */
   object except extends TlaFunOper {
-    override def arity: OperArity = new OperArity( k => k >= 3 && k % 2 == 1 )
+    override def arity: OperArity = new OperArity(k => k >= 3 && k % 2 == 1)
     override val name: String = "EXCEPT"
     override val precedence: (Int, Int) = (16, 16) // as the function application
 
     /**
-      * SANY always packs an EXCEPT accessor in a tuple, even if the index is one-dimensional.
-      * Unpack the one-dimensional index.
-      */
+     * SANY always packs an EXCEPT accessor in a tuple, even if the index is one-dimensional.
+     * Unpack the one-dimensional index.
+     */
     def unpackIndex: TlaEx => TlaEx = {
       case OperEx(TlaFunOper.tuple, one) => one
-      case e => e
+      case e                             => e
     }
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
@@ -99,9 +99,38 @@ package lir {
   /** A function signature, e.g., f(_, _) used in A(f(_, _), x, y) */
   case class OperFormalParam(name: String, arity: Int) extends FormalParam with Serializable {}
 
-  /** An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values. */
-  sealed abstract class TlaEx extends Identifiable with Serializable {
-    // TODO: there must be a nice way of defining default printers in scala, so we do not have to make a choice here
+  /**
+   * A type tag to be attached to a TLA+ language construct: an expression or a declaration.
+   */
+  sealed abstract class TypeTag
+
+  /**
+   * The type tag that simply indicates that the language construct is not typed.
+   */
+  case class Untyped() extends TypeTag
+
+  /**
+   * A type tag that carries a tag of type T, which the tag is parameterized with.
+   *
+   * @param myType the type that is carried by the tag
+   * @tparam T the type of the tag
+   */
+  case class Typed[T](myType: T) extends TypeTag
+
+  /**
+   * Default settings for the untyped language layer. To use the `Untyped()` tag, import the definitions from `UntypedPredefs`.
+   */
+  object UntypedPredefs {
+    implicit val untyped: TypeTag = Untyped()
+  }
+
+  /**
+   * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values.
+   * Importantly, `TlaEx` accepts an implicit type tag.
+   */
+  sealed abstract class TlaEx(implicit val typeTag: TypeTag) extends Identifiable with Serializable {
+
+    // TODO: there must be a nice way of defining default printers in scala, so we do not have to make a choice here.
     override def toString: String = UTFPrinter(this)
 
     def toSimpleString: String = ""
@@ -111,29 +140,43 @@ package lir {
    * This is a special expression that indicates that this expression does not have a meaningful value.
    * For instance, this expression can be used as the body of a library operator, which by default have
    * gibberish definitions by SANY.
-   * We could use Option[TlaEx], but that would introduce unnecessary many pattern matches, as NoneEx will be rare.
+   * We could use Option[TlaEx], but that would introduce unnecessary many pattern matches, as NoneEx is rare.
+   * NullEx is always untyped.
    */
-  object NullEx extends TlaEx with Serializable {
+  object NullEx extends TlaEx()(typeTag = Untyped()) with Serializable {
     override def toSimpleString: String = toString
   }
 
-  /** just using a TLA+ value */
-  case class ValEx(value: TlaValue) extends TlaEx with Serializable {
+  /**
+   * A constant TLA+ value, which is usually a literal such as: 42, TRUE, "foo", BOOLEAN.
+   * Importantly, `ValEx` accepts an implicit type tag.
+   */
+  case class ValEx(value: TlaValue)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     override def toSimpleString: String = value.toString
   }
 
-  /** referring to a variable, constant, operator, etc. by a name. */
-  case class NameEx(name: String) extends TlaEx with Serializable {
+  /**
+   * Referring by name to a variable, constant, operator, etc.
+   * Importantly, `NameEx` accepts an implicit type tag.
+   */
+  case class NameEx(name: String)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     override def toSimpleString: String = name
   }
 
-  // Introducing a LET-IN expression
-  case class LetInEx(body: TlaEx, decls: TlaOperDecl*) extends TlaEx with Serializable {
+  /*
+   * A let-in definition, which is part of TLA+ syntax.
+   * Importantly, `LetInEx` accepts an implicit type tag.
+   */
+  case class LetInEx(body: TlaEx, decls: TlaOperDecl*)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     override def toSimpleString: String = s"LET ${decls.mkString(" ")} IN $body"
   }
 
-  // applying an operator, including the one defined by OperFormalParam
-  case class OperEx(oper: TlaOper, args: TlaEx*) extends TlaEx with Serializable {
+  /**
+   * Application of a built-in operator. The standard operator `TlaOper.apply` allows us
+   * to apply a user-defined operator (defined with `TlaOperDecl`) or an operator that is passed via a parameter
+   * (that is, `OperFormalParam`). Importantly, `OperEx` accepts an implicit type tag.
+   */
+  case class OperEx(oper: TlaOper, args: TlaEx*)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     require(oper.isCorrectArity(args.size),
         "unexpected arity %d in %s applied to %s".format(args.size, oper.name, args.map(_.toString) mkString ", "))
 
@@ -198,6 +241,7 @@ package lir {
    * @param argDom  the expression that describes the variable bound, e.g., Nat
    * @param defBody the definition body
    */
+  @deprecated("Use TlaFunOper.recFunDef and TlaFunOper.recFunRef instead")
   case class TlaRecFunDecl(name: String, arg: String, argDom: TlaEx, defBody: TlaEx) extends TlaDecl
 
   /**

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/DeepCopy.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/DeepCopy.scala
@@ -2,43 +2,44 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaDeclTransformation, TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
-  * DeepCopy constructs a structurally identical copy of a given TlaEx or TlaDecl, with fresh unique IDs.
-  */
-class DeepCopy( tracker : TransformationTracker ) {
-  def deepCopyDecl[T <: TlaDecl]( decl : T ) : T = deepCopyDeclInternal( decl ).asInstanceOf[T]
+ * DeepCopy constructs a structurally identical copy of a given TlaEx or TlaDecl, with fresh unique IDs.
+ */
+class DeepCopy(tracker: TransformationTracker) {
+  def deepCopyDecl[T <: TlaDecl](decl: T): T = deepCopyDeclInternal(decl).asInstanceOf[T]
 
   private def deepCopyDeclInternal: TlaDeclTransformation = tracker.trackDecl {
-    case TlaAssumeDecl( bodyEx ) => TlaAssumeDecl( deepCopyEx( bodyEx ) )
-    case TlaRecFunDecl( name, arg, argDom, defBody ) =>
-      TlaRecFunDecl( name, arg, deepCopyEx( argDom ), deepCopyEx( defBody ) )
-    case TlaTheoremDecl(name, body) => TlaTheoremDecl(name, deepCopyEx( body ) )
-    case TlaVarDecl( name ) => TlaVarDecl( name )
-    case d@TlaOperDecl( name, formalParams, body) =>
-      val decl = TlaOperDecl( name, formalParams, deepCopyEx( body ) )
+    case TlaAssumeDecl(bodyEx) => TlaAssumeDecl(deepCopyEx(bodyEx))
+    case TlaRecFunDecl(name, arg, argDom, defBody) =>
+      TlaRecFunDecl(name, arg, deepCopyEx(argDom), deepCopyEx(defBody))
+    case TlaTheoremDecl(name, body) => TlaTheoremDecl(name, deepCopyEx(body))
+    case TlaVarDecl(name)           => TlaVarDecl(name)
+    case d @ TlaOperDecl(name, formalParams, body) =>
+      val decl = TlaOperDecl(name, formalParams, deepCopyEx(body))
       decl.isRecursive = d.isRecursive
       decl
-    case TlaConstDecl( name ) => TlaConstDecl( name )
+    case TlaConstDecl(name) => TlaConstDecl(name)
   }
 
-  def deepCopyEx[T <: TlaEx]( ex : T ) : T = deepCopyExInternal( ex ).asInstanceOf[T]
+  def deepCopyEx[T <: TlaEx](ex: T): T = deepCopyExInternal(ex).asInstanceOf[T]
 
-  private def deepCopyExInternal : TlaExTransformation = tracker.trackEx {
-    case NullEx => NullEx
-    case ValEx( v ) => ValEx( v )
-    case NameEx( n ) => NameEx( n )
-    case LetInEx( body, decls@_* ) =>
-      LetInEx( deepCopyEx( body ), decls map deepCopyDecl : _* )
-    case OperEx( oper, args@_* ) =>
-      OperEx( oper, args map deepCopyEx : _* )
+  private def deepCopyExInternal: TlaExTransformation = tracker.trackEx {
+    case NullEx    => NullEx
+    case ValEx(v)  => ValEx(v)
+    case NameEx(n) => NameEx(n)
+    case LetInEx(body, decls @ _*) =>
+      LetInEx(deepCopyEx(body), decls map deepCopyDecl: _*)
+    case OperEx(oper, args @ _*) =>
+      OperEx(oper, args map deepCopyEx: _*)
   }
 
-  def deepCopyModule( module: TlaModule ) = new TlaModule( module.name, module.declarations map deepCopyDecl )
+  def deepCopyModule(module: TlaModule) = new TlaModule(module.name, module.declarations map deepCopyDecl)
 }
 
 object DeepCopy {
-  def apply( tracker : TransformationTracker ) : DeepCopy = {
-    new DeepCopy( tracker )
+  def apply(tracker: TransformationTracker): DeepCopy = {
+    new DeepCopy(tracker)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
@@ -1,73 +1,72 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl, TypeTag}
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
 object Flatten {
-  private def sameOp( op : TlaOper )( ex : TlaEx ) : Boolean = ex match {
-    case OperEx( o, _* ) => o == op
-    case _ => false
+  private def sameOp(op: TlaOper)(ex: TlaEx): Boolean = ex match {
+    case OperEx(o, _*) => o == op
+    case _             => false
   }
 
-  private def flattenOne( tracker : TransformationTracker ) : TlaExTransformation =
+  private def flattenOne(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation =
     tracker.trackEx {
-      case ex@OperEx( TlaBoolOper.and | TlaBoolOper.or, args@_* ) =>
-        val hasSameOper = sameOp( ex.oper )(_)
+      case ex @ OperEx(TlaBoolOper.and | TlaBoolOper.or, args @ _*) =>
+        val hasSameOper = sameOp(ex.oper)(_)
         // We're looking for cases of OperEx( op1, ..., OperEx( op2, ...),... ) where op1 == op2
         val similar = args.exists {
           hasSameOper
         }
         // If there are no direct children with the same operator, do nothing
-        if ( !similar )
+        if (!similar)
           ex
         else {
           // We want to preserve arg. order
           val newArgs = args flatMap { x =>
-            if( hasSameOper(x) ){
+            if (hasSameOper(x)) {
               // We steal all children from OperEx subexpressions using the same operator
               x.asInstanceOf[OperEx].args
-            }
-            else
+            } else
               // These arguments stay unchanged
               Seq(x)
           }
           // We know newArgs != args, because similar = true
-          OperEx( ex.oper, newArgs : _* )
+          OperEx(ex.oper, newArgs: _*)
         }
       case e => e
     }
 
   /**
-    * Returns a transformation that replaces nested conjunction/disjunction with a flattened equivalent.
-    *
-    * Example:
-    * ( a /\ b) /\ c [/\(/\(a,b),c)] -> a /\ b /\ c [/\(a,b,c)]
-    */
-  def apply( tracker : TransformationTracker ) : TlaExTransformation = tracker.trackEx { ex =>
-    val tr = flattenOne( tracker )
-    lazy val self = apply( tracker )
+   * Returns a transformation that replaces nested conjunction/disjunction with a flattened equivalent.
+   *
+   * Example:
+   * ( a /\ b) /\ c [/\(/\(a,b),c)] -> a /\ b /\ c [/\(a,b,c)]
+   */
+  def apply(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation = tracker.trackEx { ex =>
+    val tr = flattenOne(tracker)
+    lazy val self = apply(tracker)
     ex match {
-      case LetInEx( body, defs@_* ) =>
+      case LetInEx(body, defs @ _*) =>
         // Transform bodies of all op.defs
         def xform: TlaOperDecl => TlaOperDecl =
           tracker.trackOperDecl { d: TlaOperDecl =>
             d.copy(
-              body = self(d.body)
+                body = self(d.body)
             )
           }
 
         val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
-        val newBody = self( body )
-        val retEx = if ( defs == newDefs && body == newBody ) ex else LetInEx( newBody, newDefs : _* )
-        tr( retEx )
+        val newBody = self(body)
+        val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
+        tr(retEx)
 
-      case OperEx( op, args@_* ) =>
+      case OperEx(op, args @ _*) =>
         val newArgs = args map self
-        val newEx = if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
-        tr( newEx )
+        val newEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
+        tr(newEx)
 
-      case _ => tr( ex )
+      case _ => tr(ex)
     }
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
@@ -2,7 +2,9 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaFunOper, TlaOper, TlaSetOper}
-import at.forsyte.apalache.tla.lir.transformations.{TlaDeclTransformation, TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.transformations.{
+  TlaDeclTransformation, TlaExTransformation, TlaModuleTransformation, TransformationTracker
+}
 
 import javax.inject.{Inject, Singleton}
 import scala.collection.immutable.HashMap
@@ -13,371 +15,390 @@ import scala.collection.immutable.HashMap
 // TODO: add comments
 
 object IncrementalRenaming {
-  private val separator : String = "$"
+  private val separator: String = "$"
   private val separatorRegex = s"[$separator]"
 
   /**
-    * makeName( x, i ) constructs the representation of x_i, as recognized by the renaming methods.
-    */
-  def makeName( base: String, ctr: Int ) : String = s"$base$separator$ctr"
+   * makeName( x, i ) constructs the representation of x_i, as recognized by the renaming methods.
+   */
+  def makeName(base: String, ctr: Int): String = s"$base$separator$ctr"
 
-  type counterMapType = Map[String,Int]
+  type counterMapType = Map[String, Int]
 
   /**
-    * Attempts to read a variable name as a (base,counter) pair. Reading a variable that's not written
-    * in the renaming-representation returns None, otherwise this method has the following property:
-    * parseName( makeName( a, b ) ) = Some( (a,b) )
-    */
-  def parseName( name : String ) : Option[(String, Int)] = {
-    name.split( separatorRegex ) match {
+   * Attempts to read a variable name as a (base,counter) pair. Reading a variable that's not written
+   * in the renaming-representation returns None, otherwise this method has the following property:
+   * parseName( makeName( a, b ) ) = Some( (a,b) )
+   */
+  def parseName(name: String): Option[(String, Int)] = {
+    name.split(separatorRegex) match {
       // Already renamed before
-      case Array( n, i ) if i forall {_.isDigit} => Some((n, i.toInt))
+      case Array(n, i) if i forall {
+            _.isDigit
+          } =>
+        Some((n, i.toInt))
       // Never renamed before
-      case Array( n ) => None
+      case Array(n) => None
       // Error
       case _ => throw new IllegalArgumentException("Variable names should never contain more than one separator")
     }
   }
 
-  /** Attempts to read the base-name of a variable. Has the following property:
-    * getBase( makeName( a, b ) ) = a
-    */
-  def getBase( name : String ) : String = parseName( name ).map( _._1 ).getOrElse( name )
+  /**
+   * Attempts to read the base-name of a variable. Has the following property:
+   * getBase( makeName( a, b ) ) = a
+   */
+  def getBase(name: String): String = parseName(name).map(_._1).getOrElse(name)
 
   /**
-    * Merges two maps of type `counterMapType`. The new map has the following properties:
-    *   1) \A k \in m1.keys \ m2.keys . mergeNameCounters( b )( m1, m2 )[k] = m1[k]
-    *   2) \A k \in m2.keys \ m1.keys . mergeNameCounters( b )( m1, m2 )[k] = m2[k]
-    *   3) \A k \in m1.keys \cap m2.keys .
-    *       mergeNameCounters( b )( m1, m2 )[k] = IF b THEN max(m1[k],m2[k]) ELSE min(m1[k],m2[k])
-    */
-  def mergeNameCounters( takeMax: Boolean )( m1 : counterMapType, m2 : counterMapType ) : counterMapType = {
-    val selectorFun : (Int, Int) => Int = if (takeMax) math.max else math.min
-    m2.foldLeft( m1 ) { case (m, (k, v)) =>
-      m + ( k -> selectorFun( m1.getOrElse( k, v ), v ) )
+   * Merges two maps of type `counterMapType`. The new map has the following properties:
+   * 1) \A k \in m1.keys \ m2.keys . mergeNameCounters( b )( m1, m2 )[k] = m1[k]
+   * 2) \A k \in m2.keys \ m1.keys . mergeNameCounters( b )( m1, m2 )[k] = m2[k]
+   * 3) \A k \in m1.keys \cap m2.keys .
+   * mergeNameCounters( b )( m1, m2 )[k] = IF b THEN max(m1[k],m2[k]) ELSE min(m1[k],m2[k])
+   */
+  def mergeNameCounters(takeMax: Boolean)(m1: counterMapType, m2: counterMapType): counterMapType = {
+    val selectorFun: (Int, Int) => Int = if (takeMax) math.max else math.min
+    m2.foldLeft(m1) { case (m, (k, v)) =>
+      m + (k -> selectorFun(m1.getOrElse(k, v), v))
     }
   }
 
   /**
-    * Computes a map of type `counterMapType`, that maps each base name n to the largest,
-    * if `takeMax` = true, or the smallest, if `takeMax` = false, counter k,
-    * for which a NameEx( makeName( n, k ) ) appears in a subexpression of `ex`.
-    */
-  def nameCounterMapFromEx( takeMax: Boolean )( ex: TlaEx ) : counterMapType = ex match {
-    case NameEx( n ) => parseName( n ) match {
-      case Some((base, ctr)) => Map( base -> ctr )
-      case None => Map.empty // No need to store n -> 0
-    }
+   * Computes a map of type `counterMapType`, that maps each base name n to the largest,
+   * if `takeMax` = true, or the smallest, if `takeMax` = false, counter k,
+   * for which a NameEx( makeName( n, k ) ) appears in a subexpression of `ex`.
+   */
+  def nameCounterMapFromEx(takeMax: Boolean)(ex: TlaEx): counterMapType = ex match {
+    case NameEx(n) =>
+      parseName(n) match {
+        case Some((base, ctr)) => Map(base -> ctr)
+        case None              => Map.empty // No need to store n -> 0
+      }
 
-    case OperEx( _, args@_* ) =>
-      args.map( nameCounterMapFromEx( takeMax) ).foldLeft(Map.empty[String,Int]){ mergeNameCounters( takeMax ) }
+    case OperEx(_, args @ _*) =>
+      args.map(nameCounterMapFromEx(takeMax)).foldLeft(Map.empty[String, Int]) {
+        mergeNameCounters(takeMax)
+      }
 
-    case LetInEx( body, defs@_* ) =>
-      defs.map( nameCounterMapFromDecl( takeMax ) ).foldLeft( nameCounterMapFromEx( takeMax )( body ) ) {
-        mergeNameCounters( takeMax )
+    case LetInEx(body, defs @ _*) =>
+      defs.map(nameCounterMapFromDecl(takeMax)).foldLeft(nameCounterMapFromEx(takeMax)(body)) {
+        mergeNameCounters(takeMax)
       }
 
     case _ => Map.empty
   }
 
   /**
-    * For a given TlaOperDecl d, computes nameCounterMapFromEx( d.body ), extended with entries for
-    * the formal parmeters and the name of d.
-    */
-  def nameCounterMapFromDecl( takeMax: Boolean )( decl : TlaDecl ) : counterMapType = decl match {
-    case TlaOperDecl( name, params, body ) =>
-      val nameAndParamMap = ( parseName( name ) ++: params.flatMap( p => parseName( p.name ) ) ).toMap
-      val bodyMap = nameCounterMapFromEx( takeMax )( body )
-      mergeNameCounters( takeMax )( bodyMap, nameAndParamMap )
+   * For a given TlaOperDecl d, computes nameCounterMapFromEx( d.body ), extended with entries for
+   * the formal parmeters and the name of d.
+   */
+  def nameCounterMapFromDecl(takeMax: Boolean)(decl: TlaDecl): counterMapType = decl match {
+    case TlaOperDecl(name, params, body) =>
+      val nameAndParamMap = (parseName(name) ++: params.flatMap(p => parseName(p.name))).toMap
+      val bodyMap = nameCounterMapFromEx(takeMax)(body)
+      mergeNameCounters(takeMax)(bodyMap, nameAndParamMap)
     case _ => Map.empty
   }
 
   /**
-    * Computes then merges maps for all declarations.
-    */
-  def nameCounterMapFromDecls( takeMax: Boolean )( decls: Traversable[TlaDecl] ) : counterMapType =
-    decls.map( nameCounterMapFromDecl( takeMax ) ).foldLeft( Map.empty[String, Int] ) { mergeNameCounters( takeMax ) }
+   * Computes then merges maps for all declarations.
+   */
+  def nameCounterMapFromDecls(takeMax: Boolean)(decls: Traversable[TlaDecl]): counterMapType =
+    decls.map(nameCounterMapFromDecl(takeMax)).foldLeft(Map.empty[String, Int]) {
+      mergeNameCounters(takeMax)
+    }
 
   /**
-    * If `name` is of the form makeName( a, b ) and offsets contains a,
-    * returns makeName( a, b - offsets[a] ), otherwise returns `name`.
-    * Throws if b - offsets[a] <= 0.
-    */
-  def offsetName( offsets : counterMapType )( name : String ) : String = parseName( name ) match {
-    case Some( (base, ctr) ) =>
-      offsets.getOrElse( base, 0 ) match {
+   * If `name` is of the form makeName( a, b ) and offsets contains a,
+   * returns makeName( a, b - offsets[a] ), otherwise returns `name`.
+   * Throws if b - offsets[a] <= 0.
+   */
+  def offsetName(offsets: counterMapType)(name: String): String = parseName(name) match {
+    case Some((base, ctr)) =>
+      offsets.getOrElse(base, 0) match {
         case 0 => name
         case j =>
           val newCtr = ctr - j
-          assert( newCtr > 0 )
-          makeName( base, newCtr )
+          assert(newCtr > 0)
+          makeName(base, newCtr)
       }
     case None => name
   }
 }
 
 /**
-  * Unlike Renaming, IncrementalRenaming is intended to maintain concise names under arbitrary re-application
-  */
+ * Unlike Renaming, IncrementalRenaming is intended to maintain concise names under arbitrary re-application
+ */
 @Singleton
-class IncrementalRenaming @Inject()(tracker : TransformationTracker) extends TlaExTransformation {
+class IncrementalRenaming @Inject() (tracker: TransformationTracker)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
 
   import IncrementalRenaming._
 
-  private var nameCounters : Map[String, Int] = HashMap.empty[String, Int]
+  private var nameCounters: Map[String, Int] = HashMap.empty[String, Int]
 
   /**
-    * Incrementally rename all declarations in a module, so every variable is declared only once.
-    */
-  def renameInModule: TlaModuleTransformation = {
-    mod => new TlaModule(mod.name, syncAndNormalizeDs(mod.declarations).toSeq)
+   * Incrementally rename all declarations in a module, so every variable is declared only once.
+   */
+  def renameInModule: TlaModuleTransformation = { mod =>
+    new TlaModule(mod.name, syncAndNormalizeDs(mod.declarations).toSeq)
   }
 
   /**
-    * Generates the next unique name with the given base.
-    */
-  private def getNextUnique( base : String ) : String = {
-    val newCtr = 1 + nameCounters.getOrElse( base, 0 )
+   * Generates the next unique name with the given base.
+   */
+  private def getNextUnique(base: String): String = {
+    val newCtr = 1 + nameCounters.getOrElse(base, 0)
     nameCounters += base -> newCtr
 
-    makeName( base, newCtr )
+    makeName(base, newCtr)
   }
 
   /**
-    * Safety wrapper, ensures getNextUnique is always called with the base name
-    */
-  private def getNextUniqueFromBase( name: String ) = getNextUnique( getBase( name ) )
+   * Safety wrapper, ensures getNextUnique is always called with the base name
+   */
+  private def getNextUniqueFromBase(name: String) = getNextUnique(getBase(name))
 
-  private def rename( alreadyRenamed: Map[String,String] ): TlaExTransformation = tracker.trackEx {
+  private def rename(alreadyRenamed: Map[String, String]): TlaExTransformation = tracker.trackEx {
     case ex @ NameEx(name) =>
       // If a name has been marked for replacement (i.e. is an entry in alreadyRenamed)
       // we simply substitute in the pre-computed new name
-      if ( alreadyRenamed.contains( name ) )
-        tracker.hold( ex, NameEx( alreadyRenamed( name ) ) )
+      if (alreadyRenamed.contains(name))
+        tracker.hold(ex, NameEx(alreadyRenamed(name)))
       else
         ex
 
     // Certain operators introduce new bound variables
-    case OperEx(op, nex@NameEx(name), otherArgs@_*)
-      if op == TlaSetOper.filter
-        || op == TlaBoolOper.exists || op == TlaBoolOper.forall
-        || op == TlaOper.chooseBounded || op == TlaOper.chooseUnbounded
-        || op == TlaOper.chooseIdiom =>
+    case OperEx(op, nex @ NameEx(name), otherArgs @ _*)
+        if op == TlaSetOper.filter
+          || op == TlaBoolOper.exists || op == TlaBoolOper.forall
+          || op == TlaOper.chooseBounded || op == TlaOper.chooseUnbounded
+          || op == TlaOper.chooseIdiom =>
       // We compute a unique name for the given base and store it in alreadyRenamed.
       // Recursive calls to subexpressions will take care of all the replacements,
       // where the bound variable appears
-      val newName = getNextUniqueFromBase( name )
-      val newRenamed = alreadyRenamed + ( name -> newName )
-      val newArgs = otherArgs.map( rename( newRenamed ) )
+      val newName = getNextUniqueFromBase(name)
+      val newRenamed = alreadyRenamed + (name -> newName)
+      val newArgs = otherArgs.map(rename(newRenamed))
       val trackedName = tracker.hold(nex, NameEx(newName))
-      OperEx( op, trackedName +: newArgs : _* )
+      OperEx(op, trackedName +: newArgs: _*)
 
     // Certain operators introduce several bound variables at once
-    case OperEx( op, result, varsAndSets@_* )
-      if op == TlaSetOper.map || op == TlaFunOper.funDef || op == TlaFunOper.recFunDef =>
-
+    case OperEx(op, result, varsAndSets @ _*)
+        if op == TlaSetOper.map || op == TlaFunOper.funDef || op == TlaFunOper.recFunDef =>
       // From the syntax we know that evey even-indexed subexpression is a variable name
-      val names = varsAndSets.zipWithIndex.collect { case (e : NameEx, i) if i % 2 == 0 => e }
+      val names = varsAndSets.zipWithIndex.collect { case (e: NameEx, i) if i % 2 == 0 => e }
 
       // Sanity check
-      assert( 2 * names.length == varsAndSets.length )
+      assert(2 * names.length == varsAndSets.length)
 
       // Just as in the single-variable case, we assign a new name for each bound variable
-      val newRenamed = names.map( _.name ).foldLeft( alreadyRenamed ) { case (m, n) =>
-        m + ( n -> getNextUniqueFromBase( n ) )
+      val newRenamed = names.map(_.name).foldLeft(alreadyRenamed) { case (m, n) =>
+        m + (n -> getNextUniqueFromBase(n))
       }
 
       // And recurse
-      val newArgs = ( result +: varsAndSets ).map {
-        rename( newRenamed )
+      val newArgs = (result +: varsAndSets).map {
+        rename(newRenamed)
       }
 
       OperEx(op, newArgs: _*)
 
     // All other operators don't introduce any variables, so we just recurse
-    case ex@OperEx(op, args@_*) =>
-      val newArgs = args.map( rename( alreadyRenamed ) )
-      if ( args == newArgs ) ex
-      else OperEx( op, newArgs : _* )
+    case ex @ OperEx(op, args @ _*) =>
+      val newArgs = args.map(rename(alreadyRenamed))
+      if (args == newArgs) ex
+      else OperEx(op, newArgs: _*)
 
     // LET-IN operators introduce operator names (and potentially parameter names), which
     // we rename the same way as bound variables
-    case LetInEx( body, defs@_* ) =>
-      val opersAndFParamsNameMap = ( defs flatMap {
+    case LetInEx(body, defs @ _*) =>
+      val opersAndFParamsNameMap = (defs flatMap {
         // For each operator the name and all parameters are assigned new names
-        case TlaOperDecl( n, params, _ ) => ( n -> getNextUniqueFromBase( n ) ) +: (
-          params map { p =>
+        case TlaOperDecl(n, params, _) =>
+          (n -> getNextUniqueFromBase(n)) +: (params map { p =>
             val pName = p.name
-            pName -> getNextUniqueFromBase( pName )
-          } )
-      } ).toMap
+            pName -> getNextUniqueFromBase(pName)
+          })
+      }).toMap
 
       val newRenamed = alreadyRenamed ++ opersAndFParamsNameMap
 
-      val newRenaming = rename( newRenamed )
+      val newRenaming = rename(newRenamed)
 
       // Having computed the new names, we have to change the declarations and use the precomputed new names
       def xform: TlaOperDecl => TlaOperDecl =
-        tracker.trackOperDecl {
-          case TlaOperDecl( n, ps, b ) =>
-            TlaOperDecl(
-              opersAndFParamsNameMap( n ),
+        tracker.trackOperDecl { case TlaOperDecl(n, ps, b) =>
+          TlaOperDecl(
+              opersAndFParamsNameMap(n),
               ps map {
-                case SimpleFormalParam( p ) => SimpleFormalParam( opersAndFParamsNameMap( p ) )
-                case OperFormalParam( p, a ) => OperFormalParam( opersAndFParamsNameMap( p ), a )
+                case SimpleFormalParam(p)  => SimpleFormalParam(opersAndFParamsNameMap(p))
+                case OperFormalParam(p, a) => OperFormalParam(opersAndFParamsNameMap(p), a)
               },
               // We recurse over operator bodies, because newRenamed contains parameter
               // and operator renamings
-              newRenaming( b )
-            )
+              newRenaming(b)
+          )
         }
 
       val newDefs = defs map xform
 
       // Finally, we recurse on the body
-      val newBody = newRenaming( body )
-      LetInEx( newBody, newDefs : _* )
+      val newBody = newRenaming(body)
+      LetInEx(newBody, newDefs: _*)
 
     // If it's not an operator, a let-in or a name we do nothing
     case ex => ex
   }
 
   /**
-    * Calls rename, with the initial renaming map (= empty)
-    */
-  override def apply( ex : TlaEx ) : TlaEx = rename( alreadyRenamed = Map.empty )( ex )
+   * Calls rename, with the initial renaming map (= empty)
+   */
+  override def apply(ex: TlaEx): TlaEx = rename(alreadyRenamed = Map.empty)(ex)
 
   /**
-    * Reduces all variable counters by the amount specified in offsets.
-    */
-  private[lir] def shiftCounters( offsets: counterMapType ): TlaExTransformation = tracker.trackEx {
+   * Reduces all variable counters by the amount specified in offsets.
+   */
+  private[lir] def shiftCounters(offsets: counterMapType): TlaExTransformation = tracker.trackEx {
     case ex @ NameEx(name) =>
-      val newName = offsetName( offsets )( name )
-      if ( newName == name ) ex
-      else NameEx( newName )
+      val newName = offsetName(offsets)(name)
+      if (newName == name) ex
+      else NameEx(newName)
 
-    case ex@OperEx(op, args@_*) =>
-      val newArgs = args.map( shiftCounters( offsets ) )
-      if ( args == newArgs ) ex
-      else OperEx( op, newArgs : _* )
+    case ex @ OperEx(op, args @ _*) =>
+      val newArgs = args.map(shiftCounters(offsets))
+      if (args == newArgs) ex
+      else OperEx(op, newArgs: _*)
 
-    case ex@LetInEx( body, defs@_* ) =>
-      val offsetFn : String => String = offsetName( offsets )
-      val self = shiftCounters( offsets )
+    case ex @ LetInEx(body, defs @ _*) =>
+      val offsetFn: String => String = offsetName(offsets)
+      val self = shiftCounters(offsets)
 
       def xform: TlaOperDecl => TlaOperDecl =
-        tracker.trackOperDecl {
-          case TlaOperDecl( n, params, b ) =>
-            TlaOperDecl(
-              offsetFn( n ),
+        tracker.trackOperDecl { case TlaOperDecl(n, params, b) =>
+          TlaOperDecl(
+              offsetFn(n),
               params map {
-                case SimpleFormalParam( p ) => SimpleFormalParam( offsetFn( p ) )
-                case OperFormalParam( p, a ) => OperFormalParam( offsetFn( p ), a )
+                case SimpleFormalParam(p)  => SimpleFormalParam(offsetFn(p))
+                case OperFormalParam(p, a) => OperFormalParam(offsetFn(p), a)
               },
-              self( b )
-            )
+              self(b)
+          )
         }
 
       val newDefs = defs map xform
-      val newBody = self( body )
-      if ( newBody == body && newDefs == defs ) ex
-      else LetInEx( newBody, newDefs : _* )
+      val newBody = self(body)
+      if (newBody == body && newDefs == defs) ex
+      else LetInEx(newBody, newDefs: _*)
 
     case ex => ex
   }
 
   // Lifted to decl
-  private def shiftCountersD( offsets : counterMapType ) : TlaDeclTransformation = {
+  private def shiftCountersD(offsets: counterMapType): TlaDeclTransformation = {
     tracker.fromExToDeclTransformation(shiftCounters(offsets))
   }
 
   // lifted to decls
-  private def shiftCountersDs( offsets : counterMapType ) : Traversable[TlaDecl] => Traversable[TlaDecl] = {
+  private def shiftCountersDs(offsets: counterMapType): Traversable[TlaDecl] => Traversable[TlaDecl] = {
     _.map(shiftCountersD(offsets))
   }
 
   /**
-    * This method "normalizes" a previously renamed expression, so that the variable counter for each variable
-    * starts at 1, if only variables appearing in `ex` are considered
-    * E.g. x5 + y3 > z4 becomes x1 + y1 > z1
-    * Importatntly, it is assumed that `ex` has been renamed at least once.
-    */
-  def normalize( ex: TlaEx ) : TlaEx = {
-    val offsetMap = nameCounterMapFromEx( takeMax = false )( ex ) withFilter { _._2 > 1 } map {
-      case (k,v) => (k, v - 1 )
+   * This method "normalizes" a previously renamed expression, so that the variable counter for each variable
+   * starts at 1, if only variables appearing in `ex` are considered
+   * E.g. x5 + y3 > z4 becomes x1 + y1 > z1
+   * Importatntly, it is assumed that `ex` has been renamed at least once.
+   */
+  def normalize(ex: TlaEx): TlaEx = {
+    val offsetMap = nameCounterMapFromEx(takeMax = false)(ex) withFilter {
+      _._2 > 1
+    } map { case (k, v) =>
+      (k, v - 1)
     }
-    shiftCounters( offsetMap )( ex )
+    shiftCounters(offsetMap)(ex)
   }
 
-  def normalizeExs( exs: Traversable[TlaEx] ) : Traversable[TlaEx] = {
-    val offsetMap = exs.map(
-      nameCounterMapFromEx( takeMax = false )
-    ).foldLeft(Map.empty[String, Int]) {
-      mergeNameCounters( takeMax = false )
-    } withFilter { _._2 > 1 } map {
-      case (k,v) => (k, v - 1 )
+  def normalizeExs(exs: Traversable[TlaEx]): Traversable[TlaEx] = {
+    val offsetMap = exs
+      .map(
+          nameCounterMapFromEx(takeMax = false)
+      )
+      .foldLeft(Map.empty[String, Int]) {
+        mergeNameCounters(takeMax = false)
+      } withFilter {
+      _._2 > 1
+    } map { case (k, v) =>
+      (k, v - 1)
     }
 
-    exs map { shiftCounters(offsetMap) }
+    exs map {
+      shiftCounters(offsetMap)
+    }
   }
 
   // Lifted to decl
-  def normalizeD : TlaDeclTransformation = {
+  def normalizeD: TlaDeclTransformation = {
     tracker.fromExToDeclTransformation(normalize)
   }
 
   // lifted to decls
-  def normalizeDs( decls : Traversable[TlaDecl] ) : Traversable[TlaDecl] = {
-    val offsetMap = nameCounterMapFromDecls( takeMax = false )( decls ) withFilter { _._2 > 1 } map {
-      case (k,v) => (k, v - 1 )
+  def normalizeDs(decls: Traversable[TlaDecl]): Traversable[TlaDecl] = {
+    val offsetMap = nameCounterMapFromDecls(takeMax = false)(decls) withFilter {
+      _._2 > 1
+    } map { case (k, v) =>
+      (k, v - 1)
     }
-    shiftCountersDs( offsetMap )( decls )
+    shiftCountersDs(offsetMap)(decls)
   }
 
   /**
-    * Updates `nameCounters`, so that every for every entry a -> b, if makeName(a, c) appears in
-    * `ex`, it holds that c <= b
-    */
-  def syncFrom( ex: TlaEx ): Unit = {
-    val maxMap = nameCounterMapFromEx( takeMax = true )( ex )
-    nameCounters = mergeNameCounters( takeMax = true )( nameCounters, maxMap )
+   * Updates `nameCounters`, so that every for every entry a -> b, if makeName(a, c) appears in
+   * `ex`, it holds that c <= b
+   */
+  def syncFrom(ex: TlaEx): Unit = {
+    val maxMap = nameCounterMapFromEx(takeMax = true)(ex)
+    nameCounters = mergeNameCounters(takeMax = true)(nameCounters, maxMap)
   }
 
   // Lifted to decl
-  private def syncFromD : TlaDecl => Unit = {
-    case TlaOperDecl( _, _, b ) => syncFrom( b )
-    case _ => ()
+  private def syncFromD: TlaDecl => Unit = {
+    case TlaOperDecl(_, _, b) => syncFrom(b)
+    case _                    => ()
   }
 
   // Lifted to decls
-  private def syncFromDs : Traversable[TlaDecl] => Unit = _ foreach syncFromD
+  private def syncFromDs: Traversable[TlaDecl] => Unit = _ foreach syncFromD
 
   /**
-    * Performs the following steps, in order:
-    *   - Syncs from ex
-    *   - Renames ex to ex'
-    *   - Normalizes ex'
-    */
-  def syncAndNormalize( ex: TlaEx ) : TlaEx = {
-    syncFrom( ex )
-    normalize( apply( ex ) )
+   * Performs the following steps, in order:
+   *   - Syncs from ex
+   *   - Renames ex to ex'
+   *   - Normalizes ex'
+   */
+  def syncAndNormalize(ex: TlaEx): TlaEx = {
+    syncFrom(ex)
+    normalize(apply(ex))
   }
 
-  def syncAndNormalizeExs( exs: Traversable[TlaEx] ) : Traversable[TlaEx] = {
+  def syncAndNormalizeExs(exs: Traversable[TlaEx]): Traversable[TlaEx] = {
     exs foreach syncFrom
-    normalizeExs( exs map { apply } )
+    normalizeExs(exs map {
+      apply
+    })
   }
 
   // Lifted to decl
-  def syncAndNormalizeD( d: TlaDecl) : TlaDecl = {
-    syncFromD( d )
-    normalizeD( tracker.fromExToDeclTransformation(this)(d) )
+  def syncAndNormalizeD(d: TlaDecl): TlaDecl = {
+    syncFromD(d)
+    normalizeD(tracker.fromExToDeclTransformation(this)(d))
   }
 
   // Lifted to decls
-  def syncAndNormalizeDs( ds: Traversable[TlaDecl]) : Traversable[TlaDecl] = {
-    syncFromDs( ds )
-    normalizeDs( ds.map(d => tracker.fromExToDeclTransformation(this)(d)) )
+  def syncAndNormalizeDs(ds: Traversable[TlaDecl]): Traversable[TlaDecl] = {
+    syncFromDs(ds)
+    normalizeDs(ds.map(d => tracker.fromExToDeclTransformation(this)(d)))
   }
 
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
@@ -75,7 +75,7 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)(imp
     val bodyCopy = postTr(DeepCopy(tracker).deepCopyEx(decl.body))
 
     val newBody = decl.formalParams.zip(args).foldLeft(bodyCopy) { case (b, (fParam, arg)) =>
-      ReplaceFixed(NameEx(fParam.name), arg, tracker)(typeTag)(b)
+      ReplaceFixed(NameEx(fParam.name), arg, tracker)(implicitly)(b)
     }
 
     // the step limit, if it was defined, decreases by 1

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
@@ -6,29 +6,28 @@ import at.forsyte.apalache.tla.lir.storage.BodyMap
 import at.forsyte.apalache.tla.lir.transformations.standard.InlinerOfUserOper.kStepParameters
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
-
 /**
-  * <p>Attempts to instantiate the body of the operator named `name` with the provided arguments.
-  * Returns None if the operator name is not a key in `bodyMap`, otherwise returns Some(b), where
-  * b is the body of the operator with each formal parameter replaced by the corresponding value from `args`.</p>
-  *
-  * <p>Throws IllegalArgumentException if the size of `args` does not match the operator arity.</p>
-  *
-  * @author Jure Kukovec
-  */
-class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)
+ * <p>Attempts to instantiate the body of the operator named `name` with the provided arguments.
+ * Returns None if the operator name is not a key in `bodyMap`, otherwise returns Some(b), where
+ * b is the body of the operator with each formal parameter replaced by the corresponding value from `args`.</p>
+ *
+ * <p>Throws IllegalArgumentException if the size of `args` does not match the operator arity.</p>
+ *
+ * @author Jure Kukovec
+ */
+class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)(implicit typeTag: TypeTag)
     extends TlaExTransformation {
 
   override def apply(expr: TlaEx): TlaEx = {
-    transform( stepLimitOpt = None )(expr)
+    transform(stepLimitOpt = None)(expr)
   }
 
-  def kStepInline( k : BigInt, post: TlaExTransformation = Predef.identity ) : TlaExTransformation =
-    if (k < 0) throw new IllegalArgumentException( "The number of unrolling steps must be a non-negative integer." )
+  def kStepInline(k: BigInt, post: TlaExTransformation = Predef.identity): TlaExTransformation =
+    if (k < 0) throw new IllegalArgumentException("The number of unrolling steps must be a non-negative integer.")
     // 0-step is always just the identity transform, even if post is non-trivial, because, conceptually,
     // 0-step inlining is a no-op
     else if (k == 0) Predef.identity
-    else transform( stepLimitOpt = Some( kStepParameters( k, post ) ) )
+    else transform(stepLimitOpt = Some(kStepParameters(k, post)))
 
   def transform(stepLimitOpt: Option[kStepParameters]): TlaExTransformation = tracker.trackEx {
     // interesting case: applying a user-defined operator
@@ -36,8 +35,8 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)
       // Jure, 5.7.19: Can 0-arity operators ever appear as standalone NameEx, without
       // a OperEx( TlaOper.apply, NameEx( name ), args@_* ) wrapper? Currently, we consider that invalid
       defBodyMap.get(name) match {
-        case Some( decl ) if decl.formalParams.size == args.size =>
-          instantiateWithArgs(stepLimitOpt)( decl, args )
+        case Some(decl) if decl.formalParams.size == args.size =>
+          instantiateWithArgs(stepLimitOpt)(decl, args)
 
         case Some(decl) if decl.formalParams.size != args.size =>
           val msg = s"Operator $name with arity ${decl.formalParams.size} called with ${args.size} argument(s)."
@@ -47,7 +46,7 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)
       }
 
     // recursive processing of composite operators and let-in definitions
-    case ex @ LetInEx(body, defs@_*) =>
+    case ex @ LetInEx(body, defs @ _*) =>
       // transform bodies of all op.defs
       val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = transform(stepLimitOpt)(d.body)) }
       val newBody = transform(stepLimitOpt)(body)
@@ -57,46 +56,54 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)
         LetInEx(newBody, newDefs: _*)
       }
 
-    case ex@OperEx(op, args@_*) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map transform(stepLimitOpt)
       if (args == newArgs) ex else OperEx(op, newArgs: _*)
 
     case ex => ex
   }
 
-  private def instantiateWithArgs(stepLimitOpt: Option[kStepParameters])( decl: TlaOperDecl, args: Seq[TlaEx] ) : TlaEx = {
+  private def instantiateWithArgs(stepLimitOpt: Option[kStepParameters])(decl: TlaOperDecl, args: Seq[TlaEx]): TlaEx = {
     // Assumption: |decl.formalParams| = |args|
 
-    val postTr = stepLimitOpt map { _.postTransform } getOrElse { Predef.identity[TlaEx] _ }
+    val postTr = stepLimitOpt map {
+      _.postTransform
+    } getOrElse {
+      Predef.identity[TlaEx] _
+    }
     // deep copy the body, to ensure uniqueness of the UIDs
-    val bodyCopy = postTr( DeepCopy( tracker ).deepCopyEx( decl.body ) )
+    val bodyCopy = postTr(DeepCopy(tracker).deepCopyEx(decl.body))
 
-    val newBody = decl.formalParams.zip( args ).foldLeft( bodyCopy ) {
-      case (b, (fParam, arg)) =>
-        ReplaceFixed( NameEx( fParam.name ), arg, tracker )( b )
+    val newBody = decl.formalParams.zip(args).foldLeft(bodyCopy) { case (b, (fParam, arg)) =>
+      ReplaceFixed(NameEx(fParam.name), arg, tracker)(typeTag)(b)
     }
 
     // the step limit, if it was defined, decreases by 1
-    val newStepLimit = stepLimitOpt map { _ - 1 }
+    val newStepLimit = stepLimitOpt map {
+      _ - 1
+    }
 
     // if further steps are allowed then recurse otherwise terminate with current result
-    if ( newStepLimit forall { _ > 0 } ) {
-      transform( newStepLimit )( newBody )
-    }
-    else
+    if (
+        newStepLimit forall {
+          _ > 0
+        }
+    ) {
+      transform(newStepLimit)(newBody)
+    } else
       newBody
   }
 }
 
 object InlinerOfUserOper {
 
-  sealed case class kStepParameters( k : BigInt, postTransform : TlaExTransformation ) {
-    def -( x : BigInt ) : kStepParameters = kStepParameters( k - x, postTransform )
-    def >( x : BigInt ) : Boolean = k > x
+  sealed case class kStepParameters(k: BigInt, postTransform: TlaExTransformation) {
+    def -(x: BigInt): kStepParameters = kStepParameters(k - x, postTransform)
+
+    def >(x: BigInt): Boolean = k > x
   }
 
-
-  def apply(defBodyMap: BodyMap, tracker: TransformationTracker): InlinerOfUserOper = {
+  def apply(defBodyMap: BodyMap, tracker: TransformationTracker)(implicit typeTag: TypeTag): InlinerOfUserOper = {
     new InlinerOfUserOper(defBodyMap, tracker)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
@@ -6,15 +6,16 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
 
 /**
-  * <p>A transformation which replaces all occurrences of LET-IN expressions with
-  * copies of their bodies, in which LET-IN defined operators have been expanded.
-  * If the `keepNullary` flag is set to true, only operators with strictly positive arity get expanded.</p>
-  *
-  * <p>Example: `LET X(a) == a + b IN X(0) > 1` becomes `1 + b > 1`. </p>
-  *
-  * @author Jure Kukovec
-  */
-class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extends TlaExTransformation {
+ * <p>A transformation which replaces all occurrences of LET-IN expressions with
+ * copies of their bodies, in which LET-IN defined operators have been expanded.
+ * If the `keepNullary` flag is set to true, only operators with strictly positive arity get expanded.</p>
+ *
+ * <p>Example: `LET X(a) == a + b IN X(0) > 1` becomes `1 + b > 1`. </p>
+ *
+ * @author Jure Kukovec
+ */
+class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
   override def apply(ex: TlaEx): TlaEx = transform(ex)
 
   def transform: TlaExTransformation = tracker.trackEx {
@@ -43,27 +44,25 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extend
         if (defsToKeep.nonEmpty) {
           LetInEx(expandedBody, defsToKeep: _*) // nullary definitions are still there
         } else {
-          expandedBody                          // all definitions were expanded
+          expandedBody // all definitions were expanded
         }
 
       // Inline the operators using the map of definitions
-      InlinerOfUserOper(bodyMap, tracker)(expandedLetIn)
+      InlinerOfUserOper(bodyMap, tracker)(typeTag)(expandedLetIn)
 
-      // this is the special form for LAMBDAs
-    case OperEx(TlaOper.apply,
-                LetInEx(NameEx("LAMBDA"), TlaOperDecl("LAMBDA", params, lambdaBody)),
-                args @ _*) =>
+    // this is the special form for LAMBDAs
+    case OperEx(TlaOper.apply, LetInEx(NameEx("LAMBDA"), TlaOperDecl("LAMBDA", params, lambdaBody)), args @ _*) =>
       // Substitute params with args in the body of the lambda expression.
       // I don't think we need to deep copy lambdaBody, as it should appear only once.
       assert(params.length == args.length)
       params.zip(args).foldLeft(lambdaBody) {
         // replace every parameter with the respective argument
         case (expr, (param, arg)) =>
-          ReplaceFixed(NameEx(param.name), arg, tracker)(expr)
+          ReplaceFixed(NameEx(param.name), arg, tracker)(typeTag)(expr)
       }
 
     // recursive processing of composite operators
-    case ex@OperEx(op, args@_*) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map transform
       if (args == newArgs) ex else OperEx(op, newArgs: _*)
 
@@ -72,7 +71,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extend
 }
 
 object LetInExpander {
-  def apply(tracker: TransformationTracker, keepNullary: Boolean): LetInExpander = {
+  def apply(tracker: TransformationTracker, keepNullary: Boolean)(implicit typeTag: TypeTag): LetInExpander = {
     new LetInExpander(tracker, keepNullary)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
@@ -48,7 +48,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean)(implic
         }
 
       // Inline the operators using the map of definitions
-      InlinerOfUserOper(bodyMap, tracker)(typeTag)(expandedLetIn)
+      InlinerOfUserOper(bodyMap, tracker)(implicitly)(expandedLetIn)
 
     // this is the special form for LAMBDAs
     case OperEx(TlaOper.apply, LetInEx(NameEx("LAMBDA"), TlaOperDecl("LAMBDA", params, lambdaBody)), args @ _*) =>
@@ -58,7 +58,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean)(implic
       params.zip(args).foldLeft(lambdaBody) {
         // replace every parameter with the respective argument
         case (expr, (param, arg)) =>
-          ReplaceFixed(NameEx(param.name), arg, tracker)(typeTag)(expr)
+          ReplaceFixed(NameEx(param.name), arg, tracker)(implicitly)(expr)
       }
 
     // recursive processing of composite operators

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
@@ -3,44 +3,45 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaOperDecl, TypeTag}
 
 object Prime {
-  private def primeLeaf( vars : Set[String], tracker : TransformationTracker ) : TlaExTransformation =
+  private def primeLeaf(vars: Set[String], tracker: TransformationTracker): TlaExTransformation =
     tracker.trackEx {
-      case ex@NameEx( name ) if vars.contains( name ) =>
-        tla.prime( ex )
+      case ex @ NameEx(name) if vars.contains(name) =>
+        tla.prime(ex)
 
       case ex => ex
     }
 
   /**
-    * Returns a transformation which primes all unprimed variables from `vars` appearing in a given expression
-    *
-    * Example:
-    *
-    * a' + b > 0 --> a' + b' > 0
-    */
-  def apply( vars : Set[String], tracker : TransformationTracker ) : TlaExTransformation = tracker.trackEx { ex =>
-    val tr = primeLeaf( vars, tracker )
-    lazy val self = apply(vars, tracker)
-    ex match {
-      case LetInEx( body, defs@_* ) =>
-        // Transform bodies of all op.defs
-        val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
-        val newBody = self( body )
-        val retEx = if ( defs == newDefs && body == newBody ) ex else LetInEx( newBody, newDefs : _* )
-        tr( retEx )
+   * Returns a transformation which primes all unprimed variables from `vars` appearing in a given expression
+   *
+   * Example:
+   *
+   * a' + b > 0 --> a' + b' > 0
+   */
+  def apply(vars: Set[String], tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation =
+    tracker.trackEx { ex =>
+      val tr = primeLeaf(vars, tracker)
+      lazy val self = apply(vars, tracker)
+      ex match {
+        case LetInEx(body, defs @ _*) =>
+          // Transform bodies of all op.defs
+          val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
+          val newBody = self(body)
+          val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
+          tr(retEx)
 
-      case ex@OperEx( TlaActionOper.prime, NameEx( _ ) ) =>
-        // Do not prime expressions which are already primed. This may happen when Init = Inv.
-        tr(ex)
-      case ex@OperEx( op, args@_* ) =>
-        val newArgs = args map self
-        val retEx = if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
-        tr( retEx )
+        case ex @ OperEx(TlaActionOper.prime, NameEx(_)) =>
+          // Do not prime expressions which are already primed. This may happen when Init = Inv.
+          tr(ex)
+        case ex @ OperEx(op, args @ _*) =>
+          val newArgs = args map self
+          val retEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
+          tr(retEx)
 
-      case _ => tr( ex )
+        case _ => tr(ex)
+      }
     }
-  }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimePropagation.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimePropagation.scala
@@ -1,29 +1,26 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
-import at.forsyte.apalache.tla.lir.transformations.{
-  TlaExTransformation,
-  TransformationTracker
-}
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx, TypeTag}
 
 /**
-  * A reference implementation of an expression transformer. It expands the prime operator,
-  * that is, when it meets an expression e', it propagates primes inside e.
-  *
-  * @param stateVars state variables
-  * @param tracker a transformation tracker
-  */
-class PrimePropagation(tracker: TransformationTracker, stateVars: Set[String])
+ * A reference implementation of an expression transformer. It expands the prime operator,
+ * that is, when it meets an expression e', it propagates primes inside e.
+ *
+ * @param stateVars state variables
+ * @param tracker   a transformation tracker
+ */
+class PrimePropagation(tracker: TransformationTracker, stateVars: Set[String])(implicit typeTag: TypeTag)
     extends TlaExTransformation {
 
   /**
-    * Propagate primes in the expression to the state variables.
-    * All names that are different from state variables should subsume prime.
-    *
-    * @param expr an expression to propagate primes
-    * @return the expression where primes are propagated to the level of state variables
-    */
+   * Propagate primes in the expression to the state variables.
+   * All names that are different from state variables should subsume prime.
+   *
+   * @param expr an expression to propagate primes
+   * @return the expression where primes are propagated to the level of state variables
+   */
   override def apply(expr: TlaEx): TlaEx = {
     def transform(primeToAdd: Boolean): TlaEx => TlaEx =
       tracker.trackEx {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimedEqualityToMembership.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimedEqualityToMembership.scala
@@ -1,33 +1,34 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.transformations._
+import at.forsyte.apalache.tla.lir._
 
 /**
-  * Replace every equality x' = e with x' \in {e}. This transformation is needed by the assignment solver,
-  * so we extracted it into an optional transformation.
-  *
-  * @author Jure Kukovec
-  */
-class PrimedEqualityToMembership(tracker: TransformationTracker) extends TlaExTransformation {
+ * Replace every equality x' = e with x' \in {e}. This transformation is needed by the assignment solver,
+ * so we extracted it into an optional transformation.
+ *
+ * @author Jure Kukovec
+ */
+class PrimedEqualityToMembership(tracker: TransformationTracker)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
   override def apply(ex: TlaEx): TlaEx = {
     transform(ex)
   }
 
   def transform: TlaExTransformation = tracker.trackEx {
     // interesting case
-    case OperEx(TlaOper.eq, lhs@OperEx(TlaActionOper.prime, NameEx(name)), rhs) =>
+    case OperEx(TlaOper.eq, lhs @ OperEx(TlaActionOper.prime, NameEx(name)), rhs) =>
       OperEx(TlaSetOper.in, lhs, OperEx(TlaSetOper.enumSet, rhs))
 
     // standard recursive processing of composite operators and let-in definitions
-    case ex@LetInEx(body, defs@_*) =>
+    case ex @ LetInEx(body, defs @ _*) =>
       // Transform bodies of all op.defs
       val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = transform(d.body)) }
       val newBody = transform(body)
       if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
 
-    case ex@OperEx(op, args@_*) =>
+    case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map transform
       if (args == newArgs) ex else OperEx(op, newArgs: _*)
 
@@ -36,7 +37,7 @@ class PrimedEqualityToMembership(tracker: TransformationTracker) extends TlaExTr
 }
 
 object PrimedEqualityToMembership {
-  def apply(tracker: TransformationTracker): PrimedEqualityToMembership = {
+  def apply(tracker: TransformationTracker)(implicit typeTag: TypeTag): PrimedEqualityToMembership = {
     new PrimedEqualityToMembership(tracker)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PruneApalacheAnnotations.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PruneApalacheAnnotations.scala
@@ -1,39 +1,39 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations._
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TypeTag}
 
 object PruneApalacheAnnotations {
-  private def pruneOne( tracker : TransformationTracker ) : TlaExTransformation =
+  private def pruneOne(tracker: TransformationTracker): TlaExTransformation =
     tracker.trackEx {
-      case OperEx( BmcOper.withType, arg, typeAnnotation ) => arg
-      case e => e
+      case OperEx(BmcOper.withType, arg, typeAnnotation) => arg
+      case e                                             => e
     }
 
   /**
-    * Returns a transformation that removes all Apalache operators (e.g. BMC!<:).
-    *
-    * Example:
-    * S <: {Int} -> S
-    */
-  def apply( tracker : TransformationTracker ) : TlaExTransformation = tracker.trackEx { ex =>
-    val tr = pruneOne( tracker )
-    lazy val self = apply( tracker )
+   * Returns a transformation that removes all Apalache operators (e.g. BMC!<:).
+   *
+   * Example:
+   * S <: {Int} -> S
+   */
+  def apply(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation = tracker.trackEx { ex =>
+    val tr = pruneOne(tracker)
+    lazy val self = apply(tracker)
     ex match {
-      case LetInEx( body, defs@_* ) =>
+      case LetInEx(body, defs @ _*) =>
         // Transform bodies of all op.defs
         val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
-        val newBody = self( body )
-        val retEx = if ( defs == newDefs && body == newBody ) ex else LetInEx( newBody, newDefs : _* )
-        tr( retEx )
+        val newBody = self(body)
+        val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
+        tr(retEx)
 
-      case OperEx( op, args@_* ) =>
+      case OperEx(op, args @ _*) =>
         val newArgs = args map self
-        val newEx = if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
-        tr( newEx )
+        val newEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
+        tr(newEx)
 
-      case _ => tr( ex )
+      case _ => tr(ex)
     }
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Renaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Renaming.scala
@@ -7,34 +7,35 @@ import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, Transfo
 import scala.collection.immutable.HashMap
 
 /**
-  * This class contains methods that are related to renaming.
-  *
-  * @author Igor Konnov
-  */
-class Renaming (tracker: TransformationTracker) extends TlaExTransformation {
+ * This class contains methods that are related to renaming.
+ *
+ * @author Igor Konnov
+ */
+class Renaming(tracker: TransformationTracker)(implicit typeTag: TypeTag) extends TlaExTransformation {
+
   /**
-    * The names of bindings that have been seen already.
-    */
+   * The names of bindings that have been seen already.
+   */
   private var seenNames: Map[String, Int] = HashMap[String, Int]()
 
   override def apply(e: TlaEx): TlaEx = {
     renameBindingsUnique(e)
   }
 
-  def apply( decl : TlaDecl ) : TlaDecl = decl match {
-    case TlaOperDecl( name, params, body ) =>
+  def apply(decl: TlaDecl): TlaDecl = decl match {
+    case TlaOperDecl(name, params, body) =>
       val paramMap = (params map { p =>
         val pName = p.name
-        pName -> assignUniqueName( pName )
+        pName -> assignUniqueName(pName)
       }).toMap
 
       val retDecl = TlaOperDecl(
-        name,
-        params map {
-          case SimpleFormalParam( p ) => SimpleFormalParam( paramMap( p ) )
-          case OperFormalParam( p, a ) => OperFormalParam( paramMap( p ), a )
-        },
-        rename( paramMap )( body )
+          name,
+          params map {
+            case SimpleFormalParam(p)  => SimpleFormalParam(paramMap(p))
+            case OperFormalParam(p, a) => OperFormalParam(paramMap(p), a)
+          },
+          rename(paramMap)(body)
       )
 
       retDecl
@@ -58,44 +59,41 @@ class Renaming (tracker: TransformationTracker) extends TlaExTransformation {
         ex // nothing changes, so no new id is assigned
       }
 
-    case LetInEx( body, defs@_* ) =>
-      val opersAndFParamsNameMap = ( defs flatMap {
-        case TlaOperDecl( n, params, _ ) => ( n -> assignUniqueName( n ) ) +: (
-          params map { p =>
-            val pName = p.name
-            pName -> assignUniqueName( pName )
-          } )
-      } ).toMap
+    case LetInEx(body, defs @ _*) =>
+      val opersAndFParamsNameMap = (defs flatMap { case TlaOperDecl(n, params, _) =>
+        (n -> assignUniqueName(n)) +: (params map { p =>
+          val pName = p.name
+          pName -> assignUniqueName(pName)
+        })
+      }).toMap
 
       val newMap = map ++ opersAndFParamsNameMap
 
-      val newDefs = defs map {
-        case TlaOperDecl( n, ps, b ) =>
-          TlaOperDecl(
-            opersAndFParamsNameMap( n ),
+      val newDefs = defs map { case TlaOperDecl(n, ps, b) =>
+        TlaOperDecl(
+            opersAndFParamsNameMap(n),
             ps map {
-              case SimpleFormalParam( p ) => SimpleFormalParam( opersAndFParamsNameMap( p ) )
-              case OperFormalParam( p, a ) => OperFormalParam( opersAndFParamsNameMap( p ), a )
+              case SimpleFormalParam(p)  => SimpleFormalParam(opersAndFParamsNameMap(p))
+              case OperFormalParam(p, a) => OperFormalParam(opersAndFParamsNameMap(p), a)
             },
-            rename( newMap )( b )
-          )
+            rename(newMap)(b)
+        )
       }
-      val newBody = rename( newMap )( body )
-      LetInEx( newBody, newDefs : _* )
+      val newBody = rename(newMap)(body)
+      LetInEx(newBody, newDefs: _*)
 
-    case OperEx(op, NameEx(name), otherArgs@_*)
-      if op == TlaSetOper.filter
-        || op == TlaBoolOper.exists || op == TlaBoolOper.forall
-        || op == TlaOper.chooseBounded || op == TlaOper.chooseUnbounded
-        || op == TlaOper.chooseIdiom =>
-
+    case OperEx(op, NameEx(name), otherArgs @ _*)
+        if op == TlaSetOper.filter
+          || op == TlaBoolOper.exists || op == TlaBoolOper.forall
+          || op == TlaOper.chooseBounded || op == TlaOper.chooseUnbounded
+          || op == TlaOper.chooseIdiom =>
       val newName = assignUniqueName(name)
       val newMap = map + (name -> newName)
       val newArgs = otherArgs.map(e => rename(newMap)(e))
       OperEx(op, NameEx(newName) +: newArgs: _*)
 
-    case OperEx(op, result, varsAndSets@_*)
-      if op == TlaSetOper.map || op == TlaFunOper.funDef || op == TlaFunOper.recFunDef =>
+    case OperEx(op, result, varsAndSets @ _*)
+        if op == TlaSetOper.map || op == TlaFunOper.funDef || op == TlaFunOper.recFunDef =>
       val names = varsAndSets.zipWithIndex.collect { case (e @ NameEx(_), i) if i % 2 == 0 => e }
       val sets = varsAndSets.zipWithIndex.collect { case (e, i) if i % 2 == 1 => e }
 
@@ -123,7 +121,7 @@ class Renaming (tracker: TransformationTracker) extends TlaExTransformation {
       val newEx = OperEx(op, newResult +: newArgs: _*)
       newEx
 
-    case OperEx(op, args@_*) =>
+    case OperEx(op, args @ _*) =>
       val newEx = OperEx(op, args.map(e => rename(map)(e)): _*)
       newEx
 
@@ -131,17 +129,17 @@ class Renaming (tracker: TransformationTracker) extends TlaExTransformation {
   }
 
   /**
-    * <p>Rename all bindings so that the bound variable names become unique
-    * across all the code. For instance, \E x \in S: x > 1 /\ \E x \in T: x < 2
-    * becomes \E x1 \in S: x1 > 1 /\ \E x2 \in T: x2 < 2. This method
-    * does not expand operator definitions.</p>
-    *
-    * <p>WARNING: this method saves the unique names. That is, multiple calls to this method
-    * will produce expressions with unique bound variables.</p>
-    *
-    * @param expr an expression to modify
-    * @return an equivalent expression whose bound variables are uniquely renamed
-    */
+   * <p>Rename all bindings so that the bound variable names become unique
+   * across all the code. For instance, \E x \in S: x > 1 /\ \E x \in T: x < 2
+   * becomes \E x1 \in S: x1 > 1 /\ \E x2 \in T: x2 < 2. This method
+   * does not expand operator definitions.</p>
+   *
+   * <p>WARNING: this method saves the unique names. That is, multiple calls to this method
+   * will produce expressions with unique bound variables.</p>
+   *
+   * @param expr an expression to modify
+   * @return an equivalent expression whose bound variables are uniquely renamed
+   */
   def renameBindingsUnique(expr: TlaEx): TlaEx = {
     // rename the bound variables
     rename(HashMap())(expr)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ReplaceFixed.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ReplaceFixed.scala
@@ -1,42 +1,42 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TypeTag}
 
 object ReplaceFixed {
   def replaceOne(
-                  replacedEx : TlaEx,
-                  newEx : => TlaEx, // takes a [=> TlaEx] to allow for the creation of new instances (with distinct UIDs)
-                  tracker : TransformationTracker
-                ) : TlaExTransformation = tracker.trackEx {
-    ex => if ( ex == replacedEx ) newEx else ex
+      replacedEx: TlaEx,
+      newEx: => TlaEx, // takes a [=> TlaEx] to allow for the creation of new instances (with distinct UIDs)
+      tracker: TransformationTracker
+  ): TlaExTransformation = tracker.trackEx { ex =>
+    if (ex == replacedEx) newEx else ex
   }
 
   /**
-    * Returns a transformation which replaces every instance of `replacedEx`
-    * with an instance of `newEx`
-    */
+   * Returns a transformation which replaces every instance of `replacedEx`
+   * with an instance of `newEx`
+   */
   def apply(
-             replacedEx : TlaEx,
-             newEx : => TlaEx, // takes a [=> TlaEx] to allow for the creation of new instances (with distinct UIDs)
-             tracker : TransformationTracker
-           ) : TlaExTransformation = tracker.trackEx { ex =>
-    val tr = replaceOne( replacedEx, newEx, tracker )
-    lazy val self = apply( replacedEx, newEx, tracker )
+      replacedEx: TlaEx,
+      newEx: => TlaEx, // takes a [=> TlaEx] to allow for the creation of new instances (with distinct UIDs)
+      tracker: TransformationTracker
+  )(implicit typeTag: TypeTag): TlaExTransformation = tracker.trackEx { ex =>
+    val tr = replaceOne(replacedEx, newEx, tracker)
+    lazy val self = apply(replacedEx, newEx, tracker)
     ex match {
-      case LetInEx( body, defs@_* ) =>
+      case LetInEx(body, defs @ _*) =>
         // Transform bodies of all op.defs
         val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
-        val newBody = self( body )
-        val retEx = if ( defs == newDefs && body == newBody ) ex else LetInEx( newBody, newDefs : _* )
-        tr( retEx )
+        val newBody = self(body)
+        val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
+        tr(retEx)
 
-      case OperEx( op, args@_* ) =>
+      case OperEx(op, args @ _*) =>
         val newArgs = args map self
-        val retEx = if ( args == newArgs ) ex else OperEx( op, newArgs : _* )
-        tr( retEx )
+        val retEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
+        tr(retEx)
 
-      case _ => tr( ex )
+      case _ => tr(ex)
     }
   }
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestBuilder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestBuilder.scala
@@ -5,460 +5,461 @@ import at.forsyte.apalache.tla.lir.values._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestBuilder extends FunSuite with TestingPredefs {
 
   import at.forsyte.apalache.tla.lir.{Builder => bd}
 
-  test( "Test direct methods: Names and values" ) {
-    val nameBuild = bd.name( "a" )
+  test("Test direct methods: Names and values") {
+    val nameBuild = bd.name("a")
 
-    assert( nameBuild == NameEx( "a" ) )
+    assert(nameBuild == NameEx("a"))
 
-    val vBigInt : BigInt = BigInt( "1000000015943534656464398536" )
-    val vBigDecimal : BigDecimal = 1.111132454253626474876842798573504607
-    val vBool : Boolean = false
-    val vString : String = "a string val"
+    val vBigInt: BigInt = BigInt("1000000015943534656464398536")
+    val vBigDecimal: BigDecimal = 1.111132454253626474876842798573504607
+    val vBool: Boolean = false
+    val vString: String = "a string val"
 
-    val biBuild = bd.bigInt( vBigInt )
-    val bdBuild = bd.decimal( vBigDecimal )
-    val boolBuild = bd.bool( vBool )
-    val strBuild = bd.str( vString )
+    val biBuild = bd.bigInt(vBigInt)
+    val bdBuild = bd.decimal(vBigDecimal)
+    val boolBuild = bd.bool(vBool)
+    val strBuild = bd.str(vString)
 
-    assert( biBuild == ValEx( TlaInt( vBigInt ) ) )
-    assert( bdBuild == ValEx( TlaDecimal( vBigDecimal ) ) )
-    assert( boolBuild == ValEx( TlaBool( vBool ) ) )
-    assert( strBuild == ValEx( TlaStr( vString ) ) )
+    assert(biBuild == ValEx(TlaInt(vBigInt)))
+    assert(bdBuild == ValEx(TlaDecimal(vBigDecimal)))
+    assert(boolBuild == ValEx(TlaBool(vBool)))
+    assert(strBuild == ValEx(TlaStr(vString)))
   }
 
-  test( "Test direct methods: Declarations" ) {
-    val opEx1 = bd.declOp( "A", n_c )
-    val opEx2 = bd.declOp( "A", n_x, "x" )
-    val opEx3 = bd.declOp( "A", bd.appOp( n_B ), ("B", 0) )
-    val opEx4 = bd.declOp( "A", bd.appOp( n_B, n_x ), "x", ("B", 1) )
+  test("Test direct methods: Declarations") {
+    val opEx1 = bd.declOp("A", n_c)
+    val opEx2 = bd.declOp("A", n_x, "x")
+    val opEx3 = bd.declOp("A", bd.appOp(n_B), ("B", 0))
+    val opEx4 = bd.declOp("A", bd.appOp(n_B, n_x), "x", ("B", 1))
 
-    assert( opEx1 == TlaOperDecl( "A", List(), n_c ) )
-    assert( opEx2 == TlaOperDecl( "A", List( SimpleFormalParam( "x" ) ), n_x ) )
-    assert( opEx3 ==
-      TlaOperDecl(
-        "A",
-        List( OperFormalParam( "B", 0) ),
-        OperEx( TlaOper.apply, n_B )
-      )
-    )
-    assert( opEx4 ==
-      TlaOperDecl(
-        "A",
-        List( SimpleFormalParam( "x" ), OperFormalParam( "B", 1) ),
-        OperEx( TlaOper.apply, n_B, n_x )
-      )
-    )
+    assert(opEx1 == TlaOperDecl("A", List(), n_c))
+    assert(opEx2 == TlaOperDecl("A", List(SimpleFormalParam("x")), n_x))
+    assert(
+        opEx3 ==
+          TlaOperDecl(
+              "A",
+              List(OperFormalParam("B", 0)),
+              OperEx(TlaOper.apply, n_B)
+          ))
+    assert(
+        opEx4 ==
+          TlaOperDecl(
+              "A",
+              List(SimpleFormalParam("x"), OperFormalParam("B", 1)),
+              OperEx(TlaOper.apply, n_B, n_x)
+          ))
 
-    val appEx1 = bd.appDecl( opEx1 )
-    val appEx2 = bd.appDecl( opEx2, n_a )
-    val appEx3 = bd.appDecl( opEx3, n_a )
-    val appEx4 = bd.appDecl( opEx4, n_a, n_b )
+    val appEx1 = bd.appDecl(opEx1)
+    val appEx2 = bd.appDecl(opEx2, n_a)
+    val appEx3 = bd.appDecl(opEx3, n_a)
+    val appEx4 = bd.appDecl(opEx4, n_a, n_b)
 
-    assert( appEx1 == OperEx( TlaOper.apply, name(opEx1.name) ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx1, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx2) )
-    assert( appEx2 == OperEx( TlaOper.apply, name(opEx2.name), n_a ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx2, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx3 ) )
-    assert( appEx3 == OperEx( TlaOper.apply, name(opEx3.name), n_a ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx3, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx4 ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx4, n_a ) )
-    assert( appEx4 == OperEx( TlaOper.apply, name(opEx4.name), n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.appDecl( opEx4, n_a, n_b, n_c ) )
+    assert(appEx1 == OperEx(TlaOper.apply, name(opEx1.name)))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx1, n_a))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx2))
+    assert(appEx2 == OperEx(TlaOper.apply, name(opEx2.name), n_a))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx2, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx3))
+    assert(appEx3 == OperEx(TlaOper.apply, name(opEx3.name), n_a))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx3, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx4))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx4, n_a))
+    assert(appEx4 == OperEx(TlaOper.apply, name(opEx4.name), n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.appDecl(opEx4, n_a, n_b, n_c))
   }
 
-  test( "Test byName: bad calls" ) {
-    assertThrows[NoSuchElementException]( bd.byName( "not an operator name", NullEx, n_b ) )
+  test("Test byName: bad calls") {
+    assertThrows[NoSuchElementException](bd.byName("not an operator name", NullEx, n_b))
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.plus.name, NullEx ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.plus.name, NullEx))
   }
 
-  test( "Test byNameOrNull: bad calls" ) {
-    val nullBadName = bd.byNameOrNull( "not an operator name", NullEx, n_b )
+  test("Test byNameOrNull: bad calls") {
+    val nullBadName = bd.byNameOrNull("not an operator name", NullEx, n_b)
 
-    assert( nullBadName == NullEx )
+    assert(nullBadName == NullEx)
 
-    val nullBadArity = bd.byNameOrNull( TlaArithOper.plus.name, NullEx )
+    val nullBadArity = bd.byNameOrNull(TlaArithOper.plus.name, NullEx)
 
-    assert( nullBadArity == NullEx )
+    assert(nullBadArity == NullEx)
   }
 
-  test( "Test direct methods: TlaOper" ) {
-    val eqBuild1 = bd.eql( n_a, n_b )
-    val eqBuild2 = bd.eql( n_a, 2 )
+  test("Test direct methods: TlaOper") {
+    val eqBuild1 = bd.eql(n_a, n_b)
+    val eqBuild2 = bd.eql(n_a, 2)
 
-    assert( eqBuild1 == OperEx( TlaOper.eq, n_a, n_b ) )
-    assert( eqBuild2 == OperEx( TlaOper.eq, n_a, ValEx( TlaInt( 2 ) ) ) )
+    assert(eqBuild1 == OperEx(TlaOper.eq, n_a, n_b))
+    assert(eqBuild2 == OperEx(TlaOper.eq, n_a, ValEx(TlaInt(2))))
 
-    val neBuild1 = bd.neql( n_a, n_b )
-    val neBuild2 = bd.neql( n_a, 2 )
+    val neBuild1 = bd.neql(n_a, n_b)
+    val neBuild2 = bd.neql(n_a, 2)
 
-    assert( neBuild1 == OperEx( TlaOper.ne, n_a, n_b ) )
-    assert( neBuild2 == OperEx( TlaOper.ne, n_a, ValEx( TlaInt( 2 ) ) ) )
+    assert(neBuild1 == OperEx(TlaOper.ne, n_a, n_b))
+    assert(neBuild2 == OperEx(TlaOper.ne, n_a, ValEx(TlaInt(2))))
 
-    val applyBuild1 = bd.appOp( n_a )
-    val applyBuild2 = bd.appOp( n_a, n_b )
-    val applyBuild3 = bd.appOp( n_a, n_b, n_c )
-    val applyBuild4 = bd.appOp( n_a, n_b, n_c, n_d )
+    val applyBuild1 = bd.appOp(n_a)
+    val applyBuild2 = bd.appOp(n_a, n_b)
+    val applyBuild3 = bd.appOp(n_a, n_b, n_c)
+    val applyBuild4 = bd.appOp(n_a, n_b, n_c, n_d)
 
-    assert( applyBuild1 == OperEx( TlaOper.apply, n_a ) )
-    assert( applyBuild2 == OperEx( TlaOper.apply, n_a, n_b ) )
-    assert( applyBuild3 == OperEx( TlaOper.apply, n_a, n_b, n_c ) )
-    assert( applyBuild4 == OperEx( TlaOper.apply, n_a, n_b, n_c, n_d ) )
+    assert(applyBuild1 == OperEx(TlaOper.apply, n_a))
+    assert(applyBuild2 == OperEx(TlaOper.apply, n_a, n_b))
+    assert(applyBuild3 == OperEx(TlaOper.apply, n_a, n_b, n_c))
+    assert(applyBuild4 == OperEx(TlaOper.apply, n_a, n_b, n_c, n_d))
 
-    val chooseBuild1 = bd.choose( n_a, n_b )
-    val chooseBuild2 = bd.choose( n_a, n_b, n_c )
+    val chooseBuild1 = bd.choose(n_a, n_b)
+    val chooseBuild2 = bd.choose(n_a, n_b, n_c)
 
-    assert( chooseBuild1 == OperEx( TlaOper.chooseUnbounded, n_a, n_b ) )
-    assert( chooseBuild2 == OperEx( TlaOper.chooseBounded, n_a, n_b, n_c ) )
+    assert(chooseBuild1 == OperEx(TlaOper.chooseUnbounded, n_a, n_b))
+    assert(chooseBuild2 == OperEx(TlaOper.chooseBounded, n_a, n_b, n_c))
   }
 
-  test( "Test byName: TlaOper" ) {
-    val eqBuild = bd.byName( TlaOper.eq.name, n_a, n_b )
+  test("Test byName: TlaOper") {
+    val eqBuild = bd.byName(TlaOper.eq.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.eq.name, n_a ) )
-    assert( eqBuild == OperEx( TlaOper.eq, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.eq.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.eq.name, n_a))
+    assert(eqBuild == OperEx(TlaOper.eq, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.eq.name, n_a, n_b, n_c))
 
-    val neBuild = bd.byName( TlaOper.ne.name, n_a, n_b )
+    val neBuild = bd.byName(TlaOper.ne.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.ne.name, n_a ) )
-    assert( neBuild == OperEx( TlaOper.ne, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.ne.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.ne.name, n_a))
+    assert(neBuild == OperEx(TlaOper.ne, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.ne.name, n_a, n_b, n_c))
 
-    val cbBuild = bd.byName( TlaOper.chooseBounded.name, n_a, n_b, n_c )
+    val cbBuild = bd.byName(TlaOper.chooseBounded.name, n_a, n_b, n_c)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.chooseBounded.name, n_a, n_b ) )
-    assert( cbBuild == OperEx( TlaOper.chooseBounded, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.chooseBounded.name, n_a, n_b, n_c, n_d ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.chooseBounded.name, n_a, n_b))
+    assert(cbBuild == OperEx(TlaOper.chooseBounded, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.chooseBounded.name, n_a, n_b, n_c, n_d))
 
-    val cubBuild = bd.byName( TlaOper.chooseUnbounded.name, n_a, n_b )
+    val cubBuild = bd.byName(TlaOper.chooseUnbounded.name, n_a, n_b)
 
-    assert( cubBuild == OperEx( TlaOper.chooseUnbounded, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.chooseUnbounded.name, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaOper.chooseUnbounded.name, n_a, n_b, n_c, n_d ) )
+    assert(cubBuild == OperEx(TlaOper.chooseUnbounded, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.chooseUnbounded.name, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaOper.chooseUnbounded.name, n_a, n_b, n_c, n_d))
   }
 
-  test( "Test byNameOrNull: TlaOper" ) {
-    val eqBuildBad1 = bd.byNameOrNull( TlaOper.eq.name, n_a )
-    val eqBuild = bd.byNameOrNull( TlaOper.eq.name, n_a, n_b )
-    val eqBuildBad2 = bd.byNameOrNull( TlaOper.eq.name, n_a, n_b, n_c )
+  test("Test byNameOrNull: TlaOper") {
+    val eqBuildBad1 = bd.byNameOrNull(TlaOper.eq.name, n_a)
+    val eqBuild = bd.byNameOrNull(TlaOper.eq.name, n_a, n_b)
+    val eqBuildBad2 = bd.byNameOrNull(TlaOper.eq.name, n_a, n_b, n_c)
 
-    assert( eqBuildBad1 == NullEx )
-    assert( eqBuild == OperEx( TlaOper.eq, n_a, n_b ) )
-    assert( eqBuildBad2 == NullEx )
+    assert(eqBuildBad1 == NullEx)
+    assert(eqBuild == OperEx(TlaOper.eq, n_a, n_b))
+    assert(eqBuildBad2 == NullEx)
 
-    val neBuildBad1 = bd.byNameOrNull( TlaOper.ne.name, n_a )
-    val neBuild = bd.byNameOrNull( TlaOper.ne.name, n_a, n_b )
-    val neBuildBad2 = bd.byNameOrNull( TlaOper.ne.name, n_a, n_b, n_c )
+    val neBuildBad1 = bd.byNameOrNull(TlaOper.ne.name, n_a)
+    val neBuild = bd.byNameOrNull(TlaOper.ne.name, n_a, n_b)
+    val neBuildBad2 = bd.byNameOrNull(TlaOper.ne.name, n_a, n_b, n_c)
 
-    assert( neBuildBad1 == NullEx )
-    assert( neBuild == OperEx( TlaOper.ne, n_a, n_b ) )
-    assert( neBuildBad2 == NullEx )
+    assert(neBuildBad1 == NullEx)
+    assert(neBuild == OperEx(TlaOper.ne, n_a, n_b))
+    assert(neBuildBad2 == NullEx)
 
-    val cbBuildBad1 = bd.byNameOrNull( TlaOper.chooseBounded.name, n_a, n_b )
-    val cbBuild = bd.byNameOrNull( TlaOper.chooseBounded.name, n_a, n_b, n_c )
-    val cbBuildBad2 = bd.byNameOrNull( TlaOper.chooseBounded.name, n_a, n_b, n_c, n_d )
+    val cbBuildBad1 = bd.byNameOrNull(TlaOper.chooseBounded.name, n_a, n_b)
+    val cbBuild = bd.byNameOrNull(TlaOper.chooseBounded.name, n_a, n_b, n_c)
+    val cbBuildBad2 = bd.byNameOrNull(TlaOper.chooseBounded.name, n_a, n_b, n_c, n_d)
 
-    assert( cbBuildBad1 == NullEx )
-    assert( cbBuild == OperEx( TlaOper.chooseBounded, n_a, n_b, n_c ) )
-    assert( cbBuildBad2 == NullEx )
+    assert(cbBuildBad1 == NullEx)
+    assert(cbBuild == OperEx(TlaOper.chooseBounded, n_a, n_b, n_c))
+    assert(cbBuildBad2 == NullEx)
 
-    val cubBuild = bd.byNameOrNull( TlaOper.chooseUnbounded.name, n_a, n_b )
-    val cubBuildBad1 = bd.byNameOrNull( TlaOper.chooseUnbounded.name, n_a, n_b, n_c )
-    val cubBuildBad2 = bd.byNameOrNull( TlaOper.chooseUnbounded.name, n_a, n_b, n_c, n_d )
+    val cubBuild = bd.byNameOrNull(TlaOper.chooseUnbounded.name, n_a, n_b)
+    val cubBuildBad1 = bd.byNameOrNull(TlaOper.chooseUnbounded.name, n_a, n_b, n_c)
+    val cubBuildBad2 = bd.byNameOrNull(TlaOper.chooseUnbounded.name, n_a, n_b, n_c, n_d)
 
-    assert( cubBuild == OperEx( TlaOper.chooseUnbounded, n_a, n_b ) )
-    assert( cubBuildBad1 == NullEx )
-    assert( cubBuildBad2 == NullEx )
+    assert(cubBuild == OperEx(TlaOper.chooseUnbounded, n_a, n_b))
+    assert(cubBuildBad1 == NullEx)
+    assert(cubBuildBad2 == NullEx)
   }
 
-  test( "Test direct methods: TlaBoolOper " ) {
-    val andBuild1 = bd.and( n_a )
-    val andBuild2 = bd.and( n_a, n_b )
-    val andBuild3 = bd.and( n_a, n_b, n_c )
-    val andBuild4 = bd.and( n_a, n_b, n_c, n_d )
+  test("Test direct methods: TlaBoolOper ") {
+    val andBuild1 = bd.and(n_a)
+    val andBuild2 = bd.and(n_a, n_b)
+    val andBuild3 = bd.and(n_a, n_b, n_c)
+    val andBuild4 = bd.and(n_a, n_b, n_c, n_d)
 
-    assert( andBuild1 == OperEx( TlaBoolOper.and, n_a ) )
-    assert( andBuild2 == OperEx( TlaBoolOper.and, n_a, n_b ) )
-    assert( andBuild3 == OperEx( TlaBoolOper.and, n_a, n_b, n_c ) )
-    assert( andBuild4 == OperEx( TlaBoolOper.and, n_a, n_b, n_c, n_d ) )
+    assert(andBuild1 == OperEx(TlaBoolOper.and, n_a))
+    assert(andBuild2 == OperEx(TlaBoolOper.and, n_a, n_b))
+    assert(andBuild3 == OperEx(TlaBoolOper.and, n_a, n_b, n_c))
+    assert(andBuild4 == OperEx(TlaBoolOper.and, n_a, n_b, n_c, n_d))
 
-    val orBuild1 = bd.or( n_a )
-    val orBuild2 = bd.or( n_a, n_b )
-    val orBuild3 = bd.or( n_a, n_b, n_c )
-    val orBuild4 = bd.or( n_a, n_b, n_c, n_d )
+    val orBuild1 = bd.or(n_a)
+    val orBuild2 = bd.or(n_a, n_b)
+    val orBuild3 = bd.or(n_a, n_b, n_c)
+    val orBuild4 = bd.or(n_a, n_b, n_c, n_d)
 
-    assert( orBuild1 == OperEx( TlaBoolOper.or, n_a ) )
-    assert( orBuild2 == OperEx( TlaBoolOper.or, n_a, n_b ) )
-    assert( orBuild3 == OperEx( TlaBoolOper.or, n_a, n_b, n_c ) )
-    assert( orBuild4 == OperEx( TlaBoolOper.or, n_a, n_b, n_c, n_d ) )
+    assert(orBuild1 == OperEx(TlaBoolOper.or, n_a))
+    assert(orBuild2 == OperEx(TlaBoolOper.or, n_a, n_b))
+    assert(orBuild3 == OperEx(TlaBoolOper.or, n_a, n_b, n_c))
+    assert(orBuild4 == OperEx(TlaBoolOper.or, n_a, n_b, n_c, n_d))
 
-    val notBuild1 = bd.not( n_a )
+    val notBuild1 = bd.not(n_a)
 
-    assert( notBuild1 == OperEx( TlaBoolOper.not, n_a ) )
+    assert(notBuild1 == OperEx(TlaBoolOper.not, n_a))
 
-    val impliesBuild1 = bd.impl( n_a, n_b )
+    val impliesBuild1 = bd.impl(n_a, n_b)
 
-    assert( impliesBuild1 == OperEx( TlaBoolOper.implies, n_a, n_b ) )
+    assert(impliesBuild1 == OperEx(TlaBoolOper.implies, n_a, n_b))
 
-    val equivBuild1 = bd.equiv( n_a, n_b )
+    val equivBuild1 = bd.equiv(n_a, n_b)
 
-    assert( equivBuild1 == OperEx( TlaBoolOper.equiv, n_a, n_b ) )
+    assert(equivBuild1 == OperEx(TlaBoolOper.equiv, n_a, n_b))
 
-    val forallBuild1 = bd.forall( n_a, n_b )
-    val forallBuild2 = bd.forall( n_a, n_b, n_c )
+    val forallBuild1 = bd.forall(n_a, n_b)
+    val forallBuild2 = bd.forall(n_a, n_b, n_c)
 
-    assert( forallBuild1 == OperEx( TlaBoolOper.forallUnbounded, n_a, n_b ) )
-    assert( forallBuild2 == OperEx( TlaBoolOper.forall, n_a, n_b, n_c ) )
+    assert(forallBuild1 == OperEx(TlaBoolOper.forallUnbounded, n_a, n_b))
+    assert(forallBuild2 == OperEx(TlaBoolOper.forall, n_a, n_b, n_c))
 
-    val existsBuild1 = bd.exists( n_a, n_b )
-    val existsBuild2 = bd.exists( n_a, n_b, n_c )
+    val existsBuild1 = bd.exists(n_a, n_b)
+    val existsBuild2 = bd.exists(n_a, n_b, n_c)
 
-    assert( existsBuild1 == OperEx( TlaBoolOper.existsUnbounded, n_a, n_b ) )
-    assert( existsBuild2 == OperEx( TlaBoolOper.exists, n_a, n_b, n_c ) )
+    assert(existsBuild1 == OperEx(TlaBoolOper.existsUnbounded, n_a, n_b))
+    assert(existsBuild2 == OperEx(TlaBoolOper.exists, n_a, n_b, n_c))
   }
 
-  test( "Test byName: TlaBoolOper " ) {
-    val andBuild1 = bd.byName( TlaBoolOper.and.name )
-    val andBuild2 = bd.byName( TlaBoolOper.and.name, n_a )
-    val andBuild3 = bd.byName( TlaBoolOper.and.name, n_a, n_b )
+  test("Test byName: TlaBoolOper ") {
+    val andBuild1 = bd.byName(TlaBoolOper.and.name)
+    val andBuild2 = bd.byName(TlaBoolOper.and.name, n_a)
+    val andBuild3 = bd.byName(TlaBoolOper.and.name, n_a, n_b)
 
-    assert( andBuild1 == OperEx( TlaBoolOper.and ) )
-    assert( andBuild2 == OperEx( TlaBoolOper.and, n_a ) )
-    assert( andBuild3 == OperEx( TlaBoolOper.and, n_a, n_b ) )
+    assert(andBuild1 == OperEx(TlaBoolOper.and))
+    assert(andBuild2 == OperEx(TlaBoolOper.and, n_a))
+    assert(andBuild3 == OperEx(TlaBoolOper.and, n_a, n_b))
 
-    val orBuild1 = bd.byName( TlaBoolOper.or.name )
-    val orBuild2 = bd.byName( TlaBoolOper.or.name, n_a )
-    val orBuild3 = bd.byName( TlaBoolOper.or.name, n_a, n_b )
+    val orBuild1 = bd.byName(TlaBoolOper.or.name)
+    val orBuild2 = bd.byName(TlaBoolOper.or.name, n_a)
+    val orBuild3 = bd.byName(TlaBoolOper.or.name, n_a, n_b)
 
-    assert( orBuild1 == OperEx( TlaBoolOper.or ) )
-    assert( orBuild2 == OperEx( TlaBoolOper.or, n_a ) )
-    assert( orBuild3 == OperEx( TlaBoolOper.or, n_a, n_b ) )
+    assert(orBuild1 == OperEx(TlaBoolOper.or))
+    assert(orBuild2 == OperEx(TlaBoolOper.or, n_a))
+    assert(orBuild3 == OperEx(TlaBoolOper.or, n_a, n_b))
 
-    val notBuild = bd.byName( TlaBoolOper.not.name, n_a )
+    val notBuild = bd.byName(TlaBoolOper.not.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaBoolOper.not.name ) )
-    assert( notBuild == OperEx( TlaBoolOper.not, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaBoolOper.not.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaBoolOper.not.name))
+    assert(notBuild == OperEx(TlaBoolOper.not, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaBoolOper.not.name, n_a, n_b))
 
-    val impliesBuild = bd.byName( TlaBoolOper.implies.name, n_a, n_b )
+    val impliesBuild = bd.byName(TlaBoolOper.implies.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaBoolOper.implies.name, n_a ) )
-    assert( impliesBuild == OperEx( TlaBoolOper.implies, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaBoolOper.implies.name, n_a, n_b, n_c ) )
-
-  }
-
-  test( "Test byNameOrNull: TlaBoolOper " ) {
-    val andBuild1 = bd.byNameOrNull( TlaBoolOper.and.name )
-    val andBuild2 = bd.byNameOrNull( TlaBoolOper.and.name, n_a )
-    val andBuild3 = bd.byNameOrNull( TlaBoolOper.and.name, n_a, n_b )
-
-    assert( andBuild1 == OperEx( TlaBoolOper.and ) )
-    assert( andBuild2 == OperEx( TlaBoolOper.and, n_a ) )
-    assert( andBuild3 == OperEx( TlaBoolOper.and, n_a, n_b ) )
-
-    val orBuild1 = bd.byNameOrNull( TlaBoolOper.or.name )
-    val orBuild2 = bd.byNameOrNull( TlaBoolOper.or.name, n_a )
-    val orBuild3 = bd.byNameOrNull( TlaBoolOper.or.name, n_a, n_b )
-
-    assert( orBuild1 == OperEx( TlaBoolOper.or ) )
-    assert( orBuild2 == OperEx( TlaBoolOper.or, n_a ) )
-    assert( orBuild3 == OperEx( TlaBoolOper.or, n_a, n_b ) )
-
-    val notBuildBad1 = bd.byNameOrNull( TlaBoolOper.not.name )
-    val notBuild = bd.byNameOrNull( TlaBoolOper.not.name, n_a )
-    val notBuildBad2 = bd.byNameOrNull( TlaBoolOper.not.name, n_a, n_b )
-
-    assert( notBuildBad1 == NullEx )
-    assert( notBuild == OperEx( TlaBoolOper.not, n_a ) )
-    assert( notBuildBad2 == NullEx )
-
-    val impliesBuildBad1 = bd.byNameOrNull( TlaBoolOper.implies.name, n_a )
-    val impliesBuild = bd.byNameOrNull( TlaBoolOper.implies.name, n_a, n_b )
-    val impliesBuildBad2 = bd.byNameOrNull( TlaBoolOper.implies.name, n_a, n_b, n_c )
-
-    assert( impliesBuildBad1 == NullEx )
-    assert( impliesBuild == OperEx( TlaBoolOper.implies, n_a, n_b ) )
-    assert( impliesBuildBad2 == NullEx )
-  }
-
-  test( "Test direct methods: TlaActionOper" ) {
-    val primeBuild1 = bd.prime( n_a )
-    val primeBuild2 = bd.prime( "name" )
-
-    assert( primeBuild1 == OperEx( TlaActionOper.prime, n_a ) )
-    assert( primeBuild2 == OperEx( TlaActionOper.prime, NameEx( "name" ) ) )
-
-    val primeEqBuild1 = bd.primeEq( "name", n_a )
-    val primeEqBuild2 = bd.primeEq( n_a, n_b )
-    val primeEqBuild3 = bd.primeEq( "name", 1 )
-    val primeEqBuild4 = bd.primeEq( n_a, 2 )
-    val primeEqBuild5 = bd.primeEq( "name1", "name2" )
-
-    assert( primeEqBuild1 == OperEx( TlaOper.eq, OperEx( TlaActionOper.prime, NameEx( "name" ) ), n_a ) )
-    assert( primeEqBuild2 == OperEx( TlaOper.eq, OperEx( TlaActionOper.prime, n_a ), n_b ) )
-    assert( primeEqBuild3 == OperEx( TlaOper.eq, OperEx( TlaActionOper.prime, NameEx( "name" ) ), ValEx( TlaInt( 1 ) ) ) )
-    assert( primeEqBuild4 == OperEx( TlaOper.eq, OperEx( TlaActionOper.prime, n_a ), ValEx( TlaInt( 2 ) ) ) )
-    assert( primeEqBuild5 == OperEx( TlaOper.eq, OperEx( TlaActionOper.prime, NameEx( "name1" ) ), NameEx( "name2" ) ) )
-
-    val stutterBuild = bd.stutt( n_a, n_b )
-
-    assert( stutterBuild == OperEx( TlaActionOper.stutter, n_a, n_b ) )
-
-    val nostutterBuild = bd.nostutt( n_a, n_b )
-
-    assert( nostutterBuild == OperEx( TlaActionOper.nostutter, n_a, n_b ) )
-
-    val enabledBuild = bd.enabled( n_a )
-
-    assert( enabledBuild == OperEx( TlaActionOper.enabled, n_a ) )
-
-    val unchangedBuild = bd.unchanged( n_a )
-
-    assert( unchangedBuild == OperEx( TlaActionOper.unchanged, n_a ) )
-
-    val compositionBuild = bd.comp( n_a, n_b )
-
-    assert( compositionBuild == OperEx( TlaActionOper.composition, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaBoolOper.implies.name, n_a))
+    assert(impliesBuild == OperEx(TlaBoolOper.implies, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaBoolOper.implies.name, n_a, n_b, n_c))
 
   }
 
-  test( "Test byName: TlaActionOper" ) {
-    val primeBuild = bd.byNameOrNull( TlaActionOper.prime.name, n_a )
+  test("Test byNameOrNull: TlaBoolOper ") {
+    val andBuild1 = bd.byNameOrNull(TlaBoolOper.and.name)
+    val andBuild2 = bd.byNameOrNull(TlaBoolOper.and.name, n_a)
+    val andBuild3 = bd.byNameOrNull(TlaBoolOper.and.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.prime.name ) )
-    assert( primeBuild == OperEx( TlaActionOper.prime, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.prime.name, n_a, n_b ) )
+    assert(andBuild1 == OperEx(TlaBoolOper.and))
+    assert(andBuild2 == OperEx(TlaBoolOper.and, n_a))
+    assert(andBuild3 == OperEx(TlaBoolOper.and, n_a, n_b))
 
-    val stutterBuild = bd.byName( TlaActionOper.stutter.name, n_a, n_b )
+    val orBuild1 = bd.byNameOrNull(TlaBoolOper.or.name)
+    val orBuild2 = bd.byNameOrNull(TlaBoolOper.or.name, n_a)
+    val orBuild3 = bd.byNameOrNull(TlaBoolOper.or.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.stutter.name, n_a ) )
-    assert( stutterBuild == OperEx( TlaActionOper.stutter, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.stutter.name, n_a, n_b, n_c ) )
+    assert(orBuild1 == OperEx(TlaBoolOper.or))
+    assert(orBuild2 == OperEx(TlaBoolOper.or, n_a))
+    assert(orBuild3 == OperEx(TlaBoolOper.or, n_a, n_b))
 
-    val nostutterBuild = bd.byName( TlaActionOper.nostutter.name, n_a, n_b )
+    val notBuildBad1 = bd.byNameOrNull(TlaBoolOper.not.name)
+    val notBuild = bd.byNameOrNull(TlaBoolOper.not.name, n_a)
+    val notBuildBad2 = bd.byNameOrNull(TlaBoolOper.not.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.nostutter.name, n_a ) )
-    assert( nostutterBuild == OperEx( TlaActionOper.nostutter, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.nostutter.name, n_a, n_b, n_c ) )
+    assert(notBuildBad1 == NullEx)
+    assert(notBuild == OperEx(TlaBoolOper.not, n_a))
+    assert(notBuildBad2 == NullEx)
 
-    val enabledBuild = bd.byName( TlaActionOper.enabled.name, n_a )
+    val impliesBuildBad1 = bd.byNameOrNull(TlaBoolOper.implies.name, n_a)
+    val impliesBuild = bd.byNameOrNull(TlaBoolOper.implies.name, n_a, n_b)
+    val impliesBuildBad2 = bd.byNameOrNull(TlaBoolOper.implies.name, n_a, n_b, n_c)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.enabled.name ) )
-    assert( enabledBuild == OperEx( TlaActionOper.enabled, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.enabled.name, n_a, n_b ) )
-
-    val unchangedBuild = bd.byName( TlaActionOper.unchanged.name, n_a )
-
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.unchanged.name ) )
-    assert( unchangedBuild == OperEx( TlaActionOper.unchanged, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.unchanged.name, n_a, n_b ) )
-
-    val compositionBuild = bd.byName( TlaActionOper.composition.name, n_a, n_b )
-
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.composition.name, n_a ) )
-    assert( compositionBuild == OperEx( TlaActionOper.composition, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaActionOper.composition.name, n_a, n_b, n_c ) )
+    assert(impliesBuildBad1 == NullEx)
+    assert(impliesBuild == OperEx(TlaBoolOper.implies, n_a, n_b))
+    assert(impliesBuildBad2 == NullEx)
   }
 
-  test( "Test byNameOrNull: TlaActionOper" ) {
-    val primeBuildBad1 = bd.byNameOrNull( TlaActionOper.prime.name )
-    val primeBuild = bd.byNameOrNull( TlaActionOper.prime.name, n_a )
-    val primeBuildBad2 = bd.byNameOrNull( TlaActionOper.prime.name, n_a, n_b )
+  test("Test direct methods: TlaActionOper") {
+    val primeBuild1 = bd.prime(n_a)
+    val primeBuild2 = bd.prime("name")
 
-    assert( primeBuildBad1 == NullEx )
-    assert( primeBuild == OperEx( TlaActionOper.prime, n_a ) )
-    assert( primeBuildBad2 == NullEx )
+    assert(primeBuild1 == OperEx(TlaActionOper.prime, n_a))
+    assert(primeBuild2 == OperEx(TlaActionOper.prime, NameEx("name")))
 
-    val stutterBuildBad1 = bd.byNameOrNull( TlaActionOper.stutter.name, n_a )
-    val stutterBuild = bd.byNameOrNull( TlaActionOper.stutter.name, n_a, n_b )
-    val stutterBuildBad2 = bd.byNameOrNull( TlaActionOper.stutter.name, n_a, n_b, n_c )
+    val primeEqBuild1 = bd.primeEq("name", n_a)
+    val primeEqBuild2 = bd.primeEq(n_a, n_b)
+    val primeEqBuild3 = bd.primeEq("name", 1)
+    val primeEqBuild4 = bd.primeEq(n_a, 2)
+    val primeEqBuild5 = bd.primeEq("name1", "name2")
 
-    assert( stutterBuildBad1 == NullEx )
-    assert( stutterBuild == OperEx( TlaActionOper.stutter, n_a, n_b ) )
-    assert( stutterBuildBad2 == NullEx )
+    assert(primeEqBuild1 == OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("name")), n_a))
+    assert(primeEqBuild2 == OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, n_a), n_b))
+    assert(primeEqBuild3 == OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("name")), ValEx(TlaInt(1))))
+    assert(primeEqBuild4 == OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, n_a), ValEx(TlaInt(2))))
+    assert(primeEqBuild5 == OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("name1")), NameEx("name2")))
 
-    val nostutterBuildBad1 = bd.byNameOrNull( TlaActionOper.nostutter.name, n_a )
-    val nostutterBuild = bd.byNameOrNull( TlaActionOper.nostutter.name, n_a, n_b )
-    val nostutterBuildBad2 = bd.byNameOrNull( TlaActionOper.nostutter.name, n_a, n_b, n_c )
+    val stutterBuild = bd.stutt(n_a, n_b)
 
-    assert( nostutterBuildBad1 == NullEx )
-    assert( nostutterBuild == OperEx( TlaActionOper.nostutter, n_a, n_b ) )
-    assert( nostutterBuildBad2 == NullEx )
+    assert(stutterBuild == OperEx(TlaActionOper.stutter, n_a, n_b))
 
-    val enabledBuildBad1 = bd.byNameOrNull( TlaActionOper.enabled.name )
-    val enabledBuild = bd.byNameOrNull( TlaActionOper.enabled.name, n_a )
-    val enabledBuildBad2 = bd.byNameOrNull( TlaActionOper.enabled.name, n_a, n_b )
+    val nostutterBuild = bd.nostutt(n_a, n_b)
 
-    assert( enabledBuildBad1 == NullEx )
-    assert( enabledBuild == OperEx( TlaActionOper.enabled, n_a ) )
-    assert( enabledBuildBad2 == NullEx )
+    assert(nostutterBuild == OperEx(TlaActionOper.nostutter, n_a, n_b))
 
-    val unchangedBuildBad1 = bd.byNameOrNull( TlaActionOper.unchanged.name )
-    val unchangedBuild = bd.byNameOrNull( TlaActionOper.unchanged.name, n_a )
-    val unchangedBuildBad2 = bd.byNameOrNull( TlaActionOper.unchanged.name, n_a, n_b )
+    val enabledBuild = bd.enabled(n_a)
 
-    assert( unchangedBuildBad1 == NullEx )
-    assert( unchangedBuild == OperEx( TlaActionOper.unchanged, n_a ) )
-    assert( unchangedBuildBad2 == NullEx )
+    assert(enabledBuild == OperEx(TlaActionOper.enabled, n_a))
 
-    val compositionBuildBad1 = bd.byNameOrNull( TlaActionOper.composition.name, n_a )
-    val compositionBuild = bd.byNameOrNull( TlaActionOper.composition.name, n_a, n_b )
-    val compositionBuildBad2 = bd.byNameOrNull( TlaActionOper.composition.name, n_a, n_b, n_c )
+    val unchangedBuild = bd.unchanged(n_a)
 
-    assert( compositionBuildBad1 == NullEx )
-    assert( compositionBuild == OperEx( TlaActionOper.composition, n_a, n_b ) )
-    assert( compositionBuildBad2 == NullEx )
+    assert(unchangedBuild == OperEx(TlaActionOper.unchanged, n_a))
+
+    val compositionBuild = bd.comp(n_a, n_b)
+
+    assert(compositionBuild == OperEx(TlaActionOper.composition, n_a, n_b))
+
   }
 
-  test( "Test direct methods: TlaControlOper" ) {
+  test("Test byName: TlaActionOper") {
+    val primeBuild = bd.byNameOrNull(TlaActionOper.prime.name, n_a)
 
-    val caseBuild1 = bd.caseAny( n_a, n_b )
-    val caseBuild2 = bd.caseAny( n_a, n_b, n_c )
-    val caseBuild3 = bd.caseAny( n_a, n_b, n_c, n_d )
-    val caseBuild4 = bd.caseAny( n_a, n_b, n_c, n_d, n_e )
-    val caseBuild5 = bd.caseAny( n_a, n_b, n_c, n_d, n_e, n_f )
-    val caseBuild6 = bd.caseAny( n_a, n_b, n_c, n_d, n_e, n_f, n_g )
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.prime.name))
+    assert(primeBuild == OperEx(TlaActionOper.prime, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.prime.name, n_a, n_b))
 
-    assert( caseBuild1 == OperEx( TlaControlOper.caseNoOther, n_a, n_b ) )
-    assert( caseBuild2 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c ) )
-    assert( caseBuild3 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d ) )
-    assert( caseBuild4 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e ) )
-    assert( caseBuild5 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f ) )
-    assert( caseBuild6 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g ) )
+    val stutterBuild = bd.byName(TlaActionOper.stutter.name, n_a, n_b)
 
-    val caseSplitBuild1 = bd.caseSplit( n_a, n_b )
-    val caseSplitBuild2 = bd.caseSplit( n_a, n_b, n_c, n_d )
-    val caseSplitBuild3 = bd.caseSplit( n_a, n_b, n_c, n_d, n_e, n_f )
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.stutter.name, n_a))
+    assert(stutterBuild == OperEx(TlaActionOper.stutter, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.stutter.name, n_a, n_b, n_c))
 
-    assert( caseSplitBuild1 == OperEx( TlaControlOper.caseNoOther, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.caseSplit( n_a, n_b, n_c ) )
-    assert( caseSplitBuild2 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d ) )
-    assertThrows[IllegalArgumentException]( bd.caseSplit( n_a, n_b, n_c, n_d, n_e ) )
-    assert( caseSplitBuild3 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f ) )
+    val nostutterBuild = bd.byName(TlaActionOper.nostutter.name, n_a, n_b)
 
-    val caseOtherBuild1 = bd.caseOther( n_a, n_b, n_c )
-    val caseOtherBuild2 = bd.caseOther( n_a, n_b, n_c, n_d, n_e )
-    val caseOtherBuild3 = bd.caseOther( n_a, n_b, n_c, n_d, n_e, n_f, n_g )
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.nostutter.name, n_a))
+    assert(nostutterBuild == OperEx(TlaActionOper.nostutter, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.nostutter.name, n_a, n_b, n_c))
 
-    assert( caseOtherBuild1 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.caseOther( n_a, n_b, n_c, n_d ) )
-    assert( caseOtherBuild2 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e ) )
-    assertThrows[IllegalArgumentException]( bd.caseOther( n_a, n_b, n_c, n_d, n_e, n_f ) )
-    assert( caseOtherBuild3 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g ) )
+    val enabledBuild = bd.byName(TlaActionOper.enabled.name, n_a)
 
-    val iteBuild1 = bd.ite( n_a, n_b, n_c )
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.enabled.name))
+    assert(enabledBuild == OperEx(TlaActionOper.enabled, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.enabled.name, n_a, n_b))
 
-    assert( iteBuild1 == OperEx( TlaControlOper.ifThenElse, n_a, n_b, n_c ) )
+    val unchangedBuild = bd.byName(TlaActionOper.unchanged.name, n_a)
+
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.unchanged.name))
+    assert(unchangedBuild == OperEx(TlaActionOper.unchanged, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.unchanged.name, n_a, n_b))
+
+    val compositionBuild = bd.byName(TlaActionOper.composition.name, n_a, n_b)
+
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.composition.name, n_a))
+    assert(compositionBuild == OperEx(TlaActionOper.composition, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaActionOper.composition.name, n_a, n_b, n_c))
+  }
+
+  test("Test byNameOrNull: TlaActionOper") {
+    val primeBuildBad1 = bd.byNameOrNull(TlaActionOper.prime.name)
+    val primeBuild = bd.byNameOrNull(TlaActionOper.prime.name, n_a)
+    val primeBuildBad2 = bd.byNameOrNull(TlaActionOper.prime.name, n_a, n_b)
+
+    assert(primeBuildBad1 == NullEx)
+    assert(primeBuild == OperEx(TlaActionOper.prime, n_a))
+    assert(primeBuildBad2 == NullEx)
+
+    val stutterBuildBad1 = bd.byNameOrNull(TlaActionOper.stutter.name, n_a)
+    val stutterBuild = bd.byNameOrNull(TlaActionOper.stutter.name, n_a, n_b)
+    val stutterBuildBad2 = bd.byNameOrNull(TlaActionOper.stutter.name, n_a, n_b, n_c)
+
+    assert(stutterBuildBad1 == NullEx)
+    assert(stutterBuild == OperEx(TlaActionOper.stutter, n_a, n_b))
+    assert(stutterBuildBad2 == NullEx)
+
+    val nostutterBuildBad1 = bd.byNameOrNull(TlaActionOper.nostutter.name, n_a)
+    val nostutterBuild = bd.byNameOrNull(TlaActionOper.nostutter.name, n_a, n_b)
+    val nostutterBuildBad2 = bd.byNameOrNull(TlaActionOper.nostutter.name, n_a, n_b, n_c)
+
+    assert(nostutterBuildBad1 == NullEx)
+    assert(nostutterBuild == OperEx(TlaActionOper.nostutter, n_a, n_b))
+    assert(nostutterBuildBad2 == NullEx)
+
+    val enabledBuildBad1 = bd.byNameOrNull(TlaActionOper.enabled.name)
+    val enabledBuild = bd.byNameOrNull(TlaActionOper.enabled.name, n_a)
+    val enabledBuildBad2 = bd.byNameOrNull(TlaActionOper.enabled.name, n_a, n_b)
+
+    assert(enabledBuildBad1 == NullEx)
+    assert(enabledBuild == OperEx(TlaActionOper.enabled, n_a))
+    assert(enabledBuildBad2 == NullEx)
+
+    val unchangedBuildBad1 = bd.byNameOrNull(TlaActionOper.unchanged.name)
+    val unchangedBuild = bd.byNameOrNull(TlaActionOper.unchanged.name, n_a)
+    val unchangedBuildBad2 = bd.byNameOrNull(TlaActionOper.unchanged.name, n_a, n_b)
+
+    assert(unchangedBuildBad1 == NullEx)
+    assert(unchangedBuild == OperEx(TlaActionOper.unchanged, n_a))
+    assert(unchangedBuildBad2 == NullEx)
+
+    val compositionBuildBad1 = bd.byNameOrNull(TlaActionOper.composition.name, n_a)
+    val compositionBuild = bd.byNameOrNull(TlaActionOper.composition.name, n_a, n_b)
+    val compositionBuildBad2 = bd.byNameOrNull(TlaActionOper.composition.name, n_a, n_b, n_c)
+
+    assert(compositionBuildBad1 == NullEx)
+    assert(compositionBuild == OperEx(TlaActionOper.composition, n_a, n_b))
+    assert(compositionBuildBad2 == NullEx)
+  }
+
+  test("Test direct methods: TlaControlOper") {
+
+    val caseBuild1 = bd.caseAny(n_a, n_b)
+    val caseBuild2 = bd.caseAny(n_a, n_b, n_c)
+    val caseBuild3 = bd.caseAny(n_a, n_b, n_c, n_d)
+    val caseBuild4 = bd.caseAny(n_a, n_b, n_c, n_d, n_e)
+    val caseBuild5 = bd.caseAny(n_a, n_b, n_c, n_d, n_e, n_f)
+    val caseBuild6 = bd.caseAny(n_a, n_b, n_c, n_d, n_e, n_f, n_g)
+
+    assert(caseBuild1 == OperEx(TlaControlOper.caseNoOther, n_a, n_b))
+    assert(caseBuild2 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c))
+    assert(caseBuild3 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d))
+    assert(caseBuild4 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e))
+    assert(caseBuild5 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f))
+    assert(caseBuild6 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g))
+
+    val caseSplitBuild1 = bd.caseSplit(n_a, n_b)
+    val caseSplitBuild2 = bd.caseSplit(n_a, n_b, n_c, n_d)
+    val caseSplitBuild3 = bd.caseSplit(n_a, n_b, n_c, n_d, n_e, n_f)
+
+    assert(caseSplitBuild1 == OperEx(TlaControlOper.caseNoOther, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.caseSplit(n_a, n_b, n_c))
+    assert(caseSplitBuild2 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d))
+    assertThrows[IllegalArgumentException](bd.caseSplit(n_a, n_b, n_c, n_d, n_e))
+    assert(caseSplitBuild3 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f))
+
+    val caseOtherBuild1 = bd.caseOther(n_a, n_b, n_c)
+    val caseOtherBuild2 = bd.caseOther(n_a, n_b, n_c, n_d, n_e)
+    val caseOtherBuild3 = bd.caseOther(n_a, n_b, n_c, n_d, n_e, n_f, n_g)
+
+    assert(caseOtherBuild1 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.caseOther(n_a, n_b, n_c, n_d))
+    assert(caseOtherBuild2 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e))
+    assertThrows[IllegalArgumentException](bd.caseOther(n_a, n_b, n_c, n_d, n_e, n_f))
+    assert(caseOtherBuild3 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g))
+
+    val iteBuild1 = bd.ite(n_a, n_b, n_c)
+
+    assert(iteBuild1 == OperEx(TlaControlOper.ifThenElse, n_a, n_b, n_c))
 
     //    val letInBuild1 = bd.letIn( n_a, TlaOperDecl( "b" , List(), n_c ) )
     //    val letInBuild2 =
@@ -478,1231 +479,1231 @@ class TestBuilder extends FunSuite with TestingPredefs {
 
   }
 
-  test( "Test byName: TlaControlOper" ) {
-    val caseBuild1 = bd.byName( TlaControlOper.caseNoOther.name, n_a, n_b )
-    val caseBuild2 = bd.byName( TlaControlOper.caseWithOther.name, n_a, n_b, n_c )
-    val caseBuild3 = bd.byName( TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d )
-    val caseBuild4 = bd.byName( TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e )
-    val caseBuild5 = bd.byName( TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d, n_e, n_f )
-    val caseBuild6 = bd.byName( TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e, n_f, n_g )
+  test("Test byName: TlaControlOper") {
+    val caseBuild1 = bd.byName(TlaControlOper.caseNoOther.name, n_a, n_b)
+    val caseBuild2 = bd.byName(TlaControlOper.caseWithOther.name, n_a, n_b, n_c)
+    val caseBuild3 = bd.byName(TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d)
+    val caseBuild4 = bd.byName(TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e)
+    val caseBuild5 = bd.byName(TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d, n_e, n_f)
+    val caseBuild6 = bd.byName(TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e, n_f, n_g)
 
-    assert( caseBuild1 == OperEx( TlaControlOper.caseNoOther, n_a, n_b ) )
-    assert( caseBuild2 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c ) )
-    assert( caseBuild3 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d ) )
-    assert( caseBuild4 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e ) )
-    assert( caseBuild5 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f ) )
-    assert( caseBuild6 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g ) )
+    assert(caseBuild1 == OperEx(TlaControlOper.caseNoOther, n_a, n_b))
+    assert(caseBuild2 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c))
+    assert(caseBuild3 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d))
+    assert(caseBuild4 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e))
+    assert(caseBuild5 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f))
+    assert(caseBuild6 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g))
 
-    val caseNoOtherBuild = bd.byName( TlaControlOper.caseNoOther.name, n_a, n_b )
+    val caseNoOtherBuild = bd.byName(TlaControlOper.caseNoOther.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.caseNoOther.name ) )
-    assert( caseNoOtherBuild == OperEx( TlaControlOper.caseNoOther, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.caseNoOther.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.caseNoOther.name))
+    assert(caseNoOtherBuild == OperEx(TlaControlOper.caseNoOther, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.caseNoOther.name, n_a, n_b, n_c))
 
-    val caseWithOtherBuild = bd.byName( TlaControlOper.caseWithOther.name, n_a, n_b, n_c )
+    val caseWithOtherBuild = bd.byName(TlaControlOper.caseWithOther.name, n_a, n_b, n_c)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.caseWithOther.name ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.caseWithOther.name, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.caseWithOther.name, n_a, n_b ) )
-    assert( caseWithOtherBuild == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.caseWithOther.name))
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.caseWithOther.name, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.caseWithOther.name, n_a, n_b))
+    assert(caseWithOtherBuild == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c))
 
-    val iteBuild = bd.byName( TlaControlOper.ifThenElse.name, n_a, n_b, n_c )
+    val iteBuild = bd.byName(TlaControlOper.ifThenElse.name, n_a, n_b, n_c)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.ifThenElse.name, n_a, n_b ) )
-    assert( iteBuild == OperEx( TlaControlOper.ifThenElse, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaControlOper.ifThenElse.name, n_a, n_b, n_c, n_d ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.ifThenElse.name, n_a, n_b))
+    assert(iteBuild == OperEx(TlaControlOper.ifThenElse, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaControlOper.ifThenElse.name, n_a, n_b, n_c, n_d))
   }
 
-  test( "Test byNameOrNull: TlaControlOper" ) {
-    val caseBuild1 = bd.byNameOrNull( TlaControlOper.caseNoOther.name, n_a, n_b )
-    val caseBuild2 = bd.byNameOrNull( TlaControlOper.caseWithOther.name, n_a, n_b, n_c )
-    val caseBuild3 = bd.byNameOrNull( TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d )
-    val caseBuild4 = bd.byNameOrNull( TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e )
-    val caseBuild5 = bd.byNameOrNull( TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d, n_e, n_f )
-    val caseBuild6 = bd.byNameOrNull( TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e, n_f, n_g )
+  test("Test byNameOrNull: TlaControlOper") {
+    val caseBuild1 = bd.byNameOrNull(TlaControlOper.caseNoOther.name, n_a, n_b)
+    val caseBuild2 = bd.byNameOrNull(TlaControlOper.caseWithOther.name, n_a, n_b, n_c)
+    val caseBuild3 = bd.byNameOrNull(TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d)
+    val caseBuild4 = bd.byNameOrNull(TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e)
+    val caseBuild5 = bd.byNameOrNull(TlaControlOper.caseNoOther.name, n_a, n_b, n_c, n_d, n_e, n_f)
+    val caseBuild6 = bd.byNameOrNull(TlaControlOper.caseWithOther.name, n_a, n_b, n_c, n_d, n_e, n_f, n_g)
 
-    assert( caseBuild1 == OperEx( TlaControlOper.caseNoOther, n_a, n_b ) )
-    assert( caseBuild2 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c ) )
-    assert( caseBuild3 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d ) )
-    assert( caseBuild4 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e ) )
-    assert( caseBuild5 == OperEx( TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f ) )
-    assert( caseBuild6 == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g ) )
+    assert(caseBuild1 == OperEx(TlaControlOper.caseNoOther, n_a, n_b))
+    assert(caseBuild2 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c))
+    assert(caseBuild3 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d))
+    assert(caseBuild4 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e))
+    assert(caseBuild5 == OperEx(TlaControlOper.caseNoOther, n_a, n_b, n_c, n_d, n_e, n_f))
+    assert(caseBuild6 == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c, n_d, n_e, n_f, n_g))
 
-    val caseNoOtherBuildEmpty = bd.byNameOrNull( TlaControlOper.caseNoOther.name )
-    val caseNoOtherBuild = bd.byNameOrNull( TlaControlOper.caseNoOther.name, n_a, n_b )
-    val caseNoOtherBuildBad = bd.byNameOrNull( TlaControlOper.caseNoOther.name, n_a, n_b, n_c )
+    val caseNoOtherBuildEmpty = bd.byNameOrNull(TlaControlOper.caseNoOther.name)
+    val caseNoOtherBuild = bd.byNameOrNull(TlaControlOper.caseNoOther.name, n_a, n_b)
+    val caseNoOtherBuildBad = bd.byNameOrNull(TlaControlOper.caseNoOther.name, n_a, n_b, n_c)
 
-    assert( caseNoOtherBuildEmpty == NullEx )
-    assert( caseNoOtherBuild == OperEx( TlaControlOper.caseNoOther, n_a, n_b ) )
-    assert( caseNoOtherBuildBad == NullEx )
+    assert(caseNoOtherBuildEmpty == NullEx)
+    assert(caseNoOtherBuild == OperEx(TlaControlOper.caseNoOther, n_a, n_b))
+    assert(caseNoOtherBuildBad == NullEx)
 
-    val caseWithOtherBuildEmpty = bd.byNameOrNull( TlaControlOper.caseWithOther.name )
-    val caseWithOtherBuildSingle = bd.byNameOrNull( TlaControlOper.caseWithOther.name, n_a )
-    val caseWithOtherBuildBad = bd.byNameOrNull( TlaControlOper.caseWithOther.name, n_a, n_b )
-    val caseWithOtherBuild = bd.byNameOrNull( TlaControlOper.caseWithOther.name, n_a, n_b, n_c )
+    val caseWithOtherBuildEmpty = bd.byNameOrNull(TlaControlOper.caseWithOther.name)
+    val caseWithOtherBuildSingle = bd.byNameOrNull(TlaControlOper.caseWithOther.name, n_a)
+    val caseWithOtherBuildBad = bd.byNameOrNull(TlaControlOper.caseWithOther.name, n_a, n_b)
+    val caseWithOtherBuild = bd.byNameOrNull(TlaControlOper.caseWithOther.name, n_a, n_b, n_c)
 
-    assert( caseWithOtherBuildEmpty == NullEx )
-    assert( caseWithOtherBuildSingle == NullEx )
-    assert( caseWithOtherBuildBad == NullEx )
-    assert( caseWithOtherBuild == OperEx( TlaControlOper.caseWithOther, n_a, n_b, n_c ) )
+    assert(caseWithOtherBuildEmpty == NullEx)
+    assert(caseWithOtherBuildSingle == NullEx)
+    assert(caseWithOtherBuildBad == NullEx)
+    assert(caseWithOtherBuild == OperEx(TlaControlOper.caseWithOther, n_a, n_b, n_c))
 
-    val iteBuildBad1 = bd.byNameOrNull( TlaControlOper.ifThenElse.name, n_a, n_b )
-    val iteBuild = bd.byNameOrNull( TlaControlOper.ifThenElse.name, n_a, n_b, n_c )
-    val iteBuildBad2 = bd.byNameOrNull( TlaControlOper.ifThenElse.name, n_a, n_b, n_c, n_d )
+    val iteBuildBad1 = bd.byNameOrNull(TlaControlOper.ifThenElse.name, n_a, n_b)
+    val iteBuild = bd.byNameOrNull(TlaControlOper.ifThenElse.name, n_a, n_b, n_c)
+    val iteBuildBad2 = bd.byNameOrNull(TlaControlOper.ifThenElse.name, n_a, n_b, n_c, n_d)
 
-    assert( iteBuildBad1 == NullEx )
-    assert( iteBuild == OperEx( TlaControlOper.ifThenElse, n_a, n_b, n_c ) )
-    assert( iteBuildBad2 == NullEx )
+    assert(iteBuildBad1 == NullEx)
+    assert(iteBuild == OperEx(TlaControlOper.ifThenElse, n_a, n_b, n_c))
+    assert(iteBuildBad2 == NullEx)
   }
 
-  test( "Test direct methods: TlaTempOper" ) {
-    val AABuild = bd.AA( n_a, n_b )
+  test("Test direct methods: TlaTempOper") {
+    val AABuild = bd.AA(n_a, n_b)
 
-    assert( AABuild == OperEx( TlaTempOper.AA, n_a, n_b ) )
+    assert(AABuild == OperEx(TlaTempOper.AA, n_a, n_b))
 
-    val EEBuild = bd.EE( n_a, n_b )
+    val EEBuild = bd.EE(n_a, n_b)
 
-    assert( EEBuild == OperEx( TlaTempOper.EE, n_a, n_b ) )
+    assert(EEBuild == OperEx(TlaTempOper.EE, n_a, n_b))
 
-    val boxBuild = bd.box( n_a )
+    val boxBuild = bd.box(n_a)
 
-    assert( boxBuild == OperEx( TlaTempOper.box, n_a ) )
+    assert(boxBuild == OperEx(TlaTempOper.box, n_a))
 
-    val diamondBuild = bd.diamond( n_a )
+    val diamondBuild = bd.diamond(n_a)
 
-    assert( diamondBuild == OperEx( TlaTempOper.diamond, n_a ) )
+    assert(diamondBuild == OperEx(TlaTempOper.diamond, n_a))
 
-    val leadsToBuild = bd.leadsTo( n_a, n_b )
+    val leadsToBuild = bd.leadsTo(n_a, n_b)
 
-    assert( leadsToBuild == OperEx( TlaTempOper.leadsTo, n_a, n_b ) )
+    assert(leadsToBuild == OperEx(TlaTempOper.leadsTo, n_a, n_b))
 
-    val guaranteesBuild = bd.guarantees( n_a, n_b )
+    val guaranteesBuild = bd.guarantees(n_a, n_b)
 
-    assert( guaranteesBuild == OperEx( TlaTempOper.guarantees, n_a, n_b ) )
+    assert(guaranteesBuild == OperEx(TlaTempOper.guarantees, n_a, n_b))
 
-    val strongFairnessBuild = bd.SF( n_a, n_b )
+    val strongFairnessBuild = bd.SF(n_a, n_b)
 
-    assert( strongFairnessBuild == OperEx( TlaTempOper.strongFairness, n_a, n_b ) )
+    assert(strongFairnessBuild == OperEx(TlaTempOper.strongFairness, n_a, n_b))
 
-    val weakFairnessBuild = bd.WF( n_a, n_b )
+    val weakFairnessBuild = bd.WF(n_a, n_b)
 
-    assert( weakFairnessBuild == OperEx( TlaTempOper.weakFairness, n_a, n_b ) )
+    assert(weakFairnessBuild == OperEx(TlaTempOper.weakFairness, n_a, n_b))
   }
 
-  test( "Test byName: TlaTempOper" ) {
-    val AABuild = bd.byName( TlaTempOper.AA.name, n_a, n_b )
+  test("Test byName: TlaTempOper") {
+    val AABuild = bd.byName(TlaTempOper.AA.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.AA.name, n_a ) )
-    assert( AABuild == OperEx( TlaTempOper.AA, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.AA.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.AA.name, n_a))
+    assert(AABuild == OperEx(TlaTempOper.AA, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.AA.name, n_a, n_b, n_c))
 
-    val EEBuild = bd.byName( TlaTempOper.EE.name, n_a, n_b )
+    val EEBuild = bd.byName(TlaTempOper.EE.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.EE.name, n_a ) )
-    assert( EEBuild == OperEx( TlaTempOper.EE, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.EE.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.EE.name, n_a))
+    assert(EEBuild == OperEx(TlaTempOper.EE, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.EE.name, n_a, n_b, n_c))
 
-    val boxBuild = bd.byName( TlaTempOper.box.name, n_a )
+    val boxBuild = bd.byName(TlaTempOper.box.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.box.name ) )
-    assert( boxBuild == OperEx( TlaTempOper.box, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.box.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.box.name))
+    assert(boxBuild == OperEx(TlaTempOper.box, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.box.name, n_a, n_b))
 
-    val diamondBuild = bd.byName( TlaTempOper.diamond.name, n_a )
+    val diamondBuild = bd.byName(TlaTempOper.diamond.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.diamond.name ) )
-    assert( diamondBuild == OperEx( TlaTempOper.diamond, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.diamond.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.diamond.name))
+    assert(diamondBuild == OperEx(TlaTempOper.diamond, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.diamond.name, n_a, n_b))
 
-    val leadsToBuild = bd.byName( TlaTempOper.leadsTo.name, n_a, n_b )
+    val leadsToBuild = bd.byName(TlaTempOper.leadsTo.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.leadsTo.name, n_a ) )
-    assert( leadsToBuild == OperEx( TlaTempOper.leadsTo, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.leadsTo.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.leadsTo.name, n_a))
+    assert(leadsToBuild == OperEx(TlaTempOper.leadsTo, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.leadsTo.name, n_a, n_b, n_c))
 
-    val guaranteesBuild = bd.byName( TlaTempOper.guarantees.name, n_a, n_b )
+    val guaranteesBuild = bd.byName(TlaTempOper.guarantees.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.guarantees.name, n_a ) )
-    assert( guaranteesBuild == OperEx( TlaTempOper.guarantees, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.guarantees.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.guarantees.name, n_a))
+    assert(guaranteesBuild == OperEx(TlaTempOper.guarantees, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.guarantees.name, n_a, n_b, n_c))
 
-    val strongFairnessBuild = bd.byName( TlaTempOper.strongFairness.name, n_a, n_b )
+    val strongFairnessBuild = bd.byName(TlaTempOper.strongFairness.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.strongFairness.name, n_a ) )
-    assert( strongFairnessBuild == OperEx( TlaTempOper.strongFairness, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.strongFairness.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.strongFairness.name, n_a))
+    assert(strongFairnessBuild == OperEx(TlaTempOper.strongFairness, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.strongFairness.name, n_a, n_b, n_c))
 
-    val weakFairnessBuild = bd.byName( TlaTempOper.weakFairness.name, n_a, n_b )
+    val weakFairnessBuild = bd.byName(TlaTempOper.weakFairness.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.weakFairness.name, n_a ) )
-    assert( weakFairnessBuild == OperEx( TlaTempOper.weakFairness, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaTempOper.weakFairness.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.weakFairness.name, n_a))
+    assert(weakFairnessBuild == OperEx(TlaTempOper.weakFairness, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaTempOper.weakFairness.name, n_a, n_b, n_c))
 
   }
 
-  test( "Test byNameOrNull: TlaTempOper" ) {
-    val AABuildBad1 = bd.byNameOrNull( TlaTempOper.AA.name, n_a )
-    val AABuild = bd.byNameOrNull( TlaTempOper.AA.name, n_a, n_b )
-    val AABuildBad2 = bd.byNameOrNull( TlaTempOper.AA.name, n_a, n_b, n_c )
+  test("Test byNameOrNull: TlaTempOper") {
+    val AABuildBad1 = bd.byNameOrNull(TlaTempOper.AA.name, n_a)
+    val AABuild = bd.byNameOrNull(TlaTempOper.AA.name, n_a, n_b)
+    val AABuildBad2 = bd.byNameOrNull(TlaTempOper.AA.name, n_a, n_b, n_c)
 
-    assert( AABuildBad1 == NullEx )
-    assert( AABuild == OperEx( TlaTempOper.AA, n_a, n_b ) )
-    assert( AABuildBad2 == NullEx )
+    assert(AABuildBad1 == NullEx)
+    assert(AABuild == OperEx(TlaTempOper.AA, n_a, n_b))
+    assert(AABuildBad2 == NullEx)
 
-    val EEBuildBad1 = bd.byNameOrNull( TlaTempOper.EE.name, n_a )
-    val EEBuild = bd.byNameOrNull( TlaTempOper.EE.name, n_a, n_b )
-    val EEBuildBad2 = bd.byNameOrNull( TlaTempOper.EE.name, n_a, n_b, n_c )
+    val EEBuildBad1 = bd.byNameOrNull(TlaTempOper.EE.name, n_a)
+    val EEBuild = bd.byNameOrNull(TlaTempOper.EE.name, n_a, n_b)
+    val EEBuildBad2 = bd.byNameOrNull(TlaTempOper.EE.name, n_a, n_b, n_c)
 
-    assert( EEBuildBad1 == NullEx )
-    assert( EEBuild == OperEx( TlaTempOper.EE, n_a, n_b ) )
-    assert( EEBuildBad2 == NullEx )
+    assert(EEBuildBad1 == NullEx)
+    assert(EEBuild == OperEx(TlaTempOper.EE, n_a, n_b))
+    assert(EEBuildBad2 == NullEx)
 
-    val boxBuildBad1 = bd.byNameOrNull( TlaTempOper.box.name )
-    val boxBuild = bd.byNameOrNull( TlaTempOper.box.name, n_a )
-    val boxBuildBad2 = bd.byNameOrNull( TlaTempOper.box.name, n_a, n_b )
+    val boxBuildBad1 = bd.byNameOrNull(TlaTempOper.box.name)
+    val boxBuild = bd.byNameOrNull(TlaTempOper.box.name, n_a)
+    val boxBuildBad2 = bd.byNameOrNull(TlaTempOper.box.name, n_a, n_b)
 
-    assert( boxBuildBad1 == NullEx )
-    assert( boxBuild == OperEx( TlaTempOper.box, n_a ) )
-    assert( boxBuildBad2 == NullEx )
+    assert(boxBuildBad1 == NullEx)
+    assert(boxBuild == OperEx(TlaTempOper.box, n_a))
+    assert(boxBuildBad2 == NullEx)
 
-    val diamondBuildBad1 = bd.byNameOrNull( TlaTempOper.diamond.name )
-    val diamondBuild = bd.byNameOrNull( TlaTempOper.diamond.name, n_a )
-    val diamondBuildBad2 = bd.byNameOrNull( TlaTempOper.diamond.name, n_a, n_b )
+    val diamondBuildBad1 = bd.byNameOrNull(TlaTempOper.diamond.name)
+    val diamondBuild = bd.byNameOrNull(TlaTempOper.diamond.name, n_a)
+    val diamondBuildBad2 = bd.byNameOrNull(TlaTempOper.diamond.name, n_a, n_b)
 
-    assert( diamondBuildBad1 == NullEx )
-    assert( diamondBuild == OperEx( TlaTempOper.diamond, n_a ) )
-    assert( diamondBuildBad2 == NullEx )
+    assert(diamondBuildBad1 == NullEx)
+    assert(diamondBuild == OperEx(TlaTempOper.diamond, n_a))
+    assert(diamondBuildBad2 == NullEx)
 
-    val leadsToBuildBad1 = bd.byNameOrNull( TlaTempOper.leadsTo.name, n_a )
-    val leadsToBuild = bd.byNameOrNull( TlaTempOper.leadsTo.name, n_a, n_b )
-    val leadsToBuildBad2 = bd.byNameOrNull( TlaTempOper.leadsTo.name, n_a, n_b, n_c )
+    val leadsToBuildBad1 = bd.byNameOrNull(TlaTempOper.leadsTo.name, n_a)
+    val leadsToBuild = bd.byNameOrNull(TlaTempOper.leadsTo.name, n_a, n_b)
+    val leadsToBuildBad2 = bd.byNameOrNull(TlaTempOper.leadsTo.name, n_a, n_b, n_c)
 
-    assert( leadsToBuildBad1 == NullEx )
-    assert( leadsToBuild == OperEx( TlaTempOper.leadsTo, n_a, n_b ) )
-    assert( leadsToBuildBad2 == NullEx )
+    assert(leadsToBuildBad1 == NullEx)
+    assert(leadsToBuild == OperEx(TlaTempOper.leadsTo, n_a, n_b))
+    assert(leadsToBuildBad2 == NullEx)
 
-    val guaranteesBuildBad1 = bd.byNameOrNull( TlaTempOper.guarantees.name, n_a )
-    val guaranteesBuild = bd.byNameOrNull( TlaTempOper.guarantees.name, n_a, n_b )
-    val guaranteesBuildBad2 = bd.byNameOrNull( TlaTempOper.guarantees.name, n_a, n_b, n_c )
+    val guaranteesBuildBad1 = bd.byNameOrNull(TlaTempOper.guarantees.name, n_a)
+    val guaranteesBuild = bd.byNameOrNull(TlaTempOper.guarantees.name, n_a, n_b)
+    val guaranteesBuildBad2 = bd.byNameOrNull(TlaTempOper.guarantees.name, n_a, n_b, n_c)
 
-    assert( guaranteesBuildBad1 == NullEx )
-    assert( guaranteesBuild == OperEx( TlaTempOper.guarantees, n_a, n_b ) )
-    assert( guaranteesBuildBad2 == NullEx )
+    assert(guaranteesBuildBad1 == NullEx)
+    assert(guaranteesBuild == OperEx(TlaTempOper.guarantees, n_a, n_b))
+    assert(guaranteesBuildBad2 == NullEx)
 
-    val strongFairnessBuildBad1 = bd.byNameOrNull( TlaTempOper.strongFairness.name, n_a )
-    val strongFairnessBuild = bd.byNameOrNull( TlaTempOper.strongFairness.name, n_a, n_b )
-    val strongFairnessBuildBad2 = bd.byNameOrNull( TlaTempOper.strongFairness.name, n_a, n_b, n_c )
+    val strongFairnessBuildBad1 = bd.byNameOrNull(TlaTempOper.strongFairness.name, n_a)
+    val strongFairnessBuild = bd.byNameOrNull(TlaTempOper.strongFairness.name, n_a, n_b)
+    val strongFairnessBuildBad2 = bd.byNameOrNull(TlaTempOper.strongFairness.name, n_a, n_b, n_c)
 
-    assert( strongFairnessBuildBad1 == NullEx )
-    assert( strongFairnessBuild == OperEx( TlaTempOper.strongFairness, n_a, n_b ) )
-    assert( strongFairnessBuildBad2 == NullEx )
+    assert(strongFairnessBuildBad1 == NullEx)
+    assert(strongFairnessBuild == OperEx(TlaTempOper.strongFairness, n_a, n_b))
+    assert(strongFairnessBuildBad2 == NullEx)
 
-    val weakFairnessBuildBad1 = bd.byNameOrNull( TlaTempOper.weakFairness.name, n_a )
-    val weakFairnessBuild = bd.byNameOrNull( TlaTempOper.weakFairness.name, n_a, n_b )
-    val weakFairnessBuildBad2 = bd.byNameOrNull( TlaTempOper.weakFairness.name, n_a, n_b, n_c )
+    val weakFairnessBuildBad1 = bd.byNameOrNull(TlaTempOper.weakFairness.name, n_a)
+    val weakFairnessBuild = bd.byNameOrNull(TlaTempOper.weakFairness.name, n_a, n_b)
+    val weakFairnessBuildBad2 = bd.byNameOrNull(TlaTempOper.weakFairness.name, n_a, n_b, n_c)
 
-    assert( weakFairnessBuildBad1 == NullEx )
-    assert( weakFairnessBuild == OperEx( TlaTempOper.weakFairness, n_a, n_b ) )
-    assert( weakFairnessBuildBad2 == NullEx )
+    assert(weakFairnessBuildBad1 == NullEx)
+    assert(weakFairnessBuild == OperEx(TlaTempOper.weakFairness, n_a, n_b))
+    assert(weakFairnessBuildBad2 == NullEx)
   }
 
-  test( "Test direct methods: TlaArithOper" ) {
+  test("Test direct methods: TlaArithOper") {
     val sumBuild1 = bd.sum()
-    val sumBuild2 = bd.sum( n_a, n_b )
+    val sumBuild2 = bd.sum(n_a, n_b)
 
-    assert( sumBuild1 == OperEx( TlaArithOper.sum ) )
-    assert( sumBuild2 == OperEx( TlaArithOper.sum, n_a, n_b ) )
+    assert(sumBuild1 == OperEx(TlaArithOper.sum))
+    assert(sumBuild2 == OperEx(TlaArithOper.sum, n_a, n_b))
 
-    val plusBuild1 = bd.plus( n_a, n_b )
-    val plusBuild2 = bd.plus( n_a, 2 )
-    val plusBuild3 = bd.plus( 1, n_b )
-    val plusBuild4 = bd.plus( 1, 2 )
+    val plusBuild1 = bd.plus(n_a, n_b)
+    val plusBuild2 = bd.plus(n_a, 2)
+    val plusBuild3 = bd.plus(1, n_b)
+    val plusBuild4 = bd.plus(1, 2)
 
-    assert( plusBuild1 == OperEx( TlaArithOper.plus, n_a, n_b ) )
-    assert( plusBuild2 == OperEx( TlaArithOper.plus, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( plusBuild3 == OperEx( TlaArithOper.plus, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( plusBuild4 == OperEx( TlaArithOper.plus, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(plusBuild1 == OperEx(TlaArithOper.plus, n_a, n_b))
+    assert(plusBuild2 == OperEx(TlaArithOper.plus, n_a, ValEx(TlaInt(2))))
+    assert(plusBuild3 == OperEx(TlaArithOper.plus, ValEx(TlaInt(1)), n_b))
+    assert(plusBuild4 == OperEx(TlaArithOper.plus, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val minusBuild1 = bd.minus( n_a, n_b )
-    val minusBuild2 = bd.minus( n_a, 2 )
-    val minusBuild3 = bd.minus( 1, n_b )
-    val minusBuild4 = bd.minus( 1, 2 )
+    val minusBuild1 = bd.minus(n_a, n_b)
+    val minusBuild2 = bd.minus(n_a, 2)
+    val minusBuild3 = bd.minus(1, n_b)
+    val minusBuild4 = bd.minus(1, 2)
 
-    assert( minusBuild1 == OperEx( TlaArithOper.minus, n_a, n_b ) )
-    assert( minusBuild2 == OperEx( TlaArithOper.minus, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( minusBuild3 == OperEx( TlaArithOper.minus, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( minusBuild4 == OperEx( TlaArithOper.minus, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(minusBuild1 == OperEx(TlaArithOper.minus, n_a, n_b))
+    assert(minusBuild2 == OperEx(TlaArithOper.minus, n_a, ValEx(TlaInt(2))))
+    assert(minusBuild3 == OperEx(TlaArithOper.minus, ValEx(TlaInt(1)), n_b))
+    assert(minusBuild4 == OperEx(TlaArithOper.minus, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val uminusBuild = bd.uminus( n_a )
+    val uminusBuild = bd.uminus(n_a)
 
-    assert( uminusBuild == OperEx( TlaArithOper.uminus, n_a ) )
+    assert(uminusBuild == OperEx(TlaArithOper.uminus, n_a))
 
     val prodBuild1 = bd.prod()
-    val prodBuild2 = bd.prod( n_a, n_b )
+    val prodBuild2 = bd.prod(n_a, n_b)
 
-    assert( prodBuild1 == OperEx( TlaArithOper.prod ) )
-    assert( prodBuild2 == OperEx( TlaArithOper.prod, n_a, n_b ) )
+    assert(prodBuild1 == OperEx(TlaArithOper.prod))
+    assert(prodBuild2 == OperEx(TlaArithOper.prod, n_a, n_b))
 
-    val multBuild1 = bd.mult( n_a, n_b )
-    val multBuild2 = bd.mult( n_a, 2 )
-    val multBuild3 = bd.mult( 1, n_b )
-    val multBuild4 = bd.mult( 1, 2 )
+    val multBuild1 = bd.mult(n_a, n_b)
+    val multBuild2 = bd.mult(n_a, 2)
+    val multBuild3 = bd.mult(1, n_b)
+    val multBuild4 = bd.mult(1, 2)
 
-    assert( multBuild1 == OperEx( TlaArithOper.mult, n_a, n_b ) )
-    assert( multBuild2 == OperEx( TlaArithOper.mult, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( multBuild3 == OperEx( TlaArithOper.mult, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( multBuild4 == OperEx( TlaArithOper.mult, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(multBuild1 == OperEx(TlaArithOper.mult, n_a, n_b))
+    assert(multBuild2 == OperEx(TlaArithOper.mult, n_a, ValEx(TlaInt(2))))
+    assert(multBuild3 == OperEx(TlaArithOper.mult, ValEx(TlaInt(1)), n_b))
+    assert(multBuild4 == OperEx(TlaArithOper.mult, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val divBuild1 = bd.div( n_a, n_b )
-    val divBuild2 = bd.div( n_a, 2 )
-    val divBuild3 = bd.div( 1, n_b )
-    val divBuild4 = bd.div( 1, 2 )
+    val divBuild1 = bd.div(n_a, n_b)
+    val divBuild2 = bd.div(n_a, 2)
+    val divBuild3 = bd.div(1, n_b)
+    val divBuild4 = bd.div(1, 2)
 
-    assert( divBuild1 == OperEx( TlaArithOper.div, n_a, n_b ) )
-    assert( divBuild2 == OperEx( TlaArithOper.div, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( divBuild3 == OperEx( TlaArithOper.div, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( divBuild4 == OperEx( TlaArithOper.div, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(divBuild1 == OperEx(TlaArithOper.div, n_a, n_b))
+    assert(divBuild2 == OperEx(TlaArithOper.div, n_a, ValEx(TlaInt(2))))
+    assert(divBuild3 == OperEx(TlaArithOper.div, ValEx(TlaInt(1)), n_b))
+    assert(divBuild4 == OperEx(TlaArithOper.div, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val modBuild1 = bd.mod( n_a, n_b )
-    val modBuild2 = bd.mod( n_a, 2 )
-    val modBuild3 = bd.mod( 1, n_b )
-    val modBuild4 = bd.mod( 1, 2 )
+    val modBuild1 = bd.mod(n_a, n_b)
+    val modBuild2 = bd.mod(n_a, 2)
+    val modBuild3 = bd.mod(1, n_b)
+    val modBuild4 = bd.mod(1, 2)
 
-    assert( modBuild1 == OperEx( TlaArithOper.mod, n_a, n_b ) )
-    assert( modBuild2 == OperEx( TlaArithOper.mod, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( modBuild3 == OperEx( TlaArithOper.mod, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( modBuild4 == OperEx( TlaArithOper.mod, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(modBuild1 == OperEx(TlaArithOper.mod, n_a, n_b))
+    assert(modBuild2 == OperEx(TlaArithOper.mod, n_a, ValEx(TlaInt(2))))
+    assert(modBuild3 == OperEx(TlaArithOper.mod, ValEx(TlaInt(1)), n_b))
+    assert(modBuild4 == OperEx(TlaArithOper.mod, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val realDivBuild1 = bd.rDiv( n_a, n_b )
-    val realDivBuild2 = bd.rDiv( n_a, 2 )
-    val realDivBuild3 = bd.rDiv( 1, n_b )
-    val realDivBuild4 = bd.rDiv( 1, 2 )
+    val realDivBuild1 = bd.rDiv(n_a, n_b)
+    val realDivBuild2 = bd.rDiv(n_a, 2)
+    val realDivBuild3 = bd.rDiv(1, n_b)
+    val realDivBuild4 = bd.rDiv(1, 2)
 
-    assert( realDivBuild1 == OperEx( TlaArithOper.realDiv, n_a, n_b ) )
-    assert( realDivBuild2 == OperEx( TlaArithOper.realDiv, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( realDivBuild3 == OperEx( TlaArithOper.realDiv, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( realDivBuild4 == OperEx( TlaArithOper.realDiv, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(realDivBuild1 == OperEx(TlaArithOper.realDiv, n_a, n_b))
+    assert(realDivBuild2 == OperEx(TlaArithOper.realDiv, n_a, ValEx(TlaInt(2))))
+    assert(realDivBuild3 == OperEx(TlaArithOper.realDiv, ValEx(TlaInt(1)), n_b))
+    assert(realDivBuild4 == OperEx(TlaArithOper.realDiv, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val expBuild1 = bd.exp( n_a, n_b )
-    val expBuild2 = bd.exp( n_a, 2 )
-    val expBuild3 = bd.exp( 1, n_b )
-    val expBuild4 = bd.exp( 1, 2 )
+    val expBuild1 = bd.exp(n_a, n_b)
+    val expBuild2 = bd.exp(n_a, 2)
+    val expBuild3 = bd.exp(1, n_b)
+    val expBuild4 = bd.exp(1, 2)
 
-    assert( expBuild1 == OperEx( TlaArithOper.exp, n_a, n_b ) )
-    assert( expBuild2 == OperEx( TlaArithOper.exp, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( expBuild3 == OperEx( TlaArithOper.exp, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( expBuild4 == OperEx( TlaArithOper.exp, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(expBuild1 == OperEx(TlaArithOper.exp, n_a, n_b))
+    assert(expBuild2 == OperEx(TlaArithOper.exp, n_a, ValEx(TlaInt(2))))
+    assert(expBuild3 == OperEx(TlaArithOper.exp, ValEx(TlaInt(1)), n_b))
+    assert(expBuild4 == OperEx(TlaArithOper.exp, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val dotdotBuild1 = bd.dotdot( n_a, n_b )
-    val dotdotBuild2 = bd.dotdot( n_a, 2 )
-    val dotdotBuild3 = bd.dotdot( 1, n_b )
-    val dotdotBuild4 = bd.dotdot( 1, 2 )
+    val dotdotBuild1 = bd.dotdot(n_a, n_b)
+    val dotdotBuild2 = bd.dotdot(n_a, 2)
+    val dotdotBuild3 = bd.dotdot(1, n_b)
+    val dotdotBuild4 = bd.dotdot(1, 2)
 
-    assert( dotdotBuild1 == OperEx( TlaArithOper.dotdot, n_a, n_b ) )
-    assert( dotdotBuild2 == OperEx( TlaArithOper.dotdot, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( dotdotBuild3 == OperEx( TlaArithOper.dotdot, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( dotdotBuild4 == OperEx( TlaArithOper.dotdot, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(dotdotBuild1 == OperEx(TlaArithOper.dotdot, n_a, n_b))
+    assert(dotdotBuild2 == OperEx(TlaArithOper.dotdot, n_a, ValEx(TlaInt(2))))
+    assert(dotdotBuild3 == OperEx(TlaArithOper.dotdot, ValEx(TlaInt(1)), n_b))
+    assert(dotdotBuild4 == OperEx(TlaArithOper.dotdot, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val ltBuild1 = bd.lt( n_a, n_b )
-    val ltBuild2 = bd.lt( n_a, 2 )
-    val ltBuild3 = bd.lt( 1, n_b )
-    val ltBuild4 = bd.lt( 1, 2 )
+    val ltBuild1 = bd.lt(n_a, n_b)
+    val ltBuild2 = bd.lt(n_a, 2)
+    val ltBuild3 = bd.lt(1, n_b)
+    val ltBuild4 = bd.lt(1, 2)
 
-    assert( ltBuild1 == OperEx( TlaArithOper.lt, n_a, n_b ) )
-    assert( ltBuild2 == OperEx( TlaArithOper.lt, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( ltBuild3 == OperEx( TlaArithOper.lt, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( ltBuild4 == OperEx( TlaArithOper.lt, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(ltBuild1 == OperEx(TlaArithOper.lt, n_a, n_b))
+    assert(ltBuild2 == OperEx(TlaArithOper.lt, n_a, ValEx(TlaInt(2))))
+    assert(ltBuild3 == OperEx(TlaArithOper.lt, ValEx(TlaInt(1)), n_b))
+    assert(ltBuild4 == OperEx(TlaArithOper.lt, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val gtBuild1 = bd.gt( n_a, n_b )
-    val gtBuild2 = bd.gt( n_a, 2 )
-    val gtBuild3 = bd.gt( 1, n_b )
-    val gtBuild4 = bd.gt( 1, 2 )
+    val gtBuild1 = bd.gt(n_a, n_b)
+    val gtBuild2 = bd.gt(n_a, 2)
+    val gtBuild3 = bd.gt(1, n_b)
+    val gtBuild4 = bd.gt(1, 2)
 
-    assert( gtBuild1 == OperEx( TlaArithOper.gt, n_a, n_b ) )
-    assert( gtBuild2 == OperEx( TlaArithOper.gt, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( gtBuild3 == OperEx( TlaArithOper.gt, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( gtBuild4 == OperEx( TlaArithOper.gt, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(gtBuild1 == OperEx(TlaArithOper.gt, n_a, n_b))
+    assert(gtBuild2 == OperEx(TlaArithOper.gt, n_a, ValEx(TlaInt(2))))
+    assert(gtBuild3 == OperEx(TlaArithOper.gt, ValEx(TlaInt(1)), n_b))
+    assert(gtBuild4 == OperEx(TlaArithOper.gt, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val leBuild1 = bd.le( n_a, n_b )
-    val leBuild2 = bd.le( n_a, 2 )
-    val leBuild3 = bd.le( 1, n_b )
-    val leBuild4 = bd.le( 1, 2 )
+    val leBuild1 = bd.le(n_a, n_b)
+    val leBuild2 = bd.le(n_a, 2)
+    val leBuild3 = bd.le(1, n_b)
+    val leBuild4 = bd.le(1, 2)
 
-    assert( leBuild1 == OperEx( TlaArithOper.le, n_a, n_b ) )
-    assert( leBuild2 == OperEx( TlaArithOper.le, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( leBuild3 == OperEx( TlaArithOper.le, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( leBuild4 == OperEx( TlaArithOper.le, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(leBuild1 == OperEx(TlaArithOper.le, n_a, n_b))
+    assert(leBuild2 == OperEx(TlaArithOper.le, n_a, ValEx(TlaInt(2))))
+    assert(leBuild3 == OperEx(TlaArithOper.le, ValEx(TlaInt(1)), n_b))
+    assert(leBuild4 == OperEx(TlaArithOper.le, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
 
-    val geBuild1 = bd.ge( n_a, n_b )
-    val geBuild2 = bd.ge( n_a, 2 )
-    val geBuild3 = bd.ge( 1, n_b )
-    val geBuild4 = bd.ge( 1, 2 )
+    val geBuild1 = bd.ge(n_a, n_b)
+    val geBuild2 = bd.ge(n_a, 2)
+    val geBuild3 = bd.ge(1, n_b)
+    val geBuild4 = bd.ge(1, 2)
 
-    assert( geBuild1 == OperEx( TlaArithOper.ge, n_a, n_b ) )
-    assert( geBuild2 == OperEx( TlaArithOper.ge, n_a, ValEx( TlaInt( 2 ) ) ) )
-    assert( geBuild3 == OperEx( TlaArithOper.ge, ValEx( TlaInt( 1 ) ), n_b ) )
-    assert( geBuild4 == OperEx( TlaArithOper.ge, ValEx( TlaInt( 1 ) ), ValEx( TlaInt( 2 ) ) ) )
+    assert(geBuild1 == OperEx(TlaArithOper.ge, n_a, n_b))
+    assert(geBuild2 == OperEx(TlaArithOper.ge, n_a, ValEx(TlaInt(2))))
+    assert(geBuild3 == OperEx(TlaArithOper.ge, ValEx(TlaInt(1)), n_b))
+    assert(geBuild4 == OperEx(TlaArithOper.ge, ValEx(TlaInt(1)), ValEx(TlaInt(2))))
   }
 
-  test( "Test byName: TlaArithOper" ) {
-    val sumBuild1 = bd.byName( TlaArithOper.sum.name )
-    val sumBuild2 = bd.byName( TlaArithOper.sum.name, n_a, n_b )
+  test("Test byName: TlaArithOper") {
+    val sumBuild1 = bd.byName(TlaArithOper.sum.name)
+    val sumBuild2 = bd.byName(TlaArithOper.sum.name, n_a, n_b)
 
-    assert( sumBuild1 == OperEx( TlaArithOper.sum ) )
-    assert( sumBuild2 == OperEx( TlaArithOper.sum, n_a, n_b ) )
+    assert(sumBuild1 == OperEx(TlaArithOper.sum))
+    assert(sumBuild2 == OperEx(TlaArithOper.sum, n_a, n_b))
 
-    val plusBuild = bd.byName( TlaArithOper.plus.name, n_a, n_b )
+    val plusBuild = bd.byName(TlaArithOper.plus.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.plus.name, n_a ) )
-    assert( plusBuild == OperEx( TlaArithOper.plus, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.plus.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.plus.name, n_a))
+    assert(plusBuild == OperEx(TlaArithOper.plus, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.plus.name, n_a, n_b, n_c))
 
-    val minusBuild = bd.byName( TlaArithOper.minus.name, n_a, n_b )
+    val minusBuild = bd.byName(TlaArithOper.minus.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.minus.name, n_a ) )
-    assert( minusBuild == OperEx( TlaArithOper.minus, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.minus.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.minus.name, n_a))
+    assert(minusBuild == OperEx(TlaArithOper.minus, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.minus.name, n_a, n_b, n_c))
 
-    val uminusBuild = bd.byName( TlaArithOper.uminus.name, n_a )
+    val uminusBuild = bd.byName(TlaArithOper.uminus.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.uminus.name ) )
-    assert( uminusBuild == OperEx( TlaArithOper.uminus, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.uminus.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.uminus.name))
+    assert(uminusBuild == OperEx(TlaArithOper.uminus, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.uminus.name, n_a, n_b, n_c))
 
-    val prodBuild1 = bd.byName( TlaArithOper.prod.name )
-    val prodBuild2 = bd.byName( TlaArithOper.prod.name, n_a, n_b )
+    val prodBuild1 = bd.byName(TlaArithOper.prod.name)
+    val prodBuild2 = bd.byName(TlaArithOper.prod.name, n_a, n_b)
 
-    assert( prodBuild1 == OperEx( TlaArithOper.prod ) )
-    assert( prodBuild2 == OperEx( TlaArithOper.prod, n_a, n_b ) )
+    assert(prodBuild1 == OperEx(TlaArithOper.prod))
+    assert(prodBuild2 == OperEx(TlaArithOper.prod, n_a, n_b))
 
-    val multBuild = bd.byName( TlaArithOper.mult.name, n_a, n_b )
+    val multBuild = bd.byName(TlaArithOper.mult.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.mult.name, n_a ) )
-    assert( multBuild == OperEx( TlaArithOper.mult, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.mult.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.mult.name, n_a))
+    assert(multBuild == OperEx(TlaArithOper.mult, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.mult.name, n_a, n_b, n_c))
 
-    val divBuild = bd.byName( TlaArithOper.div.name, n_a, n_b )
+    val divBuild = bd.byName(TlaArithOper.div.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.div.name, n_a ) )
-    assert( divBuild == OperEx( TlaArithOper.div, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.div.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.div.name, n_a))
+    assert(divBuild == OperEx(TlaArithOper.div, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.div.name, n_a, n_b, n_c))
 
-    val modBuild = bd.byName( TlaArithOper.mod.name, n_a, n_b )
+    val modBuild = bd.byName(TlaArithOper.mod.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.mod.name, n_a ) )
-    assert( modBuild == OperEx( TlaArithOper.mod, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.mod.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.mod.name, n_a))
+    assert(modBuild == OperEx(TlaArithOper.mod, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.mod.name, n_a, n_b, n_c))
 
-    val realDivBuild = bd.byName( TlaArithOper.realDiv.name, n_a, n_b )
+    val realDivBuild = bd.byName(TlaArithOper.realDiv.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.realDiv.name, n_a ) )
-    assert( realDivBuild == OperEx( TlaArithOper.realDiv, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.realDiv.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.realDiv.name, n_a))
+    assert(realDivBuild == OperEx(TlaArithOper.realDiv, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.realDiv.name, n_a, n_b, n_c))
 
-    val expBuild = bd.byName( TlaArithOper.exp.name, n_a, n_b )
+    val expBuild = bd.byName(TlaArithOper.exp.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.exp.name, n_a ) )
-    assert( expBuild == OperEx( TlaArithOper.exp, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.exp.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.exp.name, n_a))
+    assert(expBuild == OperEx(TlaArithOper.exp, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.exp.name, n_a, n_b, n_c))
 
-    val dotdotBuild = bd.byName( TlaArithOper.dotdot.name, n_a, n_b )
+    val dotdotBuild = bd.byName(TlaArithOper.dotdot.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.dotdot.name, n_a ) )
-    assert( dotdotBuild == OperEx( TlaArithOper.dotdot, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.dotdot.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.dotdot.name, n_a))
+    assert(dotdotBuild == OperEx(TlaArithOper.dotdot, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.dotdot.name, n_a, n_b, n_c))
 
-    val ltBuild = bd.byName( TlaArithOper.lt.name, n_a, n_b )
+    val ltBuild = bd.byName(TlaArithOper.lt.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.lt.name, n_a ) )
-    assert( ltBuild == OperEx( TlaArithOper.lt, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.lt.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.lt.name, n_a))
+    assert(ltBuild == OperEx(TlaArithOper.lt, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.lt.name, n_a, n_b, n_c))
 
-    val gtBuild = bd.byName( TlaArithOper.gt.name, n_a, n_b )
+    val gtBuild = bd.byName(TlaArithOper.gt.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.gt.name, n_a ) )
-    assert( gtBuild == OperEx( TlaArithOper.gt, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.gt.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.gt.name, n_a))
+    assert(gtBuild == OperEx(TlaArithOper.gt, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.gt.name, n_a, n_b, n_c))
 
-    val leBuild = bd.byName( TlaArithOper.le.name, n_a, n_b )
+    val leBuild = bd.byName(TlaArithOper.le.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.le.name, n_a ) )
-    assert( leBuild == OperEx( TlaArithOper.le, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.le.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.le.name, n_a))
+    assert(leBuild == OperEx(TlaArithOper.le, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.le.name, n_a, n_b, n_c))
 
-    val geBuild = bd.byName( TlaArithOper.ge.name, n_a, n_b )
+    val geBuild = bd.byName(TlaArithOper.ge.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.ge.name, n_a ) )
-    assert( geBuild == OperEx( TlaArithOper.ge, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaArithOper.ge.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.ge.name, n_a))
+    assert(geBuild == OperEx(TlaArithOper.ge, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaArithOper.ge.name, n_a, n_b, n_c))
   }
 
-  test( "Test byNameOrNull: TlaArithOper" ) {
-    val sumBuild1 = bd.byNameOrNull( TlaArithOper.sum.name )
-    val sumBuild2 = bd.byNameOrNull( TlaArithOper.sum.name, n_a, n_b )
+  test("Test byNameOrNull: TlaArithOper") {
+    val sumBuild1 = bd.byNameOrNull(TlaArithOper.sum.name)
+    val sumBuild2 = bd.byNameOrNull(TlaArithOper.sum.name, n_a, n_b)
 
-    assert( sumBuild1 == OperEx( TlaArithOper.sum ) )
-    assert( sumBuild2 == OperEx( TlaArithOper.sum, n_a, n_b ) )
+    assert(sumBuild1 == OperEx(TlaArithOper.sum))
+    assert(sumBuild2 == OperEx(TlaArithOper.sum, n_a, n_b))
 
-    val plusBuildBad1 = bd.byNameOrNull( TlaArithOper.plus.name, n_a )
-    val plusBuild = bd.byNameOrNull( TlaArithOper.plus.name, n_a, n_b )
-    val plusBuildBad2 = bd.byNameOrNull( TlaArithOper.plus.name, n_a, n_b, n_c )
+    val plusBuildBad1 = bd.byNameOrNull(TlaArithOper.plus.name, n_a)
+    val plusBuild = bd.byNameOrNull(TlaArithOper.plus.name, n_a, n_b)
+    val plusBuildBad2 = bd.byNameOrNull(TlaArithOper.plus.name, n_a, n_b, n_c)
 
-    assert( plusBuildBad1 == NullEx )
-    assert( plusBuild == OperEx( TlaArithOper.plus, n_a, n_b ) )
-    assert( plusBuildBad2 == NullEx )
+    assert(plusBuildBad1 == NullEx)
+    assert(plusBuild == OperEx(TlaArithOper.plus, n_a, n_b))
+    assert(plusBuildBad2 == NullEx)
 
-    val minusBuildBad1 = bd.byNameOrNull( TlaArithOper.minus.name, n_a )
-    val minusBuild = bd.byNameOrNull( TlaArithOper.minus.name, n_a, n_b )
-    val minusBuildBad2 = bd.byNameOrNull( TlaArithOper.minus.name, n_a, n_b, n_c )
+    val minusBuildBad1 = bd.byNameOrNull(TlaArithOper.minus.name, n_a)
+    val minusBuild = bd.byNameOrNull(TlaArithOper.minus.name, n_a, n_b)
+    val minusBuildBad2 = bd.byNameOrNull(TlaArithOper.minus.name, n_a, n_b, n_c)
 
-    assert( minusBuildBad1 == NullEx )
-    assert( minusBuild == OperEx( TlaArithOper.minus, n_a, n_b ) )
-    assert( minusBuildBad2 == NullEx )
+    assert(minusBuildBad1 == NullEx)
+    assert(minusBuild == OperEx(TlaArithOper.minus, n_a, n_b))
+    assert(minusBuildBad2 == NullEx)
 
-    val uminusBuildBad1 = bd.byNameOrNull( TlaArithOper.uminus.name )
-    val uminusBuild = bd.byNameOrNull( TlaArithOper.uminus.name, n_a )
-    val uminusBuildBad2 = bd.byNameOrNull( TlaArithOper.uminus.name, n_a, n_b, n_c )
+    val uminusBuildBad1 = bd.byNameOrNull(TlaArithOper.uminus.name)
+    val uminusBuild = bd.byNameOrNull(TlaArithOper.uminus.name, n_a)
+    val uminusBuildBad2 = bd.byNameOrNull(TlaArithOper.uminus.name, n_a, n_b, n_c)
 
-    assert( uminusBuildBad1 == NullEx )
-    assert( uminusBuild == OperEx( TlaArithOper.uminus, n_a ) )
-    assert( uminusBuildBad2 == NullEx )
+    assert(uminusBuildBad1 == NullEx)
+    assert(uminusBuild == OperEx(TlaArithOper.uminus, n_a))
+    assert(uminusBuildBad2 == NullEx)
 
-    val prodBuild1 = bd.byNameOrNull( TlaArithOper.prod.name )
-    val prodBuild2 = bd.byNameOrNull( TlaArithOper.prod.name, n_a, n_b )
+    val prodBuild1 = bd.byNameOrNull(TlaArithOper.prod.name)
+    val prodBuild2 = bd.byNameOrNull(TlaArithOper.prod.name, n_a, n_b)
 
-    assert( prodBuild1 == OperEx( TlaArithOper.prod ) )
-    assert( prodBuild2 == OperEx( TlaArithOper.prod, n_a, n_b ) )
+    assert(prodBuild1 == OperEx(TlaArithOper.prod))
+    assert(prodBuild2 == OperEx(TlaArithOper.prod, n_a, n_b))
 
-    val multBuildBad1 = bd.byNameOrNull( TlaArithOper.mult.name, n_a )
-    val multBuild = bd.byNameOrNull( TlaArithOper.mult.name, n_a, n_b )
-    val multBuildBad2 = bd.byNameOrNull( TlaArithOper.mult.name, n_a, n_b, n_c )
+    val multBuildBad1 = bd.byNameOrNull(TlaArithOper.mult.name, n_a)
+    val multBuild = bd.byNameOrNull(TlaArithOper.mult.name, n_a, n_b)
+    val multBuildBad2 = bd.byNameOrNull(TlaArithOper.mult.name, n_a, n_b, n_c)
 
-    assert( multBuildBad1 == NullEx )
-    assert( multBuild == OperEx( TlaArithOper.mult, n_a, n_b ) )
-    assert( multBuildBad2 == NullEx )
+    assert(multBuildBad1 == NullEx)
+    assert(multBuild == OperEx(TlaArithOper.mult, n_a, n_b))
+    assert(multBuildBad2 == NullEx)
 
-    val divBuildBad1 = bd.byNameOrNull( TlaArithOper.div.name, n_a )
-    val divBuild = bd.byNameOrNull( TlaArithOper.div.name, n_a, n_b )
-    val divBuildBad2 = bd.byNameOrNull( TlaArithOper.div.name, n_a, n_b, n_c )
+    val divBuildBad1 = bd.byNameOrNull(TlaArithOper.div.name, n_a)
+    val divBuild = bd.byNameOrNull(TlaArithOper.div.name, n_a, n_b)
+    val divBuildBad2 = bd.byNameOrNull(TlaArithOper.div.name, n_a, n_b, n_c)
 
-    assert( divBuildBad1 == NullEx )
-    assert( divBuild == OperEx( TlaArithOper.div, n_a, n_b ) )
-    assert( divBuildBad2 == NullEx )
+    assert(divBuildBad1 == NullEx)
+    assert(divBuild == OperEx(TlaArithOper.div, n_a, n_b))
+    assert(divBuildBad2 == NullEx)
 
-    val modBuildBad1 = bd.byNameOrNull( TlaArithOper.mod.name, n_a )
-    val modBuild = bd.byNameOrNull( TlaArithOper.mod.name, n_a, n_b )
-    val modBuildBad2 = bd.byNameOrNull( TlaArithOper.mod.name, n_a, n_b, n_c )
+    val modBuildBad1 = bd.byNameOrNull(TlaArithOper.mod.name, n_a)
+    val modBuild = bd.byNameOrNull(TlaArithOper.mod.name, n_a, n_b)
+    val modBuildBad2 = bd.byNameOrNull(TlaArithOper.mod.name, n_a, n_b, n_c)
 
-    assert( modBuildBad1 == NullEx )
-    assert( modBuild == OperEx( TlaArithOper.mod, n_a, n_b ) )
-    assert( modBuildBad2 == NullEx )
+    assert(modBuildBad1 == NullEx)
+    assert(modBuild == OperEx(TlaArithOper.mod, n_a, n_b))
+    assert(modBuildBad2 == NullEx)
 
-    val realDivBuildBad1 = bd.byNameOrNull( TlaArithOper.realDiv.name, n_a )
-    val realDivBuild = bd.byNameOrNull( TlaArithOper.realDiv.name, n_a, n_b )
-    val realDivBuildBad2 = bd.byNameOrNull( TlaArithOper.realDiv.name, n_a, n_b, n_c )
+    val realDivBuildBad1 = bd.byNameOrNull(TlaArithOper.realDiv.name, n_a)
+    val realDivBuild = bd.byNameOrNull(TlaArithOper.realDiv.name, n_a, n_b)
+    val realDivBuildBad2 = bd.byNameOrNull(TlaArithOper.realDiv.name, n_a, n_b, n_c)
 
-    assert( realDivBuildBad1 == NullEx )
-    assert( realDivBuild == OperEx( TlaArithOper.realDiv, n_a, n_b ) )
-    assert( realDivBuildBad2 == NullEx )
+    assert(realDivBuildBad1 == NullEx)
+    assert(realDivBuild == OperEx(TlaArithOper.realDiv, n_a, n_b))
+    assert(realDivBuildBad2 == NullEx)
 
-    val expBuildBad1 = bd.byNameOrNull( TlaArithOper.exp.name, n_a )
-    val expBuild = bd.byNameOrNull( TlaArithOper.exp.name, n_a, n_b )
-    val expBuildBad2 = bd.byNameOrNull( TlaArithOper.exp.name, n_a, n_b, n_c )
+    val expBuildBad1 = bd.byNameOrNull(TlaArithOper.exp.name, n_a)
+    val expBuild = bd.byNameOrNull(TlaArithOper.exp.name, n_a, n_b)
+    val expBuildBad2 = bd.byNameOrNull(TlaArithOper.exp.name, n_a, n_b, n_c)
 
-    assert( expBuildBad1 == NullEx )
-    assert( expBuild == OperEx( TlaArithOper.exp, n_a, n_b ) )
-    assert( expBuildBad2 == NullEx )
+    assert(expBuildBad1 == NullEx)
+    assert(expBuild == OperEx(TlaArithOper.exp, n_a, n_b))
+    assert(expBuildBad2 == NullEx)
 
-    val dotdotBuildBad1 = bd.byNameOrNull( TlaArithOper.dotdot.name, n_a )
-    val dotdotBuild = bd.byNameOrNull( TlaArithOper.dotdot.name, n_a, n_b )
-    val dotdotBuildBad2 = bd.byNameOrNull( TlaArithOper.dotdot.name, n_a, n_b, n_c )
+    val dotdotBuildBad1 = bd.byNameOrNull(TlaArithOper.dotdot.name, n_a)
+    val dotdotBuild = bd.byNameOrNull(TlaArithOper.dotdot.name, n_a, n_b)
+    val dotdotBuildBad2 = bd.byNameOrNull(TlaArithOper.dotdot.name, n_a, n_b, n_c)
 
-    assert( dotdotBuildBad1 == NullEx )
-    assert( dotdotBuild == OperEx( TlaArithOper.dotdot, n_a, n_b ) )
-    assert( dotdotBuildBad2 == NullEx )
+    assert(dotdotBuildBad1 == NullEx)
+    assert(dotdotBuild == OperEx(TlaArithOper.dotdot, n_a, n_b))
+    assert(dotdotBuildBad2 == NullEx)
 
-    val ltBuildBad1 = bd.byNameOrNull( TlaArithOper.lt.name, n_a )
-    val ltBuild = bd.byNameOrNull( TlaArithOper.lt.name, n_a, n_b )
-    val ltBuildBad2 = bd.byNameOrNull( TlaArithOper.lt.name, n_a, n_b, n_c )
+    val ltBuildBad1 = bd.byNameOrNull(TlaArithOper.lt.name, n_a)
+    val ltBuild = bd.byNameOrNull(TlaArithOper.lt.name, n_a, n_b)
+    val ltBuildBad2 = bd.byNameOrNull(TlaArithOper.lt.name, n_a, n_b, n_c)
 
-    assert( ltBuildBad1 == NullEx )
-    assert( ltBuild == OperEx( TlaArithOper.lt, n_a, n_b ) )
-    assert( ltBuildBad2 == NullEx )
+    assert(ltBuildBad1 == NullEx)
+    assert(ltBuild == OperEx(TlaArithOper.lt, n_a, n_b))
+    assert(ltBuildBad2 == NullEx)
 
-    val gtBuildBad1 = bd.byNameOrNull( TlaArithOper.gt.name, n_a )
-    val gtBuild = bd.byNameOrNull( TlaArithOper.gt.name, n_a, n_b )
-    val gtBuildBad2 = bd.byNameOrNull( TlaArithOper.gt.name, n_a, n_b, n_c )
+    val gtBuildBad1 = bd.byNameOrNull(TlaArithOper.gt.name, n_a)
+    val gtBuild = bd.byNameOrNull(TlaArithOper.gt.name, n_a, n_b)
+    val gtBuildBad2 = bd.byNameOrNull(TlaArithOper.gt.name, n_a, n_b, n_c)
 
-    assert( gtBuildBad1 == NullEx )
-    assert( gtBuild == OperEx( TlaArithOper.gt, n_a, n_b ) )
-    assert( gtBuildBad2 == NullEx )
+    assert(gtBuildBad1 == NullEx)
+    assert(gtBuild == OperEx(TlaArithOper.gt, n_a, n_b))
+    assert(gtBuildBad2 == NullEx)
 
-    val leBuildBad1 = bd.byNameOrNull( TlaArithOper.le.name, n_a )
-    val leBuild = bd.byNameOrNull( TlaArithOper.le.name, n_a, n_b )
-    val leBuildBad2 = bd.byNameOrNull( TlaArithOper.le.name, n_a, n_b, n_c )
+    val leBuildBad1 = bd.byNameOrNull(TlaArithOper.le.name, n_a)
+    val leBuild = bd.byNameOrNull(TlaArithOper.le.name, n_a, n_b)
+    val leBuildBad2 = bd.byNameOrNull(TlaArithOper.le.name, n_a, n_b, n_c)
 
-    assert( leBuildBad1 == NullEx )
-    assert( leBuild == OperEx( TlaArithOper.le, n_a, n_b ) )
-    assert( leBuildBad2 == NullEx )
+    assert(leBuildBad1 == NullEx)
+    assert(leBuild == OperEx(TlaArithOper.le, n_a, n_b))
+    assert(leBuildBad2 == NullEx)
 
-    val geBuildBad1 = bd.byNameOrNull( TlaArithOper.ge.name, n_a )
-    val geBuild = bd.byNameOrNull( TlaArithOper.ge.name, n_a, n_b )
-    val geBuildBad2 = bd.byNameOrNull( TlaArithOper.ge.name, n_a, n_b, n_c )
+    val geBuildBad1 = bd.byNameOrNull(TlaArithOper.ge.name, n_a)
+    val geBuild = bd.byNameOrNull(TlaArithOper.ge.name, n_a, n_b)
+    val geBuildBad2 = bd.byNameOrNull(TlaArithOper.ge.name, n_a, n_b, n_c)
 
-    assert( geBuildBad1 == NullEx )
-    assert( geBuild == OperEx( TlaArithOper.ge, n_a, n_b ) )
-    assert( geBuildBad2 == NullEx )
+    assert(geBuildBad1 == NullEx)
+    assert(geBuild == OperEx(TlaArithOper.ge, n_a, n_b))
+    assert(geBuildBad2 == NullEx)
   }
 
-  test( "Test direct methods: TlaFiniteSetOper" ) {
-    val cardinalityBuild = bd.card( n_a )
+  test("Test direct methods: TlaFiniteSetOper") {
+    val cardinalityBuild = bd.card(n_a)
 
-    assert( cardinalityBuild == OperEx( TlaFiniteSetOper.cardinality, n_a ) )
+    assert(cardinalityBuild == OperEx(TlaFiniteSetOper.cardinality, n_a))
 
-    val isFiniteSetBuild = bd.isFin( n_a )
+    val isFiniteSetBuild = bd.isFin(n_a)
 
-    assert( isFiniteSetBuild == OperEx( TlaFiniteSetOper.isFiniteSet, n_a ) )
+    assert(isFiniteSetBuild == OperEx(TlaFiniteSetOper.isFiniteSet, n_a))
   }
 
-  test( "Test byName: TlaFiniteSetOper" ) {
-    val cardinalityBuild = bd.byName( TlaFiniteSetOper.cardinality.name, n_a )
+  test("Test byName: TlaFiniteSetOper") {
+    val cardinalityBuild = bd.byName(TlaFiniteSetOper.cardinality.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFiniteSetOper.cardinality.name ) )
-    assert( cardinalityBuild == OperEx( TlaFiniteSetOper.cardinality, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFiniteSetOper.cardinality.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFiniteSetOper.cardinality.name))
+    assert(cardinalityBuild == OperEx(TlaFiniteSetOper.cardinality, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFiniteSetOper.cardinality.name, n_a, n_b, n_c))
 
-    val isFiniteSetBuild = bd.byName( TlaFiniteSetOper.isFiniteSet.name, n_a )
+    val isFiniteSetBuild = bd.byName(TlaFiniteSetOper.isFiniteSet.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFiniteSetOper.isFiniteSet.name ) )
-    assert( isFiniteSetBuild == OperEx( TlaFiniteSetOper.isFiniteSet, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFiniteSetOper.isFiniteSet.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFiniteSetOper.isFiniteSet.name))
+    assert(isFiniteSetBuild == OperEx(TlaFiniteSetOper.isFiniteSet, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFiniteSetOper.isFiniteSet.name, n_a, n_b, n_c))
   }
 
-  test( "Test byNameOrNull: TlaFiniteSetOper" ) {
-    val cardinalityBuildBad1 = bd.byNameOrNull( TlaFiniteSetOper.cardinality.name )
-    val cardinalityBuild = bd.byNameOrNull( TlaFiniteSetOper.cardinality.name, n_a )
-    val cardinalityBuildBad2 = bd.byNameOrNull( TlaFiniteSetOper.cardinality.name, n_a, n_b, n_c )
+  test("Test byNameOrNull: TlaFiniteSetOper") {
+    val cardinalityBuildBad1 = bd.byNameOrNull(TlaFiniteSetOper.cardinality.name)
+    val cardinalityBuild = bd.byNameOrNull(TlaFiniteSetOper.cardinality.name, n_a)
+    val cardinalityBuildBad2 = bd.byNameOrNull(TlaFiniteSetOper.cardinality.name, n_a, n_b, n_c)
 
-    assert( cardinalityBuildBad1 == NullEx )
-    assert( cardinalityBuild == OperEx( TlaFiniteSetOper.cardinality, n_a ) )
-    assert( cardinalityBuildBad2 == NullEx )
+    assert(cardinalityBuildBad1 == NullEx)
+    assert(cardinalityBuild == OperEx(TlaFiniteSetOper.cardinality, n_a))
+    assert(cardinalityBuildBad2 == NullEx)
 
-    val isFiniteSetBuildBad1 = bd.byNameOrNull( TlaFiniteSetOper.isFiniteSet.name )
-    val isFiniteSetBuild = bd.byNameOrNull( TlaFiniteSetOper.isFiniteSet.name, n_a )
-    val isFiniteSetBuildBad2 = bd.byNameOrNull( TlaFiniteSetOper.isFiniteSet.name, n_a, n_b, n_c )
+    val isFiniteSetBuildBad1 = bd.byNameOrNull(TlaFiniteSetOper.isFiniteSet.name)
+    val isFiniteSetBuild = bd.byNameOrNull(TlaFiniteSetOper.isFiniteSet.name, n_a)
+    val isFiniteSetBuildBad2 = bd.byNameOrNull(TlaFiniteSetOper.isFiniteSet.name, n_a, n_b, n_c)
 
-    assert( isFiniteSetBuildBad1 == NullEx )
-    assert( isFiniteSetBuild == OperEx( TlaFiniteSetOper.isFiniteSet, n_a ) )
-    assert( isFiniteSetBuildBad2 == NullEx )
+    assert(isFiniteSetBuildBad1 == NullEx)
+    assert(isFiniteSetBuild == OperEx(TlaFiniteSetOper.isFiniteSet, n_a))
+    assert(isFiniteSetBuildBad2 == NullEx)
 
   }
 
-  test( "Test direct methods: TlaFunOper" ) {
-    val appBuild = bd.appFun( n_a, n_b )
+  test("Test direct methods: TlaFunOper") {
+    val appBuild = bd.appFun(n_a, n_b)
 
-    assert( appBuild == OperEx( TlaFunOper.app, n_a, n_b ) )
+    assert(appBuild == OperEx(TlaFunOper.app, n_a, n_b))
 
-    val domainBuild = bd.dom( n_a )
+    val domainBuild = bd.dom(n_a)
 
-    assert( domainBuild == OperEx( TlaFunOper.domain, n_a ) )
+    assert(domainBuild == OperEx(TlaFunOper.domain, n_a))
 
-    val enumBuild1 = bd.enumFun( n_a, n_b )
-    val enumBuild2 = bd.enumFun( n_a, n_b, n_c, n_d )
+    val enumBuild1 = bd.enumFun(n_a, n_b)
+    val enumBuild2 = bd.enumFun(n_a, n_b, n_c, n_d)
 
-    assert( enumBuild1 == OperEx( TlaFunOper.enum, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.enumFun( n_a, n_b, n_c ) )
-    assert( enumBuild2 == OperEx( TlaFunOper.enum, n_a, n_b, n_c, n_d ) )
-    assertThrows[IllegalArgumentException]( bd.enumFun( n_a, n_b, n_c, n_d, n_e ) )
+    assert(enumBuild1 == OperEx(TlaFunOper.enum, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.enumFun(n_a, n_b, n_c))
+    assert(enumBuild2 == OperEx(TlaFunOper.enum, n_a, n_b, n_c, n_d))
+    assertThrows[IllegalArgumentException](bd.enumFun(n_a, n_b, n_c, n_d, n_e))
 
-    val exceptBuild1 = bd.except( n_a, n_b, n_c )
-    val exceptBuild2 = bd.except( n_a, n_b, n_c, n_d, n_e )
+    val exceptBuild1 = bd.except(n_a, n_b, n_c)
+    val exceptBuild2 = bd.except(n_a, n_b, n_c, n_d, n_e)
 
-    assert( exceptBuild1 == OperEx( TlaFunOper.except, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.except( n_a, n_b, n_c, n_d ) )
-    assert( exceptBuild2 == OperEx( TlaFunOper.except, n_a, n_b, n_c, n_d, n_e ) )
-    assertThrows[IllegalArgumentException]( bd.except( n_a, n_b, n_c, n_d, n_e, n_f ) )
+    assert(exceptBuild1 == OperEx(TlaFunOper.except, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.except(n_a, n_b, n_c, n_d))
+    assert(exceptBuild2 == OperEx(TlaFunOper.except, n_a, n_b, n_c, n_d, n_e))
+    assertThrows[IllegalArgumentException](bd.except(n_a, n_b, n_c, n_d, n_e, n_f))
 
-    val funDefBuild1 = bd.funDef( n_a, n_b, n_c )
-    val funDefBuild2 = bd.funDef( n_a, n_b, n_c, n_d, n_e )
+    val funDefBuild1 = bd.funDef(n_a, n_b, n_c)
+    val funDefBuild2 = bd.funDef(n_a, n_b, n_c, n_d, n_e)
 
-    assert( funDefBuild1 == OperEx( TlaFunOper.funDef, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.funDef( n_a, n_b, n_c, n_d ) )
-    assert( funDefBuild2 == OperEx( TlaFunOper.funDef, n_a, n_b, n_c, n_d, n_e ) )
-    assertThrows[IllegalArgumentException]( bd.funDef( n_a, n_b, n_c, n_d, n_e, n_f ) )
+    assert(funDefBuild1 == OperEx(TlaFunOper.funDef, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.funDef(n_a, n_b, n_c, n_d))
+    assert(funDefBuild2 == OperEx(TlaFunOper.funDef, n_a, n_b, n_c, n_d, n_e))
+    assertThrows[IllegalArgumentException](bd.funDef(n_a, n_b, n_c, n_d, n_e, n_f))
 
     val tupleBuild1 = bd.tuple()
-    val tupleBuild2 = bd.tuple( n_a, n_b )
+    val tupleBuild2 = bd.tuple(n_a, n_b)
 
-    assert( tupleBuild1 == OperEx( TlaFunOper.tuple ) )
-    assert( tupleBuild2 == OperEx( TlaFunOper.tuple, n_a, n_b ) )
+    assert(tupleBuild1 == OperEx(TlaFunOper.tuple))
+    assert(tupleBuild2 == OperEx(TlaFunOper.tuple, n_a, n_b))
   }
 
-  test( "Test byName: TlaFunOper" ) {
-    val appBuild = bd.byName( TlaFunOper.app.name, n_a, n_b )
+  test("Test byName: TlaFunOper") {
+    val appBuild = bd.byName(TlaFunOper.app.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.app.name, n_a ) )
-    assert( appBuild == OperEx( TlaFunOper.app, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.app.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.app.name, n_a))
+    assert(appBuild == OperEx(TlaFunOper.app, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.app.name, n_a, n_b, n_c))
 
-    val domainBuild = bd.byName( TlaFunOper.domain.name, n_a )
+    val domainBuild = bd.byName(TlaFunOper.domain.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.domain.name ) )
-    assert( domainBuild == OperEx( TlaFunOper.domain, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.domain.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.domain.name))
+    assert(domainBuild == OperEx(TlaFunOper.domain, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.domain.name, n_a, n_b, n_c))
 
-    val enumBuild1 = bd.byName( TlaFunOper.enum.name, n_a, n_b )
-    val enumBuild2 = bd.byName( TlaFunOper.enum.name, n_a, n_b, n_c, n_d )
+    val enumBuild1 = bd.byName(TlaFunOper.enum.name, n_a, n_b)
+    val enumBuild2 = bd.byName(TlaFunOper.enum.name, n_a, n_b, n_c, n_d)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.enum.name ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.enum.name, n_a ) )
-    assert( enumBuild1 == OperEx( TlaFunOper.enum, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.enum.name, n_a, n_b, n_c ) )
-    assert( enumBuild2 == OperEx( TlaFunOper.enum, n_a, n_b, n_c, n_d ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.enum.name, n_a, n_b, n_c, n_d, n_e ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.enum.name))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.enum.name, n_a))
+    assert(enumBuild1 == OperEx(TlaFunOper.enum, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.enum.name, n_a, n_b, n_c))
+    assert(enumBuild2 == OperEx(TlaFunOper.enum, n_a, n_b, n_c, n_d))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.enum.name, n_a, n_b, n_c, n_d, n_e))
 
-    val exceptBuild1 = bd.byName( TlaFunOper.except.name, n_a, n_b, n_c )
-    val exceptBuild2 = bd.byName( TlaFunOper.except.name, n_a, n_b, n_c, n_d, n_e )
+    val exceptBuild1 = bd.byName(TlaFunOper.except.name, n_a, n_b, n_c)
+    val exceptBuild2 = bd.byName(TlaFunOper.except.name, n_a, n_b, n_c, n_d, n_e)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.except.name ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.except.name, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.except.name, n_a, n_b ) )
-    assert( exceptBuild1 == OperEx( TlaFunOper.except, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.except.name, n_a, n_b, n_c, n_d ) )
-    assert( exceptBuild2 == OperEx( TlaFunOper.except, n_a, n_b, n_c, n_d, n_e ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.except.name, n_a, n_b, n_c, n_d, n_e, n_f ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.except.name))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.except.name, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.except.name, n_a, n_b))
+    assert(exceptBuild1 == OperEx(TlaFunOper.except, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.except.name, n_a, n_b, n_c, n_d))
+    assert(exceptBuild2 == OperEx(TlaFunOper.except, n_a, n_b, n_c, n_d, n_e))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.except.name, n_a, n_b, n_c, n_d, n_e, n_f))
 
-    val funDefBuild1 = bd.byName( TlaFunOper.funDef.name, n_a, n_b, n_c )
-    val funDefBuild2 = bd.byName( TlaFunOper.funDef.name, n_a, n_b, n_c, n_d, n_e )
+    val funDefBuild1 = bd.byName(TlaFunOper.funDef.name, n_a, n_b, n_c)
+    val funDefBuild2 = bd.byName(TlaFunOper.funDef.name, n_a, n_b, n_c, n_d, n_e)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.funDef.name ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.funDef.name, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.funDef.name, n_a, n_b ) )
-    assert( funDefBuild1 == OperEx( TlaFunOper.funDef, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.funDef.name, n_a, n_b, n_c, n_d ) )
-    assert( funDefBuild2 == OperEx( TlaFunOper.funDef, n_a, n_b, n_c, n_d, n_e ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaFunOper.funDef.name, n_a, n_b, n_c, n_d, n_e, n_f ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.funDef.name))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.funDef.name, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.funDef.name, n_a, n_b))
+    assert(funDefBuild1 == OperEx(TlaFunOper.funDef, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.funDef.name, n_a, n_b, n_c, n_d))
+    assert(funDefBuild2 == OperEx(TlaFunOper.funDef, n_a, n_b, n_c, n_d, n_e))
+    assertThrows[IllegalArgumentException](bd.byName(TlaFunOper.funDef.name, n_a, n_b, n_c, n_d, n_e, n_f))
 
-    val tupleBuild1 = bd.byName( TlaFunOper.tuple.name )
-    val tupleBuild2 = bd.byName( TlaFunOper.tuple.name, n_a, n_b )
+    val tupleBuild1 = bd.byName(TlaFunOper.tuple.name)
+    val tupleBuild2 = bd.byName(TlaFunOper.tuple.name, n_a, n_b)
 
-    assert( tupleBuild1 == OperEx( TlaFunOper.tuple ) )
-    assert( tupleBuild2 == OperEx( TlaFunOper.tuple, n_a, n_b ) )
+    assert(tupleBuild1 == OperEx(TlaFunOper.tuple))
+    assert(tupleBuild2 == OperEx(TlaFunOper.tuple, n_a, n_b))
 
   }
 
-  test( "Test byNameOrNull: TlaFunOper" ) {
-    val appBuildBad1 = bd.byNameOrNull( TlaFunOper.app.name, n_a )
-    val appBuild = bd.byNameOrNull( TlaFunOper.app.name, n_a, n_b )
-    val appBuildBad2 = bd.byNameOrNull( TlaFunOper.app.name, n_a, n_b, n_c )
+  test("Test byNameOrNull: TlaFunOper") {
+    val appBuildBad1 = bd.byNameOrNull(TlaFunOper.app.name, n_a)
+    val appBuild = bd.byNameOrNull(TlaFunOper.app.name, n_a, n_b)
+    val appBuildBad2 = bd.byNameOrNull(TlaFunOper.app.name, n_a, n_b, n_c)
 
-    assert( appBuildBad1 == NullEx )
-    assert( appBuild == OperEx( TlaFunOper.app, n_a, n_b ) )
-    assert( appBuildBad2 == NullEx )
+    assert(appBuildBad1 == NullEx)
+    assert(appBuild == OperEx(TlaFunOper.app, n_a, n_b))
+    assert(appBuildBad2 == NullEx)
 
-    val domainBuildBad1 = bd.byNameOrNull( TlaFunOper.domain.name )
-    val domainBuild = bd.byNameOrNull( TlaFunOper.domain.name, n_a )
-    val domainBuildBad2 = bd.byNameOrNull( TlaFunOper.domain.name, n_a, n_b, n_c )
+    val domainBuildBad1 = bd.byNameOrNull(TlaFunOper.domain.name)
+    val domainBuild = bd.byNameOrNull(TlaFunOper.domain.name, n_a)
+    val domainBuildBad2 = bd.byNameOrNull(TlaFunOper.domain.name, n_a, n_b, n_c)
 
-    assert( domainBuildBad1 == NullEx )
-    assert( domainBuild == OperEx( TlaFunOper.domain, n_a ) )
-    assert( domainBuildBad2 == NullEx )
+    assert(domainBuildBad1 == NullEx)
+    assert(domainBuild == OperEx(TlaFunOper.domain, n_a))
+    assert(domainBuildBad2 == NullEx)
 
-    val enumBuildEmpty = bd.byNameOrNull( TlaFunOper.enum.name )
-    val enumBuild1 = bd.byNameOrNull( TlaFunOper.enum.name, n_a, n_b )
-    val enumBuildBad1 = bd.byNameOrNull( TlaFunOper.enum.name, n_a, n_b, n_c )
-    val enumBuild2 = bd.byNameOrNull( TlaFunOper.enum.name, n_a, n_b, n_c, n_d )
-    val enumBuildBad2 = bd.byNameOrNull( TlaFunOper.enum.name, n_a, n_b, n_c, n_d, n_e )
+    val enumBuildEmpty = bd.byNameOrNull(TlaFunOper.enum.name)
+    val enumBuild1 = bd.byNameOrNull(TlaFunOper.enum.name, n_a, n_b)
+    val enumBuildBad1 = bd.byNameOrNull(TlaFunOper.enum.name, n_a, n_b, n_c)
+    val enumBuild2 = bd.byNameOrNull(TlaFunOper.enum.name, n_a, n_b, n_c, n_d)
+    val enumBuildBad2 = bd.byNameOrNull(TlaFunOper.enum.name, n_a, n_b, n_c, n_d, n_e)
 
-    assert( enumBuildEmpty == NullEx )
-    assert( enumBuild1 == OperEx( TlaFunOper.enum, n_a, n_b ) )
-    assert( enumBuildBad1 == NullEx )
-    assert( enumBuild2 == OperEx( TlaFunOper.enum, n_a, n_b, n_c, n_d ) )
-    assert( enumBuildBad2 == NullEx )
+    assert(enumBuildEmpty == NullEx)
+    assert(enumBuild1 == OperEx(TlaFunOper.enum, n_a, n_b))
+    assert(enumBuildBad1 == NullEx)
+    assert(enumBuild2 == OperEx(TlaFunOper.enum, n_a, n_b, n_c, n_d))
+    assert(enumBuildBad2 == NullEx)
 
-    val exceptBuildEmpty = bd.byNameOrNull( TlaFunOper.except.name )
-    val exceptBuildSingle = bd.byNameOrNull( TlaFunOper.except.name, n_a )
-    val exceptBuildBad1 = bd.byNameOrNull( TlaFunOper.except.name, n_a, n_b )
-    val exceptBuild1 = bd.byNameOrNull( TlaFunOper.except.name, n_a, n_b, n_c )
-    val exceptBuildBad2 = bd.byNameOrNull( TlaFunOper.except.name, n_a, n_b, n_c, n_d )
-    val exceptBuild2 = bd.byNameOrNull( TlaFunOper.except.name, n_a, n_b, n_c, n_d, n_e )
+    val exceptBuildEmpty = bd.byNameOrNull(TlaFunOper.except.name)
+    val exceptBuildSingle = bd.byNameOrNull(TlaFunOper.except.name, n_a)
+    val exceptBuildBad1 = bd.byNameOrNull(TlaFunOper.except.name, n_a, n_b)
+    val exceptBuild1 = bd.byNameOrNull(TlaFunOper.except.name, n_a, n_b, n_c)
+    val exceptBuildBad2 = bd.byNameOrNull(TlaFunOper.except.name, n_a, n_b, n_c, n_d)
+    val exceptBuild2 = bd.byNameOrNull(TlaFunOper.except.name, n_a, n_b, n_c, n_d, n_e)
 
-    assert( exceptBuildEmpty == NullEx )
-    assert( exceptBuildSingle == NullEx )
-    assert( exceptBuildBad1 == NullEx )
-    assert( exceptBuild1 == OperEx( TlaFunOper.except, n_a, n_b, n_c ) )
-    assert( exceptBuildBad2 == NullEx )
-    assert( exceptBuild2 == OperEx( TlaFunOper.except, n_a, n_b, n_c, n_d, n_e ) )
+    assert(exceptBuildEmpty == NullEx)
+    assert(exceptBuildSingle == NullEx)
+    assert(exceptBuildBad1 == NullEx)
+    assert(exceptBuild1 == OperEx(TlaFunOper.except, n_a, n_b, n_c))
+    assert(exceptBuildBad2 == NullEx)
+    assert(exceptBuild2 == OperEx(TlaFunOper.except, n_a, n_b, n_c, n_d, n_e))
 
-    val funDefBuildEmpty = bd.byNameOrNull( TlaFunOper.funDef.name )
-    val funDefBuildSingle = bd.byNameOrNull( TlaFunOper.funDef.name, n_a )
-    val funDefBuildBad1 = bd.byNameOrNull( TlaFunOper.funDef.name, n_a, n_b )
-    val funDefBuild1 = bd.byNameOrNull( TlaFunOper.funDef.name, n_a, n_b, n_c )
-    val funDefBuildBad2 = bd.byNameOrNull( TlaFunOper.funDef.name, n_a, n_b, n_c, n_d )
-    val funDefBuild2 = bd.byNameOrNull( TlaFunOper.funDef.name, n_a, n_b, n_c, n_d, n_e )
+    val funDefBuildEmpty = bd.byNameOrNull(TlaFunOper.funDef.name)
+    val funDefBuildSingle = bd.byNameOrNull(TlaFunOper.funDef.name, n_a)
+    val funDefBuildBad1 = bd.byNameOrNull(TlaFunOper.funDef.name, n_a, n_b)
+    val funDefBuild1 = bd.byNameOrNull(TlaFunOper.funDef.name, n_a, n_b, n_c)
+    val funDefBuildBad2 = bd.byNameOrNull(TlaFunOper.funDef.name, n_a, n_b, n_c, n_d)
+    val funDefBuild2 = bd.byNameOrNull(TlaFunOper.funDef.name, n_a, n_b, n_c, n_d, n_e)
 
-    assert( funDefBuildEmpty == NullEx )
-    assert( funDefBuildSingle == NullEx )
-    assert( funDefBuildBad1 == NullEx )
-    assert( funDefBuild1 == OperEx( TlaFunOper.funDef, n_a, n_b, n_c ) )
-    assert( funDefBuildBad2 == NullEx )
-    assert( funDefBuild2 == OperEx( TlaFunOper.funDef, n_a, n_b, n_c, n_d, n_e ) )
+    assert(funDefBuildEmpty == NullEx)
+    assert(funDefBuildSingle == NullEx)
+    assert(funDefBuildBad1 == NullEx)
+    assert(funDefBuild1 == OperEx(TlaFunOper.funDef, n_a, n_b, n_c))
+    assert(funDefBuildBad2 == NullEx)
+    assert(funDefBuild2 == OperEx(TlaFunOper.funDef, n_a, n_b, n_c, n_d, n_e))
 
-    val tupleBuild1 = bd.byNameOrNull( TlaFunOper.tuple.name )
-    val tupleBuild2 = bd.byNameOrNull( TlaFunOper.tuple.name, n_a, n_b )
+    val tupleBuild1 = bd.byNameOrNull(TlaFunOper.tuple.name)
+    val tupleBuild2 = bd.byNameOrNull(TlaFunOper.tuple.name, n_a, n_b)
 
-    assert( tupleBuild1 == OperEx( TlaFunOper.tuple ) )
-    assert( tupleBuild2 == OperEx( TlaFunOper.tuple, n_a, n_b ) )
+    assert(tupleBuild1 == OperEx(TlaFunOper.tuple))
+    assert(tupleBuild2 == OperEx(TlaFunOper.tuple, n_a, n_b))
   }
 
-  test( "Test direct methods: TlaSeqOper" ) {
-    val appendBuild = bd.append( n_a, n_b )
+  test("Test direct methods: TlaSeqOper") {
+    val appendBuild = bd.append(n_a, n_b)
 
-    assert( appendBuild == OperEx( TlaSeqOper.append, n_a, n_b ) )
+    assert(appendBuild == OperEx(TlaSeqOper.append, n_a, n_b))
 
-    val concatBuild = bd.concat( n_a, n_b )
+    val concatBuild = bd.concat(n_a, n_b)
 
-    assert( concatBuild == OperEx( TlaSeqOper.concat, n_a, n_b ) )
+    assert(concatBuild == OperEx(TlaSeqOper.concat, n_a, n_b))
 
-    val headBuild = bd.head( n_a )
+    val headBuild = bd.head(n_a)
 
-    assert( headBuild == OperEx( TlaSeqOper.head, n_a ) )
+    assert(headBuild == OperEx(TlaSeqOper.head, n_a))
 
-    val tailBuild = bd.tail( n_a )
+    val tailBuild = bd.tail(n_a)
 
-    assert( tailBuild == OperEx( TlaSeqOper.tail, n_a ) )
+    assert(tailBuild == OperEx(TlaSeqOper.tail, n_a))
 
-    val lenBuild = bd.len( n_a )
+    val lenBuild = bd.len(n_a)
 
-    assert( lenBuild == OperEx( TlaSeqOper.len, n_a ) )
+    assert(lenBuild == OperEx(TlaSeqOper.len, n_a))
   }
 
-  test( "Test byName: TlaSeqOper" ) {
-    val appendBuild = bd.byName( TlaSeqOper.append.name, n_a, n_b )
+  test("Test byName: TlaSeqOper") {
+    val appendBuild = bd.byName(TlaSeqOper.append.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.append.name, n_a ) )
-    assert( appendBuild == OperEx( TlaSeqOper.append, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.append.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.append.name, n_a))
+    assert(appendBuild == OperEx(TlaSeqOper.append, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.append.name, n_a, n_b, n_c))
 
-    val concatBuild = bd.byName( TlaSeqOper.concat.name, n_a, n_b )
+    val concatBuild = bd.byName(TlaSeqOper.concat.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.concat.name, n_a ) )
-    assert( concatBuild == OperEx( TlaSeqOper.concat, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.concat.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.concat.name, n_a))
+    assert(concatBuild == OperEx(TlaSeqOper.concat, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.concat.name, n_a, n_b, n_c))
 
-    val headBuild = bd.byName( TlaSeqOper.head.name, n_a )
+    val headBuild = bd.byName(TlaSeqOper.head.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.head.name ) )
-    assert( headBuild == OperEx( TlaSeqOper.head, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.head.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.head.name))
+    assert(headBuild == OperEx(TlaSeqOper.head, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.head.name, n_a, n_b))
 
-    val tailBuild = bd.byName( TlaSeqOper.tail.name, n_a )
+    val tailBuild = bd.byName(TlaSeqOper.tail.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.tail.name ) )
-    assert( tailBuild == OperEx( TlaSeqOper.tail, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.tail.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.tail.name))
+    assert(tailBuild == OperEx(TlaSeqOper.tail, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.tail.name, n_a, n_b))
 
-    val lenBuild = bd.byName( TlaSeqOper.len.name, n_a )
+    val lenBuild = bd.byName(TlaSeqOper.len.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.len.name ) )
-    assert( lenBuild == OperEx( TlaSeqOper.len, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSeqOper.len.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.len.name))
+    assert(lenBuild == OperEx(TlaSeqOper.len, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSeqOper.len.name, n_a, n_b))
   }
 
-  test( "Test byNameOrNull: TlaSeqOper" ) {
-    val appendBuildBad1 = bd.byNameOrNull( TlaSeqOper.append.name, n_a )
-    val appendBuild = bd.byNameOrNull( TlaSeqOper.append.name, n_a, n_b )
-    val appendBuildBad2 = bd.byNameOrNull( TlaSeqOper.append.name, n_a, n_b, n_c )
+  test("Test byNameOrNull: TlaSeqOper") {
+    val appendBuildBad1 = bd.byNameOrNull(TlaSeqOper.append.name, n_a)
+    val appendBuild = bd.byNameOrNull(TlaSeqOper.append.name, n_a, n_b)
+    val appendBuildBad2 = bd.byNameOrNull(TlaSeqOper.append.name, n_a, n_b, n_c)
 
-    assert( appendBuildBad1 == NullEx )
-    assert( appendBuild == OperEx( TlaSeqOper.append, n_a, n_b ) )
-    assert( appendBuildBad2 == NullEx )
+    assert(appendBuildBad1 == NullEx)
+    assert(appendBuild == OperEx(TlaSeqOper.append, n_a, n_b))
+    assert(appendBuildBad2 == NullEx)
 
-    val concatBuildBad1 = bd.byNameOrNull( TlaSeqOper.concat.name, n_a )
-    val concatBuild = bd.byNameOrNull( TlaSeqOper.concat.name, n_a, n_b )
-    val concatBuildBad2 = bd.byNameOrNull( TlaSeqOper.concat.name, n_a, n_b, n_c )
+    val concatBuildBad1 = bd.byNameOrNull(TlaSeqOper.concat.name, n_a)
+    val concatBuild = bd.byNameOrNull(TlaSeqOper.concat.name, n_a, n_b)
+    val concatBuildBad2 = bd.byNameOrNull(TlaSeqOper.concat.name, n_a, n_b, n_c)
 
-    assert( concatBuildBad1 == NullEx )
-    assert( concatBuild == OperEx( TlaSeqOper.concat, n_a, n_b ) )
-    assert( concatBuildBad2 == NullEx )
+    assert(concatBuildBad1 == NullEx)
+    assert(concatBuild == OperEx(TlaSeqOper.concat, n_a, n_b))
+    assert(concatBuildBad2 == NullEx)
 
-    val headBuildBad1 = bd.byNameOrNull( TlaSeqOper.head.name )
-    val headBuild = bd.byNameOrNull( TlaSeqOper.head.name, n_a )
-    val headBuildBad2 = bd.byNameOrNull( TlaSeqOper.head.name, n_a, n_b )
+    val headBuildBad1 = bd.byNameOrNull(TlaSeqOper.head.name)
+    val headBuild = bd.byNameOrNull(TlaSeqOper.head.name, n_a)
+    val headBuildBad2 = bd.byNameOrNull(TlaSeqOper.head.name, n_a, n_b)
 
-    assert( headBuildBad1 == NullEx )
-    assert( headBuild == OperEx( TlaSeqOper.head, n_a ) )
-    assert( headBuildBad2 == NullEx )
+    assert(headBuildBad1 == NullEx)
+    assert(headBuild == OperEx(TlaSeqOper.head, n_a))
+    assert(headBuildBad2 == NullEx)
 
-    val tailBuildBad1 = bd.byNameOrNull( TlaSeqOper.tail.name )
-    val tailBuild = bd.byNameOrNull( TlaSeqOper.tail.name, n_a )
-    val tailBuildBad2 = bd.byNameOrNull( TlaSeqOper.tail.name, n_a, n_b )
+    val tailBuildBad1 = bd.byNameOrNull(TlaSeqOper.tail.name)
+    val tailBuild = bd.byNameOrNull(TlaSeqOper.tail.name, n_a)
+    val tailBuildBad2 = bd.byNameOrNull(TlaSeqOper.tail.name, n_a, n_b)
 
-    assert( tailBuildBad1 == NullEx )
-    assert( tailBuild == OperEx( TlaSeqOper.tail, n_a ) )
-    assert( tailBuildBad2 == NullEx )
+    assert(tailBuildBad1 == NullEx)
+    assert(tailBuild == OperEx(TlaSeqOper.tail, n_a))
+    assert(tailBuildBad2 == NullEx)
 
-    val lenBuildBad1 = bd.byNameOrNull( TlaSeqOper.len.name )
-    val lenBuild = bd.byNameOrNull( TlaSeqOper.len.name, n_a )
-    val lenBuildBad2 = bd.byNameOrNull( TlaSeqOper.len.name, n_a, n_b )
+    val lenBuildBad1 = bd.byNameOrNull(TlaSeqOper.len.name)
+    val lenBuild = bd.byNameOrNull(TlaSeqOper.len.name, n_a)
+    val lenBuildBad2 = bd.byNameOrNull(TlaSeqOper.len.name, n_a, n_b)
 
-    assert( lenBuildBad1 == NullEx )
-    assert( lenBuild == OperEx( TlaSeqOper.len, n_a ) )
-    assert( lenBuildBad2 == NullEx )
+    assert(lenBuildBad1 == NullEx)
+    assert(lenBuild == OperEx(TlaSeqOper.len, n_a))
+    assert(lenBuildBad2 == NullEx)
   }
 
-  test( "Test direct methods: TlaSetOper" ) {
+  test("Test direct methods: TlaSetOper") {
     val enumSetBuild1 = bd.enumSet()
-    val enumSetBuild2 = bd.enumSet( n_a, n_b )
+    val enumSetBuild2 = bd.enumSet(n_a, n_b)
 
-    assert( enumSetBuild1 == OperEx( TlaSetOper.enumSet ) )
-    assert( enumSetBuild2 == OperEx( TlaSetOper.enumSet, n_a, n_b ) )
+    assert(enumSetBuild1 == OperEx(TlaSetOper.enumSet))
+    assert(enumSetBuild2 == OperEx(TlaSetOper.enumSet, n_a, n_b))
 
-    val inBuild = bd.in( n_a, n_b )
+    val inBuild = bd.in(n_a, n_b)
 
-    assert( inBuild == OperEx( TlaSetOper.in, n_a, n_b ) )
+    assert(inBuild == OperEx(TlaSetOper.in, n_a, n_b))
 
-    val notinBuild = bd.notin( n_a, n_b )
+    val notinBuild = bd.notin(n_a, n_b)
 
-    assert( notinBuild == OperEx( TlaSetOper.notin, n_a, n_b ) )
+    assert(notinBuild == OperEx(TlaSetOper.notin, n_a, n_b))
 
-    val capBuild = bd.cap( n_a, n_b )
+    val capBuild = bd.cap(n_a, n_b)
 
-    assert( capBuild == OperEx( TlaSetOper.cap, n_a, n_b ) )
+    assert(capBuild == OperEx(TlaSetOper.cap, n_a, n_b))
 
-    val cupBuild = bd.cup( n_a, n_b )
+    val cupBuild = bd.cup(n_a, n_b)
 
-    assert( cupBuild == OperEx( TlaSetOper.cup, n_a, n_b ) )
+    assert(cupBuild == OperEx(TlaSetOper.cup, n_a, n_b))
 
-    val unionBuild = bd.union( n_a )
+    val unionBuild = bd.union(n_a)
 
-    assert( unionBuild == OperEx( TlaSetOper.union, n_a ) )
+    assert(unionBuild == OperEx(TlaSetOper.union, n_a))
 
-    val filterBuild = bd.filter( n_a, n_b, n_c )
+    val filterBuild = bd.filter(n_a, n_b, n_c)
 
-    assert( filterBuild == OperEx( TlaSetOper.filter, n_a, n_b, n_c ) )
+    assert(filterBuild == OperEx(TlaSetOper.filter, n_a, n_b, n_c))
 
-    val mapBuild1 = bd.map( n_a, n_b, n_c )
-    val mapBuild2 = bd.map( n_a, n_b, n_c, n_d, n_e )
+    val mapBuild1 = bd.map(n_a, n_b, n_c)
+    val mapBuild2 = bd.map(n_a, n_b, n_c, n_d, n_e)
 
-    assert( mapBuild1 == OperEx( TlaSetOper.map, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.map( n_a, n_b, n_c, n_d ) )
-    assert( mapBuild2 == OperEx( TlaSetOper.map, n_a, n_b, n_c, n_d, n_e ) )
-    assertThrows[IllegalArgumentException]( bd.map( n_a, n_b, n_c, n_d, n_e, n_f ) )
+    assert(mapBuild1 == OperEx(TlaSetOper.map, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.map(n_a, n_b, n_c, n_d))
+    assert(mapBuild2 == OperEx(TlaSetOper.map, n_a, n_b, n_c, n_d, n_e))
+    assertThrows[IllegalArgumentException](bd.map(n_a, n_b, n_c, n_d, n_e, n_f))
 
-    val funSetBuild = bd.funSet( n_a, n_b )
+    val funSetBuild = bd.funSet(n_a, n_b)
 
-    assert( funSetBuild == OperEx( TlaSetOper.funSet, n_a, n_b ) )
+    assert(funSetBuild == OperEx(TlaSetOper.funSet, n_a, n_b))
 
     val recSetBuild1 = bd.recSet()
-    val recSetBuild2 = bd.recSet( n_a, n_b )
+    val recSetBuild2 = bd.recSet(n_a, n_b)
 
-    assert( recSetBuild1 == OperEx( TlaSetOper.recSet ) )
-    assertThrows[IllegalArgumentException]( bd.recSet( n_a ) )
-    assert( recSetBuild2 == OperEx( TlaSetOper.recSet, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.recSet( n_a, n_b, n_c ) )
+    assert(recSetBuild1 == OperEx(TlaSetOper.recSet))
+    assertThrows[IllegalArgumentException](bd.recSet(n_a))
+    assert(recSetBuild2 == OperEx(TlaSetOper.recSet, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.recSet(n_a, n_b, n_c))
 
-    val seqSetBuild = bd.seqSet( n_a )
+    val seqSetBuild = bd.seqSet(n_a)
 
-    assert( seqSetBuild == OperEx( TlaSetOper.seqSet, n_a ) )
+    assert(seqSetBuild == OperEx(TlaSetOper.seqSet, n_a))
 
-    val subsetBuild = bd.subset( n_a, n_b )
+    val subsetBuild = bd.subset(n_a, n_b)
 
-    assert( subsetBuild == OperEx( TlaSetOper.subsetProper, n_a, n_b ) )
+    assert(subsetBuild == OperEx(TlaSetOper.subsetProper, n_a, n_b))
 
-    val subseteqBuild = bd.subseteq( n_a, n_b )
+    val subseteqBuild = bd.subseteq(n_a, n_b)
 
-    assert( subseteqBuild == OperEx( TlaSetOper.subseteq, n_a, n_b ) )
+    assert(subseteqBuild == OperEx(TlaSetOper.subseteq, n_a, n_b))
 
-    val supsetBuild = bd.supset( n_a, n_b )
+    val supsetBuild = bd.supset(n_a, n_b)
 
-    assert( supsetBuild == OperEx( TlaSetOper.supsetProper, n_a, n_b ) )
+    assert(supsetBuild == OperEx(TlaSetOper.supsetProper, n_a, n_b))
 
-    val supseteqBuild = bd.supseteq( n_a, n_b )
+    val supseteqBuild = bd.supseteq(n_a, n_b)
 
-    assert( supseteqBuild == OperEx( TlaSetOper.supseteq, n_a, n_b ) )
+    assert(supseteqBuild == OperEx(TlaSetOper.supseteq, n_a, n_b))
 
-    val setminusBuild = bd.setminus( n_a, n_b )
+    val setminusBuild = bd.setminus(n_a, n_b)
 
-    assert( setminusBuild == OperEx( TlaSetOper.setminus, n_a, n_b ) )
+    assert(setminusBuild == OperEx(TlaSetOper.setminus, n_a, n_b))
 
     val timesBuild1 = bd.times()
-    val timesBuild2 = bd.times( n_a, n_b )
+    val timesBuild2 = bd.times(n_a, n_b)
 
-    assert( timesBuild1 == OperEx( TlaSetOper.times ) )
-    assert( timesBuild2 == OperEx( TlaSetOper.times, n_a, n_b ) )
+    assert(timesBuild1 == OperEx(TlaSetOper.times))
+    assert(timesBuild2 == OperEx(TlaSetOper.times, n_a, n_b))
 
-    val powSetBuild = bd.powSet( n_a )
+    val powSetBuild = bd.powSet(n_a)
 
-    assert( powSetBuild == OperEx( TlaSetOper.powerset, n_a ) )
+    assert(powSetBuild == OperEx(TlaSetOper.powerset, n_a))
   }
 
-  test( "Test byName: TlaSetOper" ) {
-    val enumSetBuild1 = bd.byName( TlaSetOper.enumSet.name )
-    val enumSetBuild2 = bd.byName( TlaSetOper.enumSet.name, n_a, n_b )
+  test("Test byName: TlaSetOper") {
+    val enumSetBuild1 = bd.byName(TlaSetOper.enumSet.name)
+    val enumSetBuild2 = bd.byName(TlaSetOper.enumSet.name, n_a, n_b)
 
-    assert( enumSetBuild1 == OperEx( TlaSetOper.enumSet ) )
-    assert( enumSetBuild2 == OperEx( TlaSetOper.enumSet, n_a, n_b ) )
+    assert(enumSetBuild1 == OperEx(TlaSetOper.enumSet))
+    assert(enumSetBuild2 == OperEx(TlaSetOper.enumSet, n_a, n_b))
 
-    val inBuild = bd.byName( TlaSetOper.in.name, n_a, n_b )
+    val inBuild = bd.byName(TlaSetOper.in.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.in.name, n_a ) )
-    assert( inBuild == OperEx( TlaSetOper.in, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.in.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.in.name, n_a))
+    assert(inBuild == OperEx(TlaSetOper.in, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.in.name, n_a, n_b, n_c))
 
-    val notinBuild = bd.byName( TlaSetOper.notin.name, n_a, n_b )
+    val notinBuild = bd.byName(TlaSetOper.notin.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.notin.name, n_a ) )
-    assert( notinBuild == OperEx( TlaSetOper.notin, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.notin.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.notin.name, n_a))
+    assert(notinBuild == OperEx(TlaSetOper.notin, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.notin.name, n_a, n_b, n_c))
 
-    val capBuild = bd.byName( TlaSetOper.cap.name, n_a, n_b )
+    val capBuild = bd.byName(TlaSetOper.cap.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.cap.name, n_a ) )
-    assert( capBuild == OperEx( TlaSetOper.cap, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.cap.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.cap.name, n_a))
+    assert(capBuild == OperEx(TlaSetOper.cap, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.cap.name, n_a, n_b, n_c))
 
-    val cupBuild = bd.byName( TlaSetOper.cup.name, n_a, n_b )
+    val cupBuild = bd.byName(TlaSetOper.cup.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.cup.name, n_a ) )
-    assert( cupBuild == OperEx( TlaSetOper.cup, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.cup.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.cup.name, n_a))
+    assert(cupBuild == OperEx(TlaSetOper.cup, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.cup.name, n_a, n_b, n_c))
 
-    val unionBuild = bd.byName( TlaSetOper.union.name, n_a )
+    val unionBuild = bd.byName(TlaSetOper.union.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.union.name ) )
-    assert( unionBuild == OperEx( TlaSetOper.union, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.union.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.union.name))
+    assert(unionBuild == OperEx(TlaSetOper.union, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.union.name, n_a, n_b))
 
-    val filterBuild = bd.byName( TlaSetOper.filter.name, n_a, n_b, n_c )
+    val filterBuild = bd.byName(TlaSetOper.filter.name, n_a, n_b, n_c)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.filter.name, n_a, n_b ) )
-    assert( filterBuild == OperEx( TlaSetOper.filter, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.filter.name, n_a, n_b, n_c, n_d ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.filter.name, n_a, n_b))
+    assert(filterBuild == OperEx(TlaSetOper.filter, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.filter.name, n_a, n_b, n_c, n_d))
 
-    val mapBuild1 = bd.byNameOrNull( TlaSetOper.map.name, n_a, n_b, n_c )
-    val mapBuild2 = bd.byNameOrNull( TlaSetOper.map.name, n_a, n_b, n_c, n_d, n_e )
+    val mapBuild1 = bd.byNameOrNull(TlaSetOper.map.name, n_a, n_b, n_c)
+    val mapBuild2 = bd.byNameOrNull(TlaSetOper.map.name, n_a, n_b, n_c, n_d, n_e)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.map.name, n_a, n_b ) )
-    assert( mapBuild1 == OperEx( TlaSetOper.map, n_a, n_b, n_c ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.map.name, n_a, n_b, n_c, n_d ) )
-    assert( mapBuild2 == OperEx( TlaSetOper.map, n_a, n_b, n_c, n_d, n_e ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.map.name, n_a, n_b))
+    assert(mapBuild1 == OperEx(TlaSetOper.map, n_a, n_b, n_c))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.map.name, n_a, n_b, n_c, n_d))
+    assert(mapBuild2 == OperEx(TlaSetOper.map, n_a, n_b, n_c, n_d, n_e))
 
-    val funSetBuild = bd.byName( TlaSetOper.funSet.name, n_a, n_b )
+    val funSetBuild = bd.byName(TlaSetOper.funSet.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.funSet.name, n_a ) )
-    assert( funSetBuild == OperEx( TlaSetOper.funSet, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.funSet.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.funSet.name, n_a))
+    assert(funSetBuild == OperEx(TlaSetOper.funSet, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.funSet.name, n_a, n_b, n_c))
 
-    val recSetBuild1 = bd.byNameOrNull( TlaSetOper.recSet.name )
-    val recSetBuild2 = bd.byNameOrNull( TlaSetOper.recSet.name, n_a, n_b )
+    val recSetBuild1 = bd.byNameOrNull(TlaSetOper.recSet.name)
+    val recSetBuild2 = bd.byNameOrNull(TlaSetOper.recSet.name, n_a, n_b)
 
-    assert( recSetBuild1 == OperEx( TlaSetOper.recSet ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.recSet.name, n_a ) )
-    assert( recSetBuild2 == OperEx( TlaSetOper.recSet, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.recSet.name, n_a, n_b, n_c ) )
+    assert(recSetBuild1 == OperEx(TlaSetOper.recSet))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.recSet.name, n_a))
+    assert(recSetBuild2 == OperEx(TlaSetOper.recSet, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.recSet.name, n_a, n_b, n_c))
 
-    val seqSetBuild = bd.byName( TlaSetOper.seqSet.name, n_a )
+    val seqSetBuild = bd.byName(TlaSetOper.seqSet.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.seqSet.name ) )
-    assert( seqSetBuild == OperEx( TlaSetOper.seqSet, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.seqSet.name, n_a, n_b ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.seqSet.name))
+    assert(seqSetBuild == OperEx(TlaSetOper.seqSet, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.seqSet.name, n_a, n_b))
 
-    val subsetBuild = bd.byName( TlaSetOper.subsetProper.name, n_a, n_b )
+    val subsetBuild = bd.byName(TlaSetOper.subsetProper.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.subsetProper.name, n_a ) )
-    assert( subsetBuild == OperEx( TlaSetOper.subsetProper, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.subsetProper.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.subsetProper.name, n_a))
+    assert(subsetBuild == OperEx(TlaSetOper.subsetProper, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.subsetProper.name, n_a, n_b, n_c))
 
-    val subseteqBuild = bd.byName( TlaSetOper.subseteq.name, n_a, n_b )
+    val subseteqBuild = bd.byName(TlaSetOper.subseteq.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.subseteq.name, n_a ) )
-    assert( subseteqBuild == OperEx( TlaSetOper.subseteq, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.subseteq.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.subseteq.name, n_a))
+    assert(subseteqBuild == OperEx(TlaSetOper.subseteq, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.subseteq.name, n_a, n_b, n_c))
 
-    val supsetBuild = bd.byName( TlaSetOper.supsetProper.name, n_a, n_b )
+    val supsetBuild = bd.byName(TlaSetOper.supsetProper.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.supsetProper.name, n_a ) )
-    assert( supsetBuild == OperEx( TlaSetOper.supsetProper, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.supsetProper.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.supsetProper.name, n_a))
+    assert(supsetBuild == OperEx(TlaSetOper.supsetProper, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.supsetProper.name, n_a, n_b, n_c))
 
-    val supseteqBuild = bd.byName( TlaSetOper.supseteq.name, n_a, n_b )
+    val supseteqBuild = bd.byName(TlaSetOper.supseteq.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.supseteq.name, n_a ) )
-    assert( supseteqBuild == OperEx( TlaSetOper.supseteq, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.supseteq.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.supseteq.name, n_a))
+    assert(supseteqBuild == OperEx(TlaSetOper.supseteq, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.supseteq.name, n_a, n_b, n_c))
 
-    val setminusBuild = bd.byName( TlaSetOper.setminus.name, n_a, n_b )
+    val setminusBuild = bd.byName(TlaSetOper.setminus.name, n_a, n_b)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.setminus.name, n_a ) )
-    assert( setminusBuild == OperEx( TlaSetOper.setminus, n_a, n_b ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.setminus.name, n_a, n_b, n_c ) )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.setminus.name, n_a))
+    assert(setminusBuild == OperEx(TlaSetOper.setminus, n_a, n_b))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.setminus.name, n_a, n_b, n_c))
 
-    val timesBuild1 = bd.byName( TlaSetOper.times.name )
-    val timesBuild2 = bd.byName( TlaSetOper.times.name, n_a, n_b )
+    val timesBuild1 = bd.byName(TlaSetOper.times.name)
+    val timesBuild2 = bd.byName(TlaSetOper.times.name, n_a, n_b)
 
-    assert( timesBuild1 == OperEx( TlaSetOper.times ) )
-    assert( timesBuild2 == OperEx( TlaSetOper.times, n_a, n_b ) )
+    assert(timesBuild1 == OperEx(TlaSetOper.times))
+    assert(timesBuild2 == OperEx(TlaSetOper.times, n_a, n_b))
 
-    val powSetBuild = bd.byName( TlaSetOper.powerset.name, n_a )
+    val powSetBuild = bd.byName(TlaSetOper.powerset.name, n_a)
 
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.powerset.name ) )
-    assert( powSetBuild == OperEx( TlaSetOper.powerset, n_a ) )
-    assertThrows[IllegalArgumentException]( bd.byName( TlaSetOper.powerset.name, n_a, n_b ) )
-
-  }
-
-  test( "Test byNameOrNull: TlaSetOper" ) {
-    val enumSetBuild1 = bd.byNameOrNull( TlaSetOper.enumSet.name )
-    val enumSetBuild2 = bd.byNameOrNull( TlaSetOper.enumSet.name, n_a, n_b )
-
-    assert( enumSetBuild1 == OperEx( TlaSetOper.enumSet ) )
-    assert( enumSetBuild2 == OperEx( TlaSetOper.enumSet, n_a, n_b ) )
-
-    val inBuildBad1 = bd.byNameOrNull( TlaSetOper.in.name, n_a )
-    val inBuild = bd.byNameOrNull( TlaSetOper.in.name, n_a, n_b )
-    val inBuildBad2 = bd.byNameOrNull( TlaSetOper.in.name, n_a, n_b, n_c )
-
-    assert( inBuildBad1 == NullEx )
-    assert( inBuild == OperEx( TlaSetOper.in, n_a, n_b ) )
-    assert( inBuildBad2 == NullEx )
-
-    val notinBuildBad1 = bd.byNameOrNull( TlaSetOper.notin.name, n_a )
-    val notinBuild = bd.byNameOrNull( TlaSetOper.notin.name, n_a, n_b )
-    val notinBuildBad2 = bd.byNameOrNull( TlaSetOper.notin.name, n_a, n_b, n_c )
-
-    assert( notinBuildBad1 == NullEx )
-    assert( notinBuild == OperEx( TlaSetOper.notin, n_a, n_b ) )
-    assert( notinBuildBad2 == NullEx )
-
-    val capBuildBad1 = bd.byNameOrNull( TlaSetOper.cap.name, n_a )
-    val capBuild = bd.byNameOrNull( TlaSetOper.cap.name, n_a, n_b )
-    val capBuildBad2 = bd.byNameOrNull( TlaSetOper.cap.name, n_a, n_b, n_c )
-
-    assert( capBuildBad1 == NullEx )
-    assert( capBuild == OperEx( TlaSetOper.cap, n_a, n_b ) )
-    assert( capBuildBad2 == NullEx )
-
-    val cupBuildBad1 = bd.byNameOrNull( TlaSetOper.cup.name, n_a )
-    val cupBuild = bd.byNameOrNull( TlaSetOper.cup.name, n_a, n_b )
-    val cupBuildBad2 = bd.byNameOrNull( TlaSetOper.cup.name, n_a, n_b, n_c )
-
-    assert( cupBuildBad1 == NullEx )
-    assert( cupBuild == OperEx( TlaSetOper.cup, n_a, n_b ) )
-    assert( cupBuildBad2 == NullEx )
-
-    val unionBuildBad1 = bd.byNameOrNull( TlaSetOper.union.name )
-    val unionBuild = bd.byNameOrNull( TlaSetOper.union.name, n_a )
-    val unionBuildBad2 = bd.byNameOrNull( TlaSetOper.union.name, n_a, n_b )
-
-    assert( unionBuildBad1 == NullEx )
-    assert( unionBuild == OperEx( TlaSetOper.union, n_a ) )
-    assert( unionBuildBad2 == NullEx )
-
-    val filterBuildBad1 = bd.byNameOrNull( TlaSetOper.filter.name, n_a, n_b )
-    val filterBuild = bd.byNameOrNull( TlaSetOper.filter.name, n_a, n_b, n_c )
-    val filterBuildBad2 = bd.byNameOrNull( TlaSetOper.filter.name, n_a, n_b, n_c, n_d )
-
-    assert( filterBuildBad1 == NullEx )
-    assert( filterBuild == OperEx( TlaSetOper.filter, n_a, n_b, n_c ) )
-    assert( filterBuildBad2 == NullEx )
-
-    val mapBuildBad1 = bd.byNameOrNull( TlaSetOper.map.name, n_a, n_b )
-    val mapBuild1 = bd.byNameOrNull( TlaSetOper.map.name, n_a, n_b, n_c )
-    val mapBuildBad2 = bd.byNameOrNull( TlaSetOper.map.name, n_a, n_b, n_c, n_d )
-    val mapBuild2 = bd.byNameOrNull( TlaSetOper.map.name, n_a, n_b, n_c, n_d, n_e )
-
-    assert( mapBuildBad1 == NullEx )
-    assert( mapBuild1 == OperEx( TlaSetOper.map, n_a, n_b, n_c ) )
-    assert( mapBuildBad2 == NullEx )
-    assert( mapBuild2 == OperEx( TlaSetOper.map, n_a, n_b, n_c, n_d, n_e ) )
-
-    val funSetBuildBad1 = bd.byNameOrNull( TlaSetOper.funSet.name, n_a )
-    val funSetBuild = bd.byNameOrNull( TlaSetOper.funSet.name, n_a, n_b )
-    val funSetBuildBad2 = bd.byNameOrNull( TlaSetOper.funSet.name, n_a, n_b, n_c )
-
-    assert( funSetBuildBad1 == NullEx )
-    assert( funSetBuild == OperEx( TlaSetOper.funSet, n_a, n_b ) )
-    assert( funSetBuildBad2 == NullEx )
-
-    val recSetBuild1 = bd.byNameOrNull( TlaSetOper.recSet.name )
-    val recSetBuildBad1 = bd.byNameOrNull( TlaSetOper.recSet.name, n_a )
-    val recSetBuild2 = bd.byNameOrNull( TlaSetOper.recSet.name, n_a, n_b )
-    val recSetBuildBad2 = bd.byNameOrNull( TlaSetOper.recSet.name, n_a, n_b, n_c )
-
-    assert( recSetBuild1 == OperEx( TlaSetOper.recSet ) )
-    assert( recSetBuildBad1 == NullEx )
-    assert( recSetBuild2 == OperEx( TlaSetOper.recSet, n_a, n_b ) )
-    assert( recSetBuildBad2 == NullEx )
-
-    val seqSetBuildBad1 = bd.byNameOrNull( TlaSetOper.seqSet.name )
-    val seqSetBuild = bd.byNameOrNull( TlaSetOper.seqSet.name, n_a )
-    val seqSetBuildBad2 = bd.byNameOrNull( TlaSetOper.seqSet.name, n_a, n_b )
-
-    assert( seqSetBuildBad1 == NullEx )
-    assert( seqSetBuild == OperEx( TlaSetOper.seqSet, n_a ) )
-    assert( seqSetBuildBad2 == NullEx )
-
-    val subsetBuildBad1 = bd.byNameOrNull( TlaSetOper.subsetProper.name, n_a )
-    val subsetBuild = bd.byNameOrNull( TlaSetOper.subsetProper.name, n_a, n_b )
-    val subsetBuildBad2 = bd.byNameOrNull( TlaSetOper.subsetProper.name, n_a, n_b, n_c )
-
-    assert( subsetBuildBad1 == NullEx )
-    assert( subsetBuild == OperEx( TlaSetOper.subsetProper, n_a, n_b ) )
-    assert( subsetBuildBad2 == NullEx )
-
-    val subseteqBuildBad1 = bd.byNameOrNull( TlaSetOper.subseteq.name, n_a )
-    val subseteqBuild = bd.byNameOrNull( TlaSetOper.subseteq.name, n_a, n_b )
-    val subseteqBuildBad2 = bd.byNameOrNull( TlaSetOper.subseteq.name, n_a, n_b, n_c )
-
-    assert( subseteqBuildBad1 == NullEx )
-    assert( subseteqBuild == OperEx( TlaSetOper.subseteq, n_a, n_b ) )
-    assert( subseteqBuildBad2 == NullEx )
-
-    val supsetBuildBad1 = bd.byNameOrNull( TlaSetOper.supsetProper.name, n_a )
-    val supsetBuild = bd.byNameOrNull( TlaSetOper.supsetProper.name, n_a, n_b )
-    val supsetBuildBad2 = bd.byNameOrNull( TlaSetOper.supsetProper.name, n_a, n_b, n_c )
-
-    assert( supsetBuildBad1 == NullEx )
-    assert( supsetBuild == OperEx( TlaSetOper.supsetProper, n_a, n_b ) )
-    assert( supsetBuildBad2 == NullEx )
-
-    val supseteqBuildBad1 = bd.byNameOrNull( TlaSetOper.supseteq.name, n_a )
-    val supseteqBuild = bd.byNameOrNull( TlaSetOper.supseteq.name, n_a, n_b )
-    val supseteqBuildBad2 = bd.byNameOrNull( TlaSetOper.supseteq.name, n_a, n_b, n_c )
-
-    assert( supseteqBuildBad1 == NullEx )
-    assert( supseteqBuild == OperEx( TlaSetOper.supseteq, n_a, n_b ) )
-    assert( supseteqBuildBad2 == NullEx )
-
-    val setminusBuildBad1 = bd.byNameOrNull( TlaSetOper.setminus.name, n_a )
-    val setminusBuild = bd.byNameOrNull( TlaSetOper.setminus.name, n_a, n_b )
-    val setminusBuildBad2 = bd.byNameOrNull( TlaSetOper.setminus.name, n_a, n_b, n_c )
-
-    assert( setminusBuildBad1 == NullEx )
-    assert( setminusBuild == OperEx( TlaSetOper.setminus, n_a, n_b ) )
-    assert( setminusBuildBad2 == NullEx )
-
-    val timesBuild1 = bd.byNameOrNull( TlaSetOper.times.name )
-    val timesBuild2 = bd.byNameOrNull( TlaSetOper.times.name, n_a, n_b )
-
-    assert( timesBuild1 == OperEx( TlaSetOper.times ) )
-    assert( timesBuild2 == OperEx( TlaSetOper.times, n_a, n_b ) )
-
-    val powersetBuildBad1 = bd.byNameOrNull( TlaSetOper.powerset.name )
-    val powersetBuild = bd.byNameOrNull( TlaSetOper.powerset.name, n_a )
-    val powersetBuildBad2 = bd.byNameOrNull( TlaSetOper.powerset.name, n_a, n_b )
-
-    assert( powersetBuildBad1 == NullEx )
-    assert( powersetBuild == OperEx( TlaSetOper.powerset, n_a ) )
-    assert( powersetBuildBad2 == NullEx )
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.powerset.name))
+    assert(powSetBuild == OperEx(TlaSetOper.powerset, n_a))
+    assertThrows[IllegalArgumentException](bd.byName(TlaSetOper.powerset.name, n_a, n_b))
 
   }
 
-  test( "Test direct methods: TlctOper" ) {
+  test("Test byNameOrNull: TlaSetOper") {
+    val enumSetBuild1 = bd.byNameOrNull(TlaSetOper.enumSet.name)
+    val enumSetBuild2 = bd.byNameOrNull(TlaSetOper.enumSet.name, n_a, n_b)
+
+    assert(enumSetBuild1 == OperEx(TlaSetOper.enumSet))
+    assert(enumSetBuild2 == OperEx(TlaSetOper.enumSet, n_a, n_b))
+
+    val inBuildBad1 = bd.byNameOrNull(TlaSetOper.in.name, n_a)
+    val inBuild = bd.byNameOrNull(TlaSetOper.in.name, n_a, n_b)
+    val inBuildBad2 = bd.byNameOrNull(TlaSetOper.in.name, n_a, n_b, n_c)
+
+    assert(inBuildBad1 == NullEx)
+    assert(inBuild == OperEx(TlaSetOper.in, n_a, n_b))
+    assert(inBuildBad2 == NullEx)
+
+    val notinBuildBad1 = bd.byNameOrNull(TlaSetOper.notin.name, n_a)
+    val notinBuild = bd.byNameOrNull(TlaSetOper.notin.name, n_a, n_b)
+    val notinBuildBad2 = bd.byNameOrNull(TlaSetOper.notin.name, n_a, n_b, n_c)
+
+    assert(notinBuildBad1 == NullEx)
+    assert(notinBuild == OperEx(TlaSetOper.notin, n_a, n_b))
+    assert(notinBuildBad2 == NullEx)
+
+    val capBuildBad1 = bd.byNameOrNull(TlaSetOper.cap.name, n_a)
+    val capBuild = bd.byNameOrNull(TlaSetOper.cap.name, n_a, n_b)
+    val capBuildBad2 = bd.byNameOrNull(TlaSetOper.cap.name, n_a, n_b, n_c)
+
+    assert(capBuildBad1 == NullEx)
+    assert(capBuild == OperEx(TlaSetOper.cap, n_a, n_b))
+    assert(capBuildBad2 == NullEx)
+
+    val cupBuildBad1 = bd.byNameOrNull(TlaSetOper.cup.name, n_a)
+    val cupBuild = bd.byNameOrNull(TlaSetOper.cup.name, n_a, n_b)
+    val cupBuildBad2 = bd.byNameOrNull(TlaSetOper.cup.name, n_a, n_b, n_c)
+
+    assert(cupBuildBad1 == NullEx)
+    assert(cupBuild == OperEx(TlaSetOper.cup, n_a, n_b))
+    assert(cupBuildBad2 == NullEx)
+
+    val unionBuildBad1 = bd.byNameOrNull(TlaSetOper.union.name)
+    val unionBuild = bd.byNameOrNull(TlaSetOper.union.name, n_a)
+    val unionBuildBad2 = bd.byNameOrNull(TlaSetOper.union.name, n_a, n_b)
+
+    assert(unionBuildBad1 == NullEx)
+    assert(unionBuild == OperEx(TlaSetOper.union, n_a))
+    assert(unionBuildBad2 == NullEx)
+
+    val filterBuildBad1 = bd.byNameOrNull(TlaSetOper.filter.name, n_a, n_b)
+    val filterBuild = bd.byNameOrNull(TlaSetOper.filter.name, n_a, n_b, n_c)
+    val filterBuildBad2 = bd.byNameOrNull(TlaSetOper.filter.name, n_a, n_b, n_c, n_d)
+
+    assert(filterBuildBad1 == NullEx)
+    assert(filterBuild == OperEx(TlaSetOper.filter, n_a, n_b, n_c))
+    assert(filterBuildBad2 == NullEx)
+
+    val mapBuildBad1 = bd.byNameOrNull(TlaSetOper.map.name, n_a, n_b)
+    val mapBuild1 = bd.byNameOrNull(TlaSetOper.map.name, n_a, n_b, n_c)
+    val mapBuildBad2 = bd.byNameOrNull(TlaSetOper.map.name, n_a, n_b, n_c, n_d)
+    val mapBuild2 = bd.byNameOrNull(TlaSetOper.map.name, n_a, n_b, n_c, n_d, n_e)
+
+    assert(mapBuildBad1 == NullEx)
+    assert(mapBuild1 == OperEx(TlaSetOper.map, n_a, n_b, n_c))
+    assert(mapBuildBad2 == NullEx)
+    assert(mapBuild2 == OperEx(TlaSetOper.map, n_a, n_b, n_c, n_d, n_e))
+
+    val funSetBuildBad1 = bd.byNameOrNull(TlaSetOper.funSet.name, n_a)
+    val funSetBuild = bd.byNameOrNull(TlaSetOper.funSet.name, n_a, n_b)
+    val funSetBuildBad2 = bd.byNameOrNull(TlaSetOper.funSet.name, n_a, n_b, n_c)
+
+    assert(funSetBuildBad1 == NullEx)
+    assert(funSetBuild == OperEx(TlaSetOper.funSet, n_a, n_b))
+    assert(funSetBuildBad2 == NullEx)
+
+    val recSetBuild1 = bd.byNameOrNull(TlaSetOper.recSet.name)
+    val recSetBuildBad1 = bd.byNameOrNull(TlaSetOper.recSet.name, n_a)
+    val recSetBuild2 = bd.byNameOrNull(TlaSetOper.recSet.name, n_a, n_b)
+    val recSetBuildBad2 = bd.byNameOrNull(TlaSetOper.recSet.name, n_a, n_b, n_c)
+
+    assert(recSetBuild1 == OperEx(TlaSetOper.recSet))
+    assert(recSetBuildBad1 == NullEx)
+    assert(recSetBuild2 == OperEx(TlaSetOper.recSet, n_a, n_b))
+    assert(recSetBuildBad2 == NullEx)
+
+    val seqSetBuildBad1 = bd.byNameOrNull(TlaSetOper.seqSet.name)
+    val seqSetBuild = bd.byNameOrNull(TlaSetOper.seqSet.name, n_a)
+    val seqSetBuildBad2 = bd.byNameOrNull(TlaSetOper.seqSet.name, n_a, n_b)
+
+    assert(seqSetBuildBad1 == NullEx)
+    assert(seqSetBuild == OperEx(TlaSetOper.seqSet, n_a))
+    assert(seqSetBuildBad2 == NullEx)
+
+    val subsetBuildBad1 = bd.byNameOrNull(TlaSetOper.subsetProper.name, n_a)
+    val subsetBuild = bd.byNameOrNull(TlaSetOper.subsetProper.name, n_a, n_b)
+    val subsetBuildBad2 = bd.byNameOrNull(TlaSetOper.subsetProper.name, n_a, n_b, n_c)
+
+    assert(subsetBuildBad1 == NullEx)
+    assert(subsetBuild == OperEx(TlaSetOper.subsetProper, n_a, n_b))
+    assert(subsetBuildBad2 == NullEx)
+
+    val subseteqBuildBad1 = bd.byNameOrNull(TlaSetOper.subseteq.name, n_a)
+    val subseteqBuild = bd.byNameOrNull(TlaSetOper.subseteq.name, n_a, n_b)
+    val subseteqBuildBad2 = bd.byNameOrNull(TlaSetOper.subseteq.name, n_a, n_b, n_c)
+
+    assert(subseteqBuildBad1 == NullEx)
+    assert(subseteqBuild == OperEx(TlaSetOper.subseteq, n_a, n_b))
+    assert(subseteqBuildBad2 == NullEx)
+
+    val supsetBuildBad1 = bd.byNameOrNull(TlaSetOper.supsetProper.name, n_a)
+    val supsetBuild = bd.byNameOrNull(TlaSetOper.supsetProper.name, n_a, n_b)
+    val supsetBuildBad2 = bd.byNameOrNull(TlaSetOper.supsetProper.name, n_a, n_b, n_c)
+
+    assert(supsetBuildBad1 == NullEx)
+    assert(supsetBuild == OperEx(TlaSetOper.supsetProper, n_a, n_b))
+    assert(supsetBuildBad2 == NullEx)
+
+    val supseteqBuildBad1 = bd.byNameOrNull(TlaSetOper.supseteq.name, n_a)
+    val supseteqBuild = bd.byNameOrNull(TlaSetOper.supseteq.name, n_a, n_b)
+    val supseteqBuildBad2 = bd.byNameOrNull(TlaSetOper.supseteq.name, n_a, n_b, n_c)
+
+    assert(supseteqBuildBad1 == NullEx)
+    assert(supseteqBuild == OperEx(TlaSetOper.supseteq, n_a, n_b))
+    assert(supseteqBuildBad2 == NullEx)
+
+    val setminusBuildBad1 = bd.byNameOrNull(TlaSetOper.setminus.name, n_a)
+    val setminusBuild = bd.byNameOrNull(TlaSetOper.setminus.name, n_a, n_b)
+    val setminusBuildBad2 = bd.byNameOrNull(TlaSetOper.setminus.name, n_a, n_b, n_c)
+
+    assert(setminusBuildBad1 == NullEx)
+    assert(setminusBuild == OperEx(TlaSetOper.setminus, n_a, n_b))
+    assert(setminusBuildBad2 == NullEx)
+
+    val timesBuild1 = bd.byNameOrNull(TlaSetOper.times.name)
+    val timesBuild2 = bd.byNameOrNull(TlaSetOper.times.name, n_a, n_b)
+
+    assert(timesBuild1 == OperEx(TlaSetOper.times))
+    assert(timesBuild2 == OperEx(TlaSetOper.times, n_a, n_b))
+
+    val powersetBuildBad1 = bd.byNameOrNull(TlaSetOper.powerset.name)
+    val powersetBuild = bd.byNameOrNull(TlaSetOper.powerset.name, n_a)
+    val powersetBuildBad2 = bd.byNameOrNull(TlaSetOper.powerset.name, n_a, n_b)
+
+    assert(powersetBuildBad1 == NullEx)
+    assert(powersetBuild == OperEx(TlaSetOper.powerset, n_a))
+    assert(powersetBuildBad2 == NullEx)
+
+  }
+
+  test("Test direct methods: TlctOper") {
     val assertMsg = "None"
-    val assertion = bd.tlcAssert( NullEx, assertMsg )
+    val assertion = bd.tlcAssert(NullEx, assertMsg)
 
-    assert( assertion == OperEx( TlcOper.assert, NullEx, bd.str( assertMsg ) ) )
+    assert(assertion == OperEx(TlcOper.assert, NullEx, bd.str(assertMsg)))
   }
 
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIDAllocation.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIDAllocation.scala
@@ -5,197 +5,158 @@ import at.forsyte.apalache.tla.lir.values._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
-  * Created by jkukovec on 11/30/16.
-  */
+ * Created by jkukovec on 11/30/16.
+ */
 
 @RunWith(classOf[JUnitRunner])
-class TestIDAllocation extends FunSuite{
+class TestIDAllocation extends FunSuite {
 
-  def show( thisSpec : TlaSpec) = {
-    thisSpec.declarations.foreach(
-      x => x match {
-        case TlaOperDecl( _, _, ex ) => println( ex )
+  def show(thisSpec: TlaSpec) = {
+    thisSpec.declarations.foreach(x =>
+      x match {
+        case TlaOperDecl(_, _, ex) => println(ex)
       }
     )
   }
 
   /**
-    * SndNewValue(d) == /\ sAck      = sBit
-    *                   /\ sent'     = d
-    *                   /\ sBit'     = 1 - sBit
-    *                   /\ msgQ'     = Append( msgQ, << sBit', d >> )
-    *                   /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
-    */
+   * SndNewValue(d) == /\ sAck      = sBit
+   * /\ sent'     = d
+   * /\ sBit'     = 1 - sBit
+   * /\ msgQ'     = Append( msgQ, << sBit', d >> )
+   * /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
+   */
   val SndNewValue =
-    new TlaOperDecl( "SndNewValue",
-                     List( SimpleFormalParam( "d" ) ),
-                     OperEx( TlaBoolOper.and,
-                             OperEx( TlaOper.eq,
-                                     NameEx( "sAck" ),
-                                     NameEx( "sBit" )
-                             ),
-                             OperEx( TlaOper.eq,
-                                     OperEx( TlaActionOper.prime,
-                                             NameEx( "sent" )
-                                     ),
-                                     NameEx( "d" )
-                             ),
-                             OperEx( TlaOper.eq,
-                                     OperEx( TlaActionOper.prime,
-                                             NameEx( "sBit" )
-                                     ),
-                                     OperEx( TlaArithOper.minus,
-                                             ValEx(TlaInt( 1 )),
-                                             NameEx( "sBit" )
-                                     )
-                             ),
-                             OperEx( TlaOper.eq,
-                                     OperEx( TlaActionOper.prime,
-                                             NameEx( "msgQ" )
-                                     ),
-                                     OperEx( TlaSeqOper.append,
-                                             NameEx( "msgQ" ),
-                                             OperEx( TlaFunOper.tuple,
-                                                     OperEx( TlaActionOper.prime,
-                                                             NameEx( "sBit" )
-                                                     ),
-                                                     NameEx( "d" )
-                                             )
-                                     )
-                             ),
-                             OperEx( TlaActionOper.unchanged,
-                                     OperEx( TlaFunOper.tuple,
-                                             NameEx( "ackQ" ),
-                                             NameEx( "sAck" ),
-                                             NameEx( "rBit" ),
-                                             NameEx( "rcvd" )
-                                     )
-                             )
-                     )
-    )
+    new TlaOperDecl("SndNewValue", List(SimpleFormalParam("d")),
+        OperEx(
+            TlaBoolOper.and,
+            OperEx(TlaOper.eq, NameEx("sAck"), NameEx("sBit")),
+            OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("sent")), NameEx("d")),
+            OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("sBit")),
+                OperEx(TlaArithOper.minus, ValEx(TlaInt(1)), NameEx("sBit"))),
+            OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("msgQ")),
+                OperEx(TlaSeqOper.append, NameEx("msgQ"),
+                    OperEx(TlaFunOper.tuple, OperEx(TlaActionOper.prime, NameEx("sBit")), NameEx("d")))),
+            OperEx(TlaActionOper.unchanged,
+                OperEx(TlaFunOper.tuple, NameEx("ackQ"), NameEx("sAck"), NameEx("rBit"), NameEx("rcvd")))
+        ))
 
-  val sum = OperEx( TlaOper.eq,
-    OperEx( TlaArithOper.plus, ValEx(TlaInt(4)), ValEx(TlaInt(0)) ),
-    OperEx( TlaArithOper.plus, ValEx(TlaInt(2)), ValEx(TlaInt(2)) )
-  )
+  val sum = OperEx(TlaOper.eq, OperEx(TlaArithOper.plus, ValEx(TlaInt(4)), ValEx(TlaInt(0))),
+      OperEx(TlaArithOper.plus, ValEx(TlaInt(2)), ValEx(TlaInt(2))))
 
-  val redundantbool = OperEx( TlaOper.eq,
-    OperEx( TlaBoolOper.and, NameEx( "x" ), ValEx( TlaBool(true) ) ),
-    OperEx( TlaBoolOper.or, ValEx( TlaBool(false) ), NameEx( "x" ) )
-  )
-
+  val redundantbool = OperEx(TlaOper.eq, OperEx(TlaBoolOper.and, NameEx("x"), ValEx(TlaBool(true))),
+      OperEx(TlaBoolOper.or, ValEx(TlaBool(false)), NameEx("x")))
 
   val specSnd = new TlaSpec("Test spec.", List(SndNewValue))
-  val specSum = new TlaSpec( "someSum", List( TlaOperDecl( "sum", List( ), sum ) ) )
-  val specBool = new TlaSpec( "boolSimplification", List( TlaOperDecl( "redundant bool", List( ), redundantbool ) ) )
+  val specSum = new TlaSpec("someSum", List(TlaOperDecl("sum", List(), sum)))
+  val specBool = new TlaSpec("boolSimplification", List(TlaOperDecl("redundant bool", List(), redundantbool)))
   val specRec =
     new TlaSpec(
-      "Recursive arity1",
-      List(
-        TlaOperDecl(
-          "Op",
-          List( SimpleFormalParam( "x" ) ),
-          OperEx(
-            TlaControlOper.ifThenElse,
-            OperEx(
-              TlaOper.eq,
-              NameEx( "x" ),
-              ValEx(TlaInt(0))
-            ),
-            ValEx(TlaInt(0)),
-            OperEx(
-              TlaArithOper.plus,
-              ValEx(TlaInt(1)),
-              OperEx(
-                TlaOper.apply,
-                NameEx( "Op" ),
+        "Recursive arity1",
+        List(
+            TlaOperDecl(
+                "Op",
+                List(SimpleFormalParam("x")),
                 OperEx(
-                  TlaArithOper.minus,
-                  NameEx( "x" ),
-                  ValEx(TlaInt(1))
+                    TlaControlOper.ifThenElse,
+                    OperEx(
+                        TlaOper.eq,
+                        NameEx("x"),
+                        ValEx(TlaInt(0))
+                    ),
+                    ValEx(TlaInt(0)),
+                    OperEx(
+                        TlaArithOper.plus,
+                        ValEx(TlaInt(1)),
+                        OperEx(
+                            TlaOper.apply,
+                            NameEx("Op"),
+                            OperEx(
+                                TlaArithOper.minus,
+                                NameEx("x"),
+                                ValEx(TlaInt(1))
+                            )
+                        )
+                    )
                 )
-              )
             )
-          )
         )
-      )
     )
 
   val ABody =
     OperEx(
-      TlaArithOper.plus,
-      NameEx( "x" ),
-      ValEx(TlaInt(1))
+        TlaArithOper.plus,
+        NameEx("x"),
+        ValEx(TlaInt(1))
     )
   val plusOne =
     new TlaOperDecl(
-      "A",
-      List(SimpleFormalParam( "x" )),
-      ABody
+        "A",
+        List(SimpleFormalParam("x")),
+        ABody
     )
 
   val emc2 =
     new TlaOperDecl(
-      "Esub",
-      List(),
-      OperEx(
-        TlaArithOper.mult,
-        NameEx( "m" ),
+        "Esub",
+        List(),
         OperEx(
-          TlaArithOper.exp,
-          NameEx( "c" ),
-          ValEx(TlaInt(2))
+            TlaArithOper.mult,
+            NameEx("m"),
+            OperEx(
+                TlaArithOper.exp,
+                NameEx("c"),
+                ValEx(TlaInt(2))
+            )
         )
-      )
     )
 
   val importantTheorem =
     new TlaOperDecl(
-      "thrm",
-      List(),
-//      OperEx(
-//        TlaBoolOper.and,
-//        OperEx(
-//          TlaOper.eq,
-//          NameEx( "E" ),
-//          NameEx( "Esub" )
-//        ),
+        "thrm",
+        List(),
+        //      OperEx(
+        //        TlaBoolOper.and,
+        //        OperEx(
+        //          TlaOper.eq,
+        //          NameEx( "E" ),
+        //          NameEx( "Esub" )
+        //        ),
         OperEx(
-          TlaOper.eq,
-          OperEx(
-            TlaArithOper.minus,
-            ValEx(TlaInt(2)),
-            ValEx(TlaInt(1))
-          ),
-          OperEx(
-            TlaArithOper.plus,
+            TlaOper.eq,
             OperEx(
-              TlaOper.apply,
-              NameEx( "A" ),
-              ValEx(TlaInt(0))
+                TlaArithOper.minus,
+                ValEx(TlaInt(2)),
+                ValEx(TlaInt(1))
             ),
-            ValEx(TlaInt(0))
-          )
+            OperEx(
+                TlaArithOper.plus,
+                OperEx(
+                    TlaOper.apply,
+                    NameEx("A"),
+                    ValEx(TlaInt(0))
+                ),
+                ValEx(TlaInt(0))
+            )
         )
 //      )
     )
 
   val specOper = new TlaSpec(
-    "Replace operators",
-    List( plusOne, /*emc2,*/ importantTheorem)
+      "Replace operators",
+      List(plusOne, /*emc2,*/ importantTheorem)
   )
 
-  def sterileRun( f: () => Unit ): Unit ={
+  def sterileRun(f: () => Unit): Unit = {
     f()
   }
 
-  def printSpec( spec:TlaSpec ): Unit ={
+  def printSpec(spec: TlaSpec): Unit = {
     println("\n" + spec.name + ":\n")
-    spec.declarations.foreach( println )
+    spec.declarations.foreach(println)
   }
 
-
-
-  }
+}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIncrementalRenaming.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIncrementalRenaming.scala
@@ -2,11 +2,12 @@ package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestIncrementalRenaming extends FunSuite with TestingPredefs with BeforeAndAfterEach {
 
   import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming._
@@ -18,248 +19,248 @@ class TestIncrementalRenaming extends FunSuite with TestingPredefs with BeforeAn
     renaming = new IncrementalRenaming(TrackerWithListeners())
   }
 
-  test( "Test parseName" ) {
+  test("Test parseName") {
     val initialName = "name"
-    val renamed = makeName( initialName, 42 )
-    val invalid = makeName( renamed, 2 )
+    val renamed = makeName(initialName, 42)
+    val invalid = makeName(renamed, 2)
 
-    assert( parseName( initialName ).isEmpty )
-    assert( parseName( renamed ).contains( (initialName, 42) ) )
+    assert(parseName(initialName).isEmpty)
+    assert(parseName(renamed).contains((initialName, 42)))
     assertThrows[IllegalArgumentException] {
-      parseName( invalid )
+      parseName(invalid)
     }
   }
 
-  test( "Test mergeNameCounters" ) {
-    val m1 = Map( "x" -> 1 )
-    val m2 = Map( "x" -> 2 )
-    val m3 = Map( "y" -> 2 )
-    val m4 = Map( "x" -> 99, "y" -> 99 )
+  test("Test mergeNameCounters") {
+    val m1 = Map("x" -> 1)
+    val m2 = Map("x" -> 2)
+    val m3 = Map("y" -> 2)
+    val m4 = Map("x" -> 99, "y" -> 99)
 
-    val mergeMax = mergeNameCounters( takeMax = true )(_,_)
-    val mergeMin = mergeNameCounters( takeMax = false )(_,_)
+    val mergeMax = mergeNameCounters(takeMax = true)(_, _)
+    val mergeMin = mergeNameCounters(takeMax = false)(_, _)
 
-    assert( mergeMax( Map.empty, Map.empty ).isEmpty )
-    assert( mergeMax( Map.empty, m1 ) == m1 )
-    assert( mergeMax( m1, Map.empty ) == m1 )
-    assert( mergeMax( m1, m2 ) == m2 )
-    assert( mergeMax( m2, m1 ) == m2 )
-    assert( mergeMax( m2, m3 ) == Map( "x" -> 2, "y" -> 2 ) )
-    assert( mergeMax( m3, m2 ) == Map( "x" -> 2, "y" -> 2 ) )
-    assert( List( m1, m2, m3, m4 ).foldLeft( Map.empty[String, Int] ) {
+    assert(mergeMax(Map.empty, Map.empty).isEmpty)
+    assert(mergeMax(Map.empty, m1) == m1)
+    assert(mergeMax(m1, Map.empty) == m1)
+    assert(mergeMax(m1, m2) == m2)
+    assert(mergeMax(m2, m1) == m2)
+    assert(mergeMax(m2, m3) == Map("x" -> 2, "y" -> 2))
+    assert(mergeMax(m3, m2) == Map("x" -> 2, "y" -> 2))
+    assert(List(m1, m2, m3, m4).foldLeft(Map.empty[String, Int]) {
       mergeMax
-    } == m4 )
-    assert( List( m4, m2, m3, m1 ).foldLeft( Map.empty[String, Int] ) {
+    } == m4)
+    assert(List(m4, m2, m3, m1).foldLeft(Map.empty[String, Int]) {
       mergeMax
-    } == m4 )
+    } == m4)
 
-    assert( mergeMin( Map.empty, Map.empty ).isEmpty )
-    assert( mergeMin( Map.empty, m1 ) == m1 )
-    assert( mergeMin( m1, Map.empty ) == m1 )
-    assert( mergeMin( m1, m2 ) == m1 )
-    assert( mergeMin( m2, m1 ) == m1 )
-    assert( mergeMin( m2, m3 ) == Map( "x" -> 2, "y" -> 2 ) )
-    assert( mergeMin( m3, m2 ) == Map( "x" -> 2, "y" -> 2 ) )
-    assert( List( m1, m2, m3, m4 ).foldLeft( Map.empty[String, Int] ) {
+    assert(mergeMin(Map.empty, Map.empty).isEmpty)
+    assert(mergeMin(Map.empty, m1) == m1)
+    assert(mergeMin(m1, Map.empty) == m1)
+    assert(mergeMin(m1, m2) == m1)
+    assert(mergeMin(m2, m1) == m1)
+    assert(mergeMin(m2, m3) == Map("x" -> 2, "y" -> 2))
+    assert(mergeMin(m3, m2) == Map("x" -> 2, "y" -> 2))
+    assert(List(m1, m2, m3, m4).foldLeft(Map.empty[String, Int]) {
       mergeMin
-    } == Map( "x" -> 1, "y" -> 2 ) )
-    assert( List( m4, m2, m3, m1 ).foldLeft( Map.empty[String, Int] ) {
+    } == Map("x" -> 1, "y" -> 2))
+    assert(List(m4, m2, m3, m1).foldLeft(Map.empty[String, Int]) {
       mergeMin
-    } == Map( "x" -> 1, "y" -> 2 ) )
+    } == Map("x" -> 1, "y" -> 2))
   }
 
-  test( "Test nameCounterMapFromEx [TlaEx]" ) {
-    val ex = and( n_x, n_y, n_z, eql( plus( n_t, n_z ), int( 2 ) ) )
+  test("Test nameCounterMapFromEx [TlaEx]") {
+    val ex = and(n_x, n_y, n_z, eql(plus(n_t, n_z), int(2)))
 
-    assert( nameCounterMapFromEx( takeMax = true )(ex).isEmpty )
+    assert(nameCounterMapFromEx(takeMax = true)(ex).isEmpty)
 
     val ex2 = and(
-      name( makeName( "x", 2 ) ),
-      name( makeName( "y", 8 ) ),
-      n_z,
-      eql(
-        plus(
-          name( makeName( "x", 1 ) ),
-          prime( name( makeName( "z", 3 ) ) )
+        name(makeName("x", 2)),
+        name(makeName("y", 8)),
+        n_z,
+        eql(
+            plus(
+                name(makeName("x", 1)),
+                prime(name(makeName("z", 3)))
+            ),
+            int(2)
         ),
-        int( 2 )
-      ),
-      prime( n_x ),
-      name( makeName( "x", 2 ) )
+        prime(n_x),
+        name(makeName("x", 2))
     )
 
-    val ex2Map = nameCounterMapFromEx( takeMax = true )( ex2 )
-    assert( ex2Map ==
-      Map(
-        "x" -> 2,
-        "y" -> 8,
-        "z" -> 3
-      )
-    )
+    val ex2Map = nameCounterMapFromEx(takeMax = true)(ex2)
+    assert(
+        ex2Map ==
+          Map(
+              "x" -> 2,
+              "y" -> 8,
+              "z" -> 3
+          ))
   }
 
-  test( "Test nameCounterMapFromEx [LET-IN TlaDecl]" ){
-    val p1Name = makeName( "p", 1 )
-    val p3Name = makeName( "p", 3 )
-    val p8Name = makeName( "p", 8 )
-    val s3Name = makeName( "s", 3 )
-    val s5Name = makeName( "s", 5 )
+  test("Test nameCounterMapFromEx [LET-IN TlaDecl]") {
+    val p1Name = makeName("p", 1)
+    val p3Name = makeName("p", 3)
+    val p8Name = makeName("p", 8)
+    val s3Name = makeName("s", 3)
+    val s5Name = makeName("s", 5)
 
     val xDecl =
       declOp(
-        "X",
-        and(
-          ge(
-            name( p1Name ),
-            int(0)
+          "X",
+          and(
+              ge(
+                  name(p1Name),
+                  int(0)
+              ),
+              primeInSingleton(n_x, name(p1Name))
           ),
-          primeInSingleton( n_x, name( p1Name ) )
-        ),
-        p1Name,
-        (makeName( "t", 99 ),2) //unused
+          p1Name,
+          (makeName("t", 99), 2) //unused
       )
 
     val yDecl =
       declOp(
-        makeName( "Y", 6 ),
-        exists(
-          name( s3Name ),
-          name( makeName( "T", 1 ) ),
-          eql(
-            plus(
-              name( s3Name ),
-              name( p3Name )
-            ),
-            n_x
-          )
-        ),
-        p3Name
+          makeName("Y", 6),
+          exists(
+              name(s3Name),
+              name(makeName("T", 1)),
+              eql(
+                  plus(
+                      name(s3Name),
+                      name(p3Name)
+                  ),
+                  n_x
+              )
+          ),
+          p3Name
       )
 
     val zDecl =
       declOp(
-        makeName( "Z", 1 ),
-        name( p8Name ),
-        p8Name
+          makeName("Z", 1),
+          name(p8Name),
+          p8Name
       )
 
     /**
-      * LET X(p1,t99(_,_)) == /\ p1 >= 0
-      *                       /\ x' \in {p1}
-      *             Z1(p8) == p8
-      *  IN LET Y6(p3) == \E s3 \in T1 : s3 + p3 = x
-      *      IN /\ \A s5 \in T1 : /\ Z1(s5)
-      *                           /\ Y6(s5)
-      *         /\ y
-      *         /\ X(0,x)
-      */
+     * LET X(p1,t99(_,_)) == /\ p1 >= 0
+     * /\ x' \in {p1}
+     * Z1(p8) == p8
+     * IN LET Y6(p3) == \E s3 \in T1 : s3 + p3 = x
+     * IN /\ \A s5 \in T1 : /\ Z1(s5)
+     * /\ Y6(s5)
+     * /\ y
+     * /\ X(0,x)
+     */
     val letInEx =
       letIn(
-        letIn(
-          and(
-            forall(
-              name( s5Name ),
-              name( makeName( "T", 1 ) ),
+          letIn(
               and(
-                appDecl( zDecl, name( s5Name ) ),
-                appDecl( yDecl, name( s5Name ) )
-              )
-            ),
-            n_y,
-            appDecl( xDecl, int( 0 ), n_x )
+                  forall(
+                      name(s5Name),
+                      name(makeName("T", 1)),
+                      and(
+                          appDecl(zDecl, name(s5Name)),
+                          appDecl(yDecl, name(s5Name))
+                      )
+                  ),
+                  n_y,
+                  appDecl(xDecl, int(0), n_x)
+              ),
+              yDecl
           ),
-          yDecl
-        ),
-        xDecl,
-        zDecl
+          xDecl,
+          zDecl
       )
 
-    val letInExMap = nameCounterMapFromEx( takeMax = true )( letInEx )
-    assert( letInExMap ==
-      Map(
-        "p" -> 8,
-        "s" -> 5,
-        "T" -> 1,
-        "Y" -> 6,
-        "Z" -> 1,
-        "t" -> 99
-      )
-    )
+    val letInExMap = nameCounterMapFromEx(takeMax = true)(letInEx)
+    assert(
+        letInExMap ==
+          Map(
+              "p" -> 8,
+              "s" -> 5,
+              "T" -> 1,
+              "Y" -> 6,
+              "Z" -> 1,
+              "t" -> 99
+          ))
 
   }
 
-  test( "Test apply: basic" ) {
+  test("Test apply: basic") {
     val ex1 = n_x
-    val renamed1 = renaming( ex1 )
+    val renamed1 = renaming(ex1)
 
-    assert( ex1 == renamed1 )
+    assert(ex1 == renamed1)
 
-    val ex2 = exists( n_s, n_T, n_s )
-    val renamed2 = renaming( ex2 )
-    assert( renamed2 == exists( name( makeName("s", 1 ) ), n_T, name( makeName("s", 1 ) ) ) )
+    val ex2 = exists(n_s, n_T, n_s)
+    val renamed2 = renaming(ex2)
+    assert(renamed2 == exists(name(makeName("s", 1)), n_T, name(makeName("s", 1))))
 
-    val renamed2again = renaming( renamed2 )
-    assert( renamed2again == exists( name( makeName("s", 2 ) ), n_T, name( makeName("s", 2 ) ) ) )
+    val renamed2again = renaming(renamed2)
+    assert(renamed2again == exists(name(makeName("s", 2)), n_T, name(makeName("s", 2))))
 
   }
 
   test("Test apply: exists/forall") {
     val original =
-      and(
-        exists(n_x, n_S, gt(n_x, int(1))),
-        forall( n_x, n_T, lt( n_x, int( 42 ) ) ) )
+      and(exists(n_x, n_S, gt(n_x, int(1))), forall(n_x, n_T, lt(n_x, int(42))))
 
-    def expected( offset : Int ) : TlaEx =
+    def expected(offset: Int): TlaEx =
       and(
-        exists( name( makeName( "x", offset + 1 ) ), n_S, gt( name( makeName( "x", offset + 1 ) ), int( 1 ) ) ),
-        forall( name( makeName( "x", offset + 2 ) ), n_T, lt( name( makeName( "x", offset + 2 ) ), int( 42 ) ) )
+          exists(name(makeName("x", offset + 1)), n_S, gt(name(makeName("x", offset + 1)), int(1))),
+          forall(name(makeName("x", offset + 2)), n_T, lt(name(makeName("x", offset + 2)), int(42)))
       )
 
-    val renamed = renaming( original )
-    assert( renamed == expected( 0 ) )
+    val renamed = renaming(original)
+    assert(renamed == expected(0))
 
-    val renamedTwice = renaming( renamed )
-    assert( renamedTwice == expected( 2 ) )
+    val renamedTwice = renaming(renamed)
+    assert(renamedTwice == expected(2))
 
   }
 
   test("Test apply: filter") {
     val original =
       cup(
-        filter(n_x, n_S, eql(n_x, int(1))),
-        filter(n_x, n_S, eql(n_x, int(2)))
+          filter(n_x, n_S, eql(n_x, int(1))),
+          filter(n_x, n_S, eql(n_x, int(2)))
       )
-    val x1 = makeName( "x", 1 )
-    val x2 = makeName( "x", 2 )
+    val x1 = makeName("x", 1)
+    val x2 = makeName("x", 2)
 
     def expected(offset: Int): TlaEx =
       cup(
-        filter(name(makeName( "x", offset + 1 )), n_S, eql(name(makeName( "x", offset + 1 )), int(1))),
-        filter(name(makeName( "x", offset + 2 )), n_S, eql(name(makeName( "x", offset + 2 )), int(2)))
+          filter(name(makeName("x", offset + 1)), n_S, eql(name(makeName("x", offset + 1)), int(1))),
+          filter(name(makeName("x", offset + 2)), n_S, eql(name(makeName("x", offset + 2)), int(2)))
       )
 
-    val renamed = renaming( original )
-    assert( renamed == expected( 0 ) )
+    val renamed = renaming(original)
+    assert(renamed == expected(0))
 
-    val renamedTwice = renaming( renamed )
-    assert( renamedTwice == expected( 2 ) )
+    val renamedTwice = renaming(renamed)
+    assert(renamedTwice == expected(2))
   }
 
-  test( "Test apply: LET-IN" ) {
+  test("Test apply: LET-IN") {
     // LET p(t) == \A x \in S . R(t,x) IN \E x \in S . p(x)
     val original =
       letIn(
-        exists( n_x, n_S, appOp( name( "p" ), n_x ) ),
-        declOp( "p", forall( n_x, n_S, appOp( name( "R" ), name( "t" ), n_x ) ), "t" )
+          exists(n_x, n_S, appOp(name("p"), n_x)),
+          declOp("p", forall(n_x, n_S, appOp(name("R"), name("t"), n_x)), "t")
       )
 
     val expected =
       letIn(
-        exists( name( makeName( "x", 2 ) ), n_S, appOp( name( makeName( "p", 1 ) ), name( makeName( "x", 2 ) ) ) ),
-        declOp( makeName( "p", 1 ), forall( name( makeName( "x", 1 ) ), n_S, appOp( name( "R" ), name( makeName( "t", 1 ) ), name( makeName( "x", 1 ) ) ) ), makeName( "t", 1 ) )
+          exists(name(makeName("x", 2)), n_S, appOp(name(makeName("p", 1)), name(makeName("x", 2)))),
+          declOp(makeName("p", 1),
+              forall(name(makeName("x", 1)), n_S, appOp(name("R"), name(makeName("t", 1)), name(makeName("x", 1)))),
+              makeName("t", 1))
       )
 
-    val actual = renaming( original )
+    val actual = renaming(original)
 
     assert(expected == actual)
 
@@ -267,155 +268,156 @@ class TestIncrementalRenaming extends FunSuite with TestingPredefs with BeforeAn
 
     val expected2 =
       letIn(
-        exists( name( makeName( "x", 4 ) ), n_S, appOp( name( makeName( "p", 2 ) ), name( makeName( "x", 4 ) ) ) ),
-        declOp( makeName( "p", 2 ), forall( name( makeName( "x", 3 ) ), n_S, appOp( name( "R" ), name( makeName( "t", 2 ) ), name( makeName( "x", 3 ) ) ) ), makeName( "t", 2 ) )
+          exists(name(makeName("x", 4)), n_S, appOp(name(makeName("p", 2)), name(makeName("x", 4)))),
+          declOp(makeName("p", 2),
+              forall(name(makeName("x", 3)), n_S, appOp(name("R"), name(makeName("t", 2)), name(makeName("x", 3)))),
+              makeName("t", 2))
       )
 
-    assert( renamedTwice == expected2 )
+    assert(renamedTwice == expected2)
   }
 
-  test( "Test apply: multiple LET-IN" ) {
+  test("Test apply: multiple LET-IN") {
     // LET X == TRUE IN X /\ LET X == FALSE IN X
     val original =
       and(
-        letIn(
-          appOp( name( "X" ) ),
-          declOp( "X", trueEx )
-        ),
-        letIn(
-          appOp( name( "X" ) ),
-          declOp( "X", falseEx )
-        )
+          letIn(
+              appOp(name("X")),
+              declOp("X", trueEx)
+          ),
+          letIn(
+              appOp(name("X")),
+              declOp("X", falseEx)
+          )
       )
 
     def expected(offset: Int) =
       and(
-        letIn(
-          appOp( name( makeName( "X", offset + 1 ) ) ),
-          declOp( makeName( "X", offset + 1 ), trueEx )
-        ),
-        letIn(
-          appOp( name( makeName( "X", offset + 2 ) ) ),
-          declOp( makeName( "X", offset + 2 ), falseEx )
-        )
+          letIn(
+              appOp(name(makeName("X", offset + 1))),
+              declOp(makeName("X", offset + 1), trueEx)
+          ),
+          letIn(
+              appOp(name(makeName("X", offset + 2))),
+              declOp(makeName("X", offset + 2), falseEx)
+          )
       )
 
-    val renamed = renaming( original )
+    val renamed = renaming(original)
 
-    assert( renamed == expected( 0 ) )
+    assert(renamed == expected(0))
 
-    val renamedTwice = renaming( renamed )
+    val renamedTwice = renaming(renamed)
 
-    assert( renamedTwice == expected( 2 ) )
+    assert(renamedTwice == expected(2))
   }
 
-  test( "Test offsetName" ){
+  test("Test offsetName") {
     val offsets = Map(
-      "x" -> 1
+        "x" -> 1
     )
 
-    val fn : String => String = offsetName( offsets )
+    val fn: String => String = offsetName(offsets)
 
     val name1 = "x"
     val expected1 = "x"
     val actual1 = fn(name1)
-    assert( expected1 == actual1 )
+    assert(expected1 == actual1)
 
-    val name2 = makeName( "x", 1 )
+    val name2 = makeName("x", 1)
     assertThrows[AssertionError] {
-      fn( name2 )
+      fn(name2)
     }
 
-    val name3 = makeName( "x", 2 )
-    val expected3 = makeName( "x", 1 )
-    val actual3 = fn( name3 )
-    assert( expected3 == actual3 )
+    val name3 = makeName("x", 2)
+    val expected3 = makeName("x", 1)
+    val actual3 = fn(name3)
+    assert(expected3 == actual3)
 
-
-    val name4 = makeName( "y", 2 )
-    val expected4 = makeName( "y", 2 )
-    val actual4 = fn( name4 )
-    assert( expected4 == actual4 )
+    val name4 = makeName("y", 2)
+    val expected4 = makeName("y", 2)
+    val actual4 = fn(name4)
+    assert(expected4 == actual4)
 
   }
 
-  test( "Test shiftCounters" ){
+  test("Test shiftCounters") {
     val offsets = Map(
-      "x" -> 4,
-      "y" -> 2,
-      "z" -> 3
+        "x" -> 4,
+        "y" -> 2,
+        "z" -> 3
     )
 
     val ex = gt(
-      plus(
-        name( makeName( "x", 5 ) ),
-        name( makeName( "y", 3 ) )
-      ),
-      name( makeName("z", 4 ) )
+        plus(
+            name(makeName("x", 5)),
+            name(makeName("y", 3))
+        ),
+        name(makeName("z", 4))
     )
 
     val expected = gt(
-      plus(
-        name( makeName( "x", 1 ) ),
-        name( makeName( "y", 1 ) )
-      ),
-      name( makeName("z", 1 ) )
+        plus(
+            name(makeName("x", 1)),
+            name(makeName("y", 1))
+        ),
+        name(makeName("z", 1))
     )
 
-    val actual = renaming.shiftCounters( offsets )( ex )
-    assert( expected == actual )
+    val actual = renaming.shiftCounters(offsets)(ex)
+    assert(expected == actual)
   }
 
-  test( "Test normalize" ){
+  test("Test normalize") {
     val ex = gt(
-      plus(
-        name( makeName( "x", 5 ) ),
-        name( makeName( "y", 3 ) )
-      ),
-      name( makeName("z", 4 ) )
+        plus(
+            name(makeName("x", 5)),
+            name(makeName("y", 3))
+        ),
+        name(makeName("z", 4))
     )
 
     val expected = gt(
-      plus(
-        name( makeName( "x", 1 ) ),
-        name( makeName( "y", 1 ) )
-      ),
-      name( makeName("z", 1 ) )
+        plus(
+            name(makeName("x", 1)),
+            name(makeName("y", 1))
+        ),
+        name(makeName("z", 1))
     )
 
-    val actual = renaming.normalize( ex )
-    assert( expected == actual )
+    val actual = renaming.normalize(ex)
+    assert(expected == actual)
   }
 
-  test( "Test syncFrom" ){
-    val ex = exists( name( makeName( "x", 5 ) ), n_S, n_p )
+  test("Test syncFrom") {
+    val ex = exists(name(makeName("x", 5)), n_S, n_p)
 
-    val expected = exists( name( makeName( "x", 6 ) ), n_S, n_p )
+    val expected = exists(name(makeName("x", 6)), n_S, n_p)
 
-    renaming.syncFrom( ex )
-    val actual = renaming( ex )
-    assert( expected == actual )
+    renaming.syncFrom(ex)
+    val actual = renaming(ex)
+    assert(expected == actual)
   }
 
-  test( "Test syncAndNormalizeDs" ) {
-    val syncEx = exists( name( makeName( "x", 99 ) ), n_S, n_p )
-    renaming.syncFrom( syncEx ) // Set x -> 99 in the map
+  test("Test syncAndNormalizeDs") {
+    val syncEx = exists(name(makeName("x", 99)), n_S, n_p)
+    renaming.syncFrom(syncEx) // Set x -> 99 in the map
 
-    val ex1 = exists( name( makeName( "x", 3 ) ), n_S, n_p )
-    val ex2 = exists( name( makeName( "x", 105 ) ), n_S, n_p )
+    val ex1 = exists(name(makeName("x", 3)), n_S, n_p)
+    val ex2 = exists(name(makeName("x", 105)), n_S, n_p)
 
-    val xDecl = declOp( "X", ex1 )
-    val yDecl = declOp( "Y", ex2 )
+    val xDecl = declOp("X", ex1)
+    val yDecl = declOp("Y", ex2)
 
     val decls = Seq(xDecl, yDecl)
     val expected = Seq(
-      declOp( "X", exists( name( makeName( "x", 1 ) ), n_S, n_p ) ),
-      declOp( "Y", exists( name( makeName( "x", 2 ) ), n_S, n_p ) )
+        declOp("X", exists(name(makeName("x", 1)), n_S, n_p)),
+        declOp("Y", exists(name(makeName("x", 2)), n_S, n_p))
     )
 
-    val actual = renaming.syncAndNormalizeDs( decls )
+    val actual = renaming.syncAndNormalizeDs(decls)
 
-    assert( expected == actual )
+    assert(expected == actual)
 
   }
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestLetInExpander.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestLetInExpander.scala
@@ -1,36 +1,37 @@
 package at.forsyte.apalache.tla.lir
 
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSeqOper}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestLetInExpander extends FunSuite with TestingPredefs {
+
   import Builder._
 
-  test( "Test LetInExpander, skip0Arity = false" ) {
-    val transformation = LetInExpander( new IdleTracker(), keepNullary = false )
+  test("Test LetInExpander, skip0Arity = false") {
+    val transformation = LetInExpander(new IdleTracker(), keepNullary = false)
 
     val ex1 = n_x
-    val ex2 = letIn( appOp( n_A ), declOp( "A", n_x ) )
-    val ex3 = letIn( appOp( n_A, n_x ), declOp( "A", n_y, SimpleFormalParam( "y" ) ) )
+    val ex2 = letIn(appOp(n_A), declOp("A", n_x))
+    val ex3 = letIn(appOp(n_A, n_x), declOp("A", n_y, SimpleFormalParam("y")))
     val ex4 =
       letIn(
-        ite(
-          ge( n_c, int( 0 ) ),
-          letIn(
-            appOp( NameEx( "Y" ) ),
-            declOp( "Y", appOp( NameEx( "X" ), n_c, n_c ) )
+          ite(
+              ge(n_c, int(0)),
+              letIn(
+                  appOp(NameEx("Y")),
+                  declOp("Y", appOp(NameEx("X"), n_c, n_c))
+              ),
+              appOp(NameEx("X"), n_p, int(3))
           ),
-          appOp( NameEx( "X" ), n_p, int( 3 ) )
-        ),
-        declOp( "X", ge( plus( n_a, n_b ), int( 0 ) ), "a", "b" )
+          declOp("X", ge(plus(n_a, n_b), int(0)), "a", "b")
       )
 
     val expected1 = n_x
@@ -38,75 +39,75 @@ class TestLetInExpander extends FunSuite with TestingPredefs {
     val expected3 = n_x
     val expected4 =
       ite(
-        ge( n_c, int( 0 ) ),
-        ge( plus( n_c, n_c ), int( 0 ) ),
-        ge( plus( n_p, int( 3 ) ), int( 0 ) )
+          ge(n_c, int(0)),
+          ge(plus(n_c, n_c), int(0)),
+          ge(plus(n_p, int(3)), int(0))
       )
 
-    val exs = Seq( ex1, ex2, ex3, ex4 )
-    val expected = Seq( expected1, expected2, expected3, expected4 )
+    val exs = Seq(ex1, ex2, ex3, ex4)
+    val expected = Seq(expected1, expected2, expected3, expected4)
     val actual = exs map transformation
 
-    assert( expected == actual )
+    assert(expected == actual)
 
   }
 
-  test( "Test LetInExpander, skip0Arity = true" ) {
-    val transformation = LetInExpander( new IdleTracker(), keepNullary = true )
+  test("Test LetInExpander, skip0Arity = true") {
+    val transformation = LetInExpander(new IdleTracker(), keepNullary = true)
 
     val ex1 = n_x
-    val ex2 = letIn( appOp( n_A ), declOp( "A", n_x ) )
-    val ex3 = letIn( appOp( n_A, n_x ), declOp( "A", n_y, SimpleFormalParam( "y" ) ) )
+    val ex2 = letIn(appOp(n_A), declOp("A", n_x))
+    val ex3 = letIn(appOp(n_A, n_x), declOp("A", n_y, SimpleFormalParam("y")))
     val ex4 =
       letIn(
-        ite(
-          ge( n_c, int( 0 ) ),
-          letIn(
-            appOp( NameEx( "Y" ) ),
-            declOp( "Y", appOp( NameEx( "X" ), n_c, n_c ) )
+          ite(
+              ge(n_c, int(0)),
+              letIn(
+                  appOp(NameEx("Y")),
+                  declOp("Y", appOp(NameEx("X"), n_c, n_c))
+              ),
+              appOp(NameEx("X"), n_p, int(3))
           ),
-          appOp( NameEx( "X" ), n_p, int( 3 ) )
-        ),
-        declOp( "X", ge( plus( n_a, n_b ), int( 0 ) ), "a", "b" )
+          declOp("X", ge(plus(n_a, n_b), int(0)), "a", "b")
       )
 
     val expected1 = n_x
-    val expected2 = letIn( appOp( n_A ), declOp( "A", n_x ) )
+    val expected2 = letIn(appOp(n_A), declOp("A", n_x))
     val expected3 = n_x
     val expected4 =
       ite(
-        ge( n_c, int( 0 ) ),
-        letIn(
-          appOp( NameEx( "Y" ) ),
-          declOp( "Y", ge( plus( n_c, n_c ), int( 0 ) ) )
-        ),
-        ge( plus( n_p, int( 3 ) ), int( 0 ) )
+          ge(n_c, int(0)),
+          letIn(
+              appOp(NameEx("Y")),
+              declOp("Y", ge(plus(n_c, n_c), int(0)))
+          ),
+          ge(plus(n_p, int(3)), int(0))
       )
 
-    val exs = Seq( ex1, ex2, ex3, ex4 )
-    val expected = Seq( expected1, expected2, expected3, expected4 )
+    val exs = Seq(ex1, ex2, ex3, ex4)
+    val expected = Seq(expected1, expected2, expected3, expected4)
     val actual = exs map transformation
 
-    assert( expected == actual )
+    assert(expected == actual)
 
   }
 
-  test( "Test LetInExpander and LAMBDA" ) {
+  test("Test LetInExpander and LAMBDA") {
     val transformation = LetInExpander(new IdleTracker(), keepNullary = false)
     // this is how we represent LAMBDA in IR
-    val lambdaAsLetIn = tla.letIn(tla.name("LAMBDA"),
-      tla.declOp("LAMBDA", tla.eql(tla.name("x"), tla.name("e")), SimpleFormalParam("x")))
+    val lambdaAsLetIn =
+      tla.letIn(tla.name("LAMBDA"), tla.declOp("LAMBDA", tla.eql(tla.name("x"), tla.name("e")), SimpleFormalParam("x")))
     val input = OperEx(TlaSeqOper.selectseq, tla.name("s"), lambdaAsLetIn)
     val output = transformation(input)
     // there is nothing to expand here, as SelectSeq is the standard operator
     assert(output == input)
   }
 
-  test( "Do not expand LAMBDA" ) {
+  test("Do not expand LAMBDA") {
     val transformation = LetInExpander(new IdleTracker(), keepNullary = false)
     // this is how we represent LAMBDA in IR
-    val lambdaAsLetIn = tla.letIn(tla.name("LAMBDA"),
-      tla.declOp("LAMBDA", tla.eql(tla.name("x"), tla.name("e")), SimpleFormalParam("x")))
+    val lambdaAsLetIn =
+      tla.letIn(tla.name("LAMBDA"), tla.declOp("LAMBDA", tla.eql(tla.name("x"), tla.name("e")), SimpleFormalParam("x")))
     // in this case, we cannot do anything, as the lambda operator is passed into the built-in operator
     val input = OperEx(TlaSeqOper.selectseq, tla.name("s"), lambdaAsLetIn)
     val output = transformation(input)
@@ -114,11 +115,11 @@ class TestLetInExpander extends FunSuite with TestingPredefs {
     assert(output == input)
   }
 
-  test( "Expand LAMBDA when it is applied to an argument" ) {
+  test("Expand LAMBDA when it is applied to an argument") {
     val transformation = LetInExpander(new IdleTracker(), keepNullary = false)
     // this is how we represent LAMBDA in IR
-    val lambdaAsLetIn = tla.letIn(tla.name("LAMBDA"),
-      tla.declOp("LAMBDA", tla.eql(tla.name("x"), tla.name("e")), SimpleFormalParam("x")))
+    val lambdaAsLetIn =
+      tla.letIn(tla.name("LAMBDA"), tla.declOp("LAMBDA", tla.eql(tla.name("x"), tla.name("e")), SimpleFormalParam("x")))
     val input = OperEx(TlaOper.apply, lambdaAsLetIn, ValEx(TlaInt(3)))
     val output = transformation(input)
     // application of the lambda expression should be replaced with the body

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestModule.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestModule.scala
@@ -1,540 +1,246 @@
 package at.forsyte.apalache.tla.lir
 
 /**
-  * Created by jkukovec on 11/16/16.
-  */
+ * Created by jkukovec on 11/16/16.
+ */
 
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
-
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 @RunWith(classOf[JUnitRunner])
-class TestModule extends FunSuite{
+class TestModule extends FunSuite {
   test("AlternatingBit module from Lamport's book") {
+
     /** CONSTANTS Data */
     val Data = new TlaConstDecl("Data")
 
     /** VARIABLES msgQ, ackQ, sBit, sAck, rBit, sent, rcvd */
-    val msgQ = new TlaVarDecl( "msgQ" )
-    val ackQ = new TlaVarDecl( "ackQ" )
-    val sBit = new TlaVarDecl( "sBit" )
-    val sAck = new TlaVarDecl( "sAck" )
-    val rBit = new TlaVarDecl( "rBit" )
-    val sent = new TlaVarDecl( "sent" )
-    val rcvd = new TlaVarDecl( "rcvd" )
+    val msgQ = new TlaVarDecl("msgQ")
+    val ackQ = new TlaVarDecl("ackQ")
+    val sBit = new TlaVarDecl("sBit")
+    val sAck = new TlaVarDecl("sAck")
+    val rBit = new TlaVarDecl("rBit")
+    val sent = new TlaVarDecl("sent")
+    val rcvd = new TlaVarDecl("rcvd")
 
     /** Constants {0,1} and <<>> */
     val ZeroOneSet = OperEx(TlaSetOper.enumSet, ValEx(TlaInt(0)), ValEx(TlaInt(1)))
     val emptySeq = OperEx(TlaFunOper.tuple)
 
-    /**---------------------------------------------------------------------------------------------------------------*/
+    /** --------------------------------------------------------------------------------------------------------------- */
 
     /**
-      * ABInit = /\ msgQ =   <<>>
-      *          /\ ackQ =   <<>>
-      *          /\ sBit \in {0,1}
-      *          /\ sAck =   sBit
-      *          /\ rBit =   sBit
-      *          /\ sent \in Data
-      *          /\ rcvd \in Data
-      */
+     * ABInit = /\ msgQ =   <<>>
+     * /\ ackQ =   <<>>
+     * /\ sBit \in {0,1}
+     * /\ sAck =   sBit
+     * /\ rBit =   sBit
+     * /\ sent \in Data
+     * /\ rcvd \in Data
+     */
     val ABInit =
-        new TlaOperDecl( "ABInit",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.eq,
-                                         NameEx( "msgQ" ),
-                                         emptySeq
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         NameEx( "ackQ" ),
-                                         emptySeq
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "sBit" ),
-                                         ZeroOneSet
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         NameEx( "sAck" ),
-                                         NameEx( "sBit" )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         NameEx( "rBit" ),
-                                         NameEx( "sBit" )
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "sBit" ),
-                                         ZeroOneSet
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "sBit" ),
-                                         ZeroOneSet
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("ABInit", List(),
+          OperEx(TlaBoolOper.and, OperEx(TlaOper.eq, NameEx("msgQ"), emptySeq),
+              OperEx(TlaOper.eq, NameEx("ackQ"), emptySeq), OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet),
+              OperEx(TlaOper.eq, NameEx("sAck"), NameEx("sBit")), OperEx(TlaOper.eq, NameEx("rBit"), NameEx("sBit")),
+              OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet), OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet)))
 
     /**
-      * ABTypeInv == /\ msgQ \in Seq( {0,1} \times Data )
-      *              /\ ackQ \in Seq( {0,1} )
-      *              /\ sBit \in {0,1}
-      *              /\ sAck \in {0,1}
-      *              /\ rBit \in {0,1}
-      *              /\ sent \in Data
-      *              /\ rcvd \in Data
-      */
+     * ABTypeInv == /\ msgQ \in Seq( {0,1} \times Data )
+     * /\ ackQ \in Seq( {0,1} )
+     * /\ sBit \in {0,1}
+     * /\ sAck \in {0,1}
+     * /\ rBit \in {0,1}
+     * /\ sent \in Data
+     * /\ rcvd \in Data
+     */
     val ABTypeInv =
-        new TlaOperDecl( "ABTypeInv",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "msgQ" ),
-                                         OperEx( TlaSetOper.seqSet,
-                                                 OperEx( TlaSetOper.times,
-                                                         ZeroOneSet,
-                                                         NameEx( "Data" )
-                                                         )
-                                                 )
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "ackQ" ),
-                                         OperEx( TlaSetOper.seqSet,
-                                                 ZeroOneSet
-                                                 )
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "sBit" ),
-                                         ZeroOneSet
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "sAck" ),
-                                         ZeroOneSet
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "rBit" ),
-                                         ZeroOneSet
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "sent" ),
-                                         NameEx( "Data" )
-                                         ),
-                                 OperEx( TlaSetOper.in,
-                                         NameEx( "rcvd" ),
-                                         NameEx( "Data" )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("ABTypeInv", List(),
+          OperEx(TlaBoolOper.and,
+              OperEx(TlaSetOper.in, NameEx("msgQ"),
+                  OperEx(TlaSetOper.seqSet, OperEx(TlaSetOper.times, ZeroOneSet, NameEx("Data")))),
+              OperEx(TlaSetOper.in, NameEx("ackQ"), OperEx(TlaSetOper.seqSet, ZeroOneSet)),
+              OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet), OperEx(TlaSetOper.in, NameEx("sAck"), ZeroOneSet),
+              OperEx(TlaSetOper.in, NameEx("rBit"), ZeroOneSet), OperEx(TlaSetOper.in, NameEx("sent"), NameEx("Data")),
+              OperEx(TlaSetOper.in, NameEx("rcvd"), NameEx("Data"))))
 
-    /**---------------------------------------------------------------------------------------------------------------*/
+    /** --------------------------------------------------------------------------------------------------------------- */
 
     /**
-      * SndNewValue(d) == /\ sAck      = sBit
-      *                   /\ sent'     = d
-      *                   /\ sBit'     = 1 - sBit
-      *                   /\ msgQ'     = Append( msgQ, << sBit', d >> )
-      *                   /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
-      */
+     * SndNewValue(d) == /\ sAck      = sBit
+     * /\ sent'     = d
+     * /\ sBit'     = 1 - sBit
+     * /\ msgQ'     = Append( msgQ, << sBit', d >> )
+     * /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
+     */
     val SndNewValue =
-        new TlaOperDecl( "SndNewValue",
-                         List( SimpleFormalParam( "d" ) ),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.eq,
-                                         NameEx( "sAck" ),
-                                         NameEx( "sBit" )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "sent" )
-                                                 ),
-                                         NameEx( "d" )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "sBit" )
-                                                 ),
-                                         OperEx( TlaArithOper.minus,
-                                                 ValEx( TlaInt( 1 ) ),
-                                                 NameEx( "sBit" )
-                                                 )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "msgQ" )
-                                                 ),
-                                         OperEx( TlaSeqOper.append,
-                                                 NameEx( "msgQ" ),
-                                                 OperEx( TlaFunOper.tuple,
-                                                         OperEx( TlaActionOper.prime,
-                                                                 NameEx( "sBit" )
-                                                         ),
-                                                         NameEx( "d" )
-                                                         )
-                                                 )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         OperEx( TlaFunOper.tuple,
-                                                 NameEx( "ackQ" ),
-                                                 NameEx( "sAck" ),
-                                                 NameEx( "rBit" ),
-                                                 NameEx( "rcvd" )
-                                                 )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("SndNewValue", List(SimpleFormalParam("d")),
+          OperEx(
+              TlaBoolOper.and,
+              OperEx(TlaOper.eq, NameEx("sAck"), NameEx("sBit")),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("sent")), NameEx("d")),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("sBit")),
+                  OperEx(TlaArithOper.minus, ValEx(TlaInt(1)), NameEx("sBit"))),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("msgQ")),
+                  OperEx(TlaSeqOper.append, NameEx("msgQ"),
+                      OperEx(TlaFunOper.tuple, OperEx(TlaActionOper.prime, NameEx("sBit")), NameEx("d")))),
+              OperEx(TlaActionOper.unchanged,
+                  OperEx(TlaFunOper.tuple, NameEx("ackQ"), NameEx("sAck"), NameEx("rBit"), NameEx("rcvd")))
+          ))
 
     /**
-      * ReSndMsg == /\ sAck      # sBit
-      *             /\ msgQ'     = Append( msgQ, << sBit, sent >> )
-      *             /\ UNCHANGED   << ackQ, sBit, sAck, rBit, sent, rcvd >>
-      */
+     * ReSndMsg == /\ sAck      # sBit
+     * /\ msgQ'     = Append( msgQ, << sBit, sent >> )
+     * /\ UNCHANGED   << ackQ, sBit, sAck, rBit, sent, rcvd >>
+     */
     val ReSndMsg =
-        new TlaOperDecl( "ReSndMsg",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.ne,
-                                         NameEx( "sAck" ),
-                                         NameEx( "sBit" )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "msgQ" )
-                                                 ),
-                                         OperEx( TlaSeqOper.append,
-                                                 NameEx( "msgQ" ),
-                                                 OperEx( TlaFunOper.tuple,
-                                                         NameEx( "sBit" ),
-                                                         NameEx( "sent" )
-                                                         )
-                                                 )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         OperEx( TlaFunOper.tuple,
-                                                 NameEx( "ackQ" ),
-                                                 NameEx( "sBit" ),
-                                                 NameEx( "sAck" ),
-                                                 NameEx( "rBit" ),
-                                                 NameEx( "sent" ),
-                                                 NameEx( "rcvd" )
-                                                 )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("ReSndMsg", List(),
+          OperEx(TlaBoolOper.and, OperEx(TlaOper.ne, NameEx("sAck"), NameEx("sBit")),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("msgQ")),
+                  OperEx(TlaSeqOper.append, NameEx("msgQ"), OperEx(TlaFunOper.tuple, NameEx("sBit"), NameEx("sent")))),
+              OperEx(TlaActionOper.unchanged,
+                  OperEx(TlaFunOper.tuple, NameEx("ackQ"), NameEx("sBit"), NameEx("sAck"), NameEx("rBit"),
+                      NameEx("sent"), NameEx("rcvd")))))
 
     /**
-      * RcvMsg == /\ msgQ      # <<>>
-      *           /\ msgQ'     = Tail( msgQ )
-      *           /\ rBit'     = Head( msgQ ) [ 1 ]
-      *           /\ rcvd'     = Head( msgQ ) [ 2 ]
-      *           /\ UNCHANGED   << ackQ, sBit, sAck, sent >>
-      */
+     * RcvMsg == /\ msgQ      # <<>>
+     * /\ msgQ'     = Tail( msgQ )
+     * /\ rBit'     = Head( msgQ ) [ 1 ]
+     * /\ rcvd'     = Head( msgQ ) [ 2 ]
+     * /\ UNCHANGED   << ackQ, sBit, sAck, sent >>
+     */
     val RcvMsg =
-        new TlaOperDecl( "RcvMsg",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.ne,
-                                         NameEx( "msgQ" ),
-                                         emptySeq
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "msgQ" )
-                                                 ),
-                                         OperEx( TlaSeqOper.tail,
-                                                 NameEx( "msgQ" )
-                                                 )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "rBit" )
-                                                 ),
-                                         OperEx( TlaFunOper.app,
-                                                 OperEx( TlaSeqOper.head,
-                                                         NameEx( "msgQ" )
-                                                         ),
-                                                 ValEx( TlaInt( 1 ) )
-                                                 )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "rcvd" )
-                                                 ),
-                                         OperEx( TlaFunOper.app,
-                                                 OperEx( TlaSeqOper.head,
-                                                 NameEx( "msgQ" )
-                                                 ),
-                                                 ValEx( TlaInt( 2 ) )
-                                                 )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         OperEx( TlaFunOper.tuple,
-                                                 NameEx( "ackQ" ),
-                                                 NameEx( "sBit" ),
-                                                 NameEx( "sAck" ),
-                                                 NameEx( "sent" )
-                                                 )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("RcvMsg", List(),
+          OperEx(
+              TlaBoolOper.and,
+              OperEx(TlaOper.ne, NameEx("msgQ"), emptySeq),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("msgQ")), OperEx(TlaSeqOper.tail, NameEx("msgQ"))),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("rBit")),
+                  OperEx(TlaFunOper.app, OperEx(TlaSeqOper.head, NameEx("msgQ")), ValEx(TlaInt(1)))),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("rcvd")),
+                  OperEx(TlaFunOper.app, OperEx(TlaSeqOper.head, NameEx("msgQ")), ValEx(TlaInt(2)))),
+              OperEx(TlaActionOper.unchanged,
+                  OperEx(TlaFunOper.tuple, NameEx("ackQ"), NameEx("sBit"), NameEx("sAck"), NameEx("sent")))
+          ))
 
     /**
-      * SndAck == /\ ackQ'     = Append( ackQ, rBit )
-      *           /\ UNCHANGED   << msgQ, sBit, sAck, rBit, sent, rcvd >>
-      */
+     * SndAck == /\ ackQ'     = Append( ackQ, rBit )
+     * /\ UNCHANGED   << msgQ, sBit, sAck, rBit, sent, rcvd >>
+     */
     val SndAck =
-        new TlaOperDecl( "SndAck",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "ackQ" )
-                                                 ),
-                                         OperEx( TlaSeqOper.append,
-                                                 NameEx( "ackQ" ),
-                                                 NameEx( "rBit" )
-                                                 )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         OperEx( TlaFunOper.tuple,
-                                                 NameEx( "msgQ" ),
-                                                 NameEx( "sBit" ),
-                                                 NameEx( "sAck" ),
-                                                 NameEx( "rBit" ),
-                                                 NameEx( "sent" ),
-                                                 NameEx( "rcvd" )
-                                                 )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("SndAck", List(),
+          OperEx(TlaBoolOper.and,
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("ackQ")),
+                  OperEx(TlaSeqOper.append, NameEx("ackQ"), NameEx("rBit"))),
+              OperEx(TlaActionOper.unchanged,
+                  OperEx(TlaFunOper.tuple, NameEx("msgQ"), NameEx("sBit"), NameEx("sAck"), NameEx("rBit"),
+                      NameEx("sent"), NameEx("rcvd")))))
 
     /**
-      * RcvAck == /\ ackQ      # <<>>
-      *           /\ ackQ'     = Tail( ackQ )
-      *           /\ sAck'     = Head( ackQ )
-      *           /\ UNCHANGED   << msgQ, sBit, rBit, sent, rcvd >>
-      */
+     * RcvAck == /\ ackQ      # <<>>
+     * /\ ackQ'     = Tail( ackQ )
+     * /\ sAck'     = Head( ackQ )
+     * /\ UNCHANGED   << msgQ, sBit, rBit, sent, rcvd >>
+     */
     val RcvAck =
-        new TlaOperDecl( "RcvAck",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.ne,
-                                         NameEx( "ackQ" ),
-                                         emptySeq
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "ackQ" )
-                                                 ),
-                                         OperEx( TlaSeqOper.tail,
-                                                 NameEx( "ackQ" )
-                                                 )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "sAck" )
-                                                 ),
-                                         OperEx( TlaSeqOper.head,
-                                                 NameEx( "ackQ" )
-                                                 )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         OperEx( TlaFunOper.tuple,
-                                                 NameEx( "msgQ" ),
-                                                 NameEx( "sBit" ),
-                                                 NameEx( "rBit" ),
-                                                 NameEx( "sent" ),
-                                                 NameEx( "rcvd" )
-                                                 )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("RcvAck", List(),
+          OperEx(TlaBoolOper.and, OperEx(TlaOper.ne, NameEx("ackQ"), emptySeq),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("ackQ")), OperEx(TlaSeqOper.tail, NameEx("ackQ"))),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("sAck")), OperEx(TlaSeqOper.head, NameEx("ackQ"))),
+              OperEx(TlaActionOper.unchanged,
+                  OperEx(TlaFunOper.tuple, NameEx("msgQ"), NameEx("sBit"), NameEx("rBit"), NameEx("sent"),
+                      NameEx("rcvd")))))
+
     /**
-      * Lose( q ) == /\ q # <<>>
-      *              /\ \exists i \in 1 .. Len( q ) :
-      *                 q' = [ j \in 1 .. ( Len( q ) - 1 ) |-> IF j < i THEN q[ j ]
-      *                                                                 ELSE q[ j + 1 ] ]
-      *              /\ UNCHANGED << sBit, sAck, rBit, sent, rcvd >>
-      */
+     * Lose( q ) == /\ q # <<>>
+     * /\ \exists i \in 1 .. Len( q ) :
+     * q' = [ j \in 1 .. ( Len( q ) - 1 ) |-> IF j < i THEN q[ j ]
+     * ELSE q[ j + 1 ] ]
+     * /\ UNCHANGED << sBit, sAck, rBit, sent, rcvd >>
+     */
     val Lose =
-        new TlaOperDecl( "Lose",
-                         List( SimpleFormalParam( "q" ) ),
-                         OperEx( TlaBoolOper.exists,
-                                 NameEx( "i" ),
-                                 OperEx( TlaArithOper.dotdot,
-                                         ValEx( TlaInt( 1 ) ),
-                                         OperEx( TlaSeqOper.len,
-                                                 NameEx( "q" )
-                                                 )
-                                         ),
-                                 OperEx( TlaOper.eq,
-                                         OperEx( TlaActionOper.prime,
-                                                 NameEx( "q" )
-                                                 ),
-                                         OperEx( TlaFunOper.funDef,
-                                                 NameEx( "j" ),
-                                                 OperEx( TlaArithOper.dotdot,
-                                                         ValEx( TlaInt( 1 ) ),
-                                                         OperEx( TlaArithOper.minus,
-                                                                 OperEx( TlaSeqOper.len,
-                                                                         NameEx( "q" )
-                                                                         ),
-                                                                 ValEx( TlaInt ( 1 ) )
-                                                                 )
-                                                         ),
-                                                 OperEx( TlaControlOper.ifThenElse ,
-                                                         OperEx( TlaArithOper.lt,
-                                                                 NameEx( "j" ),
-                                                                 NameEx( "i" )
-                                                                 ),
-                                                         OperEx( TlaFunOper.app,
-                                                                 NameEx( "q" ),
-                                                                 NameEx( "j")
-                                                                 ),
-                                                         OperEx( TlaFunOper.app,
-                                                                 NameEx( "q" ),
-                                                                 OperEx( TlaArithOper.plus,
-                                                                         NameEx( "j" ),
-                                                                         ValEx( TlaInt(1) )
-                                                                         )
-                                                                 )
-                                                         )
-                                                 )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("Lose", List(SimpleFormalParam("q")),
+          OperEx(TlaBoolOper.exists, NameEx("i"),
+              OperEx(TlaArithOper.dotdot, ValEx(TlaInt(1)), OperEx(TlaSeqOper.len, NameEx("q"))),
+              OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("q")),
+                  OperEx(TlaFunOper.funDef, NameEx("j"),
+                      OperEx(TlaArithOper.dotdot, ValEx(TlaInt(1)),
+                          OperEx(TlaArithOper.minus, OperEx(TlaSeqOper.len, NameEx("q")), ValEx(TlaInt(1)))),
+                      OperEx(TlaControlOper.ifThenElse, OperEx(TlaArithOper.lt, NameEx("j"), NameEx("i")),
+                          OperEx(TlaFunOper.app, NameEx("q"), NameEx("j")),
+                          OperEx(TlaFunOper.app, NameEx("q"),
+                              OperEx(TlaArithOper.plus, NameEx("j"), ValEx(TlaInt(1)))))))))
 
     /**
-      * LoseMsg == Lose( msgQ ) /\ UNCHANGED ackQ
-      */
+     * LoseMsg == Lose( msgQ ) /\ UNCHANGED ackQ
+     */
     val LoseMsg =
-        new TlaOperDecl( "LoseMsg",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.apply,
-                                         NameEx( "Lose" ),
-                                         NameEx( "msgQ" )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         NameEx( "ackQ" )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("LoseMsg", List(),
+          OperEx(TlaBoolOper.and, OperEx(TlaOper.apply, NameEx("Lose"), NameEx("msgQ")),
+              OperEx(TlaActionOper.unchanged, NameEx("ackQ"))))
 
     /**
-      * LoseAck == Lose( ackQ ) /\ UNCHANGED msgQ
-      */
+     * LoseAck == Lose( ackQ ) /\ UNCHANGED msgQ
+     */
     val LoseAck =
-        new TlaOperDecl( "LoseAck",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaOper.apply,
-                                         NameEx( "Lose" ),
-                                         NameEx( "ackQ" )
-                                         ),
-                                 OperEx( TlaActionOper.unchanged,
-                                         NameEx( "msgQ" )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("LoseAck", List(),
+          OperEx(TlaBoolOper.and, OperEx(TlaOper.apply, NameEx("Lose"), NameEx("ackQ")),
+              OperEx(TlaActionOper.unchanged, NameEx("msgQ"))))
 
     /**
-      * ABNext == \/ \exists d \in Data : SndNewValue(d)
-      *           \/ ReSndMsg \/ RcvMsg \/ SndAck \/ RcvAck
-      *           \/ LoseMsg \/ LoseAck
-      */
+     * ABNext == \/ \exists d \in Data : SndNewValue(d)
+     * \/ ReSndMsg \/ RcvMsg \/ SndAck \/ RcvAck
+     * \/ LoseMsg \/ LoseAck
+     */
     val ABNext =
-    new TlaOperDecl( "ABNext",
-                     List(),
-                     OperEx( TlaBoolOper.or,
-                             OperEx( TlaBoolOper.exists,
-                                     NameEx( "d" ),
-                                     NameEx( "Data" ),
-                                     OperEx( TlaOper.apply,
-                                             NameEx( "SndNewValue" ),
-                                             NameEx( "d" )
-                                             )
-                                     ),
-                             NameEx( "ReSndMsg" ),
-                             NameEx( "RcvMsg" ),
-                             NameEx( "SndAck" ),
-                             NameEx( "RcvAck" ),
-                             NameEx( "LoseMsg" ),
-                             NameEx( "LoseAck" )
-                             )
-                     )
+      new TlaOperDecl("ABNext", List(),
+          OperEx(TlaBoolOper.or,
+              OperEx(TlaBoolOper.exists, NameEx("d"), NameEx("Data"),
+                  OperEx(TlaOper.apply, NameEx("SndNewValue"), NameEx("d"))), NameEx("ReSndMsg"), NameEx("RcvMsg"),
+              NameEx("SndAck"), NameEx("RcvAck"), NameEx("LoseMsg"), NameEx("LoseAck")))
 
-    /**---------------------------------------------------------------------------------------------------------------*/
+    /** --------------------------------------------------------------------------------------------------------------- */
 
     /**
-      * abvars == << msgQ, ackQ, sBit, sAck, rBit, sent, rcvd >>
-      */
+     * abvars == << msgQ, ackQ, sBit, sAck, rBit, sent, rcvd >>
+     */
     val abvars =
-        new TlaOperDecl( "abvars",               // NOTE: Is this really an operator? Seems contrived.
-                         List(),
-                         OperEx( TlaFunOper.tuple,
-                                 NameEx( "msgQ" ),
-                                 NameEx( "ackQ" ),
-                                 NameEx( "sBit" ),
-                                 NameEx( "sAck" ),
-                                 NameEx( "rBit" ),
-                                 NameEx( "sent" ),
-                                 NameEx( "rcvd" )
-                                 )
-                         )
+      new TlaOperDecl("abvars", // NOTE: Is this really an operator? Seems contrived.
+          List(),
+          OperEx(TlaFunOper.tuple, NameEx("msgQ"), NameEx("ackQ"), NameEx("sBit"), NameEx("sAck"), NameEx("rBit"),
+              NameEx("sent"), NameEx("rcvd")))
 
     /**
-      * ABFairness == /\ WF_abvars( ReSndMsg ) /\ WF_abvars( SndAck )
-      *               /\ SF_abvars( RcvMsg ) /\ SF_abvars( RcvAck )
-      */
+     * ABFairness == /\ WF_abvars( ReSndMsg ) /\ WF_abvars( SndAck )
+     * /\ SF_abvars( RcvMsg ) /\ SF_abvars( RcvAck )
+     */
     val ABFairness =
-        new TlaOperDecl( "AbFairness",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 OperEx( TlaTempOper.weakFairness,
-                                         NameEx( "abvars" ),
-                                         NameEx( "ReSndMsg" )
-                                         ),
-                                 OperEx( TlaTempOper.weakFairness,
-                                         NameEx( "abvars" ),
-                                         NameEx( "SndAck" )
-                                         ) ,
-                                 OperEx( TlaTempOper.strongFairness,
-                                         NameEx( "abvars" ),
-                                         NameEx( "RcvMsg" )
-                                         ),
-                                 OperEx( TlaTempOper.strongFairness,
-                                         NameEx( "abvars" ),
-                                         NameEx( "RcvAck" )
-                                         )
-                                 )
-                         )
+      new TlaOperDecl("AbFairness", List(),
+          OperEx(TlaBoolOper.and, OperEx(TlaTempOper.weakFairness, NameEx("abvars"), NameEx("ReSndMsg")),
+              OperEx(TlaTempOper.weakFairness, NameEx("abvars"), NameEx("SndAck")),
+              OperEx(TlaTempOper.strongFairness, NameEx("abvars"), NameEx("RcvMsg")),
+              OperEx(TlaTempOper.strongFairness, NameEx("abvars"), NameEx("RcvAck"))))
 
-    /**---------------------------------------------------------------------------------------------------------------*/
+    /** --------------------------------------------------------------------------------------------------------------- */
 
     /**
-      * ABSpec == ABInit /\ [][ABNext]_abvars /\ ABFairness
-      */
+     * ABSpec == ABInit /\ [][ABNext]_abvars /\ ABFairness
+     */
 
     val ABSpec =
-        new TlaOperDecl( "ABSpec",
-                         List(),
-                         OperEx( TlaBoolOper.and,
-                                 NameEx( "ABInit" ),
-                                 OperEx( TlaActionOper.stutter,
-                                         NameEx( "ABNext" ),
-                                         NameEx( "abvars" )
-                                         ),
-                                 NameEx( "ABFairness" )
-                                 )
-                         )
+      new TlaOperDecl("ABSpec", List(),
+          OperEx(TlaBoolOper.and, NameEx("ABInit"), OperEx(TlaActionOper.stutter, NameEx("ABNext"), NameEx("abvars")),
+              NameEx("ABFairness")))
 
-    /**---------------------------------------------------------------------------------------------------------------*/
+    /** --------------------------------------------------------------------------------------------------------------- */
 
     /**
-      * THEOREM ABSpec => []( ABTypeInv )
-      */
-
+     * THEOREM ABSpec => []( ABTypeInv )
+     */
 
   }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -5,8 +5,9 @@ import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestPrinter extends FunSuite with TestingPredefs {
   val bd = Builder
 
@@ -63,7 +64,6 @@ class TestPrinter extends FunSuite with TestingPredefs {
     val chooseEx2: String = bd.choose(n_x, n_S, n_p)
     val chooseEx3: String = bd.choose(n_x, bd.and(n_p, n_q))
     val chooseEx4: String = bd.choose(n_x, bd.times(n_S, n_T), bd.and(n_p, n_q))
-
 
     if (ALSO_PRINT) {
       printsep()
@@ -165,7 +165,6 @@ class TestPrinter extends FunSuite with TestingPredefs {
     assert(forallEx3 == "%sa %s b: c".format(up.m_forall, up.m_in))
     assert(forallEx4 == "%sa %s (b %s c): (d %s e)".format(up.m_forall, up.m_in, up.m_times, up.m_and))
 
-
     val existsEx1: String = bd.exists(n_a, n_b)
     val existsEx2: String = bd.exists(n_a, bd.or(seq(2, 1): _*))
     val existsEx3: String = bd.exists(n_a, n_b, n_c)
@@ -181,13 +180,9 @@ class TestPrinter extends FunSuite with TestingPredefs {
     assert(existsEx3 == "%sa %s b: c".format(up.m_exists, up.m_in))
     assert(existsEx4 == "%sa %s (b %s c): (d %s e)".format(up.m_exists, up.m_in, up.m_times, up.m_and))
 
-
   }
 
-  test("Test UTF8: TlaArithOper") {
-
-
-  }
+  test("Test UTF8: TlaArithOper") {}
 
   test("Test UTF8: TlaSetOper") {
     val inEx1: String = bd.in(n_a, n_b)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestRenaming.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestRenaming.scala
@@ -2,13 +2,14 @@ package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard.Renaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 /**
-  * Test variable renaming.
-  */
+ * Test variable renaming.
+ */
 @RunWith(classOf[JUnitRunner])
 class TestRenaming extends FunSuite with BeforeAndAfterEach with TestingPredefs {
   import at.forsyte.apalache.tla.lir.Builder._
@@ -21,78 +22,73 @@ class TestRenaming extends FunSuite with BeforeAndAfterEach with TestingPredefs 
 
   test("test renaming exists/forall") {
     val original =
-        and(
-          exists(n_x, n_S, gt(n_x, int(1))),
-          forall(n_x, n_T, lt(n_x, int(42))))
+      and(exists(n_x, n_S, gt(n_x, int(1))), forall(n_x, n_T, lt(n_x, int(42))))
     ///
     val expected =
-      and(
-        exists(name("x_1"), n_S, gt(name("x_1"), int(1))),
-        forall(name("x_2"), n_T, lt(name("x_2"), int(42))))
+      and(exists(name("x_1"), n_S, gt(name("x_1"), int(1))), forall(name("x_2"), n_T, lt(name("x_2"), int(42))))
     val renamed = renaming.renameBindingsUnique(original)
     assert(expected == renamed)
   }
 
   test("test renaming filter") {
     val original =
-        cup(
+      cup(
           filter(name("x"), name("S"), eql(name("x"), int(1))),
           filter(name("x"), name("S"), eql(name("x"), int(2)))
-        )
+      )
     val expected =
-      cup(
-        filter(name("x_1"), name("S"), eql(name("x_1"), int(1))),
-        filter(name("x_2"), name("S"), eql(name("x_2"), int(2))))
+      cup(filter(name("x_1"), name("S"), eql(name("x_1"), int(1))),
+          filter(name("x_2"), name("S"), eql(name("x_2"), int(2))))
     val renamed = renaming.renameBindingsUnique(original)
     assert(expected == renamed)
   }
 
-  test( "Test renaming LET-IN" ) {
+  test("Test renaming LET-IN") {
     // LET p(t) == \A x \in S . R(t,x) IN \E x \in S . p(x)
     val original =
       letIn(
-        exists( n_x, n_S, appOp( name( "p" ), n_x ) ),
-        declOp( "p", forall( n_x, n_S, appOp( name( "R" ), name( "t" ), n_x ) ), "t" )
+          exists(n_x, n_S, appOp(name("p"), n_x)),
+          declOp("p", forall(n_x, n_S, appOp(name("R"), name("t"), n_x)), "t")
       )
 
     val expected =
       letIn(
-        exists( name( "x_2" ), n_S, appOp( name( "p_1" ), name( "x_2" ) ) ),
-        declOp( "p_1", forall( name( "x_1" ), n_S, appOp( name( "R" ), name( "t_1" ), name( "x_1" ) ) ), "t_1" )
+          exists(name("x_2"), n_S, appOp(name("p_1"), name("x_2"))),
+          declOp("p_1", forall(name("x_1"), n_S, appOp(name("R"), name("t_1"), name("x_1"))), "t_1")
       )
 
-    val actual = renaming( original )
+    val actual = renaming(original)
 
     assert(expected == actual)
   }
 
-  test( "Test renaming multiple LET-IN" ) {
+  test("Test renaming multiple LET-IN") {
     // LET X == TRUE IN X /\ LET X == FALSE IN X
     val original =
       and(
-        letIn(
-          appOp( name( "X" ) ),
-          declOp( "X", trueEx )
-        ),
-        letIn(
-          appOp( name( "X" ) ),
-          declOp( "X", falseEx )
-        )
+          letIn(
+              appOp(name("X")),
+              declOp("X", trueEx)
+          ),
+          letIn(
+              appOp(name("X")),
+              declOp("X", falseEx)
+          )
       )
 
     val expected =
       and(
-      letIn(
-        appOp( name( "X_1" ) ),
-        declOp( "X_1", trueEx )
-      ),
-      letIn(
-        appOp( name( "X_2" ) ),
-        declOp( "X_2", falseEx )
+          letIn(
+              appOp(name("X_1")),
+              declOp("X_1", trueEx)
+          ),
+          letIn(
+              appOp(name("X_2")),
+              declOp("X_2", falseEx)
+          )
       )
-    )
 
-    val actual = renaming( original )
+    val actual = renaming(original)
 
     assert(expected == actual)
   }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceLocator.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceLocator.scala
@@ -14,89 +14,92 @@ import at.forsyte.apalache.tla.lir.transformations.standard._
 
 import scala.collection.mutable
 
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestSourceLocator extends FunSuite with TestingPredefs {
 
-  val decl1 = declOp( "plus", plus( n_a, n_b ), "a", "b" )
-  val decl2 = declOp( "App", appOp( "X", n_p ), ("X", 1), "p" )
+  val decl1 = declOp("plus", plus(n_a, n_b), "a", "b")
+  val decl2 = declOp("App", appOp("X", n_p), ("X", 1), "p")
 
   val decls = List(
-    decl1,
-    decl2
+      decl1,
+      decl2
   )
 
-  val bodyMap = BodyMapFactory.makeFromDecls( decls )
+  val bodyMap = BodyMapFactory.makeFromDecls(decls)
 
-  val ex1 = and( prime( n_x ), n_y )
+  val ex1 = and(prime(n_x), n_y)
   val ex2 = letIn(
-    ge( appOp( n_A, int( 1 ) ), int( 0 ) ),
-    declOp( "A", plus( n_p, int( 1 ) ), "p" )
+      ge(appOp(n_A, int(1)), int(0)),
+      declOp("A", plus(n_p, int(1)), "p")
   )
-  val ex3 = appDecl( decl1, n_x, int( 1 ) )
+  val ex3 = appDecl(decl1, n_x, int(1))
   val ex4 = letIn(
-    ite( n_y, appDecl( decl2, "I", int( 0 ) ), falseEx ),
-    declOp( "I", n_p, "p" )
+      ite(n_y, appDecl(decl2, "I", int(0)), falseEx),
+      declOp("I", n_p, "p")
   )
   val ex5 =
     letIn(
-      letIn(
         letIn(
-          appOp( "C", appOp( "D" ) ),
-          declOp( "D", n_x )
+            letIn(
+                appOp("C", appOp("D")),
+                declOp("D", n_x)
+            ),
+            declOp("B", n_b),
+            declOp("C", appOp(n_A, n_p, appOp("B")), "p")
         ),
-        declOp( "B", n_b ),
-        declOp( "C", appOp( n_A, n_p, appOp( "B" ) ), "p" )
-      ),
-      declOp( "A", appOp( "IntentionallyUndefinedOper", n_p, n_q ), "p", "q" )
+        declOp("A", appOp("IntentionallyUndefinedOper", n_p, n_q), "p", "q")
     )
-  val ex6 = unchanged( n_x )
-  val ex7 = unchangedTup( n_x, n_y )
+  val ex6 = unchanged(n_x)
+  val ex7 = unchangedTup(n_x, n_y)
   val ex8 =
     withType(
-      enumFun( str( "x" ), int( 1 ) ),
-      enumFun(
-        str( "x" ), ValEx( TlaIntSet ),
-        str( "y" ), enumSet( ValEx( TlaStrSet ) )
-      )
+        enumFun(str("x"), int(1)),
+        enumFun(
+            str("x"),
+            ValEx(TlaIntSet),
+            str("y"),
+            enumSet(ValEx(TlaStrSet))
+        )
     )
-  val ex9 = appFun( enumFun( str( "x" ), int( 1 ) ), str( "x" ) )
+  val ex9 = appFun(enumFun(str("x"), int(1)), str("x"))
 
   val exs = List(
-    ex1,
-    ex2,
-    ex3,
-    ex4,
-    ex5,
-    ex6,
-    ex7,
-    ex8,
-    ex9
+      ex1,
+      ex2,
+      ex3,
+      ex4,
+      ex5,
+      ex6,
+      ex7,
+      ex8,
+      ex9
   )
 
-  def generateLoc( uid : UID ) =
+  def generateLoc(uid: UID) =
     new SourceLocation(
-      "filename",
-      new SourceRegion(
-        new SourcePosition( uid.id.toInt ),
-        new SourcePosition( uid.id.toInt )
-      )
+        "filename",
+        new SourceRegion(
+            new SourcePosition(uid.id.toInt),
+            new SourcePosition(uid.id.toInt)
+        )
     )
 
   // Arbitrary assignment, all exs get a unique position equal to their UID
-  val sourceMap : SourceMap =
-    ( ( exs.map( allUidsBelow ) ++ decls.map( _.body ).map( allUidsBelow ) ).foldLeft( Set.empty[UID] ) {
+  val sourceMap: SourceMap =
+    ((exs.map(allUidsBelow) ++ decls.map(_.body).map(allUidsBelow)).foldLeft(Set.empty[UID]) {
       _ ++ _
-    } map {
-      x => x -> generateLoc( x )
-    } ).toMap
+    } map { x =>
+      x -> generateLoc(x)
+    }).toMap
 
   val exMap = new mutable.HashMap[UID, TlaEx]()
 
   val mapListener = new TransformationListener {
-    override def onTransformation( originalEx : TlaEx, newEx : TlaEx ) : Unit = {
-      exMap.update( originalEx.ID, originalEx )
-      exMap.update( newEx.ID, newEx )
+    override def onTransformation(originalEx: TlaEx, newEx: TlaEx): Unit = {
+      exMap.update(originalEx.ID, originalEx)
+      exMap.update(newEx.ID, newEx)
     }
 
     override def onDeclTransformation(originalDecl: TlaDecl, newDecl: TlaDecl): Unit = {
@@ -105,74 +108,74 @@ class TestSourceLocator extends FunSuite with TestingPredefs {
   }
 
   val changeListener = new ChangeListener()
-  val tracker        = TrackerWithListeners( changeListener, mapListener )
+  val tracker = TrackerWithListeners(changeListener, mapListener)
 
-  val locator = SourceLocator( sourceMap, changeListener )
+  val locator = SourceLocator(sourceMap, changeListener)
 
-  def testTransformation( t : TlaExTransformation ) : Unit = {
+  def testTransformation(t: TlaExTransformation): Unit = {
     val post = exs map t
-    val postIds = post.map( allUidsBelow ).foldLeft( Set.empty[UID] ) {
+    val postIds = post.map(allUidsBelow).foldLeft(Set.empty[UID]) {
       _ ++ _
     }
 
-    val failures = postIds.filterNot( i => locator.sourceOf( i ).nonEmpty )
-    assert( failures.isEmpty )
+    val failures = postIds.filterNot(i => locator.sourceOf(i).nonEmpty)
+    assert(failures.isEmpty)
   }
 
-  test( "Test DeepCopy" ) {
-    val transformation = DeepCopy( tracker ).deepCopyEx[TlaEx] _
+  test("Test DeepCopy") {
+    val transformation = DeepCopy(tracker).deepCopyEx[TlaEx] _
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test EqualityAsContainment" ) {
-    val transformation = PrimedEqualityToMembership( tracker )
+  test("Test EqualityAsContainment") {
+    val transformation = PrimedEqualityToMembership(tracker)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test ExplicitLetIn" ) {
-    val transformation = LetInExpander( tracker, keepNullary = false )
+  test("Test ExplicitLetIn") {
+    val transformation = LetInExpander(tracker, keepNullary = false)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test Flatten" ) {
-    val transformation = Flatten( tracker )
+  test("Test Flatten") {
+    val transformation = Flatten(tracker)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test IncrementalRenaming" ) {
-    val transformation = new IncrementalRenaming( tracker )
+  test("Test IncrementalRenaming") {
+    val transformation = new IncrementalRenaming(tracker)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test Inline" ) {
-    val transformation = InlinerOfUserOper( bodyMap, tracker )
+  test("Test Inline") {
+    val transformation = InlinerOfUserOper(bodyMap, tracker)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test NoOp" ) {
+  test("Test NoOp") {
     val transformation = tracker.trackEx {
       identity
     }
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test Prime" ) {
-    val vars = Set( "x", "y" )
-    val transformation = Prime( vars, tracker )
+  test("Test Prime") {
+    val vars = Set("x", "y")
+    val transformation = Prime(vars, tracker)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 
-  test( "Test PruneApalacheAnnotations" ) {
-    val transformation = PruneApalacheAnnotations( tracker )
+  test("Test PruneApalacheAnnotations") {
+    val transformation = PruneApalacheAnnotations(tracker)
 
-    testTransformation( transformation )
+    testTransformation(transformation)
   }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExpr.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExpr.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.lir
 
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
 import org.junit.runner.RunWith
@@ -7,10 +8,39 @@ import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 /**
-  * Tests for the TLA+ expressions that we can construct.
-  */
+ * Tests for the TLA+ expressions that we can construct.
+ */
 @RunWith(classOf[JUnitRunner])
 class TestTlaExpr extends FunSuite {
+  test("no type tag") {
+    // this expression is constructed with the implicit value for typeTag = Untyped().
+    val ex = ValEx(TlaInt(42))
+    // pattern matching should work without worrying about type tags
+    ex match {
+      case matched @ ValEx(TlaInt(i)) =>
+        assert(42 == i)
+        assert(Untyped() == matched.typeTag)
+
+      case _ =>
+        fail("Expected valEx")
+    }
+  }
+
+  test("type tag") {
+    // this expression is annotated with a type tag. For testing purposes, the type tag is just a string.
+    val ex = ValEx(TlaInt(42))(Typed[String]("foo"))
+    // although we have have set a type tag, pattern matching should be oblivious to that
+    ex match {
+      case matched @ ValEx(TlaInt(i)) =>
+        assert(42 == i)
+        // we can extract the type, whenever we want to do it
+        assert(Typed[String]("foo") == matched.typeTag)
+
+      case _ =>
+        fail("Expected ValEx")
+    }
+  }
+
   test("create a conjunction") {
     val x = NameEx("x")
     val y = NameEx("y")
@@ -102,34 +132,24 @@ class TestTlaExpr extends FunSuite {
     OperEx(TlaSetOper.enumSet)
 
     // an intersection with another set
-    OperEx(TlaSetOper.cap,
-      OperEx(TlaSetOper.enumSet),
-      OperEx(TlaSetOper.enumSet, ValEx(TlaInt(1)))
-    )
+    OperEx(TlaSetOper.cap, OperEx(TlaSetOper.enumSet), OperEx(TlaSetOper.enumSet, ValEx(TlaInt(1))))
   }
 
   test("strange set operations") {
     // We can write something like 2 \cup {4}. TLA Toolbox would not complain.
-    OperEx(TlaSetOper.cup,
-      ValEx(TlaInt(2)),
-      OperEx(TlaSetOper.enumSet, ValEx(TlaInt(4))))
+    OperEx(TlaSetOper.cup, ValEx(TlaInt(2)), OperEx(TlaSetOper.enumSet, ValEx(TlaInt(4))))
   }
 
   test("declaring an order 0 operator") {
     // A == x' /\ y
-    val odef = TlaOperDecl("A", List(),
-      OperEx(TlaBoolOper.and,
-        OperEx(TlaActionOper.prime, NameEx("x")),
-        NameEx("y")
-      )
-    )
+    val odef = TlaOperDecl("A", List(), OperEx(TlaBoolOper.and, OperEx(TlaActionOper.prime, NameEx("x")), NameEx("y")))
 
     // this is the way to use a user-defined operator
-    Builder.appDecl( odef )
+    Builder.appDecl(odef)
 
     // we should get an exception when the number of arguments is incorrect
     try {
-      Builder.appDecl( odef, NameEx("a") )
+      Builder.appDecl(odef, NameEx("a"))
       fail("Expected an IllegalArgumentException")
     } catch {
       case _: IllegalArgumentException => () // OK
@@ -139,18 +159,14 @@ class TestTlaExpr extends FunSuite {
   test("declaring an order 1 operator") {
     // A(x, y) == x' /\ y
     val odef = TlaOperDecl("A", List(SimpleFormalParam("x"), SimpleFormalParam("y")),
-      OperEx(TlaBoolOper.and,
-        OperEx(TlaActionOper.prime, NameEx("x")),
-        NameEx("y")
-      )
-    )
+        OperEx(TlaBoolOper.and, OperEx(TlaActionOper.prime, NameEx("x")), NameEx("y")))
 
     // this is the way to use a user-defined operator
-    Builder.appDecl( odef, NameEx("a"), NameEx("b") )
+    Builder.appDecl(odef, NameEx("a"), NameEx("b"))
 
     // we should get an exception when the number of arguments is incorrect
     try {
-      Builder.appDecl( odef, NameEx("a") )
+      Builder.appDecl(odef, NameEx("a"))
       fail("Expected an IllegalArgumentException")
     } catch {
       case _: IllegalArgumentException => () // OK
@@ -162,33 +178,22 @@ class TestTlaExpr extends FunSuite {
     val fOper = OperFormalParam("f", 2)
 
     // A(f(_, _), x, y) == f(x, y)
-    val odef = TlaOperDecl("A",
-      List(fOper, SimpleFormalParam("x"), SimpleFormalParam("y")),
-      OperEx(TlaOper.apply,
-        NameEx("f"),
-        NameEx("x"),
-        NameEx("y")
-      )
-    )
+    val odef = TlaOperDecl("A", List(fOper, SimpleFormalParam("x"), SimpleFormalParam("y")),
+        OperEx(TlaOper.apply, NameEx("f"), NameEx("x"), NameEx("y")))
 
     // this is the way to use a user-defined operator
-    Builder.appDecl( odef, NameEx(TlaSetOper.cup.name), NameEx("a"), NameEx("b") )
+    Builder.appDecl(odef, NameEx(TlaSetOper.cup.name), NameEx("a"), NameEx("b"))
 
     // The following expression does not make a lot of sense, but it is legal to construct it.
     // Later, there will be a plugin to detect inconsistent expressions like this.
-    Builder.appDecl( odef, NameEx("a"), NameEx("b"), NameEx("b") )
+    Builder.appDecl(odef, NameEx("a"), NameEx("b"), NameEx("b"))
   }
-
 
   test("existentials") {
     val ex1 =
-      OperEx(TlaBoolOper.existsUnbounded, NameEx("x"),
-        OperEx(TlaOper.eq, NameEx("x"), NameEx("x"))
-      )
+      OperEx(TlaBoolOper.existsUnbounded, NameEx("x"), OperEx(TlaOper.eq, NameEx("x"), NameEx("x")))
     val ex2 =
-      OperEx(TlaBoolOper.existsUnbounded, NameEx("x"),
-        OperEx(TlaOper.eq, NameEx("x"), NameEx("x"))
-      )
+      OperEx(TlaBoolOper.existsUnbounded, NameEx("x"), OperEx(TlaOper.eq, NameEx("x"), NameEx("x")))
     val conj = OperEx(TlaBoolOper.and, ex1, ex2)
   }
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
@@ -3,105 +3,110 @@ package at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
+@RunWith(classOf[JUnitRunner])
 class TestTransformations extends FunSuite with TestingPredefs {
 
   import Builder._
 
-  private def depthOf( ex : TlaEx ) : Int = ex match {
-    case OperEx( oper, args@_* ) => 1 + ( if ( args.nonEmpty ) ( args map depthOf ).max else 0 )
-    case _ => 1
+  private def depthOf(ex: TlaEx): Int = ex match {
+    case OperEx(oper, args @ _*) => 1 + (if (args.nonEmpty) (args map depthOf).max else 0)
+    case _                       => 1
   }
 
-  test( "Test ReplaceFixed" ) {
-    val transformation = ReplaceFixed( n_x, NameEx( "y" ), new IdleTracker() )
+  test("Test ReplaceFixed") {
+    val transformation = ReplaceFixed(n_x, NameEx("y"), new IdleTracker())
 
     val pa1 = n_x -> n_y
     val pa2 = n_z -> n_z
-    val pa3 = prime( n_x ) -> prime( n_y )
-    val pa4 = ite( n_p, n_x, n_y ) -> ite( n_p, n_y, n_y )
+    val pa3 = prime(n_x) -> prime(n_y)
+    val pa4 = ite(n_p, n_x, n_y) -> ite(n_p, n_y, n_y)
     val pa5 = letIn(
-      plus( n_z, appOp( n_A ) ),
-      declOp( "A", n_q )
+        plus(n_z, appOp(n_A)),
+        declOp("A", n_q)
     ) -> letIn(
-      plus( n_z, appOp( n_A ) ),
-      declOp( "A", n_q )
+        plus(n_z, appOp(n_A)),
+        declOp("A", n_q)
     )
     val pa6 = letIn(
-      enumSet( plus( n_x, appOp( n_A ) ), appOp( n_B, n_x ) ),
-      declOp( "A", n_x ),
-      declOp( "B", n_p, "p" )
+        enumSet(plus(n_x, appOp(n_A)), appOp(n_B, n_x)),
+        declOp("A", n_x),
+        declOp("B", n_p, "p")
     ) -> letIn(
-      enumSet( plus( n_y, appOp( n_A ) ), appOp( n_B, n_y ) ),
-      declOp( "A", n_y ),
-      declOp( "B", n_p, "p" )
+        enumSet(plus(n_y, appOp(n_A)), appOp(n_B, n_y)),
+        declOp("A", n_y),
+        declOp("B", n_p, "p")
     )
-
 
     val expected = Seq(
-      pa1, pa2, pa3, pa4, pa5, pa6
+        pa1,
+        pa2,
+        pa3,
+        pa4,
+        pa5,
+        pa6
     )
     val cmp = expected map { case (k, v) =>
-      (v, transformation( k ))
+      (v, transformation(k))
     }
     cmp foreach { case (ex, act) =>
-      assert( ex == act )
+      assert(ex == act)
     }
   }
 
-  test( "Test EqualityAsContainment" ) {
-    val transformation = PrimedEqualityToMembership( new IdleTracker() )
+  test("Test EqualityAsContainment") {
+    val transformation = PrimedEqualityToMembership(new IdleTracker())
 
-    val ex1 = primeEq( n_x, n_y )
-    val ex2 = or( primeEq( n_x, n_y ), ge( prime( n_x ), int( 0 ) ) )
-    val ex3 = ite( primeEq( n_x, n_y ), primeEq( n_z, int( 0 ) ), primeEq( n_z, int( 1 ) ) )
+    val ex1 = primeEq(n_x, n_y)
+    val ex2 = or(primeEq(n_x, n_y), ge(prime(n_x), int(0)))
+    val ex3 = ite(primeEq(n_x, n_y), primeEq(n_z, int(0)), primeEq(n_z, int(1)))
     val ex4 = letIn(
-      appOp( n_A ),
-      declOp( "A", primeEq( n_x, n_y ) )
+        appOp(n_A),
+        declOp("A", primeEq(n_x, n_y))
     )
 
-    val expected1 = in( prime( n_x ), enumSet( n_y ) )
-    val expected2 = or( in( prime( n_x ), enumSet( n_y ) ), ge( prime( n_x ), int( 0 ) ) )
+    val expected1 = in(prime(n_x), enumSet(n_y))
+    val expected2 = or(in(prime(n_x), enumSet(n_y)), ge(prime(n_x), int(0)))
     val expected3 = ite(
-      in( prime( n_x ), enumSet( n_y ) ),
-      in( prime( n_z ), enumSet( int( 0 ) ) ),
-      in( prime( n_z ), enumSet( int( 1 ) ) )
+        in(prime(n_x), enumSet(n_y)),
+        in(prime(n_z), enumSet(int(0))),
+        in(prime(n_z), enumSet(int(1)))
     )
     val expected4 = letIn(
-      appOp( n_A ),
-      declOp( "A", in( prime( n_x ), enumSet( n_y ) ) )
+        appOp(n_A),
+        declOp("A", in(prime(n_x), enumSet(n_y)))
     )
 
-    val exs = Seq( ex1, ex2, ex3, ex4 )
-    val expected = Seq( expected1, expected2, expected3, expected4 )
+    val exs = Seq(ex1, ex2, ex3, ex4)
+    val expected = Seq(expected1, expected2, expected3, expected4)
     val actual = exs map transformation
-    assert( expected == actual )
+    assert(expected == actual)
   }
 
-  test( "Test Inline" ) {
-    val cDecl = declOp( "C", plus( n_x, int( 1 ) ), SimpleFormalParam( "x" ) )
+  test("Test Inline") {
+    val cDecl = declOp("C", plus(n_x, int(1)), SimpleFormalParam("x"))
     val operDecls = Seq(
-      declOp( "A", appOp( n_B ) ),
-      declOp( "B", n_c ),
-      cDecl
+        declOp("A", appOp(n_B)),
+        declOp("B", n_c),
+        cDecl
     )
 
-    val bodies = BodyMapFactory.makeFromDecls( operDecls )
+    val bodies = BodyMapFactory.makeFromDecls(operDecls)
 
-    val transformation = InlinerOfUserOper( bodies, new IdleTracker() )
+    val transformation = InlinerOfUserOper(bodies, new IdleTracker())
 
     val ex1 = n_B
-    val ex2 = appOp( n_B )
+    val ex2 = appOp(n_B)
     val ex3 = n_A
-    val ex4 = appOp( n_A )
-    val ex5 = or( eql( int( 1 ), int( 0 ) ), ge( appDecl( cDecl, appOp( n_A ) ), int( 0 ) ) )
+    val ex4 = appOp(n_A)
+    val ex5 = or(eql(int(1), int(0)), ge(appDecl(cDecl, appOp(n_A)), int(0)))
     val ex6 = letIn(
-      appOp( NameEx( "X" ) ),
-      declOp( "X", appOp( NameEx( "C" ), n_p ) )
+        appOp(NameEx("X")),
+        declOp("X", appOp(NameEx("C"), n_p))
     )
 
     val expected1 = n_B // Operators need to be called with apply
@@ -109,100 +114,110 @@ class TestTransformations extends FunSuite with TestingPredefs {
     val expected3 = n_A // Operators need to be called with apply
     val expected4 = n_c
     val expected5 = or(
-      eql( int( 1 ), int( 0 ) ),
-      ge( plus( n_c, int( 1 ) ), int( 0 ) )
+        eql(int(1), int(0)),
+        ge(plus(n_c, int(1)), int(0))
     )
     val expected6 = letIn(
-      appOp( NameEx( "X" ) ),
-      declOp( "X", plus( n_p, int( 1 ) ) )
+        appOp(NameEx("X")),
+        declOp("X", plus(n_p, int(1)))
     )
 
-    val exs = Seq( ex1, ex2, ex3, ex4, ex5, ex6 )
-    val expected = Seq( expected1, expected2, expected3, expected4, expected5, expected6 )
+    val exs = Seq(ex1, ex2, ex3, ex4, ex5, ex6)
+    val expected = Seq(expected1, expected2, expected3, expected4, expected5, expected6)
     val actual = exs map transformation
 
-    assert( expected == actual )
+    assert(expected == actual)
 
     assertThrows[IllegalArgumentException] {
-      transformation( appOp( NameEx( "C" ) ) )
+      transformation(appOp(NameEx("C")))
     }
     assertThrows[IllegalArgumentException] {
-      transformation( appOp( NameEx( "C" ), n_a, n_b ) )
+      transformation(appOp(NameEx("C"), n_a, n_b))
     }
   }
 
-  test( "Test Prime" ) {
-    val vars : Set[String] = Set(
-      "x", "a"
+  test("Test Prime") {
+    val vars: Set[String] = Set(
+        "x",
+        "a"
     )
-    val transformation = Prime( vars, new IdleTracker() )
+    val transformation = Prime(vars, new IdleTracker())
 
-    val pa1 = n_x -> prime( n_x )
+    val pa1 = n_x -> prime(n_x)
     val pa2 = n_y -> n_y
-    val pa3 = prime( n_x ) -> prime( n_x )
-    val pa4 = and( n_x, n_y, prime( n_a ) ) -> and( prime( n_x ), n_y, prime( n_a ) )
+    val pa3 = prime(n_x) -> prime(n_x)
+    val pa4 = and(n_x, n_y, prime(n_a)) -> and(prime(n_x), n_y, prime(n_a))
 
     val expected = Seq(
-      pa1, pa2, pa3, pa4
+        pa1,
+        pa2,
+        pa3,
+        pa4
     )
     val cmp = expected map { case (k, v) =>
-      (v, transformation( k ))
+      (v, transformation(k))
     }
     cmp foreach { case (ex, act) =>
-      assert( ex == act )
+      assert(ex == act)
     }
   }
 
-  test( "Test Flatten" ) {
-    val transformation = Flatten( new IdleTracker() )
+  test("Test Flatten") {
+    val transformation = Flatten(new IdleTracker())
 
     val pa1 = n_x -> n_x
-    val pa2 = and( n_x, and( n_y, n_z ) ) -> and( n_x, n_y, n_z )
-    val pa3 = or( n_x, or( n_y, n_z ) ) -> or( n_x, n_y, n_z )
-    val pa4 = or( n_x, and( n_y, n_z ) ) -> or( n_x, and( n_y, n_z ) )
+    val pa2 = and(n_x, and(n_y, n_z)) -> and(n_x, n_y, n_z)
+    val pa3 = or(n_x, or(n_y, n_z)) -> or(n_x, n_y, n_z)
+    val pa4 = or(n_x, and(n_y, n_z)) -> or(n_x, and(n_y, n_z))
     val pa5 = and(
-      and(
-        or(
-          or( n_a, n_b ),
-          or( n_c, n_d )
+        and(
+            or(
+                or(n_a, n_b),
+                or(n_c, n_d)
+            )
+        ),
+        and(
+            or(
+                or(n_e, n_f),
+                or(n_g, NameEx("h"))
+            )
         )
-      ),
-      and(
-        or(
-          or( n_e, n_f ),
-          or( n_g, NameEx( "h" ) )
-        )
-      )
     ) -> and(
-      or( n_a, n_b, n_c, n_d ),
-      or( n_e, n_f, n_g, NameEx( "h" ) )
+        or(n_a, n_b, n_c, n_d),
+        or(n_e, n_f, n_g, NameEx("h"))
     )
-    val pa6 = enumSet( or( n_x, and( n_y, n_z ) ) ) -> enumSet( or( n_x, and( n_y, n_z ) ) )
+    val pa6 = enumSet(or(n_x, and(n_y, n_z))) -> enumSet(or(n_x, and(n_y, n_z)))
     val pa7 = letIn(
-      appOp( n_A ),
-      declOp( "A", int(1) )
+        appOp(n_A),
+        declOp("A", int(1))
     ) -> letIn(
-      appOp( n_A ),
-      declOp( "A", int(1) )
+        appOp(n_A),
+        declOp("A", int(1))
     )
 
     val pa8 = letIn(
-      appOp( n_A ),
-      declOp( "A", or( n_x, or( n_y, n_z ) ) )
+        appOp(n_A),
+        declOp("A", or(n_x, or(n_y, n_z)))
     ) -> letIn(
-      appOp( n_A ),
-      declOp( "A", or( n_x, n_y, n_z ) )
+        appOp(n_A),
+        declOp("A", or(n_x, n_y, n_z))
     )
-
 
     val expected = Seq(
-      pa1, pa2, pa3, pa4, pa5, pa6, pa7, pa8
+        pa1,
+        pa2,
+        pa3,
+        pa4,
+        pa5,
+        pa6,
+        pa7,
+        pa8
     )
     val cmp = expected map { case (k, v) =>
-      (v, transformation( k ))
+      (v, transformation(k))
     }
     cmp foreach { case (ex, act) =>
-      assert( ex == act )
+      assert(ex == act)
     }
   }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJson.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJson.scala
@@ -7,11 +7,13 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * <p>Geeneric set of tests for conversion between TLA and JSON.</p>
+ *
  * @author Andrey Kuprianov
- **/
+ */
 
 @RunWith(classOf[JUnitRunner])
 abstract class TestJson extends FunSuite {
@@ -34,72 +36,72 @@ abstract class TestJson extends FunSuite {
   test("id") {
     // awesome
     compare(
-      name("awesome"),
-      """"awesome""""
+        name("awesome"),
+        """"awesome""""
     )
   }
 
   test("str") {
     // "Hello, World!"
     compare(
-      str("Hello, World!"),
-      """{"str":"Hello, World!"}"""
+        str("Hello, World!"),
+        """{"str":"Hello, World!"}"""
     )
   }
 
   test("int") {
     // int
     compare(
-      int(42),
-      """42"""
+        int(42),
+        """42"""
     )
   }
 
   test("big int") {
     // int
     compare(
-      bigInt(BigInt("9876543210")),
-      """{"int":"9876543210"}"""
+        bigInt(BigInt("9876543210")),
+        """{"int":"9876543210"}"""
     )
   }
 
   test("RealSet") {
     // Real
     compare(
-      ValEx(TlaRealSet), // TODO: builders for sets? (Andrey)
-      """{"set":"Real"}"""
+        ValEx(TlaRealSet), // TODO: builders for sets? (Andrey)
+        """{"set":"Real"}"""
     )
   }
 
   test("prime name") {
     // awesome'
     compare(
-      prime("awesome"),
-      """{"prime":"awesome"}"""
+        prime("awesome"),
+        """{"prime":"awesome"}"""
     )
   }
 
   test("empty set") {
     // { }
     compare(
-      enumSet(),
-      """{"enumSet":[]}"""
+        enumSet(),
+        """{"enumSet":[]}"""
     )
   }
   //
   test("singleton set") {
     // { 42 }
     compare(
-      enumSet(42),
-      """{"enumSet":[42]}"""
+        enumSet(42),
+        """{"enumSet":[42]}"""
     )
   }
 
   test("singleton set multi-line") {
     // { 42 }
     compareMultiLine(
-      enumSet(42),
-      """{
+        enumSet(42),
+        """{
         |  "enumSet": [
         |    42
         |  ]
@@ -110,16 +112,16 @@ abstract class TestJson extends FunSuite {
   test("enum") {
     // { 1, 2, 3 }
     compare(
-      enumSet(int(1), int(2), int(3)),
-      """{"enumSet":[1,2,3]}"""
+        enumSet(int(1), int(2), int(3)),
+        """{"enumSet":[1,2,3]}"""
     )
   }
 
   test("enum multi-line") {
     // { 1, 2, 3 }
     compareMultiLine(
-      enumSet(int(1), int(2), int(3)),
-      """{
+        enumSet(int(1), int(2), int(3)),
+        """{
         |  "enumSet": [
         |    1,
         |    2,
@@ -132,32 +134,32 @@ abstract class TestJson extends FunSuite {
   test("tuple") {
     // << 1, two, "three" >>
     compare(
-      tuple(int(1), name("two"), str("three")),
-      """{"tuple":[1,"two",{"str":"three"}]}"""
+        tuple(int(1), name("two"), str("three")),
+        """{"tuple":[1,"two",{"str":"three"}]}"""
     )
   }
 
   test("conjunction") {
     // a /\ b /\ c
     compare(
-      and(name("a"), name("b"), name("c")),
-      """{"and":["a","b","c"]}"""
+        and(name("a"), name("b"), name("c")),
+        """{"and":["a","b","c"]}"""
     )
   }
 
   test("minus") {
     // 1 - 2
     compare(
-      minus(int(1), int(2)),
-      """{"minus":1,"arg":2}"""
+        minus(int(1), int(2)),
+        """{"minus":1,"arg":2}"""
     )
   }
 
   test("function constructor") {
     // [ x \in S, y \in T |-> x + y ]
     compareMultiLine(
-      funDef(plus("x", "y"), "x", "S", "y", "T"),
-      """{
+        funDef(plus("x", "y"), "x", "S", "y", "T"),
+        """{
         |  "funDef": {
         |    "plus": "x",
         |    "arg": "y"
@@ -179,88 +181,94 @@ abstract class TestJson extends FunSuite {
   test("recursive function constructor") {
     // [x \in S] == 1 + recFunRef
     compare(
-      recFunDef(plus(int(1), recFunRef()), "x", "S"),
-      """{"recFunDef":{"plus":1,"arg":{"applyOp":"recFunRef","args":[]}},"where":[{"key":"x","value":"S"}]}""".stripMargin
+        recFunDef(plus(int(1), recFunRef()), "x", "S"),
+        """{"recFunDef":{"plus":1,"arg":{"applyOp":"recFunRef","args":[]}},"where":[{"key":"x","value":"S"}]}""".stripMargin
     )
   }
 
   test("function application") {
     // f[e]
     compare(
-      appFun("f", "e"),
-      """{"applyFun":"f","arg":"e"}"""
+        appFun("f", "e"),
+        """{"applyFun":"f","arg":"e"}"""
     )
   }
 
   test("operator application") {
     // A(1,2)
     compare(
-      OperEx(TlaOper.apply, "A", 1, 2),
-      """{"applyOp":"A","args":[1,2]}"""
+        OperEx(TlaOper.apply, "A", 1, 2),
+        """{"applyOp":"A","args":[1,2]}"""
     )
   }
 
   test("double function application") {
     // f[e][g]
     compare(
-      appFun(appFun("f", "e"), "g"),
-      """{"applyFun":{"applyFun":"f","arg":"e"},"arg":"g"}"""
+        appFun(appFun("f", "e"), "g"),
+        """{"applyFun":{"applyFun":"f","arg":"e"},"arg":"g"}"""
     )
   }
 
   test("function except") {
     // [f EXCEPT ![k] = v]
     compare(
-      except("f", "k", "v"),
-      """{"except":"f","where":[{"key":"k","value":"v"}]}"""
+        except("f", "k", "v"),
+        """{"except":"f","where":[{"key":"k","value":"v"}]}"""
     )
   }
 
   test("record / function enumeration") {
     // [ k_1 |-> v_1, ..., k_n |-> v_n ]
     compare(
-      enumFun(
-        str("x1"), "y1",
-        str("x2"), "y2",
-        str("x3"), "y3"
-      ),
-      """{"record":[{"key":{"str":"x1"},"value":"y1"},{"key":{"str":"x2"},"value":"y2"},{"key":{"str":"x3"},"value":"y3"}]}"""
+        enumFun(
+            str("x1"),
+            "y1",
+            str("x2"),
+            "y2",
+            str("x3"),
+            "y3"
+        ),
+        """{"record":[{"key":{"str":"x1"},"value":"y1"},{"key":{"str":"x2"},"value":"y2"},{"key":{"str":"x3"},"value":"y3"}]}"""
     )
   }
 
   test("function set") {
     // [S -> T]
     compare(
-      funSet(name("S"), name("T")),
-      """{"funSet":"S","arg":"T"}"""
+        funSet(name("S"), name("T")),
+        """{"funSet":"S","arg":"T"}"""
     )
   }
 
   test("record set") {
     // [x: S -> T]
     compare(
-      recSet(
-        str("x"), "S",
-        str("y"), "T",
-        str("z"), "U"
-      ),
-      """{"recSet":[{"key":{"str":"x"},"value":"S"},{"key":{"str":"y"},"value":"T"},{"key":{"str":"z"},"value":"U"}]}"""
+        recSet(
+            str("x"),
+            "S",
+            str("y"),
+            "T",
+            str("z"),
+            "U"
+        ),
+        """{"recSet":[{"key":{"str":"x"},"value":"S"},{"key":{"str":"y"},"value":"T"},{"key":{"str":"z"},"value":"U"}]}"""
     )
   }
 
   test("filter") {
     // {x \in S: P}
     compare(
-      filter("x", "S", "P"),
-      """{"filter":{"key":"x","value":"S"},"that":"P"}"""
+        filter("x", "S", "P"),
+        """{"filter":{"key":"x","value":"S"},"that":"P"}"""
     )
   }
 
   test("filter with predicate") {
     // {x \in S: P}
     compareMultiLine(
-      filter("x", "S", lt("x", 5)),
-      """{
+        filter("x", "S", lt("x", 5)),
+        """{
         |  "filter": {
         |    "key": "x",
         |    "value": "S"
@@ -276,40 +284,40 @@ abstract class TestJson extends FunSuite {
   test("map") {
     // {x+y: x \in S, y \in T}
     compare(
-      map(plus("x", "y"), "x", "S", "y", "T"),
-      """{"map":{"plus":"x","arg":"y"},"where":[{"key":"x","value":"S"},{"key":"y","value":"T"}]}"""
+        map(plus("x", "y"), "x", "S", "y", "T"),
+        """{"map":{"plus":"x","arg":"y"},"where":[{"key":"x","value":"S"},{"key":"y","value":"T"}]}"""
     )
   }
 
   test("exists bounded") {
     // \E x \in S : P
     compare(
-      exists("x", "S", "P"),
-      """{"existsBounded":{"key":"x","value":"S"},"that":"P"}"""
+        exists("x", "S", "P"),
+        """{"existsBounded":{"key":"x","value":"S"},"that":"P"}"""
     )
   }
 
   test("exists unbounded") {
     // \E x : P
     compare(
-      exists("x", "P"),
-      """{"exists":"x","that":"P"}"""
+        exists("x", "P"),
+        """{"exists":"x","that":"P"}"""
     )
   }
 
   test("choose bounded") {
     // CHOOSE x \in S : x > 3
     compare(
-      choose("x", "S", gt("x",3)),
-      """{"chooseBounded":{"key":"x","value":"S"},"that":{"gt":"x","arg":3}}"""
+        choose("x", "S", gt("x", 3)),
+        """{"chooseBounded":{"key":"x","value":"S"},"that":{"gt":"x","arg":3}}"""
     )
   }
 
   test("choose unbounded") {
     // CHOOSE <<x, y>> : x + y <= 5
     compareMultiLine(
-      choose(tuple("x", "y"), le(plus("x","y"),5)),
-      """{
+        choose(tuple("x", "y"), le(plus("x", "y"), 5)),
+        """{
         |  "choose": {
         |    "tuple": [
         |      "x",
@@ -330,8 +338,8 @@ abstract class TestJson extends FunSuite {
   test("if then else") {
     // \E x \in S : P
     compare(
-      ite("p", "x", "y"),
-      """{"if":"p","then":"x","else":"y"}"""
+        ite("p", "x", "y"),
+        """{"if":"p","then":"x","else":"y"}"""
     )
   }
 
@@ -339,8 +347,8 @@ abstract class TestJson extends FunSuite {
     // CASE guard1 -> action1
     //   [] guard2 -> action2
     compare(
-      caseSplit("guard1", "action1", "guard2", "action2"),
-      """{"case":[{"key":"guard1","value":"action1"},{"key":"guard2","value":"action2"}]}"""
+        caseSplit("guard1", "action1", "guard2", "action2"),
+        """{"case":[{"key":"guard1","value":"action1"},{"key":"guard2","value":"action2"}]}"""
     )
   }
 
@@ -349,94 +357,84 @@ abstract class TestJson extends FunSuite {
     //   [] guard2 -> action2
     //   [] OTHER -> otherAction
     compare(
-      caseOther("otherAction", "guard1", "action1", "guard2", "action2"),
-      """{"case":[{"key":"guard1","value":"action1"},{"key":"guard2","value":"action2"}],"other":"otherAction"}"""
+        caseOther("otherAction", "guard1", "action1", "guard2", "action2"),
+        """{"case":[{"key":"guard1","value":"action1"},{"key":"guard2","value":"action2"}],"other":"otherAction"}"""
     )
   }
 
   test("[A]_x") {
     compare(
-      stutt("A", "x"),
-      """{"stutter":"A","vars":"x"}"""
+        stutt("A", "x"),
+        """{"stutter":"A","vars":"x"}"""
     )
   }
 
   test("<A>_<<x,y>>") {
     compare(
-      nostutt("A", tuple("x", "y")),
-      """{"nostutter":"A","vars":{"tuple":["x","y"]}}"""
+        nostutt("A", tuple("x", "y")),
+        """{"nostutter":"A","vars":{"tuple":["x","y"]}}"""
     )
   }
 
   test("WF_x(A)") {
     compare(
-      WF("x", "A"),
-      """{"weakFairness":"A","vars":"x"}"""
+        WF("x", "A"),
+        """{"weakFairness":"A","vars":"x"}"""
     )
   }
 
   test("SF_<<x,y>>(A)") {
     compare(
-      SF(tuple("x", "y"), "A"),
-      """{"strongFairness":"A","vars":{"tuple":["x","y"]}}"""
+        SF(tuple("x", "y"), "A"),
+        """{"strongFairness":"A","vars":{"tuple":["x","y"]}}"""
     )
   }
 
   test("L2 :: 1") {
     compare(
-      label(int(1), "L2"),
-      """{"int":"1","label":{"name":"L2","args":[]}}"""
+        label(int(1), "L2"),
+        """{"int":"1","label":{"name":"L2","args":[]}}"""
     )
   }
 
   test("L2 :: x") {
     compare(
-      label(name("x"), "L2"),
-      """{"id":"x","label":{"name":"L2","args":[]}}"""
+        label(name("x"), "L2"),
+        """{"id":"x","label":{"name":"L2","args":[]}}"""
     )
   }
 
   test("L2(a, b) :: f(x+y)>2") {
     compare(
-      label(appFun("f", gt(plus("x","y"),2)), "L2", "a", "b"),
-      """{"applyFun":"f","arg":{"gt":{"plus":"x","arg":"y"},"arg":2},"label":{"name":"L2","args":["a","b"]}}"""
+        label(appFun("f", gt(plus("x", "y"), 2)), "L2", "a", "b"),
+        """{"applyFun":"f","arg":{"gt":{"plus":"x","arg":"y"},"arg":2},"label":{"name":"L2","args":["a","b"]}}"""
     )
   }
 
   test("LET A == 1 IN A") {
     val aDecl = TlaOperDecl("A", List(), 1)
     compare(
-      letIn(appDecl(aDecl), aDecl),
-      """{"let":[{"operator":"A","body":1,"params":[]}],"body":{"applyOp":"A","args":[]}}"""
+        letIn(appDecl(aDecl), aDecl),
+        """{"let":[{"operator":"A","body":1,"params":[]}],"body":{"applyOp":"A","args":[]}}"""
     )
   }
 
   test("LET A(x, y) == x + y IN A(1,2)") {
     // <A>_vars
-    val decl = TlaOperDecl("A",
-      List(SimpleFormalParam("x"), SimpleFormalParam("y")),
-      plus("x", "y"))
+    val decl = TlaOperDecl("A", List(SimpleFormalParam("x"), SimpleFormalParam("y")), plus("x", "y"))
     compare(
-      letIn(appDecl(decl, int(1), int(2)), decl),
-      """{"let":[{"operator":"A","body":{"plus":"x","arg":"y"},"params":[{"name":"x","arity":0},{"name":"y","arity":0}]}],"body":{"applyOp":"A","args":[1,2]}}"""
+        letIn(appDecl(decl, int(1), int(2)), decl),
+        """{"let":[{"operator":"A","body":{"plus":"x","arg":"y"},"params":[{"name":"x","arity":0},{"name":"y","arity":0}]}],"body":{"applyOp":"A","args":[1,2]}}"""
     )
   }
 
   test("LET A(x, y) == x + 1 IN B(x, y) == x - y IN A(1, 2) * B(3, 4)") {
     // <A>_vars
-    val decl1 = TlaOperDecl("A",
-      List(SimpleFormalParam("x"), SimpleFormalParam("y")),
-      plus("x", "y"))
-    val decl2 = TlaOperDecl("B",
-      List(SimpleFormalParam("x"), SimpleFormalParam("y")),
-      minus("x", "y"))
+    val decl1 = TlaOperDecl("A", List(SimpleFormalParam("x"), SimpleFormalParam("y")), plus("x", "y"))
+    val decl2 = TlaOperDecl("B", List(SimpleFormalParam("x"), SimpleFormalParam("y")), minus("x", "y"))
     compareMultiLine(
-      letIn(
-        mult(
-          appDecl(decl1, int(1), int(2)),
-          appDecl(decl2, int(3), int(4))),
-        decl1, decl2),
-      """{
+        letIn(mult(appDecl(decl1, int(1), int(2)), appDecl(decl2, int(3), int(4))), decl1, decl2),
+        """{
         |  "let": [
         |    {
         |      "operator": "A",
@@ -496,28 +494,30 @@ abstract class TestJson extends FunSuite {
   test("empty module") {
     // awesome
     compareModule(
-      new TlaModule("TEST", List()),
-      """{"module":"TEST","declarations":[]}"""
+        new TlaModule("TEST", List()),
+        """{"module":"TEST","declarations":[]}"""
     )
   }
 
   test("module trivial") {
     // awesome
     compareModule(
-      new TlaModule("trivial", List(
-        TlaOperDecl("A", List(), int(42))
-      )),
-      """{"module":"trivial","declarations":[{"operator":"A","body":42,"params":[]}]}"""
+        new TlaModule("trivial",
+            List(
+                TlaOperDecl("A", List(), int(42))
+            )),
+        """{"module":"trivial","declarations":[{"operator":"A","body":42,"params":[]}]}"""
     )
   }
 
   test("module simpleOperator") {
     // awesome
     compareModuleMultiLine(
-      new TlaModule("simpleOperator", List(
-        TlaOperDecl("A", List(SimpleFormalParam("age")), gt(name("age"),int(42)))
-      )),
-      """{
+        new TlaModule("simpleOperator",
+            List(
+                TlaOperDecl("A", List(SimpleFormalParam("age")), gt(name("age"), int(42)))
+            )),
+        """{
         |  "module": "simpleOperator",
         |  "declarations": [
         |    {
@@ -540,19 +540,18 @@ abstract class TestJson extends FunSuite {
 
   test("module level2Operators") {
     // awesome
-    val aDecl = TlaOperDecl("A",
-      List(SimpleFormalParam("i"), SimpleFormalParam("j"), OperFormalParam("f", 1)),
-      OperEx(TlaOper.apply, NameEx("f"),
-        OperEx(TlaSetOper.cup, NameEx("i"), NameEx("j"))))
+    val aDecl = TlaOperDecl("A", List(SimpleFormalParam("i"), SimpleFormalParam("j"), OperFormalParam("f", 1)),
+        OperEx(TlaOper.apply, NameEx("f"), OperEx(TlaSetOper.cup, NameEx("i"), NameEx("j"))))
     val bDecl = TlaOperDecl("B", List(SimpleFormalParam("y")), NameEx("y"))
     compareModuleMultiLine(
-      new TlaModule("level2Operators", List(
-        aDecl,
-        bDecl,
-        TlaOperDecl("C", List(SimpleFormalParam("z")),
-          appDecl( aDecl, int(0), NameEx("z"), appDecl(bDecl, int(1))))
-      )),
-      """{
+        new TlaModule("level2Operators",
+            List(
+                aDecl,
+                bDecl,
+                TlaOperDecl("C", List(SimpleFormalParam("z")),
+                    appDecl(aDecl, int(0), NameEx("z"), appDecl(bDecl, int(1))))
+            )),
+        """{
         |  "module": "level2Operators",
         |  "declarations": [
         |    {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJsonWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJsonWriter.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.io
 
 import java.io.{PrintWriter, StringWriter}
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 class TestJsonWriter extends TestJson {
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
@@ -10,12 +10,12 @@ import org.scalatest.junit.JUnitRunner
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 @RunWith(classOf[JUnitRunner])
 class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   private var stringWriter = new StringWriter()
   private var printWriter = new PrintWriter(stringWriter)
-
 
   override protected def beforeEach(): Unit = {
     stringWriter = new StringWriter()
@@ -369,9 +369,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a one-line record") {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = enumFun(
-      str("x1"), "x2",
-      str("x3"), "x4",
-      str("x5"), "x6"
+        str("x1"),
+        "x2",
+        str("x3"),
+        "x4",
+        str("x5"),
+        "x6"
     ) ////
     writer.write(expr)
     printWriter.flush()
@@ -383,9 +386,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a multi-line record") {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = enumFun(
-      str("verylong1"), "verylong2",
-      str("verylong3"), "verylong4",
-      str("verylong5"), "verylong6"
+        str("verylong1"),
+        "verylong2",
+        str("verylong3"),
+        "verylong4",
+        str("verylong5"),
+        "verylong6"
     ) ////
     writer.write(expr)
     printWriter.flush()
@@ -399,9 +405,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a narrow multi-line record") {
     val writer = new PrettyWriter(printWriter, 20)
     val expr = enumFun(
-      str("verylong1"), "verylong2",
-      str("verylong3"), "verylong4",
-      str("verylong5"), "verylong6"
+        str("verylong1"),
+        "verylong2",
+        str("verylong3"),
+        "verylong4",
+        str("verylong5"),
+        "verylong6"
     ) ////
     writer.write(expr)
     printWriter.flush()
@@ -427,9 +436,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a one-line set of records") {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = recSet(
-      str("x1"), "x2",
-      str("x3"), "x4",
-      str("x5"), "x6"
+        str("x1"),
+        "x2",
+        str("x3"),
+        "x4",
+        str("x5"),
+        "x6"
     ) ////
     writer.write(expr)
     printWriter.flush()
@@ -441,9 +453,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a multi-line set of records") {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = recSet(
-      str("verylong1"), "verylong2",
-      str("verylong3"), "verylong4",
-      str("verylong5"), "verylong6"
+        str("verylong1"),
+        "verylong2",
+        str("verylong3"),
+        "verylong4",
+        str("verylong5"),
+        "verylong6"
     ) ////
     writer.write(expr)
     printWriter.flush()
@@ -456,8 +471,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a one-line function") {
     val writer = new PrettyWriter(printWriter, 80)
-    val expr = funDef(plus("x", "y"),
-      "x", "S", "y", "T")
+    val expr = funDef(plus("x", "y"), "x", "S", "y", "T")
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -467,9 +481,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a multi-line function") {
     val writer = new PrettyWriter(printWriter, 30)
-    val expr = funDef(plus("verylong1", "verylong2"),
-      "verylong1", "verylong3",
-      "verylong2", "verylong4")
+    val expr = funDef(plus("verylong1", "verylong2"), "verylong1", "verylong3", "verylong2", "verylong4")
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -483,8 +495,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a one-line map") {
     val writer = new PrettyWriter(printWriter, 80)
-    val expr = map(plus("x", "y"),
-      "x", "S", "y", "T")
+    val expr = map(plus("x", "y"), "x", "S", "y", "T")
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -494,9 +505,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a multi-line map") {
     val writer = new PrettyWriter(printWriter, 30)
-    val expr = map(plus("verylong1", "verylong2"),
-      "verylong1", "verylong3",
-      "verylong2", "verylong4")
+    val expr = map(plus("verylong1", "verylong2"), "verylong1", "verylong3", "verylong2", "verylong4")
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -530,10 +539,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a multi-line filter") {
     val writer = new PrettyWriter(printWriter, 40)
-    val expr = filter(
-      "verylongname1",
-      "verylongname2",
-      "verylongname3")
+    val expr = filter("verylongname1", "verylongname2", "verylongname3")
 
     writer.write(expr)
     printWriter.flush()
@@ -577,9 +583,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a multi-line IF-THEN-ELSE") {
     val writer = new PrettyWriter(printWriter, 20)
-    val expr = ite("verylongname1",
-      "verylongname2",
-      "verylongname3")
+    val expr = ite("verylongname1", "verylongname2", "verylongname3")
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -601,9 +605,9 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a multi-line EXCEPT") {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = except(
-      "verylongname1",
-      "verylongname2",
-      "verylongname3"
+        "verylongname1",
+        "verylongname2",
+        "verylongname3"
     ) ///
 
     writer.write(expr)
@@ -619,11 +623,11 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a monster EXCEPT") {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = except(
-      "verylongname1",
-      "verylongname2",
-      "verylongname3",
-      "verylongname4",
-      "verylongname5"
+        "verylongname1",
+        "verylongname2",
+        "verylongname3",
+        "verylongname4",
+        "verylongname5"
     ) ///
 
     writer.write(expr)
@@ -714,9 +718,8 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a multi-line LET-IN") {
     val writer = new PrettyWriter(printWriter, 40)
     val decl =
-      TlaOperDecl("AVeryLongName",
-        List(SimpleFormalParam("param1"), SimpleFormalParam("param2")),
-        plus("param1", "param2"))
+      TlaOperDecl("AVeryLongName", List(SimpleFormalParam("param1"), SimpleFormalParam("param2")),
+          plus("param1", "param2"))
     val expr = letIn(appDecl(decl, int(1), int(2)), decl)
     writer.write(expr)
     printWriter.flush()
@@ -731,17 +734,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("multiple definitions in LET-IN") {
     val writer = new PrettyWriter(printWriter, 40)
     val decl1 =
-      TlaOperDecl("AVeryLongName",
-        List(SimpleFormalParam("param1"), SimpleFormalParam("param2")),
-        plus("param1", "param2"))
+      TlaOperDecl("AVeryLongName", List(SimpleFormalParam("param1"), SimpleFormalParam("param2")),
+          plus("param1", "param2"))
     val decl2 =
-      TlaOperDecl("BVeryLongName",
-        List(SimpleFormalParam("param1"), SimpleFormalParam("param2")),
-        plus("param1", "param2"))
-    val expr = letIn(
-      mult(appDecl(decl1, int(1), int(2)),
-        appDecl(decl2, int(3), int(4))),
-      decl1, decl2)
+      TlaOperDecl("BVeryLongName", List(SimpleFormalParam("param1"), SimpleFormalParam("param2")),
+          plus("param1", "param2"))
+    val expr = letIn(mult(appDecl(decl1, int(1), int(2)), appDecl(decl2, int(3), int(4))), decl1, decl2)
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -777,7 +775,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
     val innerA = tla.appOp(tla.name("A"), innerLambda, tla.name("x"))
     // A(LAMBDA x: A(LAMBDA y: y + 1, x), z)
     val outerDecl =
-        TlaOperDecl("LAMBDA", List(SimpleFormalParam("x")), innerA)
+      TlaOperDecl("LAMBDA", List(SimpleFormalParam("x")), innerA)
     val outerLambda = letIn(NameEx("LAMBDA"), outerDecl)
     val outerA = tla.appOp(tla.name("A"), outerLambda, tla.name("z"))
     writer.write(outerA)
@@ -793,9 +791,9 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
       OperEx(TlaArithOper.plus, ValEx(TlaInt(1)), NameEx("x"))
 
     val fDecl = TlaOperDecl(
-      "A",
-      List(SimpleFormalParam("x")),
-      body
+        "A",
+        List(SimpleFormalParam("x")),
+        body
     ) ///
     writer.write(fDecl)
     printWriter.flush()
@@ -807,13 +805,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a recursive operator declaration") {
     val writer = new PrettyWriter(printWriter, 40)
     val body =
-      OperEx(TlaArithOper.plus,
-          ValEx(TlaInt(1)), OperEx(TlaOper.apply, NameEx("A"), NameEx("x")))
+      OperEx(TlaArithOper.plus, ValEx(TlaInt(1)), OperEx(TlaOper.apply, NameEx("A"), NameEx("x")))
 
     val fDecl = TlaOperDecl(
-      "A",
-      List(SimpleFormalParam("x")),
-      body
+        "A",
+        List(SimpleFormalParam("x")),
+        body
     ) ///
     fDecl.isRecursive = true
 
@@ -828,13 +825,12 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a recursive operator declaration in LET-IN") {
     val writer = new PrettyWriter(printWriter, 40)
     val body =
-      OperEx(TlaArithOper.plus,
-          ValEx(TlaInt(1)), OperEx(TlaOper.apply, NameEx("A"), NameEx("x")))
+      OperEx(TlaArithOper.plus, ValEx(TlaInt(1)), OperEx(TlaOper.apply, NameEx("A"), NameEx("x")))
 
     val fDecl = TlaOperDecl(
-      "A",
-      List(SimpleFormalParam("x")),
-      body
+        "A",
+        List(SimpleFormalParam("x")),
+        body
     ) ///
     fDecl.isRecursive = true
 
@@ -853,18 +849,13 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a one-line recursive function in LET-IN") {
     val writer = new PrettyWriter(printWriter, 40)
     val recFun =
-      OperEx(
-        TlaFunOper.recFunDef,
-        OperEx(
-          TlaArithOper.plus,
-          ValEx(TlaInt(1)),
-          OperEx(TlaFunOper.app, OperEx(TlaFunOper.recFunRef), NameEx("x"))),
-        NameEx("x"),
-        NameEx("S"))
+      OperEx(TlaFunOper.recFunDef,
+          OperEx(TlaArithOper.plus, ValEx(TlaInt(1)),
+              OperEx(TlaFunOper.app, OperEx(TlaFunOper.recFunRef), NameEx("x"))), NameEx("x"), NameEx("S"))
     val fDecl = TlaOperDecl(
-      "f",
-      List(),
-      recFun
+        "f",
+        List(),
+        recFun
     ) ///
     val expr = letIn(appDecl(fDecl), fDecl)
     writer.write(expr)
@@ -877,18 +868,13 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   test("a one-line recursive function declaration") {
     val writer = new PrettyWriter(printWriter, 40)
     val recFun =
-      OperEx(
-        TlaFunOper.recFunDef,
-        OperEx(
-          TlaArithOper.plus,
-          ValEx(TlaInt(1)),
-          OperEx(TlaFunOper.app, OperEx(TlaFunOper.recFunRef), NameEx("x"))),
-        NameEx("x"),
-        NameEx("S"))
+      OperEx(TlaFunOper.recFunDef,
+          OperEx(TlaArithOper.plus, ValEx(TlaInt(1)),
+              OperEx(TlaFunOper.app, OperEx(TlaFunOper.recFunRef), NameEx("x"))), NameEx("x"), NameEx("S"))
     val fDecl = TlaOperDecl(
-      "f",
-      List(),
-      recFun
+        "f",
+        List(),
+        recFun
     ) ///
     writer.write(fDecl)
     printWriter.flush()
@@ -912,4 +898,3 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
   }
 
 }
-

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/storage/TestChangeListener.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/storage/TestChangeListener.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.storage
 
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlcOper
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 class TestKeraLanguagePred extends LanguagePredTestSuite {
   private val pred = new KeraLanguagePred
@@ -122,7 +123,9 @@ class TestKeraLanguagePred extends LanguagePredTestSuite {
     expectFail(pred.isExprOk(caseSplit(bool(false), int(2))))
   }
 
-  /****************************** the tests from TestFlatLanguagePred *********************************************/
+  /**
+   * **************************** the tests from TestFlatLanguagePred ********************************************
+   */
 
   test("a call to a user operator") {
     val expr = enumSet(int(1), str("abc"), bool(false))
@@ -132,30 +135,21 @@ class TestKeraLanguagePred extends LanguagePredTestSuite {
 
   test("a non-nullary let-in ") {
     val app = appOp(name("UserOp"), int(3))
-    val letInDef = letIn(app,
-      declOp("UserOp",
-        plus(int(1), name("x")),
-        SimpleFormalParam("x")))
+    val letInDef = letIn(app, declOp("UserOp", plus(int(1), name("x")), SimpleFormalParam("x")))
     expectFail(pred.isExprOk(letInDef))
   }
 
   test("a nullary let-in ") {
     val app = appOp(name("UserOp"))
-    val letInDef = letIn(app,
-      declOp("UserOp",
-        plus(int(1), int(2))))
+    val letInDef = letIn(app, declOp("UserOp", plus(int(1), int(2))))
     expectOk(pred.isExprOk(letInDef))
   }
 
   test("nested nullary let-in ") {
     val app = plus(appOp(name("A")), appOp(name("B")))
-    val letInDef = letIn(app,
-      declOp("A",
-        plus(int(1), int(2))))
+    val letInDef = letIn(app, declOp("A", plus(int(1), int(2))))
     val outerLetIn =
-      letIn(letInDef,
-        declOp("B",
-          int(3)))
+      letIn(letInDef, declOp("B", int(3)))
     expectOk(pred.isExprOk(outerLetIn))
   }
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestPrimePropagation.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestPrimePropagation.scala
@@ -3,11 +3,12 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.{LetInEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 /**
-  * Tests of PrimePropagation.
-  */
+ * Tests of PrimePropagation.
+ */
 class TestPrimePropagation extends FunSuite with BeforeAndAfter {
   import tla._
 


### PR DESCRIPTION
This PR contains a change to `TlaEx`. It is the core structure of the whole project, so we have to discuss the proposed solution and its impact. See the discussion below.

Apart from this change, this PR contains 130 files that import a single implicit parameter:

```scala
import at.forsyte.apalache.tla.lir.UntypedPredefs._
```

Unfortunately, `scalafmt` turned this simple change into a massive PR.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

**The problem.** Having the new type checker, we have to figure out how to integrate the type information in the TLA+ expressions. The old type checker is run in the very end of the pipeline. Hence the preprocessing code does not have to care about types at all. The new type checker is run before any preprocessing, which allows us to give much better feedback to the user.

There are several issues here:

 - We want to write most of the code as if TLA+ was untyped, e.g., `SanyImporter` should work for both typed and untyped code.
 - We want to write some code as if TLA+ was typed. This is basically the code in the end of the pipeline that is implemented in the translator to SMT.
 - We want to gradually transform some preprocessing code into type-aware, but we shall not do it in one hop.
 - Type-unaware code should not erase types of the expressions, but it should propagate them further, without knowing how to interpret the types.

For the context, our definitions for `TlaEx` and its case classes looked like that before this PR:

```scala
  /**
   * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values.
   */
  sealed abstract class TlaEx extends Identifiable with Serializable { ... }

  /**
   * A constant TLA+ value, which is usually a literal such as: 42, TRUE, "foo", BOOLEAN.
   */
  case class ValEx(value: TlaValue) extends TlaEx with Serializable { ... }

  /**
   * Referring by name to a variable, constant, operator, etc.
   */
  case class NameEx(name: String) extends TlaEx with Serializable { ... }

  /*
   * A let-in definition, which is part of TLA+ syntax.
   */
  case class LetInEx(body: TlaEx, decls: TlaOperDecl*) extends TlaEx with Serializable { ... }

  /**
   * Application of a built-in operator. The standard operator `TlaOper.apply` allows us
   * to apply a user-defined operator (defined with `TlaOperDecl`) or an operator that is passed via a parameter
   * (that is, `OperFormalParam`).
   */
  case class OperEx(oper: TlaOper, args: TlaEx*) extends TlaEx with Serializable { ... }
```

**Alternative solutions.** Here are the alternatives that I considered (on top of the solution proposed in this PR):
 
 - Using a map similar to `AnnotationStore`. However, if we annotate every single expression, the overhead will be massive.
 - Instrumenting code to produce a proxy for `TlaEx` that would carry the type. This solution seems to be fragile and ugly. The type-unaware code could easily erase the types.
 - Inherit specialized cases classes from `TlaEx`, `ValEx`, `NameEx`, `OperEx`, and `LetInEx`, e.g., `TypedTlaEx[T](myType:  T) extends TlaEx`. This would produce two parallel data structures. I am not even sure how to compose them, as `OperEx` receives other expressions as its arguments. Again, type-unaware code could easily erase the types.
 - Use parameterized types. I do not have a clear solution here.

**Proposed solution: types as implicit parameters.** The most clean solution seems to be to use implicit parameters. Although we have tried to avoid implicits in Scala, it looks like the right job for them.

Below are the definitions of type tags that we introduce for annotating TLA+ expressions (see `at.forsyte.apalache.tla.lir`):

```scala
  /**
   * A type tag to be attached to a TLA+ language construct: an expression or a declaration.
   */
  sealed abstract class TypeTag

  /**
   * The type tag that simply indicates that the language construct is not typed.
   */
  case class Untyped() extends TypeTag

  /**
   * A type tag that carries a tag of type T, which the tag is parameterized with.
   *
   * @param myType the type that is carried by the tag
   * @tparam T the type of the tag
   */
  case class Typed[T](myType: T) extends TypeTag

  /**
   * Default settings for the untyped language layer. To use the `Untyped()` tag, import the definitions from `UntypedPredefs`.
   */
  object UntypedPredefs {
    implicit val untyped: TypeTag = Untyped()
  }
```

Then we introduce a type tag as an implicit parameter of `TlaEx`:

```scala
  /**
   * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values.
   * Importantly, `TlaEx` accepts an implicit type tag.
   */
  sealed abstract class TlaEx(implicit val typeTag: TypeTag) extends Identifiable with Serializable { ... }
```

The case classes also carry an implicit parameter, e.g., `ValEx`:

```scala
  /**
   * A constant TLA+ value, which is usually a literal such as: 42, TRUE, "foo", BOOLEAN.
   * Importantly, `ValEx` accepts an implicit type tag.
   */
  case class ValEx(value: TlaValue)(implicit typeTag: TypeTag) extends TlaEx with Serializable { ... }
```

The cool thing about this solution is that we can introduce this change without modifying lots of code. Essentially, all users of `TlaEx` have to import the implicit value `untyped`:

```scala
import at.forsyte.apalache.tla.lir.UntypedPredefs._
```

(I had to extend several transformations to received an implicit parameter and pass it with `implicitly`.)

The pattern matching code works as before. The type-aware code can access the tag via `ex.myType`. The type-unaware transformations may copy the types without unpacking them. On top of that, type-aware code can work with different type systems, as `Typed` is parameterized. If we try to mix different type systems, the compiler will help us.

The only downside that I see is that all of us have to read the chapter on implicit parameters in [Programming in Scala](https://booksites.artima.com/programming_in_scala_4ed). But we have to understand implicits anyways, if we want to use advanced frameworks as [cats](https://typelevel.org/cats/).
