### PR TITLE
Fix the release PR title

### DIFF
--- a/script/release-prepare.sh
+++ b/script/release-prepare.sh
@@ -85,6 +85,7 @@ instructions="
 # See https://hub.github.com/hub-pull-request.1.html
 hub pull-request \
     --push \
+    --message="$commit_msg" \
     --message="$instructions" \
-    --message="$commit_msg" --message="$body" \
+    --message="$body" \
     --base="unstable"


### PR DESCRIPTION
Follow up to #612

The wrong phrase ended up as the title of release PRs. The first
`--message` argument given to `hub` will end up as the title of the PR,
which should be the commit. This is change returns the commit message of
the release commit to that position, as intended.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~~Tests added for any new code~~
- [ ] ~~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~~
- [ ] ~~Documentation added for any new functionality~~
- [ ] ~~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~~