### PR TITLE
inlining nullary operators

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Changes
+
+* Nullary operators are now inlined as all other operators, see #620

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -56,7 +56,7 @@ class InlinePassImpl @Inject() (val options: PassOptions, gen: UniqueNameGenerat
     val transformationSequence =
       List(
           InlinerOfUserOper(defBodyMap, tracker),
-          LetInExpander(tracker, keepNullary = true),
+          LetInExpander(tracker, keepNullary = false),
           // the second pass of Inliner may be needed, when the higher-order operators were inlined by LetInExpander
           InlinerOfUserOper(defBodyMap, tracker)
       ) ///


### PR DESCRIPTION
This PR forces the inliner to inline nullary operators too. Although I like nullary operators a lot, they are in conflict with the preprocessing code. It often happens that the optimizers cannot rewrite expressions because they are partially hidden in a LET-definition.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
