### PR TITLE
closes #688: update the manual with the new types

### DIFF
--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -1,9 +1,7 @@
 # How to write type annotations
 
 **Warning:** *This HOWTO discusses how to write type annotations for the new
-type checker [Snowcat][], which has not been integrated with the model checker
-yet.  If you want to run the model checker, you have to write the [old type
-annotations][], until we release the integration (soon!)* :(
+type checker [Snowcat][], which is used in Apalache since version 0.15.0.*
 
 This HOWTO gives you concrete steps to extend TLA+ specifications with type
 annotations. You can find the detailed syntax of type annotations in

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,7 +21,6 @@
     - [Profiling Your Specification](./apalache/profiling.md)
     - [Five minutes of theory](./apalache/theory.md)
 - [TLC Configuration Files](./apalache/tlc-config.md)
-- [Types and Annotations](./apalache/types-and-annotations.md)
 - [The Snowcat Type Checker](./apalache/typechecker-snowcat.md)
 - [Supported Features](./apalache/features.md)
 - [TLA+ Preprocessing](./apalache/preprocessing.md)

--- a/docs/src/apalache/typechecker-snowcat.md
+++ b/docs/src/apalache/typechecker-snowcat.md
@@ -1,14 +1,8 @@
 ## The new type checker Snowcat
 
-**WARNING:** Snowcat has not been integrated with the model checker yet. The
-integration is coming soon. The model checker is still expecting the [old type
-annotations](./types-and-annotations.md).
-
-For the moment, you can use Snowcat as a standalone tool. New type annotations are written in comments, so they are
-ignored by the model checker (until the integration happens). Hence, you can start writing new type annotations and
-debug them with Snowcat. As the new type annotations are written in comments, they will be ignored by the model
-checker (until the integration happens). Snowcat ignores the old annotations and warns the user about the new type
-annotations. So you can start preparing for the transition to new annotations right now.
+**WARNING:** Snowcat is our type checker starting with Apalache version 0.15.0.
+If you are using Apalache prior to version 0.15.0, check the chapter on
+[old type annotations](./types-and-annotations.md).
 
 ---------------------------------------------------------------------------------
 

--- a/docs/src/apalache/types-and-annotations.md
+++ b/docs/src/apalache/types-and-annotations.md
@@ -1,20 +1,34 @@
-## Simple type inference and type annotations
+## Old type inference and type annotations (prior to version 0.15.0)
 
-**WARNING:** We have recently implemented a new type checker called Snowcat.
+**WARNING:** This page is describing old type annotations, which were used
+in Apalache prior to version 0.15.0.
+
+We have recently implemented a new type checker called Snowcat.
 See the [chapter in the manual](./typechecker-snowcat.md).
 Snowcat is user-friendly and much smarter than the current trivial type
 checker.  To get the idea about the new type checker, see [the talk at TLA+
 Community Meeting 2020](https://youtu.be/hnp25hmCMN8). We are preparing a
-tutorial on the new typechecker. The old type annotations will be replaced with
+tutorial on the new typechecker. The old type annotations are replaced with
 the new annotations as documented in [ADR002](../adr/002adr-types.md)
 and [ADR004](../adr/004adr-annotations.md).
 
-You can try Snowcat and the new type annotations in the [unstable
-branch](https://github.com/informalsystems/apalache).  Be warned though that
-the model checker is still expecting the old type annotations, which are
-explained below.
-
 ---------------------------------------------------------------------------------
+
+### Do I use the old type annotations?
+
+You can easily check, whether the old type annotations are used in your specification.
+Simply, search for the following declaration:
+
+```tla
+a <: b == a
+```
+
+If your specification contains such a declaration and it is used somewhere,
+then you are using the old type annotations. You have to remove them and write
+the new ones.  The old and new type annotations are conceptually, so there is
+no automatic upgrade process.
+
+### Description of the old type annotations
 
 Our model checker assigns types to variables, in order to encode TLA+ expressions
 in [Z3](https://github.com/Z3Prover/z3). Hence, the expressions that are ill-typed
@@ -28,7 +42,8 @@ expanded before the type inference is run.
 
 ### 1. Type inference
 
-Starting with the version ``0.4.0``, our model checker runs the naive type
+Starting with the version `0.4.0` (and ending with version `0.11.0`),
+our model checker runs the naive type
 inference algorithm for every computation step:
 
  1. It assumes that all operator definitions have been replaced with their

--- a/docs/src/apalache/types-and-annotations.md
+++ b/docs/src/apalache/types-and-annotations.md
@@ -25,7 +25,7 @@ a <: b == a
 
 If your specification contains such a declaration and it is used somewhere,
 then you are using the old type annotations. You have to remove them and write
-the new ones.  The old and new type annotations are conceptually, so there is
+the new ones.  The old and new type annotations are conceptually different, so there is
 no automatic upgrade process.
 
 ### Description of the old type annotations


### PR DESCRIPTION
Updated the manual to reflect that Snowcat and the new types is the way to do things right now.

- [ ] ~Tests added for any new code~
- [ ] ~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~
- [x] Documentation added for any new functionality
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
