### PR TITLE
update the HOWTO with type aliases

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,4 +14,6 @@
 
 * Manual: added a tutorial on the type checker Snowcat, see #689
 * Language manual: add types for the standard operators, see #547
-* Type checker: add support for type aliases, e.g., `@typeAlias FOO = [a: Int, b: Int]`, see #704
+* Type checker: add support for type aliases,
+  e.g., `@typeAlias FOO = [a: Int, b: Int]`, see #704
+* Manual: updated the HOWTO on type annotations with type aliases

--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -295,6 +295,57 @@ This time the type checker can find the types of all expressions:
  > Your types are great!
 ```
 
+<a id="typeAliases"></a>
+## Recipe 6: type aliases
+
+Check the example [MissionariesAndCannibals.tla][] from the repository of TLA+
+examples. 
+
+We can annotate constants as follows:
+
+```tla
+CONSTANTS
+    \* @type: Set(PERSON);
+    Missionaries,
+    \* @type: Set(PERSON);
+    Cannibals 
+```
+
+If we continue annotating other declarations in the specification, we will see
+that the type `Set(PERSON)` is used quite a lot. Would not it be great to
+introduce a shortcut for this type?
+
+We can do that by declaring a type alias as follows:
+
+```tla
+CONSTANTS
+    \* @typeAlias PERSONS = Set(PERSON);
+    \* @type: PERSONS;
+    Missionaries,
+    \* @type: PERSONS;
+    Cannibals 
+```
+
+The basic rule is that we can introduce a type alias with `@typeAlias` in the
+same place, where we can write a `@type` annotation. For more precise rules,
+check [ADR002][].  Having defined the type alias, we can use it in the later
+definitions:
+
+```tla
+VARIABLES
+    \* @type: Str;
+    bank_of_boat,
+    \* @type: Str -> PERSONS;
+    who_is_on_bank 
+```
+
+Surely, we did not gain much by writing `PERSONS` instead of `Set(PERSON)`.  If
+your specification has complex types, e.g., records, aliases may help you in
+minimizing the burden of specification maintenance. When you add one more field
+to the record type, it suffices to change the definition of the type alias,
+instead of changing the record type everywhere.
+
+
 ## Known issues
 
 In contrast to all other cases, a local operator definition does require
@@ -320,3 +371,4 @@ This may change later, when the tlaplus [Issue 578][] is resolved.
 [Specifying Systems]: http://lamport.azurewebsites.net/tla/book.html?back-link=learning.html#book
 [Issue 401]: https://github.com/informalsystems/apalache/issues/401
 [Issue 578]: https://github.com/tlaplus/tlaplus/issues/578
+[MissionariesAndCannibals.tla]: https://github.com/tlaplus/Examples/blob/master/specifications/MissionariesAndCannibals/MissionariesAndCannibals.tla

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -7,7 +7,7 @@ annotating a specification with types.
 ## Related documents
 
 - [ADR002][] that introduces Type System 1, which is used by Snowcat.
-- A technical [HOWTO on writing type annotations][].
+- A more technical [HOWTO on writing type annotations][].
 - [ADR004][] that introduces Java-like annotations in TLA+ comments.
 
 ## Setup
@@ -306,12 +306,18 @@ Pos ==
     {<<x, y>>: x, y \in 1..N}
 ```
 
+## Further reading
+
 For more advanced type annotations, check the following examples:
 
 - [CigaretteSmokersTyped.tla][],
 - [CarTalkPuzzleTyped.tla][],
 - [FunctionsTyped.tla][],
 - [QueensTyped.tla][].
+
+We have not discussed type aliases, which are a more advanced feature of the
+type checker. To learn about type aliases, see [HOWTO on writing type
+annotations][].
 
 If you are experiencing a problem with Snowcat, feel free to [open an issue]
 or drop us a message on [Zulip chat].

--- a/test/tla/MissionariesAndCannibalsTyped.tla
+++ b/test/tla/MissionariesAndCannibalsTyped.tla
@@ -31,9 +31,10 @@ EXTENDS Integers, FiniteSets
 (* Next comes the declaration of the sets of missionaries and cannibals.   *)
 (***************************************************************************)
 CONSTANTS
-    \* @type: Set(PERSON);
+    \* @typeAlias: PERSONS = Set(PERSON);
+    \* @type: PERSONS;
     Missionaries,
-    \* @type: Set(PERSON);
+    \* @type: PERSONS;
     Cannibals 
 
 (***************************************************************************)
@@ -75,7 +76,7 @@ CONSTANTS
 VARIABLES
     \* @type: Str;
     bank_of_boat,
-    \* @type: Str -> Set(PERSON);
+    \* @type: Str -> PERSONS;
     who_is_on_bank 
 
 (***************************************************************************)
@@ -174,7 +175,7 @@ OtherBank(b) == IF b = "E" THEN "W" ELSE "E"
 (* of the two variables (their values in state t) in terms of their old    *)
 (* values (their values in state s).                                       *)
 (***************************************************************************)
-\* @type: (Set(PERSON), Str) => Bool;
+\* @type: (PERSONS, Str) => Bool;
 Move(S,b) ==
              /\ Cardinality(S) \in {1,2}
              /\ LET newThisBank  == who_is_on_bank[b] \ S


### PR DESCRIPTION
This PR adds Recipe 6 on type aliases to the HOWTO on type annotations.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
