### PR TITLE
One more step to #521

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Features
 
 * Type checker: tagging all expressions with the reconstructed types, see #608
+* Type checker: experimental option `check --with-snowcat`, see #632

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -169,6 +169,10 @@ object Tool extends App with LazyLogging {
     executor.options.set("checker.discardDisabled", check.discardDisabled)
     executor.options.set("checker.noDeadlocks", check.noDeadlocks)
     executor.options.set("checker.algo", check.algo)
+    // this option enables the new type checker in the pipeline
+    executor.options.set("typechecker.snowcatOn", check.withSnowcat)
+    // for now, enable polymorphic types. We probably want to disable this option for the type checker
+    executor.options.set("typechecker.inferPoly", true)
 
     val result = executor.run()
     if (result.isDefined) {
@@ -184,6 +188,8 @@ object Tool extends App with LazyLogging {
     executor.options.set("io.outdir", createOutputDir())
     executor.options.set("parser.filename", typecheck.file.getAbsolutePath)
     executor.options.set("typechecker.inferPoly", typecheck.inferPoly)
+    // always use Snowcat in the type checker
+    executor.options.set("typechecker.snowcatOn", true)
 
     executor.run() match {
       case None    => logger.info("Type checker [FAILED]")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -43,5 +43,5 @@ class CheckCmd extends Command(name = "check", description = "Check a TLA+ speci
   var noDeadlocks: Boolean =
     opt[Boolean](name = "no-deadlock", default = true, description = "do not check for deadlocks, default: true")
   var withSnowcat: Boolean =
-    opt[Boolean](name = "with-snowcat", default = true, description = "use the new type checker Snowcat")
+    opt[Boolean](name = "with-snowcat", default = false, description = "use the new type checker Snowcat")
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -42,4 +42,6 @@ class CheckCmd extends Command(name = "check", description = "Check a TLA+ speci
         "pre-check, whether a transition is disabled, and discard it, to make SMT queries smaller, default: true")
   var noDeadlocks: Boolean =
     opt[Boolean](name = "no-deadlock", default = true, description = "do not check for deadlocks, default: true")
+  var withSnowcat: Boolean =
+    opt[Boolean](name = "with-snowcat", default = true, description = "use the new type checker Snowcat")
 }

--- a/test/tla/Bug20190118.tla
+++ b/test/tla/Bug20190118.tla
@@ -12,10 +12,13 @@ MT == [type |-> STRING, rm |-> STRING]
 (* END OF BMCMT extensions *)
 
 VARIABLES
+  \* @type: Str;
   rmState,       \* $rmState[rm]$ is the state of resource manager RM.
+  \* @type: Set(Str);
   tmPrepared,    \* The set of RMs from which the TM has received $"Prepared"$
                  \* messages.
-  msgs           
+  \* @type: Set([type: Str, rm: Str]);
+  msgs
 
 Message ==
   {[type |-> t, rm |-> r]: t \in {"Prepared"}, r \in RM }

--- a/test/tla/Bug20201118.tla
+++ b/test/tla/Bug20201118.tla
@@ -1,6 +1,11 @@
 ------------ MODULE Bug20201118 ---------------------------
 EXTENDS Integers
-VARIABLES p, error
+
+VARIABLES
+    \* @type: [sender: Str, data: [amount: Int]];
+    p,
+    \* @type: Bool;
+    error
 
 AccountIds == { "", "A", "B" }
 
@@ -13,10 +18,12 @@ Packets == [
   data: Data
 ]
 
+\* @type: [sender: Str, data: [amount: Int]] => Bool;
 WellFormed(packet) ==
   /\ packet.sender /= ""
   /\ packet.data.amount > 0
 
+\* @type: [sender: Str, data: [amount: Int]] => Bool;
 Pre(packet) ==
   LET data == packet.data IN
   WellFormed(packet)

--- a/test/tla/Fix333.tla
+++ b/test/tla/Fix333.tla
@@ -1,5 +1,7 @@
 ------------------------- MODULE Fix333 -----------------------------------
-VARIABLES error
+VARIABLES
+    \* @type: Bool;
+    error
 
 Init ==
     error = FALSE

--- a/test/tla/Fix365_ExistsSubset.tla
+++ b/test/tla/Fix365_ExistsSubset.tla
@@ -1,7 +1,9 @@
 --------------------- MODULE Fix365_ExistsSubset ------------------------------
 EXTENDS Integers, FiniteSets
 
-VARIABLE S
+VARIABLE
+    \* @type: Set(Str);
+    S
 
 Init ==
     S = {"a", "b", "c"}

--- a/test/tla/Fix365_ExistsSubset2.tla
+++ b/test/tla/Fix365_ExistsSubset2.tla
@@ -3,7 +3,9 @@ EXTENDS Integers, FiniteSets
 
 Rounds == 0..2
 
-VARIABLE msgs
+VARIABLE
+    \* @type: Int -> Set(Str);
+    msgs
 
 Init ==
     msgs \in [Rounds -> SUBSET {"a", "b", "c"}]

--- a/test/tla/Fix365_ExistsSubset3.tla
+++ b/test/tla/Fix365_ExistsSubset3.tla
@@ -8,7 +8,9 @@ a <: b == a
 Proc == {"p1", "p2"}
 Rounds == { 0, 1, 2 }
 
-VARIABLE msgs
+VARIABLE
+    \* @type: Set([src: Str, r: Int]);
+    msgs
 
 MT == [ src |-> STRING, r |-> Int]
 
@@ -22,7 +24,8 @@ Init ==
 
 Next ==
     \* the second ingredient of the bug
-    LET Y == { m.src: m \in msgs } IN
+    LET \* @type: Set(Str);
+        Y == { m.src: m \in msgs } IN
     \* the third ingredient of the bug
     /\ msgs /= {} <: {MT}
     /\ UNCHANGED msgs

--- a/test/tla/Fix531.tla
+++ b/test/tla/Fix531.tla
@@ -1,7 +1,9 @@
 -------------------------------- MODULE Fix531 --------------------------------
 EXTENDS Integers
 
-VARIABLE f
+VARIABLE
+    \* @type: <<Int, Int>> -> Int;
+    f
 
 Init ==
     f = [<<a, b>> \in { <<1, 3>>, <<2, 4>> } |-> a + b]

--- a/test/tla/SafeMath.tla
+++ b/test/tla/SafeMath.tla
@@ -21,7 +21,17 @@ BITWIDTH == 256
 POWER == 2^BITWIDTH
 MAX_UNSIGNED == (2^BITWIDTH) - 1
 
-VARIABLE opcode, arg1, arg2, res, is_error
+VARIABLE
+    \* @type: Str;
+    opcode,
+    \* @type: Int;
+    arg1,
+    \* @type: Int;
+    arg2,
+    \* @type: Int;
+    res,
+    \* @type: Bool;
+    is_error
 
 vars == <<opcode, arg1, arg2, res, is_error>>
 
@@ -62,7 +72,8 @@ TestTry(code, Op(_, _)) ==
     \E a, b \in Int:
         /\ InRange(a)
         /\ InRange(b)
-        /\ LET flag_and_c == Op(a, b) IN
+        /\ LET \* @type: <<Bool, Int>>;
+               flag_and_c == Op(a, b) IN
             /\ opcode' = code
             /\ arg1' = a
             /\ arg2' = b

--- a/test/tla/UnchangedExpr471.tla
+++ b/test/tla/UnchangedExpr471.tla
@@ -4,9 +4,15 @@
  *)
 EXTENDS Integers
 
-CONSTANT N
+CONSTANT
+    \* @type: Int;
+    N
 
-VARIABLES f, i
+VARIABLES
+    \* @type: Int -> Int;
+    f,
+    \* @type: Int;
+    i
 
 ConstInit ==
     N' = 3

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -148,7 +148,7 @@ EXITCODE: OK
 #### check factorization find a counterexample
 
 ```sh
-$ apalache-mc check --length=2 --inv=Inv factorization.tla | sed 's/I@.*//'
+$ apalache-mc check --length=2 --inv=Inv --with-snowcat factorization.tla | sed 's/I@.*//'
 ...
 The outcome is: Error
 Checker has found an error
@@ -158,7 +158,7 @@ Checker has found an error
 ### check Fix531.tla reports no error: regression for issue 531
 
 ```sh
-$ apalache-mc check --length=1 Fix531.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --with-snowcat Fix531.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -167,7 +167,7 @@ The outcome is: NoError
 ### check UnchangedExpr471.tla reports no error: regression for issue 471
 
 ```sh
-$ apalache-mc check --cinit=ConstInit --length=1 UnchangedExpr471.tla | sed 's/I@.*//'
+$ apalache-mc check --cinit=ConstInit --length=1 --with-snowcat UnchangedExpr471.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -185,7 +185,7 @@ The outcome is: NoError
 ### check InvSub for SafeMath reports no error: regression for issue 450
 
 ```sh
-$ apalache-mc check --length=1 --inv=InvSub SafeMath.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --inv=InvSub --with-snowcat SafeMath.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -194,7 +194,7 @@ The outcome is: NoError
 ### check InvAdd for SafeMath reports no error: regression for issue 450
 
 ```sh
-$ apalache-mc check --length=1 --inv=InvAdd SafeMath.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --inv=InvAdd --with-snowcat SafeMath.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -203,7 +203,7 @@ The outcome is: NoError
 ### check Fix365_ExistsSubset succeeds: regression for issue 365
 
 ```sh
-$ apalache-mc check --length=10 Fix365_ExistsSubset.tla | sed 's/I@.*//'
+$ apalache-mc check --length=10 --with-snowcat Fix365_ExistsSubset.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -212,7 +212,7 @@ The outcome is: NoError
 ### check Fix365_ExistsSubset2 succeeds: regression for issue 365
 
 ```sh
-$ apalache-mc check --length=10 Fix365_ExistsSubset2.tla | sed 's/I@.*//'
+$ apalache-mc check --length=10 --with-snowcat Fix365_ExistsSubset2.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -221,7 +221,7 @@ The outcome is: NoError
 ### check Fix365_ExistsSubset3 succeeds: regression for issue 365
 
 ```sh
-$ apalache-mc check --length=10 Fix365_ExistsSubset3.tla | sed 's/I@.*//'
+$ apalache-mc check --length=10 --with-snowcat Fix365_ExistsSubset3.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -230,7 +230,7 @@ The outcome is: NoError
 ### check Bug20201118 succeeds: regression for issue 333
 
 ```sh
-$ apalache-mc check --length=10 --init=Init --next=Next --inv=Inv Bug20201118.tla | sed 's/I@.*//'
+$ apalache-mc check --length=10 --init=Init --next=Next --inv=Inv --with-snowcat Bug20201118.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -239,7 +239,7 @@ The outcome is: NoError
 ### check Fix333 succeeds: another regression for issue 333
 
 ```sh
-$ apalache-mc check --length=2 --init=Init --next=Next --inv=Inv Fix333.tla | sed 's/I@.*//'
+$ apalache-mc check --length=2 --init=Init --next=Next --inv=Inv --with-snowcat Fix333.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -927,7 +927,7 @@ Type checker [OK]
 ```sh
 $ apalache-mc typecheck CarTalkPuzzleTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -944,7 +944,7 @@ This test is broken until issue #617] is fixed.
 ```sh
 $ apalache-mc typecheck CigaretteSmokersTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
 Unhandled exception
 ...
@@ -955,7 +955,7 @@ Unhandled exception
 ```sh
 $ apalache-mc typecheck GameOfLifeTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -970,7 +970,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck MissionariesAndCannibalsTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -985,7 +985,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck PrisonersTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1003,7 +1003,7 @@ This test should now pass.
 ```sh
 $ apalache-mc typecheck QueensTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1018,7 +1018,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck SlidingPuzzlesTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1033,7 +1033,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck TwoPhaseTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1048,7 +1048,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck FunctionsTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1063,7 +1063,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck FiniteSetsExtTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1090,7 +1090,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck HourClockTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1117,7 +1117,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck ChannelTyped.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1132,7 +1132,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck PascalTriangle.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1147,7 +1147,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck AnnotationsAndInstances592.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed
@@ -1162,7 +1162,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck AnnotationsAndSubstitutions596.tla | sed 's/[IEW]@.*//'
 ...
-PASS #1: TypeChecker
+PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.
  > Your types are great!
  > All expressions are typed

--- a/test/tla/factorization.tla
+++ b/test/tla/factorization.tla
@@ -6,7 +6,13 @@
 
 EXTENDS Integers
 
-VARIABLE m, n, answer
+VARIABLE
+    \* @type: Int;
+    m,
+    \* @type: Int;
+    n,
+    \* @type: Bool;
+    answer
 
 Init ==
     m = 0 /\ n = 0 /\ answer = FALSE

--- a/test/tla/mis.tla
+++ b/test/tla/mis.tla
@@ -7,7 +7,21 @@ Nodes == 1..N
 
 a <: b == a \* type annotations
 
-VARIABLES Nb, round, val, awake, rem_nbrs, status, msgs
+VARIABLES
+    \* @type: Set(<<Int, Int>>);
+    Nb,
+    \* @type: Int;
+    round,
+    \* @type: Int -> Int;
+    val,
+    \* @type: Int -> Bool;
+    awake,
+    \* @type: Int -> Int;
+    rem_nbrs,
+    \* @type: Int -> Str;
+    status,
+    \* @type: [type: Str, src: Int, val: Int];
+    msgs
 
 Pred(n) == IF n > 1 THEN n - 1 ELSE N
 Succ(n) == IF n < N THEN n + 1 ELSE 1

--- a/test/tla/y2k.tla
+++ b/test/tla/y2k.tla
@@ -16,13 +16,20 @@
 
 EXTENDS Integers
  
-CONSTANT BIRTH_YEAR,    \* the year to start with, between 0 and 99
-         LICENSE_AGE    \* the minimum age to obtain a license
+CONSTANT
+    \* @type: Int;
+    BIRTH_YEAR, \* the year to start with, between 0 and 99
+    \* @type: Int;
+    LICENSE_AGE    \* the minimum age to obtain a license
          
 ASSUME(BIRTH_YEAR \in 0..99)              
 ASSUME(LICENSE_AGE \in 1..99)              
  
-VARIABLE year, hasLicense
+VARIABLE
+    \* @type: Int;
+    year,
+    \* @type: Bool;
+    hasLicense
 
 Age == year - BIRTH_YEAR 
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -9,7 +9,9 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.{LanguagePredError, MalformedTlaError, OperEx, UID}
 import at.forsyte.apalache.tla.pp.{ConfigurationError, IrrecoverablePreprocessingError, NotInKeraError, TlaInputError}
+import at.forsyte.apalache.tla.typecheck.{TypingException, TypingInputException}
 import com.typesafe.scalalogging.LazyLogging
+
 import javax.inject.{Inject, Singleton}
 
 /**
@@ -51,6 +53,12 @@ class CheckerExceptionAdapter @Inject() (sourceStore: SourceStore, changeListene
 
     case err: NotInKeraError =>
       NormalErrorMessage("%s: Input error (see the manual): %s".format(findLoc(err.causeExpr.ID), err.getMessage))
+
+    case err: TypingInputException =>
+      NormalErrorMessage("Typing input error: " + err.getMessage)
+
+    case err: TypingException =>
+      FailureMessage("Type checker error: " + err.getMessage)
 
     // tool failures
     case err: IrrecoverablePreprocessingError =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/PostTypeCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/PostTypeCheckerPassImpl.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.bmcmt.passes
 import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
 import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.typecheck.passes.EtcTypeCheckerPassImpl
 import com.google.inject.Inject
@@ -20,9 +21,11 @@ import com.typesafe.scalalogging.LazyLogging
  * @param annotationStore annotations store
  * @param nextPass        next pass to be used
  */
-class PostTypeCheckerPassImpl @Inject() (options: PassOptions, sourceStore: SourceStore, tracker: TransformationTracker,
-    annotationStore: AnnotationStore, @Named("AfterPostTypeChecker") nextPass: Pass with TlaModuleMixin)
-    extends EtcTypeCheckerPassImpl(options, sourceStore, tracker, annotationStore, nextPass) with LazyLogging {
+class PostTypeCheckerPassImpl @Inject() (options: PassOptions, sourceStore: SourceStore, changeListener: ChangeListener,
+    tracker: TransformationTracker, annotationStore: AnnotationStore,
+    @Named("AfterPostTypeChecker") nextPass: Pass with TlaModuleMixin)
+    extends EtcTypeCheckerPassImpl(options, sourceStore, changeListener, tracker, annotationStore, nextPass)
+    with LazyLogging {
 
   override def name: String = "PostTypeCheckerSnowcat"
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/PostTypeCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/PostTypeCheckerPassImpl.scala
@@ -1,0 +1,28 @@
+package at.forsyte.apalache.tla.bmcmt.passes
+
+import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
+import at.forsyte.apalache.io.annotations.store.AnnotationStore
+import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
+import at.forsyte.apalache.tla.typecheck.passes.EtcTypeCheckerPassImpl
+import com.google.inject.Inject
+import com.google.inject.name.Named
+import com.typesafe.scalalogging.LazyLogging
+
+/**
+ * A copy of EtcTypeCheckerPassImpl that we run after all preprocessing steps.
+ * We introduce one more class, as otherwise Google Guice would not let us to use the same pass in the different
+ * parts of the pipeline.
+ *
+ * @param options         options
+ * @param sourceStore     source store
+ * @param tracker         transformation tracker
+ * @param annotationStore annotations store
+ * @param nextPass        next pass to be used
+ */
+class PostTypeCheckerPassImpl @Inject() (options: PassOptions, sourceStore: SourceStore, tracker: TransformationTracker,
+    annotationStore: AnnotationStore, @Named("AfterPostTypeChecker") nextPass: Pass with TlaModuleMixin)
+    extends EtcTypeCheckerPassImpl(options, sourceStore, tracker, annotationStore, nextPass) with LazyLogging {
+
+  override def name: String = "PostTypeCheckerSnowcat"
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -782,6 +782,34 @@ class ToEtcExpr(annotationStore: AnnotationStore, varPool: TypeVarPool) extends 
         val opsig = OperT1(Seq(FunT1(IntT1(), a), IntT1()), SeqT1(a))
         mkExRefApp(opsig, Seq(fun, len))
 
+      case OperEx(BmcOper.assign, lhs, rhs) =>
+        val a = varPool.fresh
+        // (a, a) => Bool
+        val opsig = OperT1(Seq(a, a), BoolT1())
+        mkExRefApp(opsig, Seq(lhs, rhs))
+
+      case OperEx(BmcOper.expand, set) =>
+        val a = varPool.fresh
+        // a => Bool
+        val opsig = OperT1(Seq(a), a)
+        mkExRefApp(opsig, Seq(set))
+
+      case OperEx(BmcOper.skolem, predicate) =>
+        // Bool => Bool
+        val opsig = OperT1(Seq(BoolT1()), BoolT1())
+        mkExRefApp(opsig, Seq(predicate))
+
+      case OperEx(BmcOper.constCard, predicate) =>
+        // Bool => Bool
+        val opsig = OperT1(Seq(BoolT1()), BoolT1())
+        mkExRefApp(opsig, Seq(predicate))
+
+      case OperEx(BmcOper.distinct, args @ _*) =>
+        val a = varPool.fresh
+        // (a, ..., a) => Bool
+        val opsig = OperT1(args.map(_ => a), BoolT1())
+        mkExRefApp(opsig, args)
+
       //******************************************** MISC **************************************************
       case OperEx(BmcOper.withType, lhs, _) =>
         // Met an old type annotation. Warn the user and ignore the annotation.

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -100,10 +100,10 @@ class ToEtcExpr(annotationStore: AnnotationStore, varPool: TypeVarPool) extends 
         findAnnotation(annotationStore, decl.ID, StandardAnnotations.TYPE) map {
           case Annotation(StandardAnnotations.TYPE, AnnotationStr(annotationText)) =>
             parseType(decl.name, annotationText)
-        }
 
-      case a =>
-        throw new TypingInputException(s"Unexpected annotation of ${decl.name}: $a")
+          case a =>
+            throw new TypingInputException(s"Unexpected annotation of ${decl.name}: $a")
+        }
     }
   }
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.infra.passes.{Pass, PassOptions, TlaModuleMixin}
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
-import at.forsyte.apalache.tla.lir.{TypeTag, UID, Untyped}
+import at.forsyte.apalache.tla.lir.{TlaModule, TypeTag, UID, Untyped}
 import at.forsyte.apalache.tla.typecheck.TypeCheckerTool
 import com.google.inject.Inject
 import com.google.inject.name.Named
@@ -15,12 +15,14 @@ class EtcTypeCheckerPassImpl @Inject() (val options: PassOptions, val sourceStor
     @Named("AfterTypeChecker") val nextPass: Pass with TlaModuleMixin)
     extends EtcTypeCheckerPass with LazyLogging {
 
+  private var outputTlaModule: Option[TlaModule] = None
+
   /**
    * The name of the pass
    *
    * @return the name associated with the pass
    */
-  override def name: String = "TypeChecker"
+  override def name: String = "TypeCheckerSnowcat"
 
   /**
    * Run the pass.
@@ -28,7 +30,14 @@ class EtcTypeCheckerPassImpl @Inject() (val options: PassOptions, val sourceStor
    * @return true, if the pass was successful
    */
   override def execute(): Boolean = {
-    if (tlaModule.isDefined) {
+    if (tlaModule.isEmpty) {
+      logger.info(" > no input for type checker")
+      false
+    } else if (options.getOrElse("typechecker", "snowcatOn", false)) {
+      logger.info(" > Snowcat is disabled. Use --with-snowcat to enable it")
+      outputTlaModule = tlaModule
+      true
+    } else {
       logger.info(" > Running Snowcat .::.")
       val inferPoly = options.getOrElse("typecheck", "inferPoly", true)
       val tool = new TypeCheckerTool(annotationStore, inferPoly)
@@ -48,19 +57,17 @@ class EtcTypeCheckerPassImpl @Inject() (val options: PassOptions, val sourceStor
       val taggedModule = tool.checkAndTag(tracker, listener, defaultTag, tlaModule.get)
 
       taggedModule match {
-        case Some(_) =>
+        case Some(newModule) =>
           logger.info(" > Your types are great!")
           logger.info(if (isTypeCoverageComplete) " > All expressions are typed" else " > Some expressions are untyped")
           // TODO: output the module in the json format, once the PR #599 has been merged
+          outputTlaModule = Some(newModule)
           true
 
         case None =>
           logger.info(" > Snowcat asks you to fix the types. Meow.")
           false
       }
-    } else {
-      logger.info(" > no input for type checker")
-      false
     }
   }
 
@@ -71,5 +78,8 @@ class EtcTypeCheckerPassImpl @Inject() (val options: PassOptions, val sourceStor
    * @return the next pass, if exists, or None otherwise
    */
   override def next(): Option[Pass] =
-    tlaModule map { _ => nextPass }
+    outputTlaModule map { m =>
+      nextPass.setModule(m)
+      nextPass
+    }
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/TypeCheckerModule.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/TypeCheckerModule.scala
@@ -6,7 +6,8 @@ import at.forsyte.apalache.io.annotations.{AnnotationStoreProvider, PrettyWriter
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
 import at.forsyte.apalache.tla.imp.passes.{SanyParserPass, SanyParserPassImpl}
 import at.forsyte.apalache.tla.lir.io.TlaWriterFactory
-import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
+import at.forsyte.apalache.tla.lir.storage.ChangeListener
+import at.forsyte.apalache.tla.lir.transformations.{TransformationListener, TransformationTracker}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import com.google.inject.{AbstractModule, TypeLiteral}
 import com.google.inject.name.Names
@@ -33,6 +34,8 @@ class TypeCheckerModule extends AbstractModule {
     // use the idle listener, as we do not need transformation tracking
     bind(classOf[TransformationTracker])
       .to(classOf[IdleTracker])
+    bind(classOf[TransformationListener])
+      .to(classOf[ChangeListener])
 
     // SanyParserPassImpl is the default implementation of SanyParserPass
     bind(classOf[SanyParserPass])

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -707,6 +707,41 @@ class TestToEtcExpr extends FunSuite with BeforeAndAfterEach with EtcBuilder {
     assert(expected == gen(ex))
   }
 
+  test("Apalache!:=") {
+    val typ = parser("(a, a) => Bool")
+    val expected = mkAppByName(Seq(typ), "x", "y")
+    val ex = OperEx(BmcOper.assign, tla.name("x"), tla.name("y"))
+    assert(expected == gen(ex))
+  }
+
+  test("Apalache!Skolem") {
+    val typ = parser("Bool => Bool")
+    val expected = mkAppByName(Seq(typ), "P")
+    val ex = OperEx(BmcOper.skolem, tla.name("P"))
+    assert(expected == gen(ex))
+  }
+
+  test("Apalache!Expand") {
+    val typ = parser("a => a")
+    val expected = mkAppByName(Seq(typ), "S")
+    val ex = OperEx(BmcOper.expand, tla.name("S"))
+    assert(expected == gen(ex))
+  }
+
+  test("Apalache!ConstCard") {
+    val typ = parser("Bool => Bool")
+    val expected = mkAppByName(Seq(typ), "P")
+    val ex = OperEx(BmcOper.constCard, tla.name("P"))
+    assert(expected == gen(ex))
+  }
+
+  test("Apalache!Distinct") {
+    val typ = parser("(a, a) => Bool")
+    val expected = mkAppByName(Seq(typ), "x", "y")
+    val ex = OperEx(BmcOper.distinct, tla.name("x"), tla.name("y"))
+    assert(expected == gen(ex))
+  }
+
   test("unary temporal operators") {
     val unary = parser("Bool => Bool")
     val expectedUnary = mkAppByName(Seq(unary), "A")

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
@@ -95,7 +95,7 @@ class TestTypeCheckerTool extends FunSuite with BeforeAndAfterEach with EasyMock
     }
   }
 
-  test("the tools runs consumes its output") {
+  test("the tools consumes its output") {
     val (rootName, modules) =
       sanyImporter.loadFromSource("MegaSpec1", getMegaSpec1)
 


### PR DESCRIPTION
This PR makes one more step towards the integration #521:

- The command `check` has a new option `--with-snowcat`, which enables the type checker in the beginning and the end of the pipeline
- Some of the model checker's tests are adapted to Snowcat. Some are still failing, so they are running without the option `--with-snowcat`.
- The types are still not propagated to the model checker itself

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
