### PR TITLE
add type tags to TlaDecl

### DIFF
--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>tla-pp</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>at.forsyte.apalache</groupId>
+            <artifactId>tla-types</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/ModuleAdapter.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/ModuleAdapter.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.assignments
 
-import at.forsyte.apalache.tla.lir.{FormalParam, TlaEx, TlaModule, TlaOperDecl}
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.typecheck.{OperT1, TlaType1}
 
 /**
  * Moving away from SpecWithTransitions ModuleManipulator allows us to re-insert special TlaEx
@@ -11,7 +12,13 @@ import at.forsyte.apalache.tla.lir.{FormalParam, TlaEx, TlaModule, TlaOperDecl}
  */
 object ModuleAdapter {
   def exprToOperDef(name: String, expr: TlaEx): TlaOperDecl = {
-    TlaOperDecl(name, List(), expr)
+    expr.typeTag match {
+      case Typed(tt: TlaType1) =>
+        TlaOperDecl(name, List(), expr)(Typed(OperT1(Seq(), tt)))
+
+      case _ =>
+        TlaOperDecl(name, List(), expr)(Untyped())
+    }
   }
 
   def exprsToOperDefs(operPrefix: String, transitions: Seq[TlaEx]): Seq[TlaOperDecl] =
@@ -28,19 +35,9 @@ object ModuleAdapter {
       _._2
     })
 
-  def optionalOperDecl(newOperName: String, optionalBody: Option[TlaEx]): Option[TlaOperDecl] =
-    optionalBody map { b =>
-      TlaOperDecl(newOperName, List.empty[FormalParam], b)
-    }
-
   def insertTransitions(module: TlaModule, transitionOperName: String, transitions: Seq[SymbTrans]): TlaModule = {
     new TlaModule(module.name, declsFromTransitions(transitionOperName, transitions) ++ module.declarations)
   }
-
-  def optionalInsertOperator(module: TlaModule, newOperName: String, optionalBody: Option[TlaEx]): TlaModule =
-    optionalOperDecl(newOperName, optionalBody) map { d =>
-      new TlaModule(module.name, d +: module.declarations)
-    } getOrElse module
 
   /**
    * After re-inserting the transitions into the spec as operators with special names,

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/AssumeTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/AssumeTranslator.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.TlaAssumeDecl
+import at.forsyte.apalache.tla.lir.{TlaAssumeDecl, Untyped}
 import tla2sany.semantic.AssumeNode
 
 class AssumeTranslator(
@@ -16,7 +16,7 @@ class AssumeTranslator(
           context,
           OutsideRecursion()
       ).translate(node.getAssume)
-    TlaAssumeDecl(body)
+    TlaAssumeDecl(body)(Untyped())
   }
 }
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ModuleTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/ModuleTranslator.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import tla2sany.semantic.{InstanceNode, ModuleNode, OpDefNode}
 
 import scala.collection.JavaConverters._
+import UntypedPredefs._
 
 /**
  * Translate a tla2tools ModuleNode to a TlaModule.

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/NullOpDefTranslator.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/NullOpDefTranslator.scala
@@ -14,7 +14,7 @@ class NullOpDefTranslator(sourceStore: SourceStore, context: Context) {
   def translate(node: OpDefNode): TlaOperDecl = {
     val params = node.getParams.toList map FormalParamTranslator().translate
     val nodeName = node.getName.toString.intern()
-    TlaOperDecl(nodeName, params, NullEx)
+    TlaOperDecl(nodeName, params, NullEx)(Untyped())
   }
 }
 

--- a/tla-import/src/test/scala/at/forsyte/apalache/io/TestPrettyWriterWithAnnotations.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/io/TestPrettyWriterWithAnnotations.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.io
 import at.forsyte.apalache.io.annotations.{Annotation, AnnotationBool, AnnotationStr, PrettyWriterWithAnnotations}
 import at.forsyte.apalache.io.annotations.store.createAnnotationStore
 import at.forsyte.apalache.tla.lir._
+import UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>tla-import</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>at.forsyte.apalache</groupId>
+            <artifactId>tla-types</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestCaching.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestCaching.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.pp
 
 import at.forsyte.apalache.tla.lir._
+import UntypedPredefs._
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
@@ -6,6 +6,7 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.{SimpleFormalParam, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaDecl.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaDecl.scala
@@ -6,7 +6,7 @@ package at.forsyte.apalache.tla.lir
  * TLA+ definitions, see Specifying Systems, Ch. 17.3. Unfortunately, there are
  * variable declarations and operator definitions...
  */
