### PR TITLE
Ground work for #521

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterKeraSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterKeraSet.scala
@@ -6,6 +6,8 @@ import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.pp.{Keramelizer, UniqueNameGenerator}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
 /**
  * Tests for the TLA+ operators that are deal with by rewriting into KerA+.
@@ -13,6 +15,7 @@ import at.forsyte.apalache.tla.pp.{Keramelizer, UniqueNameGenerator}
  *
  * @author Igor Konnov
  */
+@RunWith(classOf[JUnitRunner])
 class TestRewriterKeraSet extends RewriterBase with TestingPredefs {
   private var keramelizer = new Keramelizer(new UniqueNameGenerator, TrackerWithListeners())
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaDecl.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaDecl.scala
@@ -55,12 +55,12 @@ class TlaModule(val name: String, val declarations: Seq[TlaDecl]) extends Serial
 
 /** a constant as defined by CONSTANT */
 case class TlaConstDecl(name: String)(implicit typeTag: TypeTag) extends TlaDecl with Serializable {
-  override def withType(newTypeTag: TypeTag): TlaDecl = TlaConstDecl(name)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): TlaConstDecl = TlaConstDecl(name)(newTypeTag)
 }
 
 /** a variable as defined by VARIABLE */
 case class TlaVarDecl(name: String)(implicit typeTag: TypeTag) extends TlaDecl with Serializable {
-  override def withType(newTypeTag: TypeTag): TlaDecl = TlaVarDecl(name)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): TlaVarDecl = TlaVarDecl(name)(newTypeTag)
 }
 
 /**
@@ -71,7 +71,7 @@ case class TlaVarDecl(name: String)(implicit typeTag: TypeTag) extends TlaDecl w
 case class TlaAssumeDecl(body: TlaEx)(implicit typeTag: TypeTag) extends TlaDecl with Serializable {
   val name: String = "ASSUME" + body.ID
 
-  override def withType(newTypeTag: TypeTag): TlaDecl = TlaAssumeDecl(body)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): TlaAssumeDecl = TlaAssumeDecl(body)(newTypeTag)
 }
 
 /**
@@ -104,7 +104,7 @@ case class TlaOperDecl(name: String, formalParams: List[FormalParam], var body: 
     ret
   }
 
-  override def withType(newTypeTag: TypeTag): TlaDecl = TlaOperDecl(name, formalParams, body)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): TlaOperDecl = TlaOperDecl(name, formalParams, body)(newTypeTag)
 }
 
 /**
@@ -114,5 +114,5 @@ case class TlaOperDecl(name: String, formalParams: List[FormalParam], var body: 
  * @param body theorem statement
  */
 case class TlaTheoremDecl(name: String, body: TlaEx)(implicit typeTag: TypeTag) extends TlaDecl {
-  override def withType(newTypeTag: TypeTag): TlaDecl = TlaTheoremDecl(name, body)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): TlaTheoremDecl = TlaTheoremDecl(name, body)(newTypeTag)
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaEx.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaEx.scala
@@ -37,7 +37,7 @@ object NullEx extends TlaEx()(typeTag = Untyped()) with Serializable {
 case class ValEx(value: TlaValue)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
   override def toSimpleString: String = value.toString
 
-  override def withType(newTypeTag: TypeTag): TlaEx = ValEx(value)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): ValEx = ValEx(value)(newTypeTag)
 }
 
 /**
@@ -47,7 +47,7 @@ case class ValEx(value: TlaValue)(implicit typeTag: TypeTag) extends TlaEx with 
 case class NameEx(name: String)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
   override def toSimpleString: String = name
 
-  override def withType(newTypeTag: TypeTag): TlaEx = NameEx(name)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): NameEx = NameEx(name)(newTypeTag)
 }
 
 /*
@@ -57,7 +57,7 @@ case class NameEx(name: String)(implicit typeTag: TypeTag) extends TlaEx with Se
 case class LetInEx(body: TlaEx, decls: TlaOperDecl*)(implicit typeTag: TypeTag) extends TlaEx with Serializable {
   override def toSimpleString: String = s"LET ${decls.mkString(" ")} IN $body"
 
-  override def withType(newTypeTag: TypeTag): TlaEx = LetInEx(body, decls: _*)(newTypeTag)
+  override def withType(newTypeTag: TypeTag): LetInEx = LetInEx(body, decls: _*)(newTypeTag)
 }
 
 /**

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/DeepCopy.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/DeepCopy.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.{TlaDeclTransformation, TlaExTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
 
 /**
  * DeepCopy constructs a structurally identical copy of a given TlaEx or TlaDecl, with fresh unique IDs.
@@ -11,26 +10,26 @@ class DeepCopy(tracker: TransformationTracker) {
   def deepCopyDecl[T <: TlaDecl](decl: T): T = deepCopyDeclInternal(decl).asInstanceOf[T]
 
   private def deepCopyDeclInternal: TlaDeclTransformation = tracker.trackDecl {
-    case TlaAssumeDecl(bodyEx)      => TlaAssumeDecl(deepCopyEx(bodyEx))
-    case TlaTheoremDecl(name, body) => TlaTheoremDecl(name, deepCopyEx(body))
-    case TlaVarDecl(name)           => TlaVarDecl(name)
+    case d @ TlaAssumeDecl(bodyEx)      => TlaAssumeDecl(deepCopyEx(bodyEx))(d.typeTag)
+    case d @ TlaTheoremDecl(name, body) => TlaTheoremDecl(name, deepCopyEx(body))(d.typeTag)
+    case d @ TlaVarDecl(name)           => TlaVarDecl(name)(d.typeTag)
     case d @ TlaOperDecl(name, formalParams, body) =>
-      val decl = TlaOperDecl(name, formalParams, deepCopyEx(body))
+      val decl = TlaOperDecl(name, formalParams, deepCopyEx(body))(d.typeTag)
       decl.isRecursive = d.isRecursive
       decl
-    case TlaConstDecl(name) => TlaConstDecl(name)
+    case d @ TlaConstDecl(name) => TlaConstDecl(name)(d.typeTag)
   }
 
   def deepCopyEx[T <: TlaEx](ex: T): T = deepCopyExInternal(ex).asInstanceOf[T]
 
   private def deepCopyExInternal: TlaExTransformation = tracker.trackEx {
-    case NullEx    => NullEx
-    case ValEx(v)  => ValEx(v)
-    case NameEx(n) => NameEx(n)
-    case LetInEx(body, decls @ _*) =>
-      LetInEx(deepCopyEx(body), decls map deepCopyDecl: _*)
-    case OperEx(oper, args @ _*) =>
-      OperEx(oper, args map deepCopyEx: _*)
+    case NullEx        => NullEx
+    case e @ ValEx(v)  => ValEx(v)(e.typeTag)
+    case e @ NameEx(n) => NameEx(n)(e.typeTag)
+    case e @ LetInEx(body, decls @ _*) =>
+      LetInEx(deepCopyEx(body), decls map deepCopyDecl: _*)(e.typeTag)
+    case e @ OperEx(oper, args @ _*) =>
+      OperEx(oper, args map deepCopyEx: _*)(e.typeTag)
   }
 
   def deepCopyModule(module: TlaModule) = new TlaModule(module.name, module.declarations map deepCopyDecl)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -197,7 +197,8 @@ trait IrGenerators {
                   genLetInEx(genTlaEx(builtInOpers))(ctx), const(OperEx(oper, args: _*).withType(tt)))
             } else {
               // as above but no user-defined operators
-              oneOf(genValEx, genNameEx, const(OperEx(oper, args: _*).withType(tt)))
+              oneOf(genValEx, genNameEx, genLetInEx(genTlaEx(builtInOpers))(ctx),
+                  const(OperEx(oper, args: _*).withType(tt)))
             }
         } yield result
       }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -160,7 +160,9 @@ trait IrGenerators {
         ndefs <- choose(1, maxDefsPerLetIn)
         defs <- listOfN(ndefs, resize(size - 1, genTlaOperDecl(exGen)(ctx))) suchThat { ds =>
           // no new name is present in the context
-          ds.map(_.name).toSet.intersect(ctx.map(_.name).toSet).isEmpty
+          ds.map(_.name).toSet.intersect(ctx.map(_.name).toSet).isEmpty &&
+          // and all new names are mutually unique
+          ds.map(_.name).toSet.size == ds.size
         }
         body <- resize(size - 1, exGen(ctx ++ defs.map(d => UserOperSig(d.name, d.formalParams.length))))
         i <- arbitrary[Int]

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -194,7 +194,7 @@ trait IrGenerators {
               // a value, a name,
               // an application of a user-defined operator in the context, an application of a built-in operator
               oneOf(genValEx, genNameEx, genOperApply(genTlaEx(builtInOpers))(ctx),
-                  const(OperEx(oper, args: _*).withType(tt)))
+                  genLetInEx(genTlaEx(builtInOpers))(ctx), const(OperEx(oper, args: _*).withType(tt)))
             } else {
               // as above but no user-defined operators
               oneOf(genValEx, genNameEx, const(OperEx(oper, args: _*).withType(tt)))

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -77,6 +77,11 @@ trait IrGenerators {
       TlaSetOper.setminus, TlaSetOper.subseteq, TlaSetOper.subsetProper, TlaSetOper.supseteq, TlaSetOper.supsetProper,
       TlaSetOper.times, TlaSetOper.union)
 
+  def genTypeTag: Gen[TypeTag] = for {
+    i <- arbitrary[Int]
+    tt <- oneOf(Untyped(), Typed[Int](i))
+  } yield tt
+
   /**
    * Generate an integer literal.
    *
@@ -84,7 +89,7 @@ trait IrGenerators {
    */
   def genInt: Gen[ValEx] = for {
     i <- arbitrary[Int]
-    tt <- oneOf(Untyped(), Typed[Int](i))
+    tt <- genTypeTag
   } yield ValEx(TlaInt(BigInt(i))).withType(tt)
 
   /**
@@ -94,8 +99,7 @@ trait IrGenerators {
    */
   def genBool: Gen[ValEx] = for {
     b <- arbitrary[Boolean]
-    i <- arbitrary[Int]
-    tt <- oneOf(Untyped(), Typed[Int](i))
+    tt <- genTypeTag
   } yield ValEx(TlaBool(b)).withType(tt)
 
   /**
@@ -105,8 +109,7 @@ trait IrGenerators {
    */
   def genStr: Gen[ValEx] = for {
     s <- identifier
-    i <- arbitrary[Int]
-    tt <- oneOf(Untyped(), Typed[Int](i))
+    tt <- genTypeTag
   } yield ValEx(TlaStr(s)).withType(tt)
 
   /**
@@ -124,8 +127,7 @@ trait IrGenerators {
    */
   def genNameEx: Gen[NameEx] = for {
     s <- identifier
-    i <- arbitrary[Int]
-    tt <- oneOf(Untyped(), Typed[Int](i))
+    tt <- genTypeTag
   } yield NameEx(s).withType(tt)
 
   /**
@@ -140,8 +142,7 @@ trait IrGenerators {
       decl = ctx(declNo)
       argGen = resize(size - 1, exGen(ctx))
       args <- argsByArity(argGen)(FixedArity(decl.nparams))
-      i <- arbitrary[Int]
-      tt <- oneOf(Untyped(), Typed[Int](i))
+      tt <- genTypeTag
     } yield OperEx(TlaOper.apply, NameEx(decl.name) +: args: _*).withType(tt)
   }
 
@@ -165,8 +166,7 @@ trait IrGenerators {
           ds.map(_.name).toSet.size == ds.size
         }
         body <- resize(size - 1, exGen(ctx ++ defs.map(d => UserOperSig(d.name, d.formalParams.length))))
-        i <- arbitrary[Int]
-        tt <- oneOf(Untyped(), Typed[Int](i))
+        tt <- genTypeTag
       } yield LetInEx(body, defs: _*).withType(tt)
     }
   }
@@ -189,8 +189,7 @@ trait IrGenerators {
           argGen = resize(size - 1, genTlaEx(builtInOpers)(ctx))
           oper = builtInOpers(operNo)
           args <- argsByArity(argGen)(oper.arity)
-          i <- arbitrary[Int]
-          tt <- oneOf(Untyped(), Typed[Int](i))
+          tt <- genTypeTag
           result <-
             if (ctx.nonEmpty) {
               // a value, a name,
@@ -220,8 +219,7 @@ trait IrGenerators {
       body <- exGen(ctx)
       nparams <- choose(0, maxArgs)
       params <- listOfN(nparams, identifier)
-      i <- arbitrary[Int]
-      tt <- oneOf(Untyped(), Typed[Int](i))
+      tt <- genTypeTag
     } yield TlaOperDecl(name, params map (n => SimpleFormalParam(n)), body).withType(tt)
   }
 
@@ -234,8 +232,7 @@ trait IrGenerators {
   def genTlaAssumeDecl(exGen: Gen[TlaEx]): Gen[TlaAssumeDecl] = {
     for {
       ex <- exGen
-      i <- arbitrary[Int]
-      tt <- oneOf(Untyped(), Typed[Int](i))
+      tt <- genTypeTag
     } yield TlaAssumeDecl(ex).withType(tt)
   }
 
@@ -248,8 +245,7 @@ trait IrGenerators {
   def genTlaConstDecl(ctx: UserContext): Gen[TlaConstDecl] = {
     for {
       name <- identifier suchThat (n => ctx.forall(d => d.name != n))
-      i <- arbitrary[Int]
-      tt <- oneOf(Untyped(), Typed[Int](i))
+      tt <- genTypeTag
     } yield TlaConstDecl(name).withType(tt)
   }
 
@@ -262,8 +258,7 @@ trait IrGenerators {
   def genTlaVarDecl(ctx: UserContext): Gen[TlaVarDecl] = {
     for {
       name <- identifier suchThat (n => ctx.forall(d => d.name != n))
-      i <- arbitrary[Int]
-      tt <- oneOf(Untyped(), Typed[Int](i))
+      tt <- genTypeTag
     } yield TlaVarDecl(name).withType(tt)
   }
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
@@ -13,60 +13,6 @@ class TestTransformations extends FunSuite with TestingPredefs {
 
   import Builder._
 
-  private def depthOf(ex: TlaEx): Int = ex match {
-    case OperEx(oper, args @ _*) => 1 + (if (args.nonEmpty) (args map depthOf).max else 0)
-    case _                       => 1
-  }
-
-  test("Test Inline") {
-    val cDecl = declOp("C", plus(n_x, int(1)), SimpleFormalParam("x"))
-    val operDecls = Seq(
-        declOp("A", appOp(n_B)),
-        declOp("B", n_c),
-        cDecl
-    )
-
-    val bodies = BodyMapFactory.makeFromDecls(operDecls)
-
-    val transformation = InlinerOfUserOper(bodies, new IdleTracker())
-
-    val ex1 = n_B
-    val ex2 = appOp(n_B)
-    val ex3 = n_A
-    val ex4 = appOp(n_A)
-    val ex5 = or(eql(int(1), int(0)), ge(appDecl(cDecl, appOp(n_A)), int(0)))
-    val ex6 = letIn(
-        appOp(NameEx("X")),
-        declOp("X", appOp(NameEx("C"), n_p))
-    )
-
-    val expected1 = n_B // Operators need to be called with apply
-    val expected2 = n_c
-    val expected3 = n_A // Operators need to be called with apply
-    val expected4 = n_c
-    val expected5 = or(
-        eql(int(1), int(0)),
-        ge(plus(n_c, int(1)), int(0))
-    )
-    val expected6 = letIn(
-        appOp(NameEx("X")),
-        declOp("X", plus(n_p, int(1)))
-    )
-
-    val exs = Seq(ex1, ex2, ex3, ex4, ex5, ex6)
-    val expected = Seq(expected1, expected2, expected3, expected4, expected5, expected6)
-    val actual = exs map transformation
-
-    assert(expected == actual)
-
-    assertThrows[IllegalArgumentException] {
-      transformation(appOp(NameEx("C")))
-    }
-    assertThrows[IllegalArgumentException] {
-      transformation(appOp(NameEx("C"), n_a, n_b))
-    }
-  }
-
   test("Test Prime") {
     val vars: Set[String] = Set(
         "x",

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeclarationSorter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeclarationSorter.scala
@@ -1,11 +1,10 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.convenience._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir._
-import UntypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.prop.Checkers
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 @RunWith(classOf[JUnitRunner])

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeepCopy.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeepCopy.scala
@@ -30,7 +30,7 @@ class TestDeepCopy extends FunSuite with BeforeAndAfter with Checkers {
       equalExCopies(lbody, rbody) &&
         l.ID != r.ID &&
         l.typeTag == r.typeTag &&
-        ldefs.length != rdefs.length &&
+        ldefs.length == rdefs.length &&
         ldefs
           .zip(rdefs)
           .forall(equalDeclCopies.tupled)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeepCopy.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestDeepCopy.scala
@@ -1,0 +1,84 @@
+package at.forsyte.apalache.tla.lir.transformations.standard
+
+import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir._
+import org.scalacheck.Prop.forAll
+import org.scalatest.prop.Checkers
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+/**
+ * Tests for DeepCopy using Scalacheck.
+ *
+ * @author Igor Konnov
+ */
+class TestDeepCopy extends FunSuite with BeforeAndAfter with Checkers {
+  private def equalExCopies: (TlaEx, TlaEx) => Boolean = {
+    case (l @ ValEx(lval), r @ ValEx(rval)) =>
+      l.ID != r.ID && lval == rval && l.typeTag == r.typeTag
+
+    case (l @ NameEx(lname), r @ NameEx(rname)) =>
+      l.ID != r.ID && lname == rname && l.typeTag == r.typeTag
+
+    case (l @ OperEx(lop, largs @ _*), r @ OperEx(rop, rargs @ _*)) =>
+      l.ID != r.ID &&
+        lop == rop &&
+        l.typeTag == r.typeTag &&
+        largs.length == rargs.length &&
+        largs.zip(rargs).forall(equalExCopies.tupled)
+
+    case (l @ LetInEx(lbody, ldefs @ _*), r @ LetInEx(rbody, rdefs @ _*)) =>
+      equalExCopies(lbody, rbody) &&
+        l.ID != r.ID &&
+        l.typeTag == r.typeTag &&
+        ldefs.length != rdefs.length &&
+        ldefs
+          .zip(rdefs)
+          .forall(equalDeclCopies.tupled)
+
+    case _ => false
+  }
+
+  private def equalDeclCopies: (TlaDecl, TlaDecl) => Boolean = {
+    case (l @ TlaConstDecl(lname), r @ TlaConstDecl(rname)) =>
+      l.ID != r.ID && lname == rname && l.typeTag == r.typeTag
+
+    case (l @ TlaVarDecl(lname), r @ TlaVarDecl(rname)) =>
+      l.ID != r.ID && lname == rname && l.typeTag == r.typeTag
+
+    case (l @ TlaAssumeDecl(lbody), r @ TlaAssumeDecl(rbody)) =>
+      l.ID != r.ID && equalExCopies(lbody, rbody) && l.typeTag == r.typeTag
+
+    case (l @ TlaTheoremDecl(lname, lbody), r @ TlaTheoremDecl(rname, rbody)) =>
+      l.ID != r.ID &&
+        lname == rname &&
+        equalExCopies(lbody, rbody) &&
+        l.typeTag == r.typeTag
+
+    case (l @ TlaOperDecl(lname, lparams, lbody), r @ TlaOperDecl(rname, rparams, rbody)) =>
+      l.ID != r.ID &&
+        lname == rname &&
+        lparams == rparams &&
+        equalExCopies(lbody, rbody) &&
+        l.isRecursive == r.isRecursive &&
+        l.typeTag == r.typeTag
+
+    case _ => false
+  }
+
+  test("deep copy replicates expressions and declarations but not their identifiers") {
+    val gens = new IrGenerators {
+      override val maxArgs: Int = 10
+    }
+
+    val prop = {
+      def exGen(ctx: gens.UserContext) = gens.genTlaEx(gens.simpleOperators ++ gens.setOperators)(ctx)
+
+      forAll(gens.genTlaDecl(exGen)(gens.emptyContext)) { input =>
+        val output = DeepCopy(new IdleTracker()).deepCopyDecl(input)
+        equalDeclCopies(input, output)
+      }
+    }
+
+    check(prop, minSuccessful(1000), sizeRange(10))
+  }
+}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestFlatLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestFlatLanguagePred.scala
@@ -2,7 +2,10 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir.{SimpleFormalParam, TlaModule}
 import at.forsyte.apalache.tla.lir.convenience._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class TestFlatLanguagePred extends LanguagePredTestSuite {
   private val pred = new FlatLanguagePred
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestIncrementalRenaming.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestIncrementalRenaming.scala
@@ -3,10 +3,13 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaFunOper, TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import org.junit.runner.RunWith
 import org.scalacheck.Prop.{falsified, forAll, passed}
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.Checkers
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
+@RunWith(classOf[JUnitRunner])
 class TestIncrementalRenaming extends FunSuite with BeforeAndAfter with Checkers {
   type CounterMap = Map[String, Int]
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestIncrementalRenamingScalacheck.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestIncrementalRenamingScalacheck.scala
@@ -10,7 +10,7 @@ import org.scalatest.prop.Checkers
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 @RunWith(classOf[JUnitRunner])
-class TestIncrementalRenaming extends FunSuite with BeforeAndAfter with Checkers {
+class TestIncrementalRenamingScalacheck extends FunSuite with BeforeAndAfter with Checkers {
   type CounterMap = Map[String, Int]
 
   private val emptyCounters: CounterMap = Map.empty
@@ -40,7 +40,7 @@ class TestIncrementalRenaming extends FunSuite with BeforeAndAfter with Checkers
       }
     }
 
-    check(prop, minSuccessful(10000), sizeRange(10))
+    check(prop, minSuccessful(2500), sizeRange(8))
   }
 
   // Collect a multiset of defined names. Every name is assigned the number of times it has been defined.

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestInlinerofUserOper.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestInlinerofUserOper.scala
@@ -1,0 +1,66 @@
+package at.forsyte.apalache.tla.lir.transformations.standard
+
+import at.forsyte.apalache.tla.lir.{NameEx, SimpleFormalParam, TestingPredefs}
+import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
+import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.transformations.standard._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.prop.Checkers
+
+@RunWith(classOf[JUnitRunner])
+class TestInlinerofUserOper extends FunSuite with TestingPredefs with Checkers {
+
+  import at.forsyte.apalache.tla.lir.Builder._
+
+  test("Test Inline") {
+    val cDecl = declOp("C", plus(n_x, int(1)), SimpleFormalParam("x"))
+    val operDecls = Seq(
+        declOp("A", appOp(n_B)),
+        declOp("B", n_c),
+        cDecl
+    )
+
+    val bodies = BodyMapFactory.makeFromDecls(operDecls)
+
+    val transformation = InlinerOfUserOper(bodies, new IdleTracker())
+
+    val ex1 = n_B
+    val ex2 = appOp(n_B)
+    val ex3 = n_A
+    val ex4 = appOp(n_A)
+    val ex5 = or(eql(int(1), int(0)), ge(appDecl(cDecl, appOp(n_A)), int(0)))
+    val ex6 = letIn(
+        appOp(NameEx("X")),
+        declOp("X", appOp(NameEx("C"), n_p))
+    )
+
+    val expected1 = n_B // Operators need to be called with apply
+    val expected2 = n_c
+    val expected3 = n_A // Operators need to be called with apply
+    val expected4 = n_c
+    val expected5 = or(
+        eql(int(1), int(0)),
+        ge(plus(n_c, int(1)), int(0))
+    )
+    val expected6 = letIn(
+        appOp(NameEx("X")),
+        declOp("X", plus(n_p, int(1)))
+    )
+
+    val exs = Seq(ex1, ex2, ex3, ex4, ex5, ex6)
+    val expected = Seq(expected1, expected2, expected3, expected4, expected5, expected6)
+    val actual = exs map transformation
+
+    assert(expected == actual)
+
+    assertThrows[IllegalArgumentException] {
+      transformation(appOp(NameEx("C")))
+    }
+    assertThrows[IllegalArgumentException] {
+      transformation(appOp(NameEx("C"), n_a, n_b))
+    }
+  }
+}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
@@ -5,7 +5,10 @@ import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlcOper
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.UntypedPredefs.untyped
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class TestKeraLanguagePred extends LanguagePredTestSuite {
   private val pred = new KeraLanguagePred
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestPrimePropagation.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestPrimePropagation.scala
@@ -3,16 +3,19 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx, IrGenerators, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{IrGenerators, LetInEx, NameEx, OperEx, TlaEx, TlaOperDecl}
 import org.scalacheck.Prop
 import org.scalacheck.Prop.{falsified, forAll, passed}
 import org.scalatest.prop.Checkers
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 /**
  * Tests of PrimePropagation.
  */
+@RunWith(classOf[JUnitRunner])
 class TestPrimePropagation extends FunSuite with BeforeAndAfter with Checkers {
 
   import tla._


### PR DESCRIPTION
More ground work towards integration of the new type checker:

1. `DeepCopy` is now copying types.
2. Add `TestDeepCopy` to test that `DeepCopy` does a complete copy, including types, but does not copy the identifiers.
3. `IrGenerators` are now generating tag types: either `Untyped()` or `Typed[Int](i)` for a random number `i`.
3. Move the test (yep, the only one!) for `InlinerOfUserOper` to its own class.
4. Add missing annotation `@RunWith(classOf[JUnitRunner])` to several tests. They were not running automatically!

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
