### PR TITLE
Add instructions to release PRs

### DIFF
--- a/script/release-prepare.sh
+++ b/script/release-prepare.sh
@@ -65,9 +65,26 @@ body=$(cat "$RELEASE_NOTES")
 # Bump the version
 "$DIR"/version-bump.sh
 
+instructions="
+# Reviewer instructions
+
+- Check the changelog to ensure the version increment is consistent with https://semver.org/.
+  - If a different version should be released, follow [the instructions](https://github.com/informalsystems/apalache/blob/unstable/CONTRIBUTING.md#via-github).
+- Review the changeset as a sanity check.
+- Approve the PR, if it pases muster.
+- **Merge** this branch (do not squash or rebase), but **DO NOT DELETE THE BRANCH**.
+- After the release has been published to github, delete this branch.
+
+---
+
+# Release notes
+
+"
+
 # Open a pull request for the release
 # See https://hub.github.com/hub-pull-request.1.html
 hub pull-request \
     --push \
+    --message="$instructions" \
     --message="$commit_msg" --message="$body" \
     --base="unstable"


### PR DESCRIPTION
Last week there was some trouble with the release process. This adds
instructions to the release PRs to reduce the chance of error (as a stop
gap to improved automation).

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [ ] ~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~
- [x] Documentation added for any new functionality
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~