### PR TITLE
removed the optional flags and warnings for Snowcat

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@
 ### Features
 
 * Model checker: receiving the types from with the type checker Snowcat, see #668 and #350
+* Model checker and type checker: Snowcat is the only way to compute types now
 * Type checker: the old Apalache type annotations are no longer supported, see #668
 * Type checker: tagging all expressions with the reconstructed types, see #608
 * Type checker: handling TLA+ labels like `lab("a", "b") :: e`, see #653

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -169,8 +169,6 @@ object Tool extends App with LazyLogging {
     executor.options.set("checker.discardDisabled", check.discardDisabled)
     executor.options.set("checker.noDeadlocks", check.noDeadlocks)
     executor.options.set("checker.algo", check.algo)
-    // this option enables the new type checker in the pipeline
-    executor.options.set("typechecker.snowcatOn", true)
     // for now, enable polymorphic types. We probably want to disable this option for the type checker
     executor.options.set("typechecker.inferPoly", true)
 
@@ -188,8 +186,6 @@ object Tool extends App with LazyLogging {
     executor.options.set("io.outdir", createOutputDir())
     executor.options.set("parser.filename", typecheck.file.getAbsolutePath)
     executor.options.set("typechecker.inferPoly", typecheck.inferPoly)
-    // always use Snowcat in the type checker
-    executor.options.set("typechecker.snowcatOn", true)
 
     executor.run() match {
       case None    => logger.info("Type checker [FAILED]")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -10,9 +10,7 @@ import org.backuity.clist.{Command, _}
  * @author Igor Konnov
  */
 class TypeCheckCmd
-    extends Command(name = "typecheck",
-        description = "Check types in a TLA+ specification\n" +
-          "  (the new type checker Snowcat, TO BE INTEGRATED with the model checker)") with General {
+    extends Command(name = "typecheck", description = "Check types in a TLA+ specification") with General {
 
   var file: File = arg[File](description = "a TLA+ specification (.tla or .json)")
   var inferPoly: Boolean = opt[Boolean](name = "infer-poly", default = true,

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
@@ -41,10 +41,6 @@ class EtcTypeCheckerPassImpl @Inject() (val options: PassOptions, val sourceStor
     if (tlaModule.isEmpty) {
       logger.info(" > no input for type checker")
       false
-    } else if (!options.getOrElse("typechecker", "snowcatOn", false)) {
-      logger.info(" > Snowcat is disabled. Use --with-snowcat to enable it")
-      outputTlaModule = tlaModule
-      true
     } else {
       logger.info(" > Running Snowcat .::.")
       dumpToJson(tlaModule.get, "pre")


### PR DESCRIPTION
Snowcat is not optional any longer. Removed the options to disable it as well as CLI warnings.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
