### PR TITLE
Add types in the language manual

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Features
+
+* Language manual: types of the standard operators, see #547 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,4 +12,4 @@
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Features
 
-* Language manual: types of the standard operators, see #547 
+* Language manual: types of the standard operators, see #547

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,4 +12,4 @@
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Features
 
-* Language manual: types of the standard operators, see #547
+* Language manual: add types for the standard operators, see #547

--- a/docs/src/lang/booleans.md
+++ b/docs/src/lang/booleans.md
@@ -244,7 +244,7 @@ not False   # True
 **Arguments:** Two arguments. Although they can be arbitrary expressions, the
 result is only defined when both arguments are evaluated to Boolean values.
 
-**Apalache type:** `(Bool, Bool) => Bool`
+**Apalache type:** `(Bool, Bool) => Bool`. Note that the `=>` operator at the type level expresses the relation of inputs types to output types for operators, and as opposed to the `=>` expressing the implication relation at the value level.
 
 **Effect:** `F => G` evaluates to:
 

--- a/docs/src/lang/booleans.md
+++ b/docs/src/lang/booleans.md
@@ -11,6 +11,9 @@ logic. These operators form _propositional logic_.
 TLA+ contains three special constants: `TRUE`, `FALSE`, and `BOOLEAN`.
 The constant `BOOLEAN` is defined as the set `{FALSE, TRUE}`.
 
+In Apalache, `TRUE`, `FALSE`, and `BOOLEAN` have the types `Bool`, `Bool`,
+and `Set(Bool)`, respectively.
+
 A note for set-theory purists: In theory, `TRUE` and `FALSE` are also sets, but
 in practice they are treated as indivisible values. For instance, Apalache and
 TLC will report an error, if you try to treat `FALSE` and `TRUE` as sets.
@@ -33,6 +36,8 @@ We discuss this effect [Control Flow and Non-determinism].
 **LaTeX notation:** ![land](./img/land.png)
 
 **Arguments:** Two or more arbitrary expressions.
+
+**Apalache type:** `(Bool, Bool) => Bool`
 
 **Effect:** The binary case `F /\ G` evaluates to:
 
@@ -106,6 +111,8 @@ is equivalent to:
 **LaTeX notation:** ![lor](./img/lor.png)
 
 **Arguments:** Two or more Boolean expressions.
+
+**Apalache type:** `(Bool, Bool) => Bool`
 
 **Effect:**
 
@@ -195,6 +202,8 @@ The above formula is equivalent to:
 
 **Arguments:** One argument that should evaluate to a Boolean value.
 
+**Apalache type:** `Bool => Bool`
+
 **Effect:**
 
   The value of `~F` is computed as follows:
@@ -234,6 +243,8 @@ not False   # True
 
 **Arguments:** Two arguments. Although they can be arbitrary expressions, the
 result is only defined when both arguments are evaluated to Boolean values.
+
+**Apalache type:** `(Bool, Bool) => Bool`
 
 **Effect:** `F => G` evaluates to:
 
@@ -282,6 +293,8 @@ Recall that `A => B` is equivalent to `~A \/ B`.
 
 **Arguments:** Two arguments. Although they can be arbitrary expressions, the
 result is only defined when both arguments are evaluated to Boolean values.
+
+**Apalache type:** `(Bool, Bool) => Bool`
 
 **Effect:** `F <=> G` evaluates to:
 

--- a/docs/src/lang/conditionals.md
+++ b/docs/src/lang/conditionals.md
@@ -36,6 +36,10 @@ _Use it when choosing between two values, not to structure your code._
 
 **Arguments:** a Boolean expression `A` and two expressions `B` and `C`
 
+**Apalache type:** `(Bool, a, a) => a`.  Note that `a` can be replaced with
+`Bool`. If `a` is `Bool`, and only in that case, the expression `IF A THEN B
+ELSE C` is equivalent to `(A => B) /\ (~A => C)`.
+
 **Effect:** `IF A THEN B ELSE C` evaluates to:
 
  - The value of `B`, if `A` evaluates to `TRUE`.
@@ -86,6 +90,9 @@ CASE p_1 -> e_1
 
 **Arguments:** Boolean expressions `p_1, ..., p_n` and expressions `e_1, ...,
 e_n`.
+
+**Apalache type:** `(Bool, a, Bool, a, ..., Bool, a) => a`, for some type `a`.
+If `a` is `Bool`, then the case operator can be a part of a Boolean formula.
 
 **Effect:** Given a state `s`, define the set `I \subseteq 1..n` as follows:
     The set `I` includes the index `j \in 1..n` if
@@ -195,6 +202,9 @@ CASE p_1 -> e_1
 
 **Arguments:** Boolean expressions `p_1, ..., p_n` and expressions `e_0, e_1, ...,
 e_n`.
+
+**Apalache type:** `(Bool, a, Bool, a, ..., Bool, a, a) => a`, for some type `a`.
+If `a` is `Bool`, then the case operator can be a part of a Boolean formula.
 
 **Effect:** This operator is equivalent to the following version of `CASE`:
 

