### PR TITLE
Clarify instructions on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,23 +7,41 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is. If you report an exception with a stack trace, no bug explanation is needed.
+<!-- Thank you for filing a report! Please ensure you have filled out all -->
+<!-- sections, as it help us to address the problem effectively. -->
 
-**Input specification**
- - If it is OK to share your spec on github, please attach it (you can attach zip files on github). Of course, we would actually prefer seeing an [MWE](https://en.wikipedia.org/wiki/Minimal_working_example), rather than a full-featured spec.
- - The command-line parameters that you use to run the tool
+## Description
 
-**Expected behavior**
-What did you expect to see?
+<!-- A clear and concise description of what the bug is. If you report an
+    exception with a stack trace, no bug explanation is needed. -->
 
-**Log files**
-If possible, submit `detailed.log` and the tool output.
+## Input specification
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Ubuntu Linux or Mac OS]
- - JDK version [e.g. OpenJDK 0.8.0]
- - Version [e.g. 0.6.0]
+ <!-- If it is OK to share your spec on github, please attach it (you can
+      attach zip files on github).
 
-**Additional context**
-Add any other context about the problem here.
+      If possible, please provide a [MWE](https://en.wikipedia.org/wiki/Minimal_working_example),
+      rather than a full-featured spec. -->
+
+## The command line parameters used to run the tool
+
+<!-- E.g. --init=Init --inv=Inv -->
+
+## Expected behavior
+
+<!-- What did you expect to see? -->
+
+## Log files
+
+<!-- If possible, attach of include the contents `detailed.log` and the tools
+     output on the command line. -->
+
+## System information
+
+- Apalache version [`apalache-mc version`]:
+- OS [e.g. Ubuntu Linux or Mac OS, and the current version]:
+- JDK version [e.g. OpenJDK 0.8.0]:
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
It wasn't clear from the template that the apalache version should be
included. This aims to make that clear, and a few other points, while
also improving the formatting of the template and making it easier for
reporters to use (hopefully) by putting the instructions in comments.

-------

<!-- Please ensure that your PR includes the following, as needed -->