### PR TITLE
close #660: UNCHANGED <<...>> treats the brackets as a tuple

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@
 * Type checker: the old Apalache type annotations are no longer supported, see #668
 * Type checker: tagging all expressions with the reconstructed types, see #608
 * Type checker: handling TLA+ labels like `lab("a", "b") :: e`, see #653
+* Type checker: always treating `<<...>>` in `UNCHANGED <<...>>` as a tuple, see #660
 * Preprocessing: handling the general case of EXCEPT, see #647
 
 ### Changed

--- a/test/tla/Paxos.tla
+++ b/test/tla/Paxos.tla
@@ -156,7 +156,7 @@ Send(m) == /\ msgs' = msgs \cup {m}
 (* m with m.type = "1a") that begins ballot b.                             *)
 (***************************************************************************)
 Phase1a(b) == /\ Send([type |-> "1a", bal |-> b])
-              /\ UNCHANGED <<maxBal, maxVBal, maxVal, 0>>
+              /\ UNCHANGED <<maxBal, maxVBal, maxVal>>
 
 (***************************************************************************)
 (* Upon receipt of a ballot b phase 1a message, acceptor a can perform a   *)
@@ -170,7 +170,7 @@ Phase1b(a) == /\ \E m \in msgs :
                   /\ maxBal' = [maxBal EXCEPT ![a] = m.bal]
                   /\ Send([type |-> "1b", acc |-> a, bal |-> m.bal,
                             mbal |-> maxVBal[a], mval |-> maxVal[a]])
-              /\ UNCHANGED <<maxVBal, maxVal, 0>>
+              /\ UNCHANGED <<maxVBal, maxVal>>
 
 (***************************************************************************)
 (* The Phase2a(b, v) action can be performed by the ballot b leader if two *)
@@ -205,7 +205,7 @@ Phase2a(b, v) ==
                     /\ m.mval = v
                     /\ \A mm \in Q1bv : m.mbal \geq mm.mbal 
   /\ Send([type |-> "2a", bal |-> b, val |-> v])
-  /\ UNCHANGED <<maxBal, maxVBal, maxVal, 0>>
+  /\ UNCHANGED <<maxBal, maxVBal, maxVal>>
 
 (***************************************************************************)
 (* The Phase2b(a) action is performed by acceptor a upon receipt of a      *)

--- a/test/tla/Unchanged660.tla
+++ b/test/tla/Unchanged660.tla
@@ -1,0 +1,20 @@
+------------------------------ MODULE Unchanged660 ----------------------------
+(*
+ * A test for issue #660: The type checker should always treat <<x, ..., z>>
+ * in UNCHANGED <<x, ..., z>> as a tuple.
+ *)
+
+VARIABLE
+    \* @type: Int;
+    x,
+    \* @type: Int;
+    y
+
+Init ==
+    x = 1 /\ y = 2
+
+Next ==
+    /\ UNCHANGED <<x>>
+    /\ UNCHANGED <<x, y>>
+
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1198,3 +1198,18 @@ Type checker [OK]
 EXITCODE: OK
 ```
 
+### typecheck Unchanged660.tla
+
+```sh
+$ apalache-mc typecheck Unchanged660.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeCheckerSnowcat
+ > Running Snowcat .::.
+ > Your types are great!
+ > All expressions are typed
+...
+Type checker [OK]
+...
+EXITCODE: OK
+```
+

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -637,10 +637,24 @@ class TestToEtcExpr extends FunSuite with BeforeAndAfterEach with EtcBuilder {
     assert(expected == gen(ex))
   }
 
-  test("UNCHANGED") {
+  test("UNCHANGED x") {
     val typ = parser("a => Bool")
     val expected = mkAppByName(Seq(typ), "x")
     val ex = tla.unchanged(tla.name("x"))
+    assert(expected == gen(ex))
+  }
+
+  test("UNCHANGED <<x>>") {
+    val ex = tla.unchanged(tla.tuple(tla.name("x")))
+    val tupleType = mkAppByName(Seq(parser("a => <<a>>")), "x")
+    val expected = mkUniqApp(Seq(parser("<<a>> => Bool")), tupleType)
+    assert(expected == gen(ex))
+  }
+
+  test("UNCHANGED <<x, y>>") {
+    val ex = tla.unchanged(tla.tuple(tla.name("x"), tla.name("y")))
+    val tupleType = mkAppByName(Seq(parser("(a, b) => <<a, b>>")), "x", "y")
+    val expected = mkUniqApp(Seq(parser("<<a, b>> => Bool")), tupleType)
     assert(expected == gen(ex))
   }
 


### PR DESCRIPTION
A fix for the annoying complaint by the type checker. It was really easy. I believe that this the effect of designing the type checker right.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