--- a/docs/src/lang/control-and-nondeterminism.md
+++ b/docs/src/lang/control-and-nondeterminism.md
@@ -469,6 +469,10 @@ Consider an `IF-THEN-ELSE` expression to be evaluated in a partial state `s`:
 IF A THEN B ELSE C
 ```
 
+In Apalache, this operator has the polymorphic type `(Bool, a, a) => a`,
+where `a` can be replaced with a concrete type. Here, we consider the case
+`(Bool, Bool, Bool) => Bool`.
+
 Here we assume that both `B` and `C` produce Boolean results and `B` and `C`
 refer to at least one primed variable `y'` that is undefined in `s`. Otherwise, the
 expression can be evaluated as a [deterministic
@@ -506,8 +510,9 @@ CASE P_1 -> e_1
   [] P_n -> e_n
 ```
 
-We assume that `e_1, ..., e_n` produce Boolean results. Otherwise,
-see [Deterministic conditionals](./conditionals.md).
+Here, we assume that `e_1, ..., e_n` produce Boolean results.  Or, in terms of
+Apalache types, this expression has the type: `(Bool, Bool, ..., Bool, Bool) =>
+Bool`.  Otherwise, see [Deterministic conditionals](./conditionals.md).
 
 This operator is equivalent to the following disjunction:
 

--- a/docs/src/lang/functions.md
+++ b/docs/src/lang/functions.md
@@ -151,7 +151,8 @@ of integers).
 Apalache enforces stricter types. It has designated types for all four
 data structures: general functions, records, tuples, and sequences.
 Moreover, all elements of the function domain must have the same type.
-The same is true for the codomain. This is enforced
+The same is true for the codomain. That is, general functions have the
+type `a -> b` for some types `a` and `b`. This is enforced
 by the type checker.
 
 In this sense, the type restrictions of Apalache are similar to those for the
@@ -272,6 +273,13 @@ arguments
 see **Advanced syntax**), a set, and a mapping expression. Instead of one
 variable and one set, you can use multiple variables and multiple sets.
 
+**Apalache type:** The formal type of this operator is a bit complex.
+Hence, we give an informal description:
+ - `x` has the type `a`, for some type `a`,
+ - `S` has the type `Set(a)`,
+ - `e` has the type `b`, for some type `b`,
+ - the expression `[ x \in S |-> e ]` has the type `a -> b`.
+
 **Effect:** We give the semantics for one argument.  We write a sequence of
 steps to ease the understanding.  This operator constructs a function `f` over
 the domain `S` as follows.  For every element `elem` of `S`, do the following:
@@ -361,6 +369,8 @@ xy = {(x, y) for x in range(1, 4) for y in range(4, 7)}
 **Arguments:** Two arguments. Both have to be sets. Otherwise, the result is
 undefined.
 
+**Apalache type:** `(Set(a), Set(b)) => Set(a -> b)`, for some types `a` and `b`.
+
 **Effect:** This operator constructs the set of all possible functions that
 have `S` as their domain, and for each argument `x \in S` return a value `y \in
 T`.
@@ -407,6 +417,10 @@ values, rather than over the alphabet of 2 values.
 the other arguments are the arguments to the function. Several arguments
 are treated as a tuple. For instance, `f[e_1, ..., e_n]` is shorthand for
 `f[<<e_1, ..., e_n>>]`.
+
+**Apalache type:** In the single-index case, the type is
+`((a -> b), a) => b`, for some types `a` and `b`. In the multi-index case,
+the type is `((<<a_1, ..., a_n>> -> b), a_1, ..., a_n) => b`.
 
 **Effect:** This operator is evaluated as follows:
 
@@ -471,6 +485,10 @@ function domain is not known in advance.
 **Arguments:** At least three arguments. The first one should be a function,
 the other arguments are interleaved pairs of argument expressions and value
 expressions.
+
+**Apalache type:** In the case of a single-point update, the type is simple:
+`(a -> b, a, b) => (a -> b)`, for some types `a` and `b`. In the general case,
+the type is: `(a -> b, a, b, ..., a, b) => (a -> b)`.
 
 **Effect:** This operator evaluates to a new function `g` that is constructed
     as follows:
@@ -601,6 +619,8 @@ code would be less efficient than the idiomatic Python code.
 
 **Arguments:** One argument, which should be a function
                (respectively, a record, tuple, sequence).
+
+**Apalache type:** `(a -> b) => Set(a)`.               
 
 **Effect:** `DOMAIN f` returns the set of values, on which the function
 has been defined, see: Function constructor and Function set constructor.

--- a/docs/src/lang/integers.md
+++ b/docs/src/lang/integers.md
@@ -5,7 +5,7 @@
 The integer literals belong to the core language. They are written by
 using the standard syntax: 0, 1, -1, 2, -2, 3, -3, ... Importantly, TLA+
 integers are unbounded. They do not have any fixed bit width, and they cannot
-overflow.
+overflow. In Apalache, these literals have the type `Int`.
 
 The integer operators are defined in the standard module `Integers`. To use
 it, write the `EXTENDS` clause in the first lines of your module. Like this:
@@ -43,9 +43,12 @@ The module `Integers` defines two constant sets (technically, they are
 operators without arguments):
 
  - The set `Int` that consists of all integers. _This set is infinite._
+    In Apalache, the set `Int` has the type `Set(Int)`.
+    A bit confusing, right? :sunglasses:
  - The set `Nat` that consists of all natural numbers, that is,
    `Nat` contains every integer `x` that has the property `x >= 0`.
    _This set is infinite._
+   In Apalache, the set `Nat` has the type... `Set(Int)`.
 
 ----------------------------------------------------------------------------
 
@@ -60,6 +63,8 @@ operators without arguments):
 
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
+
+**Apalache type:** `(Int, Int) => Set(Int)`.
 
 **Effect:** `a..b` evaluates to the finite set `{i \in Int: a <= i /\ i <= b}`,
 that is, the set of all integers in the range from `a` to `b`, including `a`
@@ -101,6 +106,8 @@ python.
 **Arguments:** One argument. The result is only defined when the argument
 evaluates to an integer.
 
+**Apalache type:** `Int => Int`.
+
 **Effect:** `-i` evaluates to the negation of `i`.
 
 **Determinism:** Deterministic.
@@ -136,6 +143,8 @@ type error, whereas TLC reports a runtime error.
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
 
+**Apalache type:** `(Int, Int) => Int`.
+
 **Effect:** `a + b` evaluates to the sum of `a` and `b`.
 
 **Determinism:** Deterministic.
@@ -169,6 +178,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
+
+**Apalache type:** `(Int, Int) => Int`.
 
 **Effect:** `a - b` evaluates to the difference of `a` and `b`.
 
@@ -206,6 +217,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
 
+**Apalache type:** `(Int, Int) => Int`.
+
 **Effect:** `a * b` evaluates to the product of `a` and `b`.
 
 **Determinism:** Deterministic.
@@ -239,6 +252,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values, and the second argument is different from 0.
+
+**Apalache type:** `(Int, Int) => Int`.
 
 **Effect:** `a \div b` is defined as follows:
 
@@ -311,6 +326,8 @@ to produce the same results as in TLA+:
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values, and the second argument is different from 0.
 
+**Apalache type:** `(Int, Int) => Int`.
+
 **Effect:** `a % b` is the number `c` that has the property:
 `a = b * (a \div b) + c`.
 
@@ -360,6 +377,8 @@ cases:
 
  1. `b > 0`,
  1. `b = 0` and `a /= 0`.
+
+**Apalache type:** `(Int, Int) => Int`.
 
 **Effect:** `a^b` evaluates to `a` raised to the `b`-th power:
 
@@ -414,6 +433,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
 
+**Apalache type:** `(Int, Int) => Bool`.
+
 **Effect:** `a < b` evaluates to:
 
   - `TRUE`, if `a` is less than `b`,
@@ -452,6 +473,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
+
+**Apalache type:** `(Int, Int) => Bool`.
 
 **Effect:** `a <= b` evaluates to:
 
@@ -492,6 +515,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
 
+**Apalache type:** `(Int, Int) => Bool`.
+
 **Effect:** `a > b` evaluates to:
 
   - `TRUE`, if `a` is greater than `b`,
@@ -530,6 +555,8 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 **Arguments:** Two arguments. The result is only defined when both arguments
 are evaluated to integer values.
+
+**Apalache type:** `(Int, Int) => Bool`.
 
 **Effect:** `a >= b` evaluates to:
 

--- a/docs/src/lang/logic.md
+++ b/docs/src/lang/logic.md
@@ -26,6 +26,13 @@ expression. As usual in TLA+, if the second argument is not a set, the result is
 undefined. You can also use multiple variables and tuples, see **Advanced
 syntax**.
 
+**Apalache type:** The formal type of this operator is a bit complex.
+Hence, we give an informal description:
+ - `x` has the type `a`, for some type `a`,
+ - `S` has the type `Set(a)`,
+ - `P` has the type `Bool`,
+ - the expression `\A x \in S: P` has the type `Bool`.
+
 **Effect:** This operator evaluates to a Boolean value. We explain
 semantics only for a single variable:
 
@@ -96,6 +103,13 @@ simply syntax sugar for the form with nested quantifiers: `\A x \in S: \A y
 expression. As usual in TLA+, if the second argument is not a set, the result is
 undefined.You can also use multiple variables and tuples, see **Advanced
 syntax**.
+
+**Apalache type:** The formal type of this operator is a bit complex.
+Hence, we give an informal description:
+ - `x` has the type `a`, for some type `a`,
+ - `S` has the type `Set(a)`,
+ - `P` has the type `Bool`,
+ - the expression `\E x \in S: P` has the type `Bool`.
 
 **Effect:** This operator evaluates to a Boolean value. We explain
 semantics only for a single variable:
@@ -175,6 +189,8 @@ _A foundational operator in TLA+_
 **LaTeX notation:** ![eq](./img/eq.png)
 
 **Arguments:** Two arguments.
+
+**Apalache type:** `(a, a) => Bool`, for some type `a`.
 
 **Effect:** This operator evaluates to a Boolean value. It tests the values
 of `e_1` and `e_2` for structural equality. The exact effect depends on the
@@ -282,6 +298,8 @@ match.
 
 **Arguments:** Two arguments.
 
+**Apalache type:** `(a, a) => Bool`, for some type `a`.
+
 **Effect:** This operator is syntax sugar for `~(e_1 = e_2)`. Full stop.
 
 ----------------------------------------------------------------------------
@@ -297,6 +315,13 @@ _This operator causes a lot of confusion. Read carefully!_
 
 **Arguments:** Three arguments: a variable name, a set, and an
 expression.
+
+**Apalache type:** The formal type of this operator is a bit complex.
+Hence, we give an informal description:
+ - `x` has the type `a`, for some type `a`,
+ - `S` has the type `Set(a)`,
+ - `P` has the type `Bool`,
+ - the expression `CHOOSE x \in S: P` has the type `a`.
 
 **Effect:** This operator implements a black-box algorithm that _somehow_ picks
 one element from the set `{x \in S: P}`.  Is it an algorithm? Yes! `CHOOSE x

--- a/docs/src/lang/records.md
+++ b/docs/src/lang/records.md
@@ -85,6 +85,9 @@ immutable dictionary.
 interleaved. At least one field is expected. Note that field names are TLA+
 identifiers, not strings.
 
+**Apalache type:** `(a_1, ..., a_n) => [field_1: a_1, ..., field_n: a_n]`, for
+some types `a_1, ..., a_n`.
+
 **Effect:** The record constructor returns a function `r` that is constructed
 as follows:
 
@@ -121,6 +124,9 @@ as follows:
 **Arguments:** An even number of arguments: field names and field values,
 interleaved. At least one field is expected. Note that field names are TLA+
 identifiers, not strings.
+
+**Apalache type:** `(Set(a_1), ..., Set(a_n)) => Set([field_1: a_1, ...,
+field_n: a_n])`, for some types `a_1, ..., a_n`.
 
 **Effect:** The record set constructor `[ field_1: S_1, ..., field_n: S_n]`
 is syntax sugar for the set comprehension:
@@ -160,13 +166,21 @@ is picked with `\E r \in [ field_1: S_1, ..., field_n: S_n]`.
 <a name="recApp"></a>
 ### Access by field name
 
-**Notation:** `r.field`
+**Notation:** `r.field_i`
 
-**LaTeX notation:** `r.field`
+**LaTeX notation:** `r.field_i`
 
 **Arguments:** Two arguments: a record and a field name (as an identifier).
 
-**Effect:** As records are also functions, this operator works as `r["field"]`.
+**Apalache type:** `[field_1: a_1, ..., field_i: a_i, ..., field_n: a_n]) =>
+a_i`, for some types `a_1, ..., a_n`. Due to the record unification rule, we
+usually write this type simply as: `[field_i: a_i] => a_i`.
+
+Note that `r.field_i` is just a syntax sugar for `r["field_i"]` in TLA+.
+Hence, if the type of `r` cannot be inferred, you can see an error message
+about Apalache not knowing, whether `r` is a record, or a function.
+
+**Effect:** As records are also functions, this operator works as `r["field_i"]`.
 
 Apalache treats records as values of a record type. In comparison to the
 general function application `r["field"]`, the operator `r.field` is handled

--- a/docs/src/lang/sequences.md
+++ b/docs/src/lang/sequences.md
@@ -73,7 +73,9 @@ As sequences are also tuples in TLA+, this poses a challenge for the Apalache
 type checker. For instance, it can immediately figure out that `<<1, "Foo">>`
 is a tuple, as Apalache does not allow sequences to carry elements of different
 types. However, there is no way to say, whether `<<1, 2, 3>>` should be treated
-as a tuple or a sequence. This needs a [type annotation].
+as a tuple or a sequence.  Usually, this problem is resolved by annotating the
+type of a variable or the type of a user operator. See [HOWTO write type
+annotations][].
 
 _The current SMT encoding of sequences in Apalache is not optimized,
 so operations on sequences are often significantly slower than operations
@@ -92,6 +94,15 @@ on sets._
 **LaTeX notation:** ![tuple](./img/tuple.png)
 
 **Arguments:** An arbitrary number of arguments.
+
+**Apalache type:** This operator is overloaded. There are two potential types:
+
+  1. A tuple constructor: `(a_1, ..., a_n) => <<a_1, ..., a_n>>`,
+    for some types `a_1, ..., a_n`.
+  1. A sequence constructor: `(a, ..., a) => Seq(a)`, for some type `a`.
+
+That is why the Apalache type checker is sometimes asking you to add annotations,
+in order to resolve this ambiguity.
 
 **Effect:** The tuple/sequence constructor returns a function `t` that is
 constructed as follows:
@@ -134,6 +145,8 @@ principle "sequences are functions", we have to use a dictionary.
 **Arguments:** Two arguments. The first argument should be a sequence, the
 second one is an arbitrary expression.
 
+**Apalache type:** `(Seq(a), a) => Seq(a)`, for some type `a`.
+
 **Effect:** The operator `Append(seq, e)`
 constructs a new sequence `newSeq` as follows:
 
@@ -174,8 +187,10 @@ the type of the sequence elements.
 <a name="app"></a>
 ### Function application
 
-As sequences are functions, you can access sequence elements with
-[function application](./functions.md#funApp), e.g., `seq[2]`.
+As sequences are functions, you can access sequence elements with [function
+application](./functions.md#funApp), e.g., `seq[2]`.  However, in the case of a
+sequence, the type of the function application is: `(Seq(a), Int) => a`, for
+some type `a`.
 
 ----------------------------------------------------------------------------
 
@@ -187,6 +202,8 @@ As sequences are functions, you can access sequence elements with
 **LaTeX notation:** `Head(seq)`
 
 **Arguments:** One argument. The argument should be a sequence (or a tuple).
+
+**Apalache type:** `Seq(a) => a`, for some type `a`.
 
 **Effect:** The operator `Head(seq)` evaluates to `seq[1]`.
 If `seq` is an empty sequence, the result is undefined.
@@ -226,6 +243,8 @@ error.
 **LaTeX notation:** `Tail(seq)`
 
 **Arguments:** One argument. The argument should be a sequence (or a tuple).
+
+**Apalache type:** `Seq(a) => Seq(a)`, for some type `a`.
 
 **Effect:** The operator `Tail(seq)` constructs a new sequence `newSeq` as
 follows:
@@ -275,6 +294,8 @@ error.
 
 **Arguments:** One argument. The argument should be a sequence (or a tuple).
 
+**Apalache type:** `Seq(a) => Int`, for some type `a`.
+
 **Effect:** The operator `Len(seq)` is semantically equivalent to
 `Cardinality(DOMAIN seq)`.
 
@@ -317,6 +338,8 @@ error.
 **LaTeX notation:** ![seq-concat](./img/seq-concat.png)
 
 **Arguments:** Two arguments: both should be sequences (or tuples).
+
+**Apalache type:** `(Seq(a), Seq(a)) => Seq(a)`, for some type `a`.
 
 **Effect:** The operator `s \o t`
 constructs a new sequence `newSeq` as follows:
@@ -367,6 +390,8 @@ incompatible.
 
 **Arguments:** Three arguments: a sequence (tuple), and two integers.
 
+**Apalache type:** `(Seq(a), Int, Int) => Seq(a)`, for some type `a`.
+
 **Effect:** The operator `SubSeq(seq, m, n)`
 constructs a new sequence `newSeq` as follows:
 
@@ -416,6 +441,8 @@ error. Apalache flags a static type error.
 **Arguments:** Two arguments: a sequence (a tuple) and a one-argument
 operator that evaluates to `TRUE` or `FALSE` when called with
 an element of `seq` as its argument.
+
+**Apalache type:** `(Seq(a), (a => Bool)) => Seq(a)`, for some type `a`.
 
 **Effect:** The operator `SelectSeq(seq, Test)` constructs a new sequence
 `newSeq` that contains every element `e` of `seq` on which `Test(e)` evaluates
@@ -473,6 +500,8 @@ result is undefined in pure TLA+. TLC raises a model checking error.
 
 **Arguments:** One argument that should be a set.
 
+**Apalache type:** `Set(a) => Set(Seq(a))`, for some type `a`.
+
 **Effect:** The operator `Seq(S)` constructs the set of all (finite) sequences
 that contain elements from `S`. This set is infinite.
 
@@ -529,5 +558,5 @@ till the end of the universe.
 [Paxos]: https://github.com/tlaplus/Examples/blob/master/specifications/Paxos/Paxos.tla
 [Apalache ADR002]: https://github.com/informalsystems/apalache/blob/unstable/docs/adr/002adr-types.md
 [Cartesian product]: https://en.wikipedia.org/wiki/Cartesian_product
-[type annotation]: ../apalache/types-and-annotations.md
 [Overriding Seq in TLC]: https://groups.google.com/g/tlaplus/c/sYx_6e3YyWk/m/4CnwPqIVAgAJ
+[HOWTO write type annotations]: ../../HOWTOs/howto-write-type-annotations.md

--- a/docs/src/lang/sets.md
+++ b/docs/src/lang/sets.md
@@ -62,8 +62,9 @@ kinds of values in a single set, TLC would not complain about your sets:
 
 
 
-Apalache requires set elements to have the same type. This is enforced by the
-type checker.
+Apalache requires set elements to have the same type, that is, `Set(a)` for
+some type `a`. This is enforced by the type checker.  (Records are an exception
+to this rule, as some records can be unified to a common type.) 
 
 ----------------------------------------------------------------------------
 
@@ -77,6 +78,8 @@ type checker.
 **LaTeX notation:** `{e_1, ..., e_n}`
 
 **Arguments:** Any number of arguments, `n >= 0`.
+
+**Apalache type:** `(a, ..., a) => Set(a)`, for some type `a`.
 
 **Effect:** Produce the set that contains the values of the expressions `e_1,
 ..., e_n`, in no particular order, and only these values. If `n = 0`, the
@@ -122,6 +125,8 @@ If this is not the case, the type checker flags an error.
 
 **Arguments:** Two arguments.  If the second argument is not a set, the result
 is undefined.
+
+**Apalache type:** `(a, Set(a)) => Bool`, for some type `a`.
 
 **Effect:** This operator evaluates to:
 
@@ -170,6 +175,8 @@ incompatible with the type of elements of `S`, or if `S` is not a set.
 
 **Arguments:** Two arguments.  If the second argument is not a set, the result
 is undefined.
+
+**Apalache type:** `(a, Set(a)) => Bool`, for some type `a`.
 
 **Effect:** This operator evaluates to:
 
@@ -227,6 +234,8 @@ see [Logic](./logic.md).
 **Arguments:** Two arguments.  If both arguments are not sets, the result
 is undefined.
 
+**Apalache type:** `(Set(a), Set(a)) => Bool`, for some type `a`.
+
 **Effect:** This operator evaluates to:
 
   - `TRUE`, if `S` and `T` are sets, and every element of `S` is a member of `T`;
@@ -261,140 +270,6 @@ either not sets, or sets of incompatible types.
 
 ----------------------------------------------------------------------------
 
-<a name="subset"></a>
-### Proper set inclusion
-
-**Notation:** `S \subset T`
-
-**LaTeX notation:** ![subset](./img/subset.png)
-
-**Arguments:** Two arguments.  If both arguments are not sets, the result
-is undefined.
-
-**Effect:** This operator evaluates to:
-
-  - `TRUE`, if `S \subseteq T /\ S /= T` evaluates to `TRUE`;
-  - `FALSE`, if `S` and `T` are sets, and `~(S \subseteq T) \/ S = T` evaluates
-    to `TRUE`.
-
-**Determinism:** Deterministic.
-
-**Errors:** Pure TLA+ does not restrict the operator arguments.  TLC flags a
-model checking error, when it discovers that elements of `S` cannot be compared
-to the elements of `T`. Apalache produces a static type error, `S` and `T` are
-either not sets, or sets of incompatible types.
-
-**Example in TLA+:**
-
-```tla
-     { 1, 2 } \subset { 1, 2, 3 }     \* TRUE
-  { 1, 2, 3 } \subset { 1, 2, 3 }     \* FALSE
-  { 1, 2, 3 } \subset { 1, 2 }        \* FALSE
-      { {1} } \subset { 1, 2, 3 }     \* FALSE, model checking error in TLC
-                                      \* static type error in Apalache
-```
-
-**Example in Python:** Python conveniently offers us `<`:
-
-```python
-  frozenset({1, 2}) < frozenset({1, 2, 3})             # True
-  frozenset({1, 2, 3}) < frozenset({1, 2, 3})          # False
-  frozenset({1, 2, 3}) < frozenset({1, 2})             # False
-  frozenset({frozenset({1})}) < frozenset({1, 2, 3})   # False
-```
-
-----------------------------------------------------------------------------
-
-<a name="supseteq"></a>
-### Set containment
-
-**Notation:** `S \supseteq T`
-
-**LaTeX notation:** ![supseteq](./img/supseteq.png)
-
-**Arguments:** Two arguments.  If both arguments are not sets, the result
-is undefined.
-
-**Effect:** This operator evaluates to:
-
-  - `TRUE`, if `S` and `T` are sets, and every element of `T` is a member of `S`;
-  - `FALSE`, if `S` and `T` are sets, and there is an element of `T` that
-    is not a member of `S`.
-
-  It is easy to see, that `S \supseteq T` if and only if `T \subseteq S`.
-
-**Determinism:** Deterministic.
-
-**Errors:** Pure TLA+ does not restrict the operator arguments.  TLC flags a
-model checking error, when it discovers that elements of `S` cannot be compared
-to the elements of `T`. Apalache produces a static type error, `S` and `T` are
-either not sets, or sets of incompatible types.
-
-**Example in TLA+:**
-
-```tla
-     { 1, 2 } \supseteq { 1, 2, 3 }     \* FALSE
-  { 1, 2, 3 } \supseteq { 1, 2, 3 }     \* TRUE
-  { 1, 2, 3 } \supseteq { 1, 2 }        \* TRUE
-      { {1} } \supseteq { 1, 2, 3 }     \* FALSE, model checking error in TLC
-                                        \* static type error in Apalache
-```
-
-**Example in Python:** Python conveniently offers us `>=`:
-
-```python
-  frozenset({1, 2}) >= frozenset({1, 2, 3})             # False
-  frozenset({1, 2, 3}) >= frozenset({1, 2, 3})          # True
-  frozenset({1, 2, 3}) >= frozenset({1, 2})             # True
-  frozenset({frozenset({1})}) >= frozenset({1, 2, 3})   # False
-```
-
-----------------------------------------------------------------------------
-
-<a name="supset"></a>
-### Proper set containment
-
-**Notation:** `S \supset T`
-
-**LaTeX notation:** ![supset](./img/supset.png)
-
-**Arguments:** Two arguments.  If both arguments are not sets, the result
-is undefined.
-
-**Effect:** This operator evaluates to:
-
-  - `TRUE`, if `S \supseteq T /\ S /= T` evaluates to `TRUE`;
-  - `FALSE`, if `S` and `T` are sets, and `~(S \supseteq T) \/ S = T` evaluates
-    to `TRUE`.
-
-**Determinism:** Deterministic.
-
-**Errors:** Pure TLA+ does not restrict the operator arguments.  TLC flags a
-model checking error, when it discovers that elements of `S` cannot be compared
-to the elements of `T`. Apalache produces a static type error, `S` and `T` are
-either not sets, or sets of incompatible types.
-
-**Example in TLA+:**
-
-```tla
-     { 1, 2 } \supset { 1, 2, 3 }       \* FALSE
-  { 1, 2, 3 } \supset { 1, 2, 3 }       \* FALSE
-  { 1, 2, 3 } \supset { 1, 2 }          \* TRUE
-      { {1} } \supseteq { 1, 2, 3 }     \* FALSE, model checking error in TLC
-                                        \* static type error in Apalache
-```
-
-**Example in Python:** Python conveniently offers us `>`:
-
-```python
-  frozenset({1, 2}) > frozenset({1, 2, 3})              # False
-  frozenset({1, 2, 3}) > frozenset({1, 2, 3})           # False
-  frozenset({1, 2, 3}) > frozenset({1, 2})              # True
-  frozenset({frozenset({1})}) >= frozenset({1, 2, 3})   # False
-```
-
-----------------------------------------------------------------------------
-
 <a name="union"></a>
 ### Binary set union
 
@@ -404,6 +279,8 @@ either not sets, or sets of incompatible types.
 
 **Arguments:** Two arguments.  If both arguments are not sets, the result
 is undefined.
+
+**Apalache type:** `(Set(a), Set(a)) => Set(a)`, for some type `a`.
 
 **Effect:** This operator evaluates to the set that contains the elements
 of `S` **as well** as the elements of `T`, and no other values.
@@ -447,6 +324,8 @@ either not sets, or sets of incompatible types.
 **Arguments:** Two arguments.  If both arguments are not sets, the result
 is undefined.
 
+**Apalache type:** `(Set(a), Set(a)) => Set(a)`, for some type `a`.
+
 **Effect:** This operator evaluates to the set that contains only those elements
 of `S` that **also** belong to `T`, and no other values.
 
@@ -488,6 +367,8 @@ either not sets, or sets of incompatible types.
 
 **Arguments:** Two arguments.  If both arguments are not sets, the result
 is undefined.
+
+**Apalache type:** `(Set(a), Set(a)) => Set(a)`, for some type `a`.
 
 **Effect:** This operator evaluates to the set that contains only those elements
 of `S` that **do not** belong to `T`, and no other values.
@@ -531,6 +412,12 @@ either not sets, or sets of incompatible types.
 **Arguments:** Three arguments: a variable name (or a tuple of names, see
 **Advanced syntax**), a set, and an expression.
 
+**Apalache type:** The formal type of this operator is a bit complex.
+Hence, we give an informal description:
+ - `x` has the type `a`, for some type `a`,
+ - `S` has the type `Set(a)`,
+ - `P` has the type `Bool`,
+ - the expression `{ x \in S: P }` has the type `Set(a)`.
 
 **Effect:** This operator constructs a new set `F` as follows.  For every
 element `e` of `S`, do the following (we give a sequence of steps to ease
@@ -588,6 +475,13 @@ syntax:
 **Arguments:** At least three arguments: a mapping expression,
     a variable name (or a tuple of names, see **Advanced syntax**),
     a set. Additional arguments are variables names and sets, interleaved.
+
+**Apalache type:** The formal type of this operator is a bit complex.
+Hence, we give an informal description for the one-argument case:
+ - `x` has the type `a`, for some type `a`,
+ - `S` has the type `Set(a)`,
+ - `e` has the type `b`, for some type `b`,
+ - the expression `{ e: x \in S }` has the type `Set(b)`.
 
 
 **Effect:** We give the semantics for two arguments.
@@ -650,6 +544,8 @@ different operators, which unfortunately have similar-looking names.
 **Arguments:** One argument. If it is not a set, the result
 is undefined.
 
+**Apalache type:** `Set(a) => Set(Set(a))`, for some type `a`.
+
 **Effect:** This operator computes the set of all subsets of `S`.
     That is, the set `T` the has the following properties:
 
@@ -687,6 +583,8 @@ different operators, which unfortunately have similar-looking names.
 
 **Arguments:** One argument. If it is not a set of sets, the result
 is undefined.
+
+**Apalache type:** `Set(Set(a)) => Set(a)`, for some type `a`.
 
 **Effect:** Given that `S` is a set of sets, this operator computes the set
 `T` that contains all elements of elements of `S`:
@@ -734,6 +632,8 @@ in Python is quite simple:
 **Arguments:** One argument. If `S` is not a set, or `S` is an infinite set,
 the result is undefined.
 
+**Apalache type:** `Set(a) => Int`, for some type `a`.
+
 **Effect:** `Cardinality(S)` evaluates to the number of (unique) elements in
 `S`.
 
@@ -772,6 +672,8 @@ different from a finite set.
 **Warning:** `IsFinite(S)` is defined in the module `FiniteSets`.
 
 **Arguments:** One argument. If `S` is not a set, the result is undefined.
+
+**Apalache type:** `Set(a) => Bool`, for some type `a`.
 
 **Effect:** `IsFinite(S)` evaluates to:
 

--- a/docs/src/lang/standard-operators.md
+++ b/docs/src/lang/standard-operators.md
@@ -92,8 +92,10 @@ _Unbounded integers like in Python._ [Learn more...](./integers.md)
 
 _String constants_. You learned it!
 
- - String literals, e.g., `"hello"` and `"TLA+ is awesome"`
- - Set of all finite strings: `STRING`
+ - String literals, e.g., `"hello"` and `"TLA+ is awesome"`.
+   - In Apalache, the literals have the type `Str`.
+ - Set of all finite strings: `STRING`.
+   - In Apalache, the set `STRING` has the type `Set(Str)`.
 
 ### Sets :sushi:
 

--- a/docs/src/lang/tuples.md
+++ b/docs/src/lang/tuples.md
@@ -60,7 +60,9 @@ As tuples are also sequences in TLA+, this poses a challenge for the Apalache
 type checker. For instance, it can immediately figure out that `<<1, "Foo">>`
 is a tuple, as Apalache does not allow sequences to carry elements of different
 types. However, there is no way to say, whether `<<1, 2, 3>>` should be treated
-as a tuple or a sequence. This needs a [type annotation][].
+as a tuple or a sequence. Usually, this problem is resolved by annotating the
+type of a variable or the type of a user operator. See [HOWTO write type
+annotations][].
 
 _Owing to the type information, tuples are translated into SMT much more efficiently
 by Apalache than the general functions and sequences!_
@@ -83,6 +85,15 @@ immutable dictionary.
 **LaTeX notation:** ![tuple](./img/tuple.png)
 
 **Arguments:** An arbitrary number of arguments.
+
+**Apalache type:** This operator is overloaded. There are two potential types:
+
+  1. A tuple constructor: `(a_1, ..., a_n) => <<a_1, ..., a_n>>`,
+    for some types `a_1, ..., a_n`.
+  1. A sequence constructor: `(a, ..., a) => Seq(a)`, for some type `a`.
+
+That is why the Apalache type checker is sometimes asking you to add annotations,
+in order to resolve this ambiguity.
 
 **Effect:** The tuple constructor returns a function `t` that is constructed
 as follows:
@@ -123,6 +134,9 @@ principle "tuples are functions", we have to use a dictionary.
 **LaTeX notation:** ![set-prod](./img/set-prod.png)
 
 **Arguments:** At least two arguments. All of them should be sets.
+
+**Apalache type:** `(Set(a_1), ..., Set(a_n)) => Set(<<a_1, ..., a_n>>)`,
+    for some types `a_1, ..., a_n`.
 
 **Effect:** The Cartesian product `S_1 \X ... \X S_n`
 is syntax sugar for the set comprehension:
@@ -166,8 +180,10 @@ is picked with `\E t \in S_1 \X S_2`.
 <a name="app"></a>
 ### Function application
 
-As tuples are functions, you can access tuple elements by
-[function application](./functions.md#funApp), e.g., `tup[2]`.
+As tuples are functions, you can access tuple elements by [function
+application](./functions.md#funApp), e.g., `tup[2]`. However, in the case of a
+tuple, the type of the function application will be: `(<<a_1, ..., a_i, ...,
+a_n>>, Int) => a_i`, for some types `a_1, ..., a_n`.
 
 
 [Control Flow and Non-determinism]: ./control-and-nondeterminism.md
@@ -176,4 +192,4 @@ As tuples are functions, you can access tuple elements by
 [Paxos]: https://github.com/tlaplus/Examples/blob/master/specifications/Paxos/Paxos.tla
 [Apalache ADR002]: ../adr/002adr-types.md
 [Cartesian product]: https://en.wikipedia.org/wiki/Cartesian_product
-[type annotation]: ../apalache/types-and-annotations.md
+[HOWTO write type annotations]: ../../HOWTOs/howto-write-type-annotations.md


### PR DESCRIPTION
This PR adds types of the standard operators in the language manual.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
