### PR TITLE
close #601: type signatures for the TLC module

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,3 +16,4 @@
 ### Bug fixes
 
 * Parser: propagating type annotations in INSTANCES, see #592 and #596
+

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,9 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Features
+* Type checker: supporting TLC operators, see #601
+
 ### Bug fixes
 
 * Parser: propagating type annotations in INSTANCES, see #592 and #596

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,4 +16,3 @@
 ### Bug fixes
 
 * Parser: propagating type annotations in INSTANCES, see #592 and #596
-

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -857,6 +857,80 @@ class ToEtcExpr(annotationStore: AnnotationStore, varPool: TypeVarPool) extends 
         logger.warn("See: https://apalache.informal.systems/docs/apalache/typechecker-snowcat.html")
         this(lhs)
 
+      //********************************************* TLC **************************************************
+      case OperEx(TlcOper.print, text, value) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(StrT1(), a), StrT1()) // (Str, a) => Str
+        mkExRefApp(opsig, Seq(text, value))
+
+      case OperEx(TlcOper.printT, text) =>
+        val opsig = OperT1(Seq(StrT1()), BoolT1()) // Str => Bool
+        mkExRefApp(opsig, Seq(text))
+
+      case OperEx(TlcOper.assert, value, text) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(a, StrT1()), BoolT1()) // (a, Str) => Bool
+        mkExRefApp(opsig, Seq(value, text))
+
+      case OperEx(TlcOper.javaTime) =>
+        val opsig = OperT1(Seq(), IntT1()) // () => Int
+        mkExRefApp(opsig, Seq())
+
+      case OperEx(TlcOper.tlcGet, index) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(IntT1()), a) // Int => a
+        mkExRefApp(opsig, Seq(index))
+
+      case OperEx(TlcOper.tlcSet, index, value) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(IntT1(), a), BoolT1()) // (Int, a) => Bool
+        mkExRefApp(opsig, Seq(index, value))
+
+      case OperEx(TlcOper.colonGreater, key, value) =>
+        val a = varPool.fresh
+        val b = varPool.fresh
+        val opsig = OperT1(Seq(a, b), FunT1(a, b)) // (a, b) => (a -> b)
+        mkExRefApp(opsig, Seq(key, value))
+
+      case OperEx(TlcOper.atat, f1, f2) =>
+        val a = varPool.fresh
+        val b = varPool.fresh
+        val opsig = OperT1(Seq(FunT1(a, b), FunT1(a, b)), FunT1(a, b)) // (a -> b, a -> b) => (a -> b)
+        mkExRefApp(opsig, Seq(f1, f2))
+
+      case OperEx(TlcOper.permutations, set) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(SetT1(a)), SetT1(FunT1(a, a))) // Set(a) => Set(a -> a)
+        mkExRefApp(opsig, Seq(set))
+
+      case OperEx(TlcOper.sortSeq, seq, op) =>
+        val a = varPool.fresh
+        // (Seq(a), (<<a, b>> => Bool)) => Seq(a)
+        val opsig = OperT1(Seq(SeqT1(a), OperT1(Seq(TupT1(a, a)), BoolT1())), SeqT1(a))
+        mkExRefApp(opsig, Seq(seq, op))
+
+      case OperEx(TlcOper.randomElement, set) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(SetT1(a)), a) // Set(a) => a
+        mkExRefApp(opsig, Seq(set))
+
+      case OperEx(TlcOper.any) =>
+        // We are adding the signature of this operator, but it is pretty useless.
+        // The type checker will most probably complain about the type variable 'a'.
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(), a) // () => a
+        mkExRefApp(opsig, Seq())
+
+      case OperEx(TlcOper.tlcToString, value) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(a), StrT1()) // a => Str
+        mkExRefApp(opsig, Seq(value))
+
+      case OperEx(TlcOper.tlcEval, value) =>
+        val a = varPool.fresh
+        val opsig = OperT1(Seq(a), a) // a => a
+        mkExRefApp(opsig, Seq(value))
+
       // This should be unreachable
       case expr =>
         throw new IllegalArgumentException(s"Unknown TlaEx expression ${expr}")

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.io.annotations.StandardAnnotations
 import at.forsyte.apalache.io.annotations.store.{AnnotationStore, createAnnotationStore}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