-abstract class TlaDecl extends Identifiable with Serializable {
+abstract class TlaDecl(implicit val typeTag: TypeTag) extends Identifiable with Serializable with TypeTagged[TlaDecl] {
   def name: String
 }
 
@@ -54,18 +54,24 @@ class TlaModule(val name: String, val declarations: Seq[TlaDecl]) extends Serial
 }
 
 /** a constant as defined by CONSTANT */
-case class TlaConstDecl(name: String) extends TlaDecl with Serializable
+case class TlaConstDecl(name: String)(implicit typeTag: TypeTag) extends TlaDecl with Serializable {
+  override def withType(newTypeTag: TypeTag): TlaDecl = TlaConstDecl(name)(newTypeTag)
+}
 
 /** a variable as defined by VARIABLE */
-case class TlaVarDecl(name: String) extends TlaDecl with Serializable
+case class TlaVarDecl(name: String)(implicit typeTag: TypeTag) extends TlaDecl with Serializable {
+  override def withType(newTypeTag: TypeTag): TlaDecl = TlaVarDecl(name)(newTypeTag)
+}
 
 /**
  * An assumption defined by ASSUME(...)
  *
  * @param body the assumption body
  */
-case class TlaAssumeDecl(body: TlaEx) extends TlaDecl with Serializable {
+case class TlaAssumeDecl(body: TlaEx)(implicit typeTag: TypeTag) extends TlaDecl with Serializable {
   val name: String = "ASSUME" + body.ID
+
+  override def withType(newTypeTag: TypeTag): TlaDecl = TlaAssumeDecl(body)(newTypeTag)
 }
 
 /**
@@ -81,7 +87,7 @@ case class TlaAssumeDecl(body: TlaEx) extends TlaDecl with Serializable {
  * @param formalParams formal parameters
  * @param body         operator definition, that is a TLA+ expression that captures the operator definition
  */
-case class TlaOperDecl(name: String, formalParams: List[FormalParam], var body: TlaEx)
+case class TlaOperDecl(name: String, formalParams: List[FormalParam], var body: TlaEx)(implicit typeTag: TypeTag)
     extends TlaDecl with Serializable {
 
   /**
@@ -93,11 +99,12 @@ case class TlaOperDecl(name: String, formalParams: List[FormalParam], var body: 
   def copy(
       name: String = this.name, formalParams: List[FormalParam] = this.formalParams, body: TlaEx = this.body
   ): TlaOperDecl = {
-    val ret = TlaOperDecl(name, formalParams, body)
+    val ret = TlaOperDecl(name, formalParams, body)(typeTag)
     ret.isRecursive = this.isRecursive
     ret
   }
 
+  override def withType(newTypeTag: TypeTag): TlaDecl = TlaOperDecl(name, formalParams, body)(newTypeTag)
 }
 
 /**
@@ -106,4 +113,6 @@ case class TlaOperDecl(name: String, formalParams: List[FormalParam], var body: 
  * @param name theorem name
  * @param body theorem statement
  */
-case class TlaTheoremDecl(name: String, body: TlaEx) extends TlaDecl
+case class TlaTheoremDecl(name: String, body: TlaEx)(implicit typeTag: TypeTag) extends TlaDecl {
+  override def withType(newTypeTag: TypeTag): TlaDecl = TlaTheoremDecl(name, body)(newTypeTag)
+}

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaEx.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaEx.scala
@@ -57,12 +57,6 @@ case class NameEx(name: String)(implicit typeTag: TypeTag) extends TlaEx with Se
 case class LetInEx(body: TlaEx, decls: TlaOperDecl*)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
   override def toSimpleString: String = s"LET ${decls.mkString(" ")} IN $body"
 
-  /**
-   * Make a shallow copy of the expression and set its type tag to a new value.
-   *
-   * @param newTypeTag a new type
-   * @return a shallow copy of TLA+ expression with the type tag set to newTypeTag
-   */
   override def withType(newTypeTag: TypeTag): TlaEx = LetInEx(body, decls: _*)(newTypeTag)
 }
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TypeTag.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TypeTag.scala
@@ -19,6 +19,27 @@ case class Untyped() extends TypeTag
 case class Typed[T](myType: T) extends TypeTag
 
 /**
+ * This trait defines the standard behavior of constructs that carry type tags.
+ *
+ * @tparam T type of the tagged object
+ */
+trait TypeTagged[T] {
+
+  /**
+   * A type tag of an object, e.g., of an expression or declaration.
+   */
+  val typeTag: TypeTag
+
+  /**
+   * Make a shallow copy of the object and set its type tag to a new value.
+   *
+   * @param newTypeTag a new type
+   * @return a shallow copy of TLA+ expression with the type tag set to newTypeTag
+   */
+  def withType(newTypeTag: TypeTag): T
+}
+
+/**
  * Default settings for the untyped language layer. To use the `Untyped()` tag, import the definitions from `UntypedPredefs`.
  */
 object UntypedPredefs {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/convenience/convenience.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/convenience/convenience.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.oper.{FixedArity, OperArity}
 
 /**
- * Convenient shortcuts and definitions. Import them, when needed.
+ * Convenient shortcuts and definitions, mostly used in tests. Import them, when needed.
  */
 package object convenience {
 
@@ -15,4 +15,42 @@ package object convenience {
   implicit def makeUID(id: Int): UID = UID(id)
 
   implicit def opArity(n: Int): OperArity = FixedArity(n)
+
+  trait TypeTaggedWithShortcuts[T] {
+
+    /**
+     * Produce a copy of the object with the type tag set to Untyped()
+     *
+     * @return a copy with the Untyped() tag
+     */
+    def asUntyped: T
+
+    /**
+     * Produce a copy of the object with the type tag set to Typed(tt)
+     *
+     * @param tt new type
+     * @return a copy with Typed(tt)
+     */
+    def asTyped[TypeT](tt: TypeT): T
+  }
+
+  implicit def typeTaggedToShortcuts[T](tagged: TypeTagged[T]): TypeTaggedWithShortcuts[T] = {
+    new TypeTaggedWithShortcuts[T] {
+
+      /**
+       * Produce a copy of the object with the type tag set to Untyped()
+       *
+       * @return a copy with the Untyped() tag
+       */
+      override def asUntyped: T = tagged.withType(Untyped())
+
+      /**
+       * Produce a copy of the object with the type tag set to Typed(tt)
+       *
+       * @param tt new type
+       * @return a copy with Typed(tt)
+       */
+      override def asTyped[TypeT](tt: TypeT): T = tagged.withType(Typed(tt))
+    }
+  }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
@@ -230,7 +230,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
 
       // Having computed the new names, we have to change the declarations and use the precomputed new names
       def xform: TlaOperDecl => TlaOperDecl =
-        tracker.trackOperDecl { case TlaOperDecl(n, ps, b) =>
+        tracker.trackOperDecl { case d @ TlaOperDecl(n, ps, b) =>
           TlaOperDecl(
               opersAndFParamsNameMap(n),
               ps map {
@@ -240,7 +240,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
               // We recurse over operator bodies, because newRenamed contains parameter
               // and operator renamings
               newRenaming(b)
-          )
+          )(d.typeTag)
         }
 
       val newDefs = defs map xform
@@ -277,7 +277,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
       val self = shiftCounters(offsets)
 
       def xform: TlaOperDecl => TlaOperDecl =
-        tracker.trackOperDecl { case TlaOperDecl(n, params, b) =>
+        tracker.trackOperDecl { case d @ TlaOperDecl(n, params, b) =>
           TlaOperDecl(
               offsetFn(n),
               params map {
@@ -285,7 +285,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
                 case OperFormalParam(p, a) => OperFormalParam(offsetFn(p), a)
               },
               self(b)
-          )
+          )(d.typeTag)
         }
 
       val newDefs = defs map xform

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ModuleByExTransformer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ModuleByExTransformer.scala
@@ -26,7 +26,7 @@ class ModuleByExTransformer(
         if (newBody.ID == body.ID) {
           d
         } else {
-          TlaAssumeDecl(newBody)
+          TlaAssumeDecl(newBody)(d.typeTag)
         }
 
       case d => d

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestAux.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestAux.scala
@@ -4,6 +4,8 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
+import UntypedPredefs._
+
 @RunWith(classOf[JUnitRunner])
 class TestAux extends FunSuite with TestingPredefs {
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestLirValues.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestLirValues.scala
@@ -5,6 +5,8 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
+import UntypedPredefs._
+
 /**
  * Tests for the low-level intermediate representation.
  */

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeclarationSorter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeclarationSorter.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir._
+import UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.Checkers


### PR DESCRIPTION
This is a step toward the integration of the type checker #521. This PR adds type tags to `TlaDecl`, similar to what we did with `TlaEx`. It includes structural changes to the code, which are not visible to the users.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
