### PR TITLE
close #582, close #583

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,3 +23,5 @@
 
 * Fixed name collisions on LOCAL operators and LOCAL INSTANCE, see #576
 * Parser: a higher-order operator calling a higher-order operator, see #575
+* Type checker: support for recursive functions of multiple arguments, see #582
+* Type checker: support for tuple unpacking in recursive functions, see #583

--- a/test/tla/PascalTriangle.tla
+++ b/test/tla/PascalTriangle.tla
@@ -1,0 +1,38 @@
+------------------------ MODULE PascalTriangle --------------------------------
+(*
+ Pascal triangle:
+ https://en.wikipedia.org/wiki/Pascal%27s_triangle#:~:text=In%20mathematics%2C%20Pascal's%20triangle%20is,theory%2C%20combinatorics%2C%20and%20algebra.
+
+ This is a test for recursive functions of multiple arguments in TLA+.
+
+ Igor Konnov, 2021
+ *)
+
+EXTENDS Integers
+
+N == 5
+
+Range == 0..N
+
+\* Pascal's triangle defined as a recursive function
+tri[n \in Range, k \in Range] ==
+    IF k > n \/ (k = 0 /\ n = 0)
+    THEN 1
+    ELSE tri[n - 1, k - 1] + tri[n - 1, k]
+
+
+VARIABLE
+    \* @type: Int;
+    result
+
+Init ==
+    result = tri[4, 2]
+
+Next ==
+    UNCHANGED result
+
+Inv ==
+    result = 6
+    
+
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1105,3 +1105,17 @@ Type checker [OK]
 EXITCODE: OK
 ```
 
+### typecheck PascalTriangle.tla
+
+```sh
+$ apalache-mc typecheck PascalTriangle.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeChecker
+ > Running Snowcat .::.
+ > Your types are great!
+...
+Type checker [OK]
+...
+EXITCODE: OK
+```
+

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -631,7 +631,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, varPool: TypeVarPool) extends 
         // fun[x \in S, y \in T |-> e] == ...
         // or, fun[<<x, y>> \in S, z \in T |-> e] == ...
         //
-        // The expected type is for a one-argument function is:
+        // The expected type for a one-argument function is:
         // (((b -> a) => (b => a)) => (b -> a)) (λ $recFun ∈ Set(c -> d). λ x ∈ Int. x)
         //
         // (The case of multiple arguments is quite complex)


### PR DESCRIPTION
This PR closes two related issues #582 and #583. That is, support for recursive functions of multiple arguments in the type checker.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