-import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaFunOper, TypingOper}
+import at.forsyte.apalache.tla.lir.oper.{BmcOper, TlaFunOper, TlcOper, TypingOper}
 import at.forsyte.apalache.tla.lir.values.TlaReal
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.typecheck._
@@ -739,5 +739,103 @@ class TestToEtcExpr extends FunSuite with BeforeAndAfterEach with EtcBuilder {
     val oldTypeAnnotation = tla.enumSet(tla.intSet())
     val input = tla.withType(tla.name("e"), oldTypeAnnotation)
     assert(mkUniqName("e") == gen(input))
+  }
+
+  test("TLC!Print") {
+    val typ = parser("(Str, a) => Str")
+    val ex = OperEx(TlcOper.print, tla.name("text"), tla.name("x"))
+    val expected = mkAppByName(Seq(typ), "text", "x")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!PrintT") {
+    val typ = parser("Str => Bool")
+    val ex = OperEx(TlcOper.printT, tla.str("hello "))
+    val expected = mkAppByType(Seq(typ), StrT1())
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!Assert") {
+    val typ = parser("(a, Str) => Bool")
+    val ex = OperEx(TlcOper.assert, tla.name("x"), tla.name("y"))
+    val expected = mkAppByName(Seq(typ), "x", "y")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!JavaTime") {
+    val typ = parser("() => Int")
+    val ex = OperEx(TlcOper.javaTime)
+    val expected = mkAppByName(Seq(typ))
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!TLCGet") {
+    val typ = parser("Int => a")
+    val ex = OperEx(TlcOper.tlcGet, tla.int(3))
+    val expected = mkAppByType(Seq(typ), IntT1())
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!TLCSet") {
+    val typ = parser("(Int, a) => Bool")
+    val ex = OperEx(TlcOper.tlcSet, tla.name("x"), tla.name("y"))
+    val expected = mkAppByName(Seq(typ), "x", "y")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!:>") {
+    val typ = parser("(a, b) => (a -> b)")
+    val ex = OperEx(TlcOper.colonGreater, tla.name("x"), tla.name("y"))
+    val expected = mkAppByName(Seq(typ), "x", "y")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!@@") {
+    val typ = parser("(a -> b, a -> b) => (a -> b)")
+    val ex = OperEx(TlcOper.atat, tla.name("f"), tla.name("g"))
+    val expected = mkAppByName(Seq(typ), "f", "g")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!Permutations") {
+    val typ = parser("Set(a) => Set(a -> a)")
+    val ex = OperEx(TlcOper.permutations, tla.name("S"))
+    val expected = mkAppByName(Seq(typ), "S")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!SortSeq") {
+    val typ = parser("(Seq(a), (<<a, a>> => Bool)) => Seq(a)")
+    val ex = OperEx(TlcOper.sortSeq, tla.name("seq"), tla.name("op"))
+    val expected = mkAppByName(Seq(typ), "seq", "op")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!RandomElement") {
+    val typ = parser("Set(a) => a")
+    val ex = OperEx(TlcOper.randomElement, tla.name("S"))
+    val expected = mkAppByName(Seq(typ), "S")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!Any") {
+    val typ = parser("() => a")
+    val ex = OperEx(TlcOper.any)
+    val expected = mkAppByName(Seq(typ))
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!ToString") {
+    val typ = parser("a => Str")
+    val ex = OperEx(TlcOper.tlcToString, tla.name("x"))
+    val expected = mkAppByName(Seq(typ), "x")
+    assert(expected == gen(ex))
+  }
+
+  test("TLC!TLCEval") {
+    val typ = parser("a => a")
+    val ex = OperEx(TlcOper.tlcEval, tla.name("x"))
+    val expected = mkAppByName(Seq(typ), "x")
+    assert(expected == gen(ex))
   }
 }


### PR DESCRIPTION
This PR adds type signatures for the operators that are defined in the module [TLC](https://github.com/jameshfisher/tlaplus/blob/master/org.lamport.tla.toolbox/StandardModules/TLC.tla). Some of these signatures are pretty useless. For instance, `TLC!Any` has the type `() => a`, which does not help the type checker. Also, `TLC!Assert` does not have a well-defined type, so we label it with `(a, Str) => Bool`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
