### PR TITLE
a simple test demonstrating 712

### DIFF
--- a/test/tla/Deadlock712.tla
+++ b/test/tla/Deadlock712.tla
@@ -1,0 +1,29 @@
+------------------------ MODULE Deadlock712 ------------------------------------
+(*
+ This test shows that Apalache 0.15.1 can miss a deadlock.
+ Discussed in issue: https://github.com/informalsystems/apalache/issues/712
+ *)
+EXTENDS Integers
+
+VARIABLE
+    \* @type: Int;
+    x
+
+Init ==
+    x = 0
+
+\* This transition leads to a deadlock state.
+A ==
+    /\ x % 2 = 0
+    /\ x' = x + 1
+
+\* An infinite sequence of B's can be applied from the initial state.
+B ==
+    /\ x % 2 = 0
+    /\ x' = x + 2
+
+\* An infinite sequences of Next's can be applied from the initial state.
+\* Hence, Apalache does not report a deadlock.
+Next ==
+    A \/ B
+================================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -689,6 +689,17 @@ $ apalache-mc check ITE_CASE.tla | sed 's/I@.*//'
 EXITCODE: ERROR (99)
 ```
 
+### check Deadlock712 succeeds
+
+This test shows that Apalache may miss a deadlock, as discussed in issue 712.
+Once this is fixed, Apalache should find a deadlock.
+
+```sh
+$ apalache-mc check Deadlock712.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+```
+
 ### check use of TLA_PATH for modules in child directory succeeds
 
 ```sh

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -698,6 +698,7 @@ Once this is fixed, Apalache should find a deadlock.
 $ apalache-mc check Deadlock712.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
+...
 ```
 
 ### check use of TLA_PATH for modules in child directory succeeds


### PR DESCRIPTION
Added a test that demonstrates #712.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
