### PR TITLE
Revert "[release] 0.15.0 (#695)"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,33 +2,6 @@
      This file is generated. Do not write release notes here.
      Notes for unreleased changes go in ./UNRELEASED.md -->
 
-## 0.15.0
-
-### Features
-
-* Model checker: receiving the types from with the type checker Snowcat, see #668 and #350
-* Model checker and type checker: Snowcat is the only way to compute types now
-* Type checker: the old Apalache type annotations are no longer supported, see #668
-* Type checker: tagging all expressions with the reconstructed types, see #608
-* Type checker: handling TLA+ labels like `lab("a", "b") :: e`, see #653
-* Type checker: always treating `<<...>>` in `UNCHANGED <<...>>` as a tuple, see #660
-* Type checker: handling the general case of EXCEPT, see #617
-* Preprocessing: handling the general case of EXCEPT, see #647
-
-### Changed
-
-* Preprocessing: massive refactoring of the passes to support types. This may have introduced unexpected bugs.
-* Model checker: translation rules for records and functions have been modified, in order to support new types. Bugs to
-  be expected.
-* Intermediate representation: renamed BmcOper to ApalacheOper. Its operators have the prefix `Apalache!` now.
-
-### Removed
-
-* Unused rewriting rules and `FailPredT` in the model checker, see #665
-* Intermediate representation: removed non-standard operators subsetProper, supset, supseteq, see #615
-* Intermediate representation: removed TlaArithOper.{sum,prod}, as they are not standard, see #580
-* Intermediate representation: removed TlaOper.chooseIdiom
-
 ## 0.11.0
 
 ### Features

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,27 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Features
+
+* Model checker: receiving the types from with the type checker Snowcat, see #668 and #350
+* Model checker and type checker: Snowcat is the only way to compute types now
+* Type checker: the old Apalache type annotations are no longer supported, see #668
+* Type checker: tagging all expressions with the reconstructed types, see #608
+* Type checker: handling TLA+ labels like `lab("a", "b") :: e`, see #653
+* Type checker: always treating `<<...>>` in `UNCHANGED <<...>>` as a tuple, see #660
+* Type checker: handling the general case of EXCEPT, see #617
+* Preprocessing: handling the general case of EXCEPT, see #647
+
+### Changed
+
+* Preprocessing: massive refactoring of the passes to support types. This may have introduced unexpected bugs.
+* Model checker: translation rules for records and functions have been modified, in order to support new types. Bugs to
+  be expected.
+* Intermediate representation: renamed BmcOper to ApalacheOper. Its operators have the prefix `Apalache!` now.
+
+### Removed
+
+* Unused rewriting rules and `FailPredT` in the model checker, see #665
+* Intermediate representation: removed non-standard operators subsetProper, supset, supseteq, see #615
+* Intermediate representation: removed TlaArithOper.{sum,prod}, as they are not standard, see #580
+* Intermediate representation: removed TlaOper.chooseIdiom

--- a/mod-distribution/pom.xml
+++ b/mod-distribution/pom.xml
@@ -8,11 +8,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apalache-pkg</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>apalache-pkg</name>

--- a/mod-infra/pom.xml
+++ b/mod-infra/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>infra</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>infra</name>

--- a/mod-tool/pom.xml
+++ b/mod-tool/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <!--
         All command line tooling and option parsing goes here... and nothing else!
     -->
     <artifactId>tool</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tool</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>at.forsyte.apalache</groupId>
     <artifactId>apalache</artifactId>
     <packaging>pom</packaging>
-    <version>0.15.1-SNAPSHOT</version>
+    <version>0.11.1-SNAPSHOT</version>
 
     <name>APALACHE project</name>
     <url>https://github.com/informalsystems/apalache</url>

--- a/tla-assignments/pom.xml
+++ b/tla-assignments/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-assignments</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-assignments</name>

--- a/tla-bmcmt/pom.xml
+++ b/tla-bmcmt/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-bmcmt</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-bmcmt</name>

--- a/tla-import/pom.xml
+++ b/tla-import/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-import</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-import</name>

--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-pp</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-pp</name>

--- a/tla-types/pom.xml
+++ b/tla-types/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tla-types</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tla-types</name>

--- a/tlair/pom.xml
+++ b/tlair/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>at.forsyte.apalache</groupId>
         <artifactId>apalache</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tlair</artifactId>
-        <version>0.15.1-SNAPSHOT</version>
+        <version>0.11.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tlair</name>


### PR DESCRIPTION
This reverts commit c8ca2080dcc0c9b9b0762e4ac8de09c7cb4660de.

The release preparation branch was squashed in instead of merged, so we
so we lost the release commit. The easiest way to fix is to revert the
offending commit and cut the release fresh.