### PR TITLE
Implicit type tag in TLA expressions (cherry-picked)

### DIFF
--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/AssignmentOperatorIntroduction.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/AssignmentOperatorIntroduction.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.assignments
 
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaActionOper, TlaOper}
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
 /**
@@ -40,6 +41,7 @@ object AssignmentOperatorIntroduction {
 
   def apply(isAssignment: UID => Boolean, tracker: TransformationTracker): AssignmentOperatorIntroduction =
     new AssignmentOperatorIntroduction(isAssignment, tracker)
+
   def apply(assignments: Set[UID], tracker: TransformationTracker): AssignmentOperatorIntroduction =
     new AssignmentOperatorIntroduction(predicateFromSet(assignments), tracker)
 }

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/Reordering.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/Reordering.scala
@@ -3,15 +3,17 @@ package at.forsyte.apalache.tla.assignments
 import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
 import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * `Reordering` allows us to change the order of arguments passed to commutative operators (e.g. /\).
  * This helps enforce a notion of, for example, left-to-right processing of arguments (like in TLC), which
  * matters in variable assignments, which should always (syntactically) precede variable use cases.
- * @param ord An ordering over `T`
+ *
+ * @param ord       An ordering over `T`
  * @param rankingFn Assigns a value in `T` to each `TlaEx`. This indirectly defines an ordering on `TlaEx`:
  *                  e1 <= e2 iff ord.le( rankingFn(e1), rankingFn(e2) ) etc.
- * @param tracker A transformation tracker.
+ * @param tracker   A transformation tracker.
  * @tparam T An orderable domain. Default: Option[Int]
  */
 class Reordering[T](ord: Ordering[T], rankingFn: TlaEx => T, tracker: TransformationTracker) {

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/PrimingPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/PrimingPassImpl.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
@@ -12,6 +12,7 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.NormalizedNames
 import com.google.inject.Inject
 import com.google.inject.name.Named

--- a/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestAlphaTransform.scala
+++ b/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestAlphaTransform.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.storage.{BodyMapFactory, ChangeListener}
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.pp.Desugarer
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -73,6 +74,7 @@ class TestAlphaTransform extends FunSuite with TestingPredefs {
 
   def correctRecursiveApplication(exs: Traversable[TlaEx]): Boolean = {
     val trs = (exs map { ex => ex -> AlphaTransform(ex) }).toMap
+
     def argMatch(exargs: Traversable[TlaEx], args: Traversable[AlphaEx]): Boolean =
       (exargs map { arg => trs.getOrElse(arg, AlphaTransform(arg)) }) == args
 

--- a/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSymbTransPass.scala
+++ b/tla-assignments/src/test/scala/at/forsyte/apalache/tla/assignments/TestSymbTransPass.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.storage.{BodyMapFactory, ChangeListener}
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.{Builder => bd, _}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.Desugarer
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -47,11 +48,11 @@ class TestSymbTransPass extends FunSuite with TestingPredefs {
 
     val ret = testFromDecls(decls, p_next)
 
-//    val saveWriter = new PrintWriter( new File( testFolderPath + "SymbNexts" + p_file ) )
+    //    val saveWriter = new PrintWriter( new File( testFolderPath + "SymbNexts" + p_file ) )
 
-//    ret.foreach( x => saveWriter.println( "%s : \n %s\n".format( x._1.map( UniqueDB.get ) , x._2 ) ) )
+    //    ret.foreach( x => saveWriter.println( "%s : \n %s\n".format( x._1.map( UniqueDB.get ) , x._2 ) ) )
 
-//    saveWriter.close()
+    //    saveWriter.close()
 
     ret
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.immutable.HashMap
 
@@ -74,6 +75,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
 
   /**
    * A fixed cell that equals to false in the Boolean theory.
+   *
    * @return the false cell
    */
   def cellFalse(): ArenaCell = {
@@ -82,6 +84,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
 
   /**
    * A fixed cell that equals to true in the Boolean theory
+   *
    * @return the true cell
    */
   def cellTrue(): ArenaCell = {
@@ -90,6 +93,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
 
   /**
    * A fixed cell that stores the set {false, true}, that is, the set BOOLEAN in TLA+.
+   *
    * @return the cell for the BOOLEAN set
    */
   def cellBooleanSet(): ArenaCell = {
@@ -98,6 +102,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
 
   /**
    * A fixed cell that stores the set Nat. As this set is infinite, it is not pointing to any other cells.
+   *
    * @return the cell for the Nat cell
    */
   def cellNatSet(): ArenaCell = {
@@ -106,6 +111,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
 
   /**
    * A fixed cell that stores the set Int. As this set is infinite, it is not pointing to any other cells.
+   *
    * @return the cell for the Int cell
    */
   def cellIntSet(): ArenaCell = {
@@ -160,6 +166,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
    * Append a sequence of cells to arena. This method returns a new arena and a sequence of the freshly
    * created cells (the cells are ordered the same way as the sequence of types). This method provides us with a
    * handy alternative to appendCell, when several cells should be created.
+   *
    * @param types a sequence of cell types
    * @return a pair: the new arena and a sequence of new cells
    */
@@ -190,7 +197,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
    * The previously added edges come first. When this method is called as appendHas(X, Y1, ..., Ym),
    * it adds a Boolean constant in_X_Yi for each i: 1 <= i <= m.
    *
-   * @param parentCell the cell that points to the children cells
+   * @param parentCell    the cell that points to the children cells
    * @param childrenCells the cells that are pointed by the parent cell
    * @return the updated arena
    */
@@ -204,7 +211,7 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
    * Append 'has' edges that connect the first cell to the other cells, in the given order.
    * The previously added edges come first. In contrast to appendHas, this method does not add any constants in SMT.
    *
-   * @param parentCell the cell that points to the children cells
+   * @param parentCell    the cell that points to the children cells
    * @param childrenCells the cells that are pointed by the parent cell
    * @return the updated arena
    */
@@ -217,8 +224,8 @@ class Arena private (val solverContext: SolverContext, val cellCount: Int, val t
   /**
    * Append a 'has' edge to connect a cell that corresponds to a set with a cell that corresponds to its element.
    *
-   * @param setCell  a set cell
-   * @param elemCell an element cell
+   * @param setCell   a set cell
+   * @param elemCell  an element cell
    * @param addInPred indicates whether the in_X_Y constant should be added in SMT.
    * @return a new arena
    */

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ArenaCell.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ArenaCell.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.Arena.namePrefix
 import at.forsyte.apalache.tla.bmcmt.types.CellT
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 object ArenaCell {
   def isValidName(name: String): Boolean = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelChecker.scala
@@ -16,6 +16,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.io._
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.immutable.SortedMap

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.bmcmt.trex.{ExecutionSnapshot, TransitionExecutor
 import at.forsyte.apalache.tla.lir.io.CounterexampleWriter
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.immutable.{HashSet, SortedSet}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -16,6 +16,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.mutable
 
@@ -28,12 +29,11 @@ import scala.collection.mutable
  *
  * <p>TODO: rename this class to RewriterImpl?</p>
  *
- * @param _solverContext  a fresh solver context that will be populated with constraints
- * @param typeFinder     a type finder (assuming that typeFinder.inferAndSave has been called already)
- * @param exprGradeStore a labeling scheme that associated a grade with each expression;
- *                       it is required to distinguish between state-level and action-level expressions.
+ * @param _solverContext   a fresh solver context that will be populated with constraints
+ * @param typeFinder       a type finder (assuming that typeFinder.inferAndSave has been called already)
+ * @param exprGradeStore   a labeling scheme that associated a grade with each expression;
+ *                         it is required to distinguish between state-level and action-level expressions.
  * @param profilerListener optional listener that is used to profile the rewriting rules
- *
  * @author Igor Konnov
  */
 class SymbStateRewriterImpl(private var _solverContext: SolverContext, var typeFinder: TypeFinder[CellT],
@@ -394,7 +394,9 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext, var typeF
         // as the new expressions there will not have source information.
         val smtWatermark = solverContext.metrics()
         val nextState = doRecursive(0, state)
-        profilerListener.foreach { _.onRewrite(state.ex, solverContext.metrics().delta(smtWatermark)) }
+        profilerListener.foreach {
+          _.onRewrite(state.ex, solverContext.metrics().delta(smtWatermark))
+        }
         exprCache.put(state.ex, nextState.ex) // the grade is not important
         nextState
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.DeepCopy
 import at.forsyte.apalache.tla.pp.NormalizedNames
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -20,7 +21,7 @@ class VCGenerator(tracker: TransformationTracker) extends LazyLogging {
   /**
    * Given a module and the name of an invariant candidate, add verification conditions in the module.
    *
-   * @param module an input module
+   * @param module  an input module
    * @param invName the name of an invariant
    * @return a transformed module
    */

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.KeraLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 
@@ -16,7 +17,7 @@ import com.typesafe.scalalogging.LazyLogging
  * to collecting constraints, rather than eagerly and lazily expanding the sets.</p>
  *
  * <p>It is a simple form of type inference on top of our type system.
- *    Can we integrate this class into the type system?</p>
+ * Can we integrate this class into the type system?</p>
  *
  * @author Igor Konnov
  */

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.analyses
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaActionOper, TlaBoolOper, TlaTempOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 
 /**
@@ -70,6 +71,7 @@ class ExprGradeAnalysis @Inject() (val store: ExprGradeStoreImpl) {
 
   /**
    * Replace disjunctions with orParallel when the expression is action-level or higher.
+   *
    * @param expr a TLA+ expression
    * @return an updated expression, all grades are updated if needed.
    */

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/SkolemizationMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/SkolemizationMarker.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt.analyses
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.tla.lir.convenience._
@@ -23,7 +24,9 @@ import at.forsyte.apalache.tla.lir.values.TlaInt
  */
 class SkolemizationMarker @Inject() (tracker: TransformationTracker) extends TlaExTransformation with LazyLogging {
 
-  override def apply(e: TlaEx): TlaEx = { transform(e) }
+  override def apply(e: TlaEx): TlaEx = {
+    transform(e)
+  }
 
   def transform: TlaExTransformation = tracker.trackEx {
     case OperEx(TlaBoolOper.exists, name, set, pred) =>
@@ -59,6 +62,7 @@ class SkolemizationMarker @Inject() (tracker: TransformationTracker) extends Tla
       def mapDef(df: TlaOperDecl) = {
         TlaOperDecl(df.name, df.formalParams, transform(df.body))
       }
+
       LetInEx(transform(body), defs map mapDef: _*)
 
     case ex @ OperEx(oper, args @ _*) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntValueCache.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * A cache for integer constants that maps an integer to an integer constant in SMT.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
@@ -10,6 +10,7 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.ModuleByExTransformer
 import at.forsyte.apalache.tla.lir.{NullEx, TlaAssumeDecl, TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.bmcmt.{CheckerException, VCGenerator}
 import at.forsyte.apalache.tla.lir.NullEx
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
@@ -1,10 +1,10 @@
 package at.forsyte.apalache.tla.bmcmt.rewriter
 
 import at.forsyte.apalache.tla.bmcmt.Arena
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.ConstSimplifierBase
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/BuiltinConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/BuiltinConstRule.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.{NameEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Rewriting BOOLEAN, Int, and Nat into predefined cells.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaArithOper, TlaFiniteSetOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Optimization for Cardinality(S) >= k, where k is constant. See [docs/smt/Cardinality.md].

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Rewriting EXCEPT for functions, tuples, and records.
@@ -121,13 +122,16 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
     val updatedKeys = indexEs map indexToStr
     val unchangedKeys = recType.fields.keySet.diff(Set(updatedKeys: _*))
+
     // create a new record
     def mkUnchanged(key: String): (TlaEx, TlaEx) = {
       (tla.str(key), tla.appFun(recCell.toNameEx, tla.str(key)))
     }
+
     def flattenPairs(list: Seq[TlaEx], pair: (TlaEx, TlaEx)): Seq[TlaEx] = {
       pair._1 +: pair._2 +: list
     }
+
     // [ [k1, v1], [k2, v2], ... ]
     val updatedPairs: Seq[(TlaEx, TlaEx)] = indexEs.zip(valueCells.map(_.toNameEx))
     val unchangedPairs: Seq[(TlaEx, TlaEx)] = unchangedKeys.toList.map(mkUnchanged)
@@ -145,6 +149,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
     val updatedIndices = indexEs map indexToInt
     val updateMap = Map(updatedIndices.zip(valueCells): _*)
+
     def updateOrKeep(i: Int): TlaEx = {
       if (updateMap.contains(i)) {
         updateMap(i)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Integer arithmetic operations: +, -, *, div, mod.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Integer comparisons: <, <=, >, >=. For equality and inequality, check EqRule and NeqRule.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PrimeRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PrimeRule.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt.rules
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Rename x' to NameEx("x'"). We only consider the case when prime is applied to a variable.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
 import com.typesafe.scalalogging.LazyLogging
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Rewrites \A x \in S: P and \E x \in S: P. The existential quantifier is often replaced with a constant (skolemized).

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.TlaIntSet
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * This rule translates the definition of a recursive function. It is similar to CHOOSE.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCtorRule.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types.FinSetT
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Rewrites the set constructor {e_1, ..., e_k}.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{NameEx, NullEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Rewrites a set comprehension { x \in S: P }.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.bmcmt.types.FinSetT
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSetOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Implements the rule for a union of all set elements, that is, UNION S for a set S that contains sets as elements.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SubstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SubstRule.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.NameEx
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Substitutes a bound name with a cell. For instance, it substitutes a name that is declared with VARIABLE or CONSTANT,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.bmcmt.util.IntTupleIterator
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.mutable
 
@@ -20,14 +21,15 @@ import scala.collection.mutable
 class MapBase(rewriter: SymbStateRewriter) {
 
   /**
-   *   <p>Implement a mapping { e: x_1 ∈ S_1, ..., x_n ∈ S_n }.</p>
+   * <p>Implement a mapping { e: x_1 ∈ S_1, ..., x_n ∈ S_n }.</p>
    *
-   *   <p>This implementation computes the cross product and maps every cell using the map expression.
-   *    It is not truly symbolic, we have to find a better way.</p>
+   * <p>This implementation computes the cross product and maps every cell using the map expression.
+   * It is not truly symbolic, we have to find a better way.</p>
    */
   def rewriteSetMapManyArgs(state: SymbState, mapEx: TlaEx, varNames: Seq[String], setEs: Seq[TlaEx]): SymbState = {
     // first, rewrite the variable domains S_1, ..., S_n
     var (nextState, sets) = rewriter.rewriteSeqUntilDone(state, setEs)
+
     def findSetCellAndElemType(setCell: ArenaCell): (ArenaCell, CellT) = {
       setCell.cellType match {
         case FinSetT(elemType) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/NeqRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/NeqRule.scala
@@ -1,9 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt.rules.deprecated
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
+import at.forsyte.apalache.tla.lir.OperEx
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper}
-import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
 
 /**
  * Implements the rule: SE-NE1.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/SetCapAndMinusRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/deprecated/SetCapAndMinusRule.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Implements the rules SE-SET-CAP1 and SE-SET-DIFF1, that is, set intersection and set difference respectively.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.bmcmt.smt.PreproSolverContext.{PreproEqEntry, Pre
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 object PreproSolverContext {
   sealed abstract class PreproCacheEntry {
@@ -27,8 +28,8 @@ object PreproSolverContext {
  * before pushing the constraints to the actual solver:</p>
  *
  * <ul>
- *   <li>Equalities between two cells: tla.eql(c1, c2) and tla.neq(c1, c2)</li>
- *   <li>Set membership assertions between two cells: tla.in(c1, c2) and tla.not(tla.in(c1, c2)).
+ * <li>Equalities between two cells: tla.eql(c1, c2) and tla.neq(c1, c2)</li>
+ * <li>Set membership assertions between two cells: tla.in(c1, c2) and tla.not(tla.in(c1, c2)).
  * </ul>
  *
  * <p>This is helpful as our rewriting rules
@@ -160,7 +161,7 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
   /**
    * Declare an arena edge of type 'has'. This method introduces a Boolean variable for the edge.
    *
-   * @param set the containing set
+   * @param set  the containing set
    * @param elem a set element
    */
   def declareInPredIfNeeded(set: ArenaCell, elem: ArenaCell): Unit = context.declareInPredIfNeeded(set, elem)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -11,6 +11,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.microsoft.z3._
 import com.microsoft.z3.enumerations.Z3_lbool
 
@@ -39,8 +40,8 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   Z3SolverContext.RANDOM_SEED_PARAMS.foreach { p =>
     Global.setParameter(p, config.randomSeed.toString)
     logWriter.println(";; %s = %s".format(p, config.randomSeed))
-//    the following fails with an exception: java.lang.NoSuchFieldError: value
-//      logWriter.println(";; %s = %s".format(p, Global.getParameter(p)))
+  //    the following fails with an exception: java.lang.NoSuchFieldError: value
+  //      logWriter.println(";; %s = %s".format(p, Global.getParameter(p)))
   }
 
   var level: Int = 0
@@ -473,17 +474,26 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
       case OperEx(BmcOper.distinct, args @ _*) =>
         val (es, ns) = (args map toExpr).unzip
         val distinct = z3context.mkDistinct(es: _*)
-        (distinct, ns.foldLeft(1L) { _ + _ })
+        (distinct,
+            ns.foldLeft(1L) {
+          _ + _
+        })
 
       case OperEx(TlaBoolOper.and, args @ _*) =>
         val (es, ns) = (args map toExpr).unzip
         val and = z3context.mkAnd(es.map(_.asInstanceOf[BoolExpr]): _*)
-        (and, ns.foldLeft(1L) { _ + _ })
+        (and,
+            ns.foldLeft(1L) {
+          _ + _
+        })
 
       case OperEx(TlaBoolOper.or, args @ _*) =>
         val (es, ns) = (args map toExpr).unzip
         val or = z3context.mkOr(es.map(_.asInstanceOf[BoolExpr]): _*)
-        (or, ns.foldLeft(1L) { _ + _ })
+        (or,
+            ns.foldLeft(1L) {
+          _ + _
+        })
 
       case OperEx(TlaBoolOper.implies, lhs, rhs) =>
         val (lhsZ3, ln) = toExpr(lhs)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/AnnotationParser.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/AnnotationParser.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaFunOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import at.forsyte.apalache.tla.lir.{NullEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.immutable.SortedMap
 
@@ -18,6 +19,7 @@ object AnnotationParser {
 
   /**
    * Parse a TLA+ expression that encodes a type.
+   *
    * @param annot a type annotation that is a TLA+ expression.
    * @return a cell type
    */
@@ -85,6 +87,7 @@ object AnnotationParser {
 
   /**
    * Convert a cell type into a TLA+ expression that encodes a respective type annotation.
+   *
    * @param tp a cell type
    * @return a TLA+ expression
    */
@@ -101,10 +104,12 @@ object AnnotationParser {
       case SeqT(elemT)               => tla.seqSet(toTla(elemT))
       case RecordT(fields) =>
         val keys = fields.keys.toSeq
+
         def fieldOrVal(i: Int) = {
           val k = keys(i / 2)
           if (i % 2 == 0) tla.str(k) else toTla(fields(k))
         }
+
         val args = 0.until(2 * fields.size) map fieldOrVal
         OperEx(TlaFunOper.enum, args: _*)
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.bmcmt.implicitConversions._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestModelChecker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestModelChecker.scala
@@ -3,18 +3,15 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.search.BfsStrategy
 import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
-import at.forsyte.apalache.tla.imp.SanyImporter
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
-
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}
-
-import scala.io.Source
 
 @RunWith(classOf[JUnitRunner])
 class TestModelChecker extends FunSuite with BeforeAndAfter {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterKeraSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterKeraSet.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{Keramelizer, UniqueNameGenerator}
 
 /**

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelChecker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelChecker.scala
@@ -12,6 +12,7 @@ import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{AnnotationParser, FinSetT, IntT, Seq
 import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
@@ -1,10 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.Continue
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
@@ -1,19 +1,16 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.NoRule
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
 import at.forsyte.apalache.tla.bmcmt.types.{AnnotationParser, BoolT, FinSetT, IntT}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaBoolOper, TlaOper}
-import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaNatSet}
-import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaBoolSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
-
-import scala.collection.immutable.HashMap
 
 @RunWith(classOf[JUnitRunner])
 class TestSymbStateRewriterBool extends RewriterBase with TestingPredefs with BeforeAndAfterEach {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{FailPredT, IntT}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -46,6 +47,7 @@ class TestSymbStateRewriterExpand extends RewriterBase {
       val mapEx = tla.ite(tla.eql(NameEx("x"), tla.int(1)), tla.bool(v1), tla.bool(v2))
       tla.funDef(mapEx, tla.name("x"), domain)
     }
+
     val expected = tla.enumSet(mkFun(false, false), mkFun(false, true), mkFun(true, false), mkFun(true, true))
     assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(expected, funSetCell.toNameEx)))
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaBoolSet
 import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{AnnotationParser, FinSetT, IntT, Pow
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.TlaIntSet
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.bmcmt.types.eager.TrivialTypeFinder
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaIntSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -58,6 +57,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-IN1: {} \in {} ~~> $B$0""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
+
     val ex = OperEx(TlaSetOper.in, emptySetWithType(IntT()), emptySetWithType(FinSetT(IntT())))
     val state = new SymbState(ex, arena, Binding())
     val nextState = create().rewriteUntilDone(state)
@@ -373,6 +373,7 @@ class TestSymbStateRewriterSet extends RewriterBase with TestingPredefs {
 
   test("""SE-SET-EQ1: {{}} = {} ~~> $B$... (false)""") {
     def mkSet(elems: TlaEx*) = OperEx(TlaSetOper.enumSet, elems: _*)
+
     def intSet() = emptySetWithType(IntT()) // empty sets need types
     def int2Set() = emptySetWithType(FinSetT(IntT())) // empty sets need types
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import at.forsyte.apalache.tla.lir.{NameEx, ValEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types.{BoolT, FailPredT}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlcOper
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestTrivialTypeFinder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestTrivialTypeFinder.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestSkolemizationMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestSkolemizationMarker.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.BmcOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfig.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfig.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.io.tlc.config.ConfigModelValue.STR_PREFIX
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.util.parsing.input.NoPosition
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.{TlaDecimal, TlaInt, TlaStr}
 import at.forsyte.apalache.io.annotations.store._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 import tla2sany.semantic._
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import tla2sany.semantic._
 
 /**
@@ -121,7 +122,7 @@ class OpApplTranslator(
         }
         .orElse {
           // a library value
-          StandardLibrary.libraryValues.get((modName, operatorName)).map(ValEx)
+          StandardLibrary.libraryValues.get((modName, operatorName)).map(ValEx(_))
         }
     }
   }

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpDefTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpDefTranslator.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.imp.src.{SaveToStoreTracker, SourceLocation, Sour
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.transformations.standard.ReplaceFixed
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.io.annotations.store._
 import tla2sany.semantic.{OpApplNode, OpDefNode}
 
@@ -45,7 +46,7 @@ class OpDefTranslator(
               NameEx(nodeName),
               recFunRef,
               new SaveToStoreTracker(sourceStore)
-          )(body)
+          )(Untyped())(body)
           // store the source location
           sourceStore.addRec(replaced, SourceLocation(node.getBody.getLocation))
           // return the operator whose body is a recursive function

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpDefTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/OpDefTranslator.scala
@@ -46,7 +46,7 @@ class OpDefTranslator(
               NameEx(nodeName),
               recFunRef,
               new SaveToStoreTracker(sourceStore)
-          )(Untyped())(body)
+          )(body)
           // store the source location
           sourceStore.addRec(replaced, SourceLocation(node.getBody.getLocation))
           // return the operator whose body is a recursive function

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaTempOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 import tla2sany.semantic._
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.{CyclicDependencyError, TlaModule}
 import at.forsyte.apalache.tla.lir.io.{JsonReader, JsonWriter, PrettyWriter}
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.standard.DeclarationSorter
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -10,6 +10,7 @@ import at.forsyte.apalache.tla.lir.src.{SourcePosition, SourceRegion}
 import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, ValEx, _}
 import at.forsyte.apalache.io.annotations.store._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalactic.source.Position
 import org.scalatest.{BeforeAndAfter, FunSuite}

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/AbstractTransformer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/AbstractTransformer.scala
@@ -10,7 +10,8 @@ import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, Transfo
  *
  * @author Igor Konnov
  */
-abstract class AbstractTransformer(tracker: TransformationTracker) extends TlaExTransformation {
+abstract class AbstractTransformer(tracker: TransformationTracker)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
 
   /**
    * The sequence of partial transformers
@@ -48,6 +49,7 @@ abstract class AbstractTransformer(tracker: TransformationTracker) extends TlaEx
 
   /**
    * Transform an expression without looking into the arguments.
+   *
    * @return a new expression
    */
   private def transformOneLevel: TlaExTransformation = {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Cacher.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Cacher.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 class Cacher(nameGenerator: UniqueNameGenerator, tracker: TransformationTracker) extends TlaModuleTransformation {
 
@@ -47,7 +48,9 @@ class Cacher(nameGenerator: UniqueNameGenerator, tracker: TransformationTracker)
     case ex @ LetInEx(body, defs @ _*) =>
       // LET-IN introduces new operators which may or may not be added
       val extendedOperNames = operNames ++ defs.withFilter(letInDecisionFn).map(_.name)
-      val modifiedDefs = defs map { cacheApplicaitons(extendedOperNames, letInDecisionFn)(_).asInstanceOf[TlaOperDecl] }
+      val modifiedDefs = defs map {
+        cacheApplicaitons(extendedOperNames, letInDecisionFn)(_).asInstanceOf[TlaOperDecl]
+      }
       val extendedAppMap = prepareAppMap(extendedOperNames, appMap)(body)
       val diffMap = extendedAppMap -- appMap.keySet
       val extendedDefs = diffMap.toSeq map { case (k, v) =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.{DeclarationSorter, ModuleByExTransformer, ReplaceFixed}
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
@@ -4,9 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.FlatLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
-
-import scala.annotation.tailrec
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * A simplifier of constant TLA+ expressions, e.g., rewriting 1 + 2 to 3.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.math.BigInt
 
@@ -105,7 +106,9 @@ abstract class ConstSimplifierBase {
 
     // boolean operations
     case OperEx(TlaBoolOper.and, args @ _*) =>
-      val simpArgs = args.filterNot { _ == ValEx(TlaBool(true)) }
+      val simpArgs = args.filterNot {
+        _ == ValEx(TlaBool(true))
+      }
       if (simpArgs.isEmpty) {
         ValEx(TlaBool(true)) // an empty conjunction is true
       } else if (simpArgs.contains(ValEx(TlaBool(false)))) {
@@ -115,7 +118,9 @@ abstract class ConstSimplifierBase {
       }
 
     case OperEx(TlaBoolOper.or, args @ _*) =>
-      val simpArgs = args.filterNot { _ == ValEx(TlaBool(false)) }
+      val simpArgs = args.filterNot {
+        _ == ValEx(TlaBool(false))
+      }
       if (simpArgs.isEmpty) {
         ValEx(TlaBool(false)) // an empty disjunction is true
       } else if (simpArgs.contains(ValEx(TlaBool(true)))) {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import javax.inject.Singleton
 
@@ -194,7 +195,7 @@ class Desugarer(tracker: TransformationTracker) extends TlaExTransformation {
     val subs = boundEs.foldLeft(Map[String, TlaEx]())(collectSubstitutions)
     val newMapEx = substituteNames(subs, mapEx)
     // collect the arguments back
-    newMapEx +: TlaOper.interleave(boundNames.map(NameEx), setEs)
+    newMapEx +: TlaOper.interleave(boundNames.map(NameEx(_)), setEs)
   }
 
   private def collectSubstitutions(subs: Map[String, TlaEx], ex: TlaEx): Map[String, TlaEx] = {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.transformations.standard.{FlatLanguagePred, ReplaceFixed}
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import javax.inject.Singleton
 
 import scala.math.BigInt

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Keramelizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Keramelizer.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.transformations.standard.FlatLanguagePred
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import javax.inject.Singleton
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.{FlatLanguagePred, ReplaceFixed}
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.TlaBool
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import javax.inject.Singleton
 
 /**
@@ -187,6 +188,7 @@ class Normalizer(tracker: TransformationTracker) extends TlaExTransformation {
         def transformDef(decl: TlaOperDecl): TlaOperDecl = {
           TlaOperDecl(decl.name, decl.formalParams, transform(decl.body))
         }
+
         LetInEx(transform(body), defs map transformDef: _*)
       }
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/OperAppToLetInDef.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/OperAppToLetInDef.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaOper}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Replaces instances of user-defined operator applications with a LET-IN wrapper.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ParameterNormalizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ParameterNormalizer.scala
@@ -4,14 +4,16 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.transformations.standard.ReplaceFixed
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * Transforms a declaration A(x,y(_,_)) == e
  * into parameter-normal form, i.e.
  * A(x,y(_,_)) == LET x_new == x
- *               y_new(p1, p2) == y(p1,p2)
- *           IN e[ x_new/x, y_new/y ]
+ * y_new(p1, p2) == y(p1,p2)
+ * IN e[ x_new/x, y_new/y ]
  * This allows us to limit the number of substitutions when inlining A.
+ *
  * @param decisionFn Normal-form transformation will only be applied to operator declarations (both top-level and LET-IN),
  *                   for which `decisionFn` evaluates to true. Default: returns true for all recursive operators.
  */
@@ -84,7 +86,7 @@ class ParameterNormalizer(
           // The body is just the operator applied to all the parameters
           val newBody = OperEx(
               TlaOper.apply,
-              name +: inventedParams map NameEx: _*
+              name +: inventedParams map (NameEx(_)): _*
           )
           val letInDef = TlaOperDecl(paramOperName, inventedParams map SimpleFormalParam, newBody)
           LetInEx(replaced, letInDef)
@@ -109,6 +111,7 @@ object ParameterNormalizer {
   // Two standard options for `decisionFn`
   object DecisionFn {
     def all: TlaOperDecl => Boolean = _ => true
+
     def recursive: TlaOperDecl => Boolean = _.isRecursive
   }
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.io.tlc.config._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Unroller.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Unroller.scala
@@ -116,7 +116,7 @@ class Unroller(nameGenerator: UniqueNameGenerator, tracker: TransformationTracke
         } else {
           // ... and must evaluate to a single integer
           ConstSimplifier(tracker)(
-              InlinerOfUserOper(bodyMap, tracker)(implicitly[TypeTag])(unrollLimitDecl.body)
+              InlinerOfUserOper(bodyMap, tracker)(unrollLimitDecl.body)
           ) match {
             case ValEx(TlaInt(n)) =>
               SucceedWith(n)
@@ -143,7 +143,7 @@ class Unroller(nameGenerator: UniqueNameGenerator, tracker: TransformationTracke
           FailWith(new TlaInputError(msg))
         } else {
           // ... but may be defined using other operators, so we call transform on it
-          SucceedWith(InlinerOfUserOper(bodyMap, tracker)(implicitly[TypeTag])(defaultDecl.body))
+          SucceedWith(InlinerOfUserOper(bodyMap, tracker)(defaultDecl.body))
         }
 
       case None =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -12,6 +12,7 @@ import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaBoolOper, TlaOper, Tl
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.pp._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
@@ -23,7 +24,7 @@ import org.apache.commons.io.FilenameUtils
  * checker.init, checker.next, checker.cinit, checker.inv. In general, passes should not override options.
  * This is a reasonable exception to this rule, as this pass configures the options based on the user input.
  *
- * @param options pass options
+ * @param options  pass options
  * @param nextPass next pass to call
  */
 class ConfigurationPassImpl @Inject() (
@@ -105,7 +106,8 @@ class ConfigurationPassImpl @Inject() (
 
   /**
    * Produce the configuration options from a TLC config, if it is present.
-   * @param module the input module
+   *
+   * @param module     the input module
    * @param outOptions the pass options to update from the configuration file
    * @return additional declarations, which originate from assignments and replacements
    */
@@ -284,7 +286,8 @@ class ConfigurationPassImpl @Inject() (
 
   /**
    * Extract Init and Next from the spec definition that has the canonical form Init /\ [Next]_vars /\ ...
-   * @param module TLA+ module
+   *
+   * @param module   TLA+ module
    * @param specName the name of the specification definition
    * @return the pair (Init, Next)
    */

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
-import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.lir.TlaModule
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
-import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
+import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{TlaDecl, TlaModule, TlaOperDecl}
-import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.pp.Desugarer
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -1,25 +1,26 @@
 package at.forsyte.apalache.tla.pp.passes
 
-import java.io.File
-import java.nio.file.Path
-
 import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.{TlaModule, TlaOperDecl}
-import at.forsyte.apalache.tla.pp.{OperAppToLetInDef, NormalizedNames, ParameterNormalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.pp.{NormalizedNames, OperAppToLetInDef, UniqueNameGenerator}
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
+import java.io.File
+import java.nio.file.Path
+
 /**
  * A pass that expands operators and let-in definitions.
  *
- * @param options pass options
- * @param gen name generator
- * @param tracker transformation tracker
+ * @param options  pass options
+ * @param gen      name generator
+ * @param tracker  transformation tracker
  * @param nextPass next pass to call
  */
 class InlinePassImpl @Inject() (val options: PassOptions, gen: UniqueNameGenerator, renaming: IncrementalRenaming,
@@ -44,7 +45,9 @@ class InlinePassImpl @Inject() (val options: PassOptions, gen: UniqueNameGenerat
     val baseModule = tlaModule.get
 
     val appWrap = OperAppToLetInDef(gen, tracker)
-    val operNames = (baseModule.operDeclarations map { _.name }).toSet
+    val operNames = (baseModule.operDeclarations map {
+      _.name
+    }).toSet
     val module = appWrap.moduleTransform(operNames)(baseModule)
 
     val defBodyMap = BodyMapFactory.makeFromDecls(module.operDeclarations)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{ConstSimplifier, ExprOptimizer, UniqueNameGenerator}
 import com.google.inject.Inject
 import com.google.inject.name.Named
@@ -15,9 +16,10 @@ import com.typesafe.scalalogging.LazyLogging
 
 /**
  * A preprocessing pass that simplifies TLA+ expression by running multiple transformation.
- * @param options pass options
- * @param gen name generator
- * @param tracker transformation tracker
+ *
+ * @param options  pass options
+ * @param gen      name generator
+ * @param tracker  transformation tracker
  * @param nextPass next pass to call
  */
 class OptPassImpl @Inject() (val options: PassOptions, gen: UniqueNameGenerator, renaming: IncrementalRenaming,

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
 import com.google.inject.Inject
 import com.google.inject.name.Named

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{UniqueNameGenerator, Unroller}
 import com.google.inject.Inject
 import com.google.inject.name.Named
@@ -16,8 +17,8 @@ import com.typesafe.scalalogging.LazyLogging
 /**
  * An unrolling pass that
  *
- * @param options pass options
- * @param tracker transformation tracker
+ * @param options  pass options
+ * @param tracker  transformation tracker
  * @param nextPass next pass to call
  */
 class UnrollPassImpl @Inject() (val options: PassOptions, nameGenerator: UniqueNameGenerator,

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestParameterNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestParameterNormalizer.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.{
   LetInEx, NameEx, OperEx, OperFormalParam, SimpleFormalParam, TestingPredefs, TlaOperDecl, Builder => tla
 }
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.imp.SanyImporter
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.io.PrettyWriter
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUnroller.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUnroller.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TypingOper}
 import at.forsyte.apalache.tla.lir.values.TlaReal
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.typecheck._
 import at.forsyte.apalache.tla.typecheck.parser.DefaultType1Parser
 import org.junit.runner.RunWith

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprDecls.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprDecls.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.io.annotations.store.{AnnotationStore, createAnnotati
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TypingOper}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.typecheck._
 import at.forsyte.apalache.tla.typecheck.parser.DefaultType1Parser
 import org.junit.runner.RunWith

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.TlaBoolSet
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * A builder for TLA expressions.
@@ -74,7 +75,8 @@ object Builder {
   /**
    * Decorate a TLA+ expression with a label (a TLA+2 feature), e.g.,
    * lab(a, b) :: e decorates e with the label "lab" whose arguments are "a" and "b".
-   * @param ex a TLA+ expression to decorate
+   *
+   * @param ex   a TLA+ expression to decorate
    * @param name label identifier
    * @param args label arguments (also identifiers)
    * @return OperEx(TlaOper.label, ex, name as ValEx(TlaStr(_)), args as ValEx(TlaStr(_)))
@@ -232,9 +234,10 @@ object Builder {
 
   /**
    * Get a subsequence of S, that is, SubSeq(S, from, to)
-   * @param seq a sequence, e.g., constructed with tla.tuple
+   *
+   * @param seq  a sequence, e.g., constructed with tla.tuple
    * @param from the first index of the subsequene, greater or equal to 1
-   * @param to the last index of the subsequence, not greater than Len(S)
+   * @param to   the last index of the subsequence, not greater than Len(S)
    * @return the expression that corresponds to SubSeq(S, from, to)
    */
   def subseq(seq: TlaEx, from: TlaEx, to: TlaEx): TlaEx =
@@ -242,7 +245,8 @@ object Builder {
 
   /**
    * Get the subsequence of S that consists of the elements matching a predicate.
-   * @param seq a sequence
+   *
+   * @param seq  a sequence
    * @param test a predicate, it should be an action name
    * @return the expression that corresponds to SelectSeq(S, test)
    */
@@ -312,6 +316,7 @@ object Builder {
 
   def assign(lhs: TlaEx, rhs: TlaEx) =
     OperEx(BmcOper.assign, lhs, rhs)
+
   def assignPrime(n: NameEx, rhs: TlaEx): OperEx =
     OperEx(BmcOper.assign, prime(n), rhs)
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TestingPredefs.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TestingPredefs.scala
@@ -1,45 +1,68 @@
 package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 // Igor@02.11.2019: why are TestingPredefs located in src/main?
 // TODO: move TestingPredefs into src/test
 trait TestingPredefs {
   implicit def name(p_s: String): NameEx = NameEx(p_s)
+
   implicit def value(p_n: Int): ValEx = ValEx(TlaInt(p_n))
+
   implicit def sfp(p_s: String): SimpleFormalParam = SimpleFormalParam(p_s)
+
   implicit def ofp(p_pair: (String, Int)): OperFormalParam =
     OperFormalParam(p_pair._1, p_pair._2)
 
   def n_a: NameEx = "a"
+
   def n_b: NameEx = "b"
+
   def n_c: NameEx = "c"
+
   def n_d: NameEx = "d"
+
   def n_e: NameEx = "e"
+
   def n_f: NameEx = "f"
+
   def n_g: NameEx = "g"
 
   def n_p: NameEx = "p"
+
   def n_q: NameEx = "q"
+
   def n_r: NameEx = "r"
+
   def n_s: NameEx = "s"
+
   def n_t: NameEx = "t"
 
   def n_A: NameEx = "A"
+
   def n_B: NameEx = "B"
+
   def n_S: NameEx = "S"
+
   def n_T: NameEx = "T"
+
   def n_P: NameEx = "P"
+
   def n_Q: NameEx = "Q"
 
   def n_x: NameEx = "x"
+
   def n_y: NameEx = "y"
+
   def n_z: NameEx = "z"
 
   def trueEx: ValEx = ValEx(TlaBool(true))
+
   def falseEx: ValEx = ValEx(TlaBool(false))
 
   def arr: Array[TlaEx] = Array(n_a, n_b, n_c, n_d, n_e, n_f, n_g)
+
   def arr_s: Seq[TlaEx] = arr.toSeq
 
   def seq(n: Int, nSkip: Int = 0): Seq[TlaEx] = arr.slice(nSkip, n + nSkip).toSeq ++ Seq.fill(n - arr.length)(n_x)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
@@ -82,7 +82,7 @@ package object aux {
         List(head) +: rec
   }
 
-  def diff(ex1: TlaEx, ex2: TlaEx): TlaEx = (ex1, ex2) match {
+  def diff(ex1: TlaEx, ex2: TlaEx)(implicit typeTag: TypeTag): TlaEx = (ex1, ex2) match {
     case (OperEx(op1, args1 @ _*), OperEx(op2, args2 @ _*)) if op1 == op2 =>
       val argDiff = args1.zipAll(args2, NullEx, NullEx) map { case (x, y) => diff(x, y) }
       OperEx(op1, argDiff: _*)
@@ -116,9 +116,13 @@ package object aux {
     case OperEx(TlaOper.apply, NameEx("Diff"), ex1, ex2) =>
       Seq(ex)
     case OperEx(_, args @ _*) =>
-      args flatMap { allDiffs }
+      args flatMap {
+        allDiffs
+      }
     case LetInEx(body, defs @ _*) =>
-      (body +: (defs map { _.body })) flatMap allDiffs
+      (body +: (defs map {
+        _.body
+      })) flatMap allDiffs
     case _ =>
       Seq.empty
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/CounterexampleWriter.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/CounterexampleWriter.scala
@@ -6,6 +6,7 @@ import java.util.Calendar
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * A printer for counterexamples, in various formats: TLA+ , as TLC output, ...
@@ -113,7 +114,7 @@ class TlcCounterexampleWriter(writer: PrintWriter) extends TlaCounterexampleWrit
       val prefix = if (i == 1) s"$i: <Initial predicate>" else s"$i: <Next>"
 
       writer.println(s"""@!@!@STARTMSG 2217:4 @!@!@
-             |$prefix""".stripMargin)
+           |$prefix""".stripMargin)
       printStateFormula(new PrettyWriter(writer), state._2)
       writer.println("""|
              |@!@!@ENDMSG 2217 @!@!@""".stripMargin)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/JsonReader.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/JsonReader.scala
@@ -7,9 +7,11 @@ import at.forsyte.apalache.tla.lir.values._
 import java.lang.NumberFormatException
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.LinkedHashMap
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * <p>A reader of TlaEx and TlaModule from JSON, for interoperability with external tools.</p>
+ *
  * @author Andrey Kuprianov
  */
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/JsonWriter.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/JsonWriter.scala
@@ -12,10 +12,11 @@ import scala.collection.mutable.ArrayBuffer
 
 /**
  * <p>A formatter of TlaEx and TlaModule to JSON, for interoperability with external tools.</p>
+ *
  * @author Andrey Kuprianov
  */
 
-class JsonWriter(writer: PrintWriter, indent: Int = 2) {
+class JsonWriter(writer: PrintWriter, indent: Int = 2)(implicit typeTag: TypeTag) {
 
   def write(mod: TlaModule): Unit = {
     writer.write(ujson.write(toJson(mod), indent))
@@ -274,10 +275,10 @@ object JsonWriter {
   /**
    * Write a module to a file (without appending).
    *
-   * @param module a TLA module
+   * @param module     a TLA module
    * @param outputFile an output file that will be created or overwritten
    */
-  def write(module: TlaModule, outputFile: File): Unit = {
+  def write(module: TlaModule, outputFile: File)(implicit typeTag: TypeTag): Unit = {
     val writer = new PrintWriter(new FileWriter(outputFile, false))
     try {
       new JsonWriter(writer).write(module)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/PrettyWriter.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/PrettyWriter.scala
@@ -23,7 +23,8 @@ import scala.collection.immutable.HashMap
  *
  * @author Igor Konnov
  */
-class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2) extends PrettyPrinter {
+class PrettyWriter(writer: PrintWriter, textWidth: Int = 80, indent: Int = 2)(implicit typeTag: TypeTag)
+    extends PrettyPrinter {
   override val defaultIndent: Int = indent
 
   val REC_FUN_UNDEFINED = "recFunNameUndefined"
@@ -503,10 +504,10 @@ object PrettyWriter {
   /**
    * Write a module to a file (without appending).
    *
-   * @param module a TLA module
+   * @param module     a TLA module
    * @param outputFile an output file that will be created or overwritten
    */
-  def write(module: TlaModule, outputFile: File): Unit = {
+  def write(module: TlaModule, outputFile: File)(implicit typeTag: TypeTag): Unit = {
     val writer = new PrintWriter(new FileWriter(outputFile, false))
     try {
       new PrettyWriter(writer).write(module)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.lir.oper
 
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, TypeTag}
 
 /**
  * Function operators.
@@ -40,7 +40,7 @@ object TlaFunOper {
    * @param elems tuple elements
    * @return a new OperEx(tuple, elems: _*)
    */
-  def mkTuple(elems: TlaEx*): OperEx =
+  def mkTuple(elems: TlaEx*)(implicit typeTag: TypeTag): OperEx =
     OperEx(tuple, elems: _*)
 
   /**
@@ -81,18 +81,18 @@ object TlaFunOper {
    * We introduce an operator that have at least 3 arguments, whose meaning is as follows:</p>
    *
    * <ul>
-   *   <li>function body of type TlaEx that may refer to the function via recFunRef,</li>
-   *   <li>NameEx(variableName1),</li>
-   *   <li>variable1 domain of type TlaEx.</li>
-   *   <li>...</li>
-   *   <li>NameEx(variableName_k),</li>
-   *   <li>variable_k domain of type TlaEx.</li>
+   * <li>function body of type TlaEx that may refer to the function via recFunRef,</li>
+   * <li>NameEx(variableName1),</li>
+   * <li>variable1 domain of type TlaEx.</li>
+   * <li>...</li>
+   * <li>NameEx(variableName_k),</li>
+   * <li>variable_k domain of type TlaEx.</li>
    * </ul>
    *
    * <p>Hence, a declaration of a recursive operator looks like a nullary operator declaration,
-   *    whose body contains the constructor of a recursive function. The body of a recursive function may
-   *    refer to the function itself by using the operator recFunRef (see below).
-   *    Note that the output methods should convert this intermediate representation to the standard TLA+ form.</p>
+   * whose body contains the constructor of a recursive function. The body of a recursive function may
+   * refer to the function itself by using the operator recFunRef (see below).
+   * Note that the output methods should convert this intermediate representation to the standard TLA+ form.</p>
    *
    * <p>There is a reason for defining a recursive function with two operators, rather than by introducing
    * a special case of `TlaDecl`. In TLA+, the operator bodies (as well as function bodies) may refer only to
@@ -107,21 +107,21 @@ object TlaFunOper {
    *
    * <p>
    * `TlaOperDecl("Fact", List(),
-   *   OperEx(recFunDef,
-   *     OperEx(TlaControlOper.ifThenElse,
-   *       (* n <= 1 *),
-   *       (* 1 *),
-   *       OperEx(Tla.ArithOper.mult,
-   *         NameEx("n"),
-   *         OperEx(TlaFunOper.app,
-   *           OperEx(recFunRef),
-   *           OperEx(TlaArithOper.minus, NameEx(n), ValEx(TlaInt(1)))
-   *         )
-   *       )
-   *     ),
-   *     NameEx("n"),
-   *     TlaIntSet
-   *   )
+   * OperEx(recFunDef,
+   * OperEx(TlaControlOper.ifThenElse,
+   * (* n <= 1 *),
+   * (* 1 *),
+   * OperEx(Tla.ArithOper.mult,
+   * NameEx("n"),
+   * OperEx(TlaFunOper.app,
+   * OperEx(recFunRef),
+   * OperEx(TlaArithOper.minus, NameEx(n), ValEx(TlaInt(1)))
+   * )
+   * )
+   * ),
+   * NameEx("n"),
+   * TlaIntSet
+   * )
    * )`
    * </p>
    */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala
@@ -99,9 +99,38 @@ package lir {
   /** A function signature, e.g., f(_, _) used in A(f(_, _), x, y) */
   case class OperFormalParam(name: String, arity: Int) extends FormalParam with Serializable {}
 
-  /** An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values. */
-  sealed abstract class TlaEx extends Identifiable with Serializable {
-    // TODO: there must be a nice way of defining default printers in scala, so we do not have to make a choice here
+  /**
+   * A type tag to be attached to a TLA+ language construct: an expression or a declaration.
+   */
+  sealed abstract class TypeTag
+
+  /**
+   * The type tag that simply indicates that the language construct is not typed.
+   */
+  case class Untyped() extends TypeTag
+
+  /**
+   * A type tag that carries a tag of type T, which the tag is parameterized with.
+   *
+   * @param myType the type that is carried by the tag
+   * @tparam T the type of the tag
+   */
+  case class Typed[T](myType: T) extends TypeTag
+
+  /**
+   * Default settings for the untyped language layer. To use the `Untyped()` tag, import the definitions from `UntypedPredefs`.
+   */
+  object UntypedPredefs {
+    implicit val untyped: TypeTag = Untyped()
+  }
+
+  /**
+   * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values.
+   * Importantly, `TlaEx` accepts an implicit type tag.
+   */
+  sealed abstract class TlaEx(implicit val typeTag: TypeTag) extends Identifiable with Serializable {
+
+    // TODO: there must be a nice way of defining default printers in scala, so we do not have to make a choice here.
     override def toString: String = UTFPrinter(this)
 
     def toSimpleString: String = ""
@@ -111,29 +140,43 @@ package lir {
    * This is a special expression that indicates that this expression does not have a meaningful value.
    * For instance, this expression can be used as the body of a library operator, which by default have
    * gibberish definitions by SANY.
-   * We could use Option[TlaEx], but that would introduce unnecessary many pattern matches, as NoneEx will be rare.
+   * We could use Option[TlaEx], but that would introduce unnecessary many pattern matches, as NoneEx is rare.
+   * NullEx is always untyped.
    */
-  object NullEx extends TlaEx with Serializable {
+  object NullEx extends TlaEx()(typeTag = Untyped()) with Serializable {
     override def toSimpleString: String = toString
   }
 
-  /** just using a TLA+ value */
-  case class ValEx(value: TlaValue) extends TlaEx with Serializable {
+  /**
+   * A constant TLA+ value, which is usually a literal such as: 42, TRUE, "foo", BOOLEAN.
+   * Importantly, `ValEx` accepts an implicit type tag.
+   */
+  case class ValEx(value: TlaValue)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     override def toSimpleString: String = value.toString
   }
 
-  /** referring to a variable, constant, operator, etc. by a name. */
-  case class NameEx(name: String) extends TlaEx with Serializable {
+  /**
+   * Referring by name to a variable, constant, operator, etc.
+   * Importantly, `NameEx` accepts an implicit type tag.
+   */
+  case class NameEx(name: String)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     override def toSimpleString: String = name
   }
 
-  // Introducing a LET-IN expression
-  case class LetInEx(body: TlaEx, decls: TlaOperDecl*) extends TlaEx with Serializable {
+  /*
+   * A let-in definition, which is part of TLA+ syntax.
+   * Importantly, `LetInEx` accepts an implicit type tag.
+   */
+  case class LetInEx(body: TlaEx, decls: TlaOperDecl*)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     override def toSimpleString: String = s"LET ${decls.mkString(" ")} IN $body"
   }
 
-  // applying an operator, including the one defined by OperFormalParam
-  case class OperEx(oper: TlaOper, args: TlaEx*) extends TlaEx with Serializable {
+  /**
+   * Application of a built-in operator. The standard operator `TlaOper.apply` allows us
+   * to apply a user-defined operator (defined with `TlaOperDecl`) or an operator that is passed via a parameter
+   * (that is, `OperFormalParam`). Importantly, `OperEx` accepts an implicit type tag.
+   */
+  case class OperEx(oper: TlaOper, args: TlaEx*)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
     require(oper.isCorrectArity(args.size),
         "unexpected arity %d in %s applied to %s".format(args.size, oper.name, args.map(_.toString) mkString ", "))
 
@@ -198,6 +241,7 @@ package lir {
    * @param argDom  the expression that describes the variable bound, e.g., Nat
    * @param defBody the definition body
    */
+  @deprecated("Use TlaFunOper.recFunDef and TlaFunOper.recFunRef instead")
   case class TlaRecFunDecl(name: String, arg: String, argDom: TlaEx, defBody: TlaEx) extends TlaDecl
 
   /**

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/DeepCopy.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/DeepCopy.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaDeclTransformation, TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * DeepCopy constructs a structurally identical copy of a given TlaEx or TlaDecl, with fresh unique IDs.

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl, TypeTag}
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
@@ -10,7 +10,7 @@ object Flatten {
     case _             => false
   }
 
-  private def flattenOne(tracker: TransformationTracker): TlaExTransformation =
+  private def flattenOne(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation =
     tracker.trackEx {
       case ex @ OperEx(TlaBoolOper.and | TlaBoolOper.or, args @ _*) =>
         val hasSameOper = sameOp(ex.oper)(_)
@@ -43,7 +43,7 @@ object Flatten {
    * Example:
    * ( a /\ b) /\ c [/\(/\(a,b),c)] -> a /\ b /\ c [/\(a,b,c)]
    */
-  def apply(tracker: TransformationTracker): TlaExTransformation = tracker.trackEx { ex =>
+  def apply(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation = tracker.trackEx { ex =>
     val tr = flattenOne(tracker)
     lazy val self = apply(tracker)
     ex match {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
@@ -10,7 +10,7 @@ object Flatten {
     case _             => false
   }
 
-  private def flattenOne(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation =
+  private def flattenOne(tracker: TransformationTracker): TlaExTransformation =
     tracker.trackEx {
       case ex @ OperEx(TlaBoolOper.and | TlaBoolOper.or, args @ _*) =>
         val hasSameOper = sameOp(ex.oper)(_)
@@ -32,7 +32,7 @@ object Flatten {
               Seq(x)
           }
           // We know newArgs != args, because similar = true
-          OperEx(ex.oper, newArgs: _*)
+          OperEx(ex.oper, newArgs: _*)(ex.typeTag)
         }
       case e => e
     }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
@@ -33,7 +33,10 @@ object IncrementalRenaming {
   def parseName(name: String): Option[(String, Int)] = {
     name.split(separatorRegex) match {
       // Already renamed before
-      case Array(n, i) if i forall { _.isDigit } => Some((n, i.toInt))
+      case Array(n, i) if i forall {
+            _.isDigit
+          } =>
+        Some((n, i.toInt))
       // Never renamed before
       case Array(n) => None
       // Error
@@ -49,10 +52,10 @@ object IncrementalRenaming {
 
   /**
    * Merges two maps of type `counterMapType`. The new map has the following properties:
-   *   1) \A k \in m1.keys \ m2.keys . mergeNameCounters( b )( m1, m2 )[k] = m1[k]
-   *   2) \A k \in m2.keys \ m1.keys . mergeNameCounters( b )( m1, m2 )[k] = m2[k]
-   *   3) \A k \in m1.keys \cap m2.keys .
-   *       mergeNameCounters( b )( m1, m2 )[k] = IF b THEN max(m1[k],m2[k]) ELSE min(m1[k],m2[k])
+   * 1) \A k \in m1.keys \ m2.keys . mergeNameCounters( b )( m1, m2 )[k] = m1[k]
+   * 2) \A k \in m2.keys \ m1.keys . mergeNameCounters( b )( m1, m2 )[k] = m2[k]
+   * 3) \A k \in m1.keys \cap m2.keys .
+   * mergeNameCounters( b )( m1, m2 )[k] = IF b THEN max(m1[k],m2[k]) ELSE min(m1[k],m2[k])
    */
   def mergeNameCounters(takeMax: Boolean)(m1: counterMapType, m2: counterMapType): counterMapType = {
     val selectorFun: (Int, Int) => Int = if (takeMax) math.max else math.min
@@ -74,7 +77,9 @@ object IncrementalRenaming {
       }
 
     case OperEx(_, args @ _*) =>
-      args.map(nameCounterMapFromEx(takeMax)).foldLeft(Map.empty[String, Int]) { mergeNameCounters(takeMax) }
+      args.map(nameCounterMapFromEx(takeMax)).foldLeft(Map.empty[String, Int]) {
+        mergeNameCounters(takeMax)
+      }
 
     case LetInEx(body, defs @ _*) =>
       defs.map(nameCounterMapFromDecl(takeMax)).foldLeft(nameCounterMapFromEx(takeMax)(body)) {
@@ -100,7 +105,9 @@ object IncrementalRenaming {
    * Computes then merges maps for all declarations.
    */
   def nameCounterMapFromDecls(takeMax: Boolean)(decls: Traversable[TlaDecl]): counterMapType =
-    decls.map(nameCounterMapFromDecl(takeMax)).foldLeft(Map.empty[String, Int]) { mergeNameCounters(takeMax) }
+    decls.map(nameCounterMapFromDecl(takeMax)).foldLeft(Map.empty[String, Int]) {
+      mergeNameCounters(takeMax)
+    }
 
   /**
    * If `name` is of the form makeName( a, b ) and offsets contains a,
@@ -124,7 +131,8 @@ object IncrementalRenaming {
  * Unlike Renaming, IncrementalRenaming is intended to maintain concise names under arbitrary re-application
  */
 @Singleton
-class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends TlaExTransformation {
+class IncrementalRenaming @Inject() (tracker: TransformationTracker)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
 
   import IncrementalRenaming._
 
@@ -304,7 +312,9 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
    * Importatntly, it is assumed that `ex` has been renamed at least once.
    */
   def normalize(ex: TlaEx): TlaEx = {
-    val offsetMap = nameCounterMapFromEx(takeMax = false)(ex) withFilter { _._2 > 1 } map { case (k, v) =>
+    val offsetMap = nameCounterMapFromEx(takeMax = false)(ex) withFilter {
+      _._2 > 1
+    } map { case (k, v) =>
       (k, v - 1)
     }
     shiftCounters(offsetMap)(ex)
@@ -317,11 +327,15 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
       )
       .foldLeft(Map.empty[String, Int]) {
         mergeNameCounters(takeMax = false)
-      } withFilter { _._2 > 1 } map { case (k, v) =>
+      } withFilter {
+      _._2 > 1
+    } map { case (k, v) =>
       (k, v - 1)
     }
 
-    exs map { shiftCounters(offsetMap) }
+    exs map {
+      shiftCounters(offsetMap)
+    }
   }
 
   // Lifted to decl
@@ -331,7 +345,9 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
 
   // lifted to decls
   def normalizeDs(decls: Traversable[TlaDecl]): Traversable[TlaDecl] = {
-    val offsetMap = nameCounterMapFromDecls(takeMax = false)(decls) withFilter { _._2 > 1 } map { case (k, v) =>
+    val offsetMap = nameCounterMapFromDecls(takeMax = false)(decls) withFilter {
+      _._2 > 1
+    } map { case (k, v) =>
       (k, v - 1)
     }
     shiftCountersDs(offsetMap)(decls)
@@ -368,7 +384,9 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
 
   def syncAndNormalizeExs(exs: Traversable[TlaEx]): Traversable[TlaEx] = {
     exs foreach syncFrom
-    normalizeExs(exs map { apply })
+    normalizeExs(exs map {
+      apply
+    })
   }
 
   // Lifted to decl

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
@@ -75,7 +75,7 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)(imp
     val bodyCopy = postTr(DeepCopy(tracker).deepCopyEx(decl.body))
 
     val newBody = decl.formalParams.zip(args).foldLeft(bodyCopy) { case (b, (fParam, arg)) =>
-      ReplaceFixed(NameEx(fParam.name), arg, tracker)(typeTag)(b)
+      ReplaceFixed(NameEx(fParam.name), arg, tracker)(implicitly)(b)
     }
 
     // the step limit, if it was defined, decreases by 1

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/InlinerOfUserOper.scala
@@ -15,8 +15,7 @@ import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, Transfo
  *
  * @author Jure Kukovec
  */
-class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)(implicit typeTag: TypeTag)
-    extends TlaExTransformation {
+class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker) extends TlaExTransformation {
 
   override def apply(expr: TlaEx): TlaEx = {
     transform(stepLimitOpt = None)(expr)
@@ -53,12 +52,12 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)(imp
       if (defs == newDefs && body == newBody) {
         ex
       } else {
-        LetInEx(newBody, newDefs: _*)
+        LetInEx(newBody, newDefs: _*)(ex.typeTag)
       }
 
     case ex @ OperEx(op, args @ _*) =>
       val newArgs = args map transform(stepLimitOpt)
-      if (args == newArgs) ex else OperEx(op, newArgs: _*)
+      if (args == newArgs) ex else OperEx(op, newArgs: _*)(ex.typeTag)
 
     case ex => ex
   }
@@ -75,7 +74,7 @@ class InlinerOfUserOper(defBodyMap: BodyMap, tracker: TransformationTracker)(imp
     val bodyCopy = postTr(DeepCopy(tracker).deepCopyEx(decl.body))
 
     val newBody = decl.formalParams.zip(args).foldLeft(bodyCopy) { case (b, (fParam, arg)) =>
-      ReplaceFixed(NameEx(fParam.name), arg, tracker)(implicitly)(b)
+      ReplaceFixed(NameEx(fParam.name)(arg.typeTag), arg, tracker)(b)
     }
 
     // the step limit, if it was defined, decreases by 1
@@ -103,7 +102,7 @@ object InlinerOfUserOper {
     def >(x: BigInt): Boolean = k > x
   }
 
-  def apply(defBodyMap: BodyMap, tracker: TransformationTracker)(implicit typeTag: TypeTag): InlinerOfUserOper = {
+  def apply(defBodyMap: BodyMap, tracker: TransformationTracker): InlinerOfUserOper = {
     new InlinerOfUserOper(defBodyMap, tracker)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
@@ -14,7 +14,8 @@ import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
  *
  * @author Jure Kukovec
  */
-class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extends TlaExTransformation {
+class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
   override def apply(ex: TlaEx): TlaEx = transform(ex)
 
   def transform: TlaExTransformation = tracker.trackEx {
@@ -47,7 +48,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extend
         }
 
       // Inline the operators using the map of definitions
-      InlinerOfUserOper(bodyMap, tracker)(expandedLetIn)
+      InlinerOfUserOper(bodyMap, tracker)(typeTag)(expandedLetIn)
 
     // this is the special form for LAMBDAs
     case OperEx(TlaOper.apply, LetInEx(NameEx("LAMBDA"), TlaOperDecl("LAMBDA", params, lambdaBody)), args @ _*) =>
@@ -57,7 +58,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extend
       params.zip(args).foldLeft(lambdaBody) {
         // replace every parameter with the respective argument
         case (expr, (param, arg)) =>
-          ReplaceFixed(NameEx(param.name), arg, tracker)(expr)
+          ReplaceFixed(NameEx(param.name), arg, tracker)(typeTag)(expr)
       }
 
     // recursive processing of composite operators
@@ -70,7 +71,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean) extend
 }
 
 object LetInExpander {
-  def apply(tracker: TransformationTracker, keepNullary: Boolean): LetInExpander = {
+  def apply(tracker: TransformationTracker, keepNullary: Boolean)(implicit typeTag: TypeTag): LetInExpander = {
     new LetInExpander(tracker, keepNullary)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/LetInExpander.scala
@@ -48,7 +48,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean)(implic
         }
 
       // Inline the operators using the map of definitions
-      InlinerOfUserOper(bodyMap, tracker)(typeTag)(expandedLetIn)
+      InlinerOfUserOper(bodyMap, tracker)(implicitly)(expandedLetIn)
 
     // this is the special form for LAMBDAs
     case OperEx(TlaOper.apply, LetInEx(NameEx("LAMBDA"), TlaOperDecl("LAMBDA", params, lambdaBody)), args @ _*) =>
@@ -58,7 +58,7 @@ class LetInExpander(tracker: TransformationTracker, keepNullary: Boolean)(implic
       params.zip(args).foldLeft(lambdaBody) {
         // replace every parameter with the respective argument
         case (expr, (param, arg)) =>
-          ReplaceFixed(NameEx(param.name), arg, tracker)(typeTag)(expr)
+          ReplaceFixed(NameEx(param.name), arg, tracker)(implicitly)(expr)
       }
 
     // recursive processing of composite operators

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaOperDecl, TypeTag}
 
 object Prime {
   private def primeLeaf(vars: Set[String], tracker: TransformationTracker): TlaExTransformation =
@@ -21,26 +21,27 @@ object Prime {
    *
    * a' + b > 0 --> a' + b' > 0
    */
-  def apply(vars: Set[String], tracker: TransformationTracker): TlaExTransformation = tracker.trackEx { ex =>
-    val tr = primeLeaf(vars, tracker)
-    lazy val self = apply(vars, tracker)
-    ex match {
-      case LetInEx(body, defs @ _*) =>
-        // Transform bodies of all op.defs
-        val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
-        val newBody = self(body)
-        val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
-        tr(retEx)
+  def apply(vars: Set[String], tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation =
+    tracker.trackEx { ex =>
+      val tr = primeLeaf(vars, tracker)
+      lazy val self = apply(vars, tracker)
+      ex match {
+        case LetInEx(body, defs @ _*) =>
+          // Transform bodies of all op.defs
+          val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
+          val newBody = self(body)
+          val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
+          tr(retEx)
 
-      case ex @ OperEx(TlaActionOper.prime, NameEx(_)) =>
-        // Do not prime expressions which are already primed. This may happen when Init = Inv.
-        tr(ex)
-      case ex @ OperEx(op, args @ _*) =>
-        val newArgs = args map self
-        val retEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
-        tr(retEx)
+        case ex @ OperEx(TlaActionOper.prime, NameEx(_)) =>
+          // Do not prime expressions which are already primed. This may happen when Init = Inv.
+          tr(ex)
+        case ex @ OperEx(op, args @ _*) =>
+          val newArgs = args map self
+          val retEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
+          tr(retEx)
 
-      case _ => tr(ex)
+        case _ => tr(ex)
+      }
     }
-  }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaOperDecl, TypeTag}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx}
 
 object Prime {
   private def primeLeaf(vars: Set[String], tracker: TransformationTracker): TlaExTransformation =
@@ -21,7 +21,7 @@ object Prime {
    *
    * a' + b > 0 --> a' + b' > 0
    */
-  def apply(vars: Set[String], tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation =
+  def apply(vars: Set[String], tracker: TransformationTracker): TlaExTransformation =
     tracker.trackEx { ex =>
       val tr = primeLeaf(vars, tracker)
       lazy val self = apply(vars, tracker)
@@ -30,7 +30,7 @@ object Prime {
           // Transform bodies of all op.defs
           val newDefs = defs map tracker.trackOperDecl { d => d.copy(body = self(d.body)) }
           val newBody = self(body)
-          val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)
+          val retEx = if (defs == newDefs && body == newBody) ex else LetInEx(newBody, newDefs: _*)(ex.typeTag)
           tr(retEx)
 
         case ex @ OperEx(TlaActionOper.prime, NameEx(_)) =>
@@ -38,7 +38,7 @@ object Prime {
           tr(ex)
         case ex @ OperEx(op, args @ _*) =>
           val newArgs = args map self
-          val retEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)
+          val retEx = if (args == newArgs) ex else OperEx(op, newArgs: _*)(ex.typeTag)
           tr(retEx)
 
         case _ => tr(ex)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimePropagation.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimePropagation.scala
@@ -2,16 +2,17 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx, TypeTag}
 
 /**
  * A reference implementation of an expression transformer. It expands the prime operator,
  * that is, when it meets an expression e', it propagates primes inside e.
  *
  * @param stateVars state variables
- * @param tracker a transformation tracker
+ * @param tracker   a transformation tracker
  */
-class PrimePropagation(tracker: TransformationTracker, stateVars: Set[String]) extends TlaExTransformation {
+class PrimePropagation(tracker: TransformationTracker, stateVars: Set[String])(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
 
   /**
    * Propagate primes in the expression to the state variables.

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimedEqualityToMembership.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimedEqualityToMembership.scala
@@ -1,8 +1,8 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.transformations._
+import at.forsyte.apalache.tla.lir._
 
 /**
  * Replace every equality x' = e with x' \in {e}. This transformation is needed by the assignment solver,
@@ -10,7 +10,8 @@ import at.forsyte.apalache.tla.lir.transformations._
  *
  * @author Jure Kukovec
  */
-class PrimedEqualityToMembership(tracker: TransformationTracker) extends TlaExTransformation {
+class PrimedEqualityToMembership(tracker: TransformationTracker)(implicit typeTag: TypeTag)
+    extends TlaExTransformation {
   override def apply(ex: TlaEx): TlaEx = {
     transform(ex)
   }
@@ -36,7 +37,7 @@ class PrimedEqualityToMembership(tracker: TransformationTracker) extends TlaExTr
 }
 
 object PrimedEqualityToMembership {
-  def apply(tracker: TransformationTracker): PrimedEqualityToMembership = {
+  def apply(tracker: TransformationTracker)(implicit typeTag: TypeTag): PrimedEqualityToMembership = {
     new PrimedEqualityToMembership(tracker)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimedEqualityToMembership.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PrimedEqualityToMembership.scala
@@ -10,6 +10,7 @@ import at.forsyte.apalache.tla.lir._
  *
  * @author Jure Kukovec
  */
+@deprecated("To be removed in #564")
 class PrimedEqualityToMembership(tracker: TransformationTracker)(implicit typeTag: TypeTag)
     extends TlaExTransformation {
   override def apply(ex: TlaEx): TlaEx = {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PruneApalacheAnnotations.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/PruneApalacheAnnotations.scala
@@ -1,8 +1,8 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations._
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TypeTag}
 
 object PruneApalacheAnnotations {
   private def pruneOne(tracker: TransformationTracker): TlaExTransformation =
@@ -17,7 +17,7 @@ object PruneApalacheAnnotations {
    * Example:
    * S <: {Int} -> S
    */
-  def apply(tracker: TransformationTracker): TlaExTransformation = tracker.trackEx { ex =>
+  def apply(tracker: TransformationTracker)(implicit typeTag: TypeTag): TlaExTransformation = tracker.trackEx { ex =>
     val tr = pruneOne(tracker)
     lazy val self = apply(tracker)
     ex match {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Renaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Renaming.scala
@@ -11,6 +11,7 @@ import scala.collection.immutable.HashMap
  *
  * @author Igor Konnov
  */
+@deprecated("To be removed in #565")
 class Renaming(tracker: TransformationTracker)(implicit typeTag: TypeTag) extends TlaExTransformation {
 
   /**

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Renaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Renaming.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable.HashMap
  *
  * @author Igor Konnov
  */
-class Renaming(tracker: TransformationTracker) extends TlaExTransformation {
+class Renaming(tracker: TransformationTracker)(implicit typeTag: TypeTag) extends TlaExTransformation {
 
   /**
    * The names of bindings that have been seen already.

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ReplaceFixed.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ReplaceFixed.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TypeTag}
 
 object ReplaceFixed {
   def replaceOne(
@@ -20,7 +20,7 @@ object ReplaceFixed {
       replacedEx: TlaEx,
       newEx: => TlaEx, // takes a [=> TlaEx] to allow for the creation of new instances (with distinct UIDs)
       tracker: TransformationTracker
-  ): TlaExTransformation = tracker.trackEx { ex =>
+  )(implicit typeTag: TypeTag): TlaExTransformation = tracker.trackEx { ex =>
     val tr = replaceOne(replacedEx, newEx, tracker)
     lazy val self = apply(replacedEx, newEx, tracker)
     ex match {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestBuilder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestBuilder.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.values._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 @RunWith(classOf[JUnitRunner])
 class TestBuilder extends FunSuite with TestingPredefs {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIDAllocation.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIDAllocation.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.values._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * Created by jkukovec on 11/30/16.
@@ -23,10 +24,10 @@ class TestIDAllocation extends FunSuite {
 
   /**
    * SndNewValue(d) == /\ sAck      = sBit
-   *                   /\ sent'     = d
-   *                   /\ sBit'     = 1 - sBit
-   *                   /\ msgQ'     = Append( msgQ, << sBit', d >> )
-   *                   /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
+   * /\ sent'     = d
+   * /\ sBit'     = 1 - sBit
+   * /\ msgQ'     = Append( msgQ, << sBit', d >> )
+   * /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
    */
   val SndNewValue =
     new TlaOperDecl("SndNewValue", List(SimpleFormalParam("d")),
@@ -117,13 +118,13 @@ class TestIDAllocation extends FunSuite {
     new TlaOperDecl(
         "thrm",
         List(),
-//      OperEx(
-//        TlaBoolOper.and,
-//        OperEx(
-//          TlaOper.eq,
-//          NameEx( "E" ),
-//          NameEx( "Esub" )
-//        ),
+        //      OperEx(
+        //        TlaBoolOper.and,
+        //        OperEx(
+        //          TlaOper.eq,
+        //          NameEx( "E" ),
+        //          NameEx( "Esub" )
+        //        ),
         OperEx(
             TlaOper.eq,
             OperEx(

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIncrementalRenaming.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestIncrementalRenaming.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.junit.JUnitRunner
@@ -145,13 +146,13 @@ class TestIncrementalRenaming extends FunSuite with TestingPredefs with BeforeAn
 
     /**
      * LET X(p1,t99(_,_)) == /\ p1 >= 0
-     *                       /\ x' \in {p1}
-     *             Z1(p8) == p8
-     *  IN LET Y6(p3) == \E s3 \in T1 : s3 + p3 = x
-     *      IN /\ \A s5 \in T1 : /\ Z1(s5)
-     *                           /\ Y6(s5)
-     *         /\ y
-     *         /\ X(0,x)
+     * /\ x' \in {p1}
+     * Z1(p8) == p8
+     * IN LET Y6(p3) == \E s3 \in T1 : s3 + p3 = x
+     * IN /\ \A s5 \in T1 : /\ Z1(s5)
+     * /\ Y6(s5)
+     * /\ y
+     * /\ X(0,x)
      */
     val letInEx =
       letIn(

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestLetInExpander.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestLetInExpander.scala
@@ -1,10 +1,10 @@
 package at.forsyte.apalache.tla.lir
 
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSeqOper}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -12,6 +12,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestLetInExpander extends FunSuite with TestingPredefs {
+
   import Builder._
 
   test("Test LetInExpander, skip0Arity = false") {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestModule.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestModule.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 @RunWith(classOf[JUnitRunner])
 class TestModule extends FunSuite {
@@ -34,12 +35,12 @@ class TestModule extends FunSuite {
 
     /**
      * ABInit = /\ msgQ =   <<>>
-     *          /\ ackQ =   <<>>
-     *          /\ sBit \in {0,1}
-     *          /\ sAck =   sBit
-     *          /\ rBit =   sBit
-     *          /\ sent \in Data
-     *          /\ rcvd \in Data
+     * /\ ackQ =   <<>>
+     * /\ sBit \in {0,1}
+     * /\ sAck =   sBit
+     * /\ rBit =   sBit
+     * /\ sent \in Data
+     * /\ rcvd \in Data
      */
     val ABInit =
       new TlaOperDecl("ABInit", List(),
@@ -50,12 +51,12 @@ class TestModule extends FunSuite {
 
     /**
      * ABTypeInv == /\ msgQ \in Seq( {0,1} \times Data )
-     *              /\ ackQ \in Seq( {0,1} )
-     *              /\ sBit \in {0,1}
-     *              /\ sAck \in {0,1}
-     *              /\ rBit \in {0,1}
-     *              /\ sent \in Data
-     *              /\ rcvd \in Data
+     * /\ ackQ \in Seq( {0,1} )
+     * /\ sBit \in {0,1}
+     * /\ sAck \in {0,1}
+     * /\ rBit \in {0,1}
+     * /\ sent \in Data
+     * /\ rcvd \in Data
      */
     val ABTypeInv =
       new TlaOperDecl("ABTypeInv", List(),
@@ -71,10 +72,10 @@ class TestModule extends FunSuite {
 
     /**
      * SndNewValue(d) == /\ sAck      = sBit
-     *                   /\ sent'     = d
-     *                   /\ sBit'     = 1 - sBit
-     *                   /\ msgQ'     = Append( msgQ, << sBit', d >> )
-     *                   /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
+     * /\ sent'     = d
+     * /\ sBit'     = 1 - sBit
+     * /\ msgQ'     = Append( msgQ, << sBit', d >> )
+     * /\ UNCHANGED   << ackQ, sAck, rBit, rcvd >>
      */
     val SndNewValue =
       new TlaOperDecl("SndNewValue", List(SimpleFormalParam("d")),
@@ -93,8 +94,8 @@ class TestModule extends FunSuite {
 
     /**
      * ReSndMsg == /\ sAck      # sBit
-     *             /\ msgQ'     = Append( msgQ, << sBit, sent >> )
-     *             /\ UNCHANGED   << ackQ, sBit, sAck, rBit, sent, rcvd >>
+     * /\ msgQ'     = Append( msgQ, << sBit, sent >> )
+     * /\ UNCHANGED   << ackQ, sBit, sAck, rBit, sent, rcvd >>
      */
     val ReSndMsg =
       new TlaOperDecl("ReSndMsg", List(),
@@ -107,10 +108,10 @@ class TestModule extends FunSuite {
 
     /**
      * RcvMsg == /\ msgQ      # <<>>
-     *           /\ msgQ'     = Tail( msgQ )
-     *           /\ rBit'     = Head( msgQ ) [ 1 ]
-     *           /\ rcvd'     = Head( msgQ ) [ 2 ]
-     *           /\ UNCHANGED   << ackQ, sBit, sAck, sent >>
+     * /\ msgQ'     = Tail( msgQ )
+     * /\ rBit'     = Head( msgQ ) [ 1 ]
+     * /\ rcvd'     = Head( msgQ ) [ 2 ]
+     * /\ UNCHANGED   << ackQ, sBit, sAck, sent >>
      */
     val RcvMsg =
       new TlaOperDecl("RcvMsg", List(),
@@ -128,7 +129,7 @@ class TestModule extends FunSuite {
 
     /**
      * SndAck == /\ ackQ'     = Append( ackQ, rBit )
-     *           /\ UNCHANGED   << msgQ, sBit, sAck, rBit, sent, rcvd >>
+     * /\ UNCHANGED   << msgQ, sBit, sAck, rBit, sent, rcvd >>
      */
     val SndAck =
       new TlaOperDecl("SndAck", List(),
@@ -141,9 +142,9 @@ class TestModule extends FunSuite {
 
     /**
      * RcvAck == /\ ackQ      # <<>>
-     *           /\ ackQ'     = Tail( ackQ )
-     *           /\ sAck'     = Head( ackQ )
-     *           /\ UNCHANGED   << msgQ, sBit, rBit, sent, rcvd >>
+     * /\ ackQ'     = Tail( ackQ )
+     * /\ sAck'     = Head( ackQ )
+     * /\ UNCHANGED   << msgQ, sBit, rBit, sent, rcvd >>
      */
     val RcvAck =
       new TlaOperDecl("RcvAck", List(),
@@ -156,10 +157,10 @@ class TestModule extends FunSuite {
 
     /**
      * Lose( q ) == /\ q # <<>>
-     *              /\ \exists i \in 1 .. Len( q ) :
-     *                 q' = [ j \in 1 .. ( Len( q ) - 1 ) |-> IF j < i THEN q[ j ]
-     *                                                                 ELSE q[ j + 1 ] ]
-     *              /\ UNCHANGED << sBit, sAck, rBit, sent, rcvd >>
+     * /\ \exists i \in 1 .. Len( q ) :
+     * q' = [ j \in 1 .. ( Len( q ) - 1 ) |-> IF j < i THEN q[ j ]
+     * ELSE q[ j + 1 ] ]
+     * /\ UNCHANGED << sBit, sAck, rBit, sent, rcvd >>
      */
     val Lose =
       new TlaOperDecl("Lose", List(SimpleFormalParam("q")),
@@ -192,8 +193,8 @@ class TestModule extends FunSuite {
 
     /**
      * ABNext == \/ \exists d \in Data : SndNewValue(d)
-     *           \/ ReSndMsg \/ RcvMsg \/ SndAck \/ RcvAck
-     *           \/ LoseMsg \/ LoseAck
+     * \/ ReSndMsg \/ RcvMsg \/ SndAck \/ RcvAck
+     * \/ LoseMsg \/ LoseAck
      */
     val ABNext =
       new TlaOperDecl("ABNext", List(),
@@ -215,7 +216,7 @@ class TestModule extends FunSuite {
 
     /**
      * ABFairness == /\ WF_abvars( ReSndMsg ) /\ WF_abvars( SndAck )
-     *               /\ SF_abvars( RcvMsg ) /\ SF_abvars( RcvAck )
+     * /\ SF_abvars( RcvMsg ) /\ SF_abvars( RcvAck )
      */
     val ABFairness =
       new TlaOperDecl("AbFairness", List(),

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 @RunWith(classOf[JUnitRunner])
 class TestPrinter extends FunSuite with TestingPredefs {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestRenaming.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestRenaming.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.transformations.standard.Renaming
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceLocator.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceLocator.scala
@@ -14,6 +14,8 @@ import at.forsyte.apalache.tla.lir.transformations.standard._
 
 import scala.collection.mutable
 
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
+
 @RunWith(classOf[JUnitRunner])
 class TestSourceLocator extends FunSuite with TestingPredefs {
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExpr.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExpr.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.lir
 
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
 import org.junit.runner.RunWith
@@ -11,6 +12,35 @@ import org.scalatest.junit.JUnitRunner
  */
 @RunWith(classOf[JUnitRunner])
 class TestTlaExpr extends FunSuite {
+  test("no type tag") {
+    // this expression is constructed with the implicit value for typeTag = Untyped().
+    val ex = ValEx(TlaInt(42))
+    // pattern matching should work without worrying about type tags
+    ex match {
+      case matched @ ValEx(TlaInt(i)) =>
+        assert(42 == i)
+        assert(Untyped() == matched.typeTag)
+
+      case _ =>
+        fail("Expected valEx")
+    }
+  }
+
+  test("type tag") {
+    // this expression is annotated with a type tag. For testing purposes, the type tag is just a string.
+    val ex = ValEx(TlaInt(42))(Typed[String]("foo"))
+    // although we have have set a type tag, pattern matching should be oblivious to that
+    ex match {
+      case matched @ ValEx(TlaInt(i)) =>
+        assert(42 == i)
+        // we can extract the type, whenever we want to do it
+        assert(Typed[String]("foo") == matched.typeTag)
+
+      case _ =>
+        fail("Expected ValEx")
+    }
+  }
+
   test("create a conjunction") {
     val x = NameEx("x")
     val y = NameEx("y")

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJson.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJson.scala
@@ -7,9 +7,11 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * <p>Geeneric set of tests for conversion between TLA and JSON.</p>
+ *
  * @author Andrey Kuprianov
  */
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJsonWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestJsonWriter.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.io
 
 import java.io.{PrintWriter, StringWriter}
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 class TestJsonWriter extends TestJson {
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
@@ -10,6 +10,7 @@ import org.scalatest.junit.JUnitRunner
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 @RunWith(classOf[JUnitRunner])
 class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/storage/TestChangeListener.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/storage/TestChangeListener.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.storage
 
 import at.forsyte.apalache.tla.lir.NameEx
 import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlcOper
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
+import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 class TestKeraLanguagePred extends LanguagePredTestSuite {
   private val pred = new KeraLanguagePred

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestPrimePropagation.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestPrimePropagation.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.{LetInEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 /**


### PR DESCRIPTION
**This is a cherry pick of #557 that has a fine-grained diff, thanks to** @shonfeder

This PR contains a change to `TlaEx`. It is the core structure of the whole project, so we have to discuss the proposed solution and its impact. See the discussion below.

Apart from this change, this PR contains 130 files that import a single implicit parameter:

```scala
import at.forsyte.apalache.tla.lir.UntypedPredefs._
```

Unfortunately, `scalafmt` turned this simple change into a massive PR.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

**The problem.** Having the new type checker, we have to figure out how to integrate the type information in the TLA+ expressions. The old type checker is run in the very end of the pipeline. Hence the preprocessing code does not have to care about types at all. The new type checker is run before any preprocessing, which allows us to give much better feedback to the user.

There are several issues here:

 - We want to write most of the code as if TLA+ was untyped, e.g., `SanyImporter` should work for both typed and untyped code.
 - We want to write some code as if TLA+ was typed. This is basically the code in the end of the pipeline that is implemented in the translator to SMT.
 - We want to gradually transform some preprocessing code into type-aware, but we shall not do it in one hop.
 - Type-unaware code should not erase types of the expressions, but it should propagate them further, without knowing how to interpret the types.

For the context, our definitions for `TlaEx` and its case classes looked like that before this PR:

```scala
  /**
   * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values.
   */
  sealed abstract class TlaEx extends Identifiable with Serializable { ... }

  /**
   * A constant TLA+ value, which is usually a literal such as: 42, TRUE, "foo", BOOLEAN.
   */
  case class ValEx(value: TlaValue) extends TlaEx with Serializable { ... }

  /**
   * Referring by name to a variable, constant, operator, etc.
   */
  case class NameEx(name: String) extends TlaEx with Serializable { ... }

  /*
   * A let-in definition, which is part of TLA+ syntax.
   */
  case class LetInEx(body: TlaEx, decls: TlaOperDecl*) extends TlaEx with Serializable { ... }

  /**
   * Application of a built-in operator. The standard operator `TlaOper.apply` allows us
   * to apply a user-defined operator (defined with `TlaOperDecl`) or an operator that is passed via a parameter
   * (that is, `OperFormalParam`).
   */
  case class OperEx(oper: TlaOper, args: TlaEx*) extends TlaEx with Serializable { ... }
```

**Alternative solutions.** Here are the alternatives that I considered (on top of the solution proposed in this PR):
 
 - Using a map similar to `AnnotationStore`. However, if we annotate every single expression, the overhead will be massive.
 - Instrumenting code to produce a proxy for `TlaEx` that would carry the type. This solution seems to be fragile and ugly. The type-unaware code could easily erase the types.
 - Inherit specialized cases classes from `TlaEx`, `ValEx`, `NameEx`, `OperEx`, and `LetInEx`, e.g., `TypedTlaEx[T](myType:  T) extends TlaEx`. This would produce two parallel data structures. I am not even sure how to compose them, as `OperEx` receives other expressions as its arguments. Again, type-unaware code could easily erase the types.
 - Use parameterized types. I do not have a clear solution here.

**Proposed solution: types as implicit parameters.** The most clean solution seems to be to use implicit parameters. Although we have tried to avoid implicits in Scala, it looks like the right job for them.

Below are the definitions of type tags that we introduce for annotating TLA+ expressions (see `at.forsyte.apalache.tla.lir`):

```scala
  /**
   * A type tag to be attached to a TLA+ language construct: an expression or a declaration.
   */
  sealed abstract class TypeTag

  /**
   * The type tag that simply indicates that the language construct is not typed.
   */
  case class Untyped() extends TypeTag

  /**
   * A type tag that carries a tag of type T, which the tag is parameterized with.
   *
   * @param myType the type that is carried by the tag
   * @tparam T the type of the tag
   */
  case class Typed[T](myType: T) extends TypeTag

  /**
   * Default settings for the untyped language layer. To use the `Untyped()` tag, import the definitions from `UntypedPredefs`.
   */
  object UntypedPredefs {
    implicit val untyped: TypeTag = Untyped()
  }
```

Then we introduce a type tag as an implicit parameter of `TlaEx`:

```scala
  /**
   * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values.
   * Importantly, `TlaEx` accepts an implicit type tag.
   */
  sealed abstract class TlaEx(implicit val typeTag: TypeTag) extends Identifiable with Serializable { ... }
```

The case classes also carry an implicit parameter, e.g., `ValEx`:

```scala
  /**
   * A constant TLA+ value, which is usually a literal such as: 42, TRUE, "foo", BOOLEAN.
   * Importantly, `ValEx` accepts an implicit type tag.
   */
  case class ValEx(value: TlaValue)(implicit typeTag: TypeTag) extends TlaEx with Serializable { ... }
```

The cool thing about this solution is that we can introduce this change without modifying lots of code. Essentially, all users of `TlaEx` have to import the implicit value `untyped`:

```scala
import at.forsyte.apalache.tla.lir.UntypedPredefs._
```

(I had to extend several transformations to received an implicit parameter and pass it with `implicitly`.)

The pattern matching code works as before. The type-aware code can access the tag via `ex.myType`. The type-unaware transformations may copy the types without unpacking them. On top of that, type-aware code can work with different type systems, as `Typed` is parameterized. If we try to mix different type systems, the compiler will help us.

The only downside that I see is that all of us have to read the chapter on implicit parameters in [Programming in Scala](https://booksites.artima.com/programming_in_scala_4ed). But we have to understand implicits anyways, if we want to use advanced frameworks as [cats](https://typelevel.org/cats/).
