### PR TITLE
Fix link to HOWTO's

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
 
 # HOWTOs
 
+- [Contents](./HOWTOs/index.md)
 - [How to write type annotations](./HOWTOs/howto-write-type-annotations.md)
 
 # TLA+ Language Manual for Engineers


### PR DESCRIPTION
Followup to #571, which added a link to HOWTOs/index.md but didn't
include that page in the summary, resulting in a 404.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~~Tests added for any new code~~
- [ ] ~~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~~
- [ ] ~~Documentation added for any new functionality~~
- [ ] ~~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~~