### PR TITLE
Generators of bounded data structures and the command 'test'

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,6 @@
 ### Features
 
 * Manual: added manual page on known issues
+* IR: added `Apalache!Gen` to generate bounded data structures, see #622
+* Checker: added support for `Apalache!Gen`, see #622
+* Tool: added a new command `test` to quickly evaluate an action in isolation, see #622

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -97,7 +97,7 @@ object Tool extends App with LazyLogging {
           case Some(test: TestCmd) =>
             logger.info(
                 "Checker options: filename=%s, before=%s, action=%s, after=%s"
-                  .format(test.file, test.before, test.action, test.after))
+                  .format(test.file, test.before, test.action, test.assertion))
             submitStatisticsIfEnabled(Map("tool" -> "apalache", "mode" -> "test", "workers" -> "1"))
             val injector = injectorFactory(test)
             handleExceptions(injector, runTest(injector, test, _))
@@ -205,7 +205,7 @@ object Tool extends App with LazyLogging {
     executor.options.set("parser.filename", test.file.getAbsolutePath)
     executor.options.set("checker.init", test.before)
     executor.options.set("checker.next", test.action)
-    executor.options.set("checker.inv", List(test.after))
+    executor.options.set("checker.inv", List(test.assertion))
     if (test.cinit != "") {
       executor.options.set("checker.cinit", test.cinit)
     }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -16,8 +16,8 @@ class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ 
     arg[String](name = "before", description = "the name of an operator to prepare the test, similar to Init")
   var action: String =
     arg[String](name = "action", description = "the name of an action to execute, similar to Next")
-  var after: String =
-    arg[String](name = "after",
+  var assertion: String =
+    arg[String](name = "assertion",
         description = "the name of an operator that should evaluate to true after executing `action`")
   var cinit: String = opt[String](name = "cinit", default = "",
       description = "the name of an operator that initializes CONSTANTS,\n" +

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -1,0 +1,25 @@
+package at.forsyte.apalache.tla.tooling.opt
+
+import org.backuity.clist.{Command, _}
+
+import java.io.File
+
+/**
+ * This command initiates the 'test' command line.
+ *
+ * @author Igor Konnov
+ */
+class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ specification") with General {
+
+  var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
+  var before: String =
+    arg[String](name = "before", description = "the name of an operator to prepare the test, similar to Init")
+  var action: String =
+    arg[String](name = "action", description = "the name of an action to execute, similar to Next")
+  var after: String =
+    arg[String](name = "after",
+        description = "the name of an operator that should evaluate to true after executing `action`")
+  var cinit: String = opt[String](name = "cinit", default = "",
+      description = "the name of an operator that initializes CONSTANTS,\n" +
+        "default: None")
+}

--- a/src/tla/Apalache.tla
+++ b/src/tla/Apalache.tla
@@ -29,6 +29,16 @@
 x := e == x = e
 
 (*****************************************************************************)
+(* A generator of a data structure. Given a positive integer `bound`, and    *)
+(* assuming that the type of the operator application is known, we           *)
+(* recursively generate a TLA+ data structure as a tree, whose width is      *)
+(* bound by the number `bound`.                                              *)
+(*                                                                           *)
+(* The body of this operator is redefined by Apalache.                       *)
+(*****************************************************************************)
+Gen(size) == {}
+
+(*****************************************************************************)
 (* As TLA+ is untyped, one can use function- and sequence-specific operators *)
 (* interchangeably. However, to maintain correctness w.r.t. our type-system, *)
 (* an explicit cast is needed when using functions as sequences.             *)

--- a/test/tla/TestGen.tla
+++ b/test/tla/TestGen.tla
@@ -12,7 +12,7 @@ VARIABLES
     seqno
 
 \* preparing a test, like you do it in unit tests
-Before ==
+Prepare ==
     /\ seqno = Gen(1)
     /\ msgs = Gen(5)
     /\ \A m \in msgs:
@@ -24,8 +24,8 @@ Test ==
         msgs' = { [seqno |-> seqno, ballot |-> b] } \union msgs
     /\ seqno' = seqno + 1    
 
-\* check the expectation after running the test
-After ==
+\* check the assertion after running the test
+Assertion ==
     \A m1, m2 \in msgs:
       m2.seqno > m1.seqno => m2.ballot >= m1.ballot
 

--- a/test/tla/TestGen.tla
+++ b/test/tla/TestGen.tla
@@ -1,0 +1,32 @@
+------------------------------ MODULE TestGen ---------------------------------
+(* A simple test for the data structure generator *)
+EXTENDS Integers, Apalache
+
+VARIABLES
+    (*
+     @typeAlias: MSG = [seqno: Int, ballot: Int];
+     @type: Set(MSG);
+    *)
+    msgs,
+    \* @type: Int;
+    seqno
+
+\* preparing a test, like you do it in unit tests
+Before ==
+    /\ seqno = Gen(1)
+    /\ msgs = Gen(5)
+    /\ \A m \in msgs:
+        m.seqno < seqno
+
+\* run the test (typically, an action)
+Test ==
+    /\ \E b \in Int:
+        msgs' = { [seqno |-> seqno, ballot |-> b] } \union msgs
+    /\ seqno' = seqno + 1    
+
+\* check the expectation after running the test
+After ==
+    \A m1, m2 \in msgs:
+      m2.seqno > m1.seqno => m2.ballot >= m1.ballot
+
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -145,7 +145,8 @@ EXITCODE: OK
 
 ### test TestGen finds an example
 
-This simple test demonstrates how to test large specs by isolating the input with generators.
+This simple test demonstrates how to test a spec by isolating the input with
+generators.
 
 ```sh
 $ apalache-mc test TestGen.tla Prepare Test Assertion | sed 's/I@.*//'

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -693,15 +693,6 @@ The outcome is: NoError
 ...
 ```
 
-### check TestGen succeeds
-
-```sh
-$ apalache-mc check TestGen.tla | sed 's/I@.*//'
-...
-The outcome is: NoError
-...
-```
-
 ### check ITE_CASE succeeds
 
 ```sh

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -148,7 +148,7 @@ EXITCODE: OK
 This simple test demonstrates how to test large specs by isolating the input with generators.
 
 ```sh
-$ apalache-mc test TestGen.tla Before Test After | sed 's/I@.*//'
+$ apalache-mc test TestGen.tla Prepare Test Assertion | sed 's/I@.*//'
 ...
 The outcome is: Error
 Checker has found an example. Check counterexample.tla.

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -143,6 +143,18 @@ EXITCODE: OK
 ...
 ```
 
+### test TestGen finds an example
+
+This simple test demonstrates how to test large specs by isolating the input with generators.
+
+```sh
+$ apalache-mc test TestGen.tla Before Test After | sed 's/I@.*//'
+...
+The outcome is: Error
+Checker has found an example. Check counterexample.tla.
+...
+```
+
 ## running the check command
 
 #### check factorization find a counterexample
@@ -676,6 +688,15 @@ EXITCODE: ERROR (99)
 
 ```sh
 $ apalache-mc check test1.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+```
+
+### check TestGen succeeds
+
+```sh
+$ apalache-mc check TestGen.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -276,6 +276,8 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
         // misc
         key(OperEx(TlaOper.label, tla.str("lab"), tla.str("x")))
           -> List(new LabelRule(this)),
+        key(OperEx(ApalacheOper.gen, tla.int(2)))
+          -> List(new GenRule(this)),
         // TLC
         key(OperEx(TlcOper.print, tla.bool(true), tla.str("msg")))
           -> List(new TlcRule(this)),

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/GenRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/GenRule.scala
@@ -1,0 +1,35 @@
+package at.forsyte.apalache.tla.bmcmt.rules
+
+import at.forsyte.apalache.tla.bmcmt._
+import at.forsyte.apalache.tla.bmcmt.rules.aux.ValueGenerator
+import at.forsyte.apalache.tla.lir.oper.ApalacheOper
+import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.{OperEx, TlaType1, ValEx}
+
+/**
+ * Implements a rule for Apalache!Gen.
+ *
+ * @author Igor Konnov
+ */
+class GenRule(rewriter: SymbStateRewriter) extends RewritingRule {
+  override def isApplicable(symbState: SymbState): Boolean = {
+    symbState.ex match {
+      case OperEx(ApalacheOper.gen, _) => true
+      case _                           => false
+    }
+  }
+
+  override def apply(state: SymbState): SymbState = {
+    state.ex match {
+      case OperEx(ApalacheOper.gen, ValEx(TlaInt(bound))) if bound.isValidInt && bound.toInt > 0 =>
+        val resultType = TlaType1.fromTypeTag(state.ex.typeTag)
+        new ValueGenerator(rewriter, bound.toInt).gen(state, resultType)
+
+      case ex @ OperEx(ApalacheOper.gen, boundEx) =>
+        throw new RewriterException("Apalache!Gen expects a constant positive integer. Found: " + boundEx, ex)
+
+      case _ =>
+        throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)
+    }
+  }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
@@ -1,0 +1,181 @@
+package at.forsyte.apalache.tla.bmcmt.rules.aux
+
+import at.forsyte.apalache.tla.bmcmt.types.{BoolT, CellT, ConstT, FinSetT, IntT, TupleT}
+import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, SymbState, SymbStateRewriter}
+import at.forsyte.apalache.tla.lir.{BoolT1, ConstT1, FunT1, IntT1, RecT1, SeqT1, SetT1, StrT1, TlaType1, TupT1, Typed}
+import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.TypedPredefs._
+
+/**
+ * This class generates symbolic data structures whose width is bounded with `bound`
+ *
+ * @param rewriter a rewriter
+ * @param bound    an upper bound on the size of the generated structures
+ * @author Igor Konnov
+ */
+class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
+  def gen(state: SymbState, resultType: TlaType1): SymbState = {
+    rewriter.solverContext.log(s"; GEN $resultType up to $bound {")
+    val nextState =
+      resultType match {
+        case IntT1() =>
+          val nextState = state.updateArena(a => a.appendCell(IntT()))
+          nextState.setRex(nextState.arena.topCell.toNameEx.withTag(Typed(resultType)))
+
+        case BoolT1() =>
+          val nextState = state.updateArena(a => a.appendCell(BoolT()))
+          nextState.setRex(nextState.arena.topCell.toNameEx.withTag(Typed(resultType)))
+
+        case StrT1() =>
+          val nextState = state.updateArena(a => a.appendCell(ConstT()))
+          nextState.setRex(nextState.arena.topCell.toNameEx.withTag(Typed(resultType)))
+
+        case ConstT1(_) =>
+          // For the moment, we do not distinguish between ConstT1 and StrT1.
+          // When issue #570 is fixed, we should come back to it.
+          val nextState = state.updateArena(a => a.appendCell(ConstT()))
+          nextState.setRex(nextState.arena.topCell.toNameEx.withTag(Typed(resultType)))
+
+        case SetT1(elemType) =>
+          genSet(state, elemType)
+
+        case SeqT1(elemType) =>
+          genSeq(state, elemType)
+
+        case rt @ RecT1(_) =>
+          genRecord(state, rt)
+
+        case tt @ TupT1(_ @_*) =>
+          genTuple(state, tt)
+
+        case ft @ FunT1(_, _) =>
+          genFun(state, ft)
+
+        case tp =>
+          throw new RewriterException(s"Apalache!Gen did not expect the type $tp", state.ex)
+      }
+
+    rewriter.solverContext.log(s"; } GEN $resultType up to $bound")
+
+    nextState
+  }
+
+  private def genRecord(state: SymbState, recordType: RecT1): SymbState = {
+    var nextState = state.updateArena(a => a.appendCell(CellT.fromType1(recordType)))
+    val recCell = nextState.arena.topCell
+    // convert the values to a list, so we don't have a lazy stream
+    val elemTypes = recordType.fieldTypes.values.toList
+    val elemCells =
+      elemTypes map { elemType =>
+        nextState = gen(nextState, elemType)
+        nextState.asCell
+      }
+    nextState = nextState.updateArena(a => a.appendHasNoSmt(recCell, elemCells: _*))
+    nextState.setRex(recCell.toNameEx.withTag(Typed(recordType)))
+  }
+
+  private def genTuple(state: SymbState, tupleType: TupT1): SymbState = {
+    var nextState = state.updateArena(a => a.appendCell(CellT.fromType1(tupleType)))
+    val tupleCell = nextState.arena.topCell
+    // convert the values to a list, so we don't have a lazy stream
+    val elemCells =
+      tupleType.elems map { elemType =>
+        nextState = gen(nextState, elemType)
+        nextState.asCell
+      }
+    nextState = nextState.updateArena(a => a.appendHasNoSmt(tupleCell, elemCells: _*))
+    nextState.setRex(tupleCell.toNameEx.withTag(Typed(tupleType)))
+  }
+
+  private def genSet(state: SymbState, elemType: TlaType1): SymbState = {
+    var nextState = state
+    var elems: List[ArenaCell] = Nil
+    for (_ <- 1 to bound) {
+      nextState = gen(nextState, elemType)
+      elems = nextState.asCell :: elems
+    }
+    val setType = FinSetT(CellT.fromType1(elemType))
+    nextState = nextState.updateArena(a => a.appendCell(setType))
+    val setCell = nextState.arena.topCell
+    nextState = nextState.updateArena(a => a.appendHas(setCell, elems: _*))
+    nextState.setRex(setCell.toNameEx.withTag(Typed(SetT1(elemType))))
+  }
+
+  private def genSeq(state: SymbState, elemType: TlaType1): SymbState = {
+    // The following code is following pretty much TupleOrSeqCtorRule.
+    // Sequences are much simpler than function because all the elements in its domain are unique
+    // Create a sequence cell.
+    val seqType = CellT.fromType1(SeqT1(elemType))
+    var nextState = state.updateArena(_.appendCell(seqType))
+    val seq = nextState.arena.topCell
+
+    // generate bound elements
+    var elems: List[ArenaCell] = Nil
+    for (_ <- 1 to bound) {
+      nextState = gen(nextState, elemType)
+      elems = nextState.asCell :: elems
+    }
+
+    // connect N + 2 elements to seqT: the start (>= 0), the end (< bound), and the sequence of values
+    nextState = rewriter.rewriteUntilDone(nextState.setRex(tla.int(0).typed()))
+    val start = nextState.asCell
+    nextState = nextState.updateArena(_.appendCell(IntT()))
+    val end = nextState.arena.topCell
+    val types = Map("i" -> IntT1(), "b" -> BoolT1())
+    rewriter.solverContext.assertGroundExpr(tla.lt(end.toNameEx ? "i", tla.int(bound)).typed(types, "b"))
+    rewriter.solverContext.assertGroundExpr(tla.ge(end.toNameEx ? "i", tla.int(0)).typed(types, "b"))
+    nextState = nextState.updateArena(_.appendHasNoSmt(seq, start +: end +: elems: _*))
+    // we do not add SMT constraints as they are not important
+    nextState.setRex(seq.toNameEx)
+  }
+
+  private def genFun(state: SymbState, funType: FunT1): SymbState = {
+    var nextState = state
+    var pairs: List[ArenaCell] = Nil
+    // generate a sequence of pairs <<x, y>> that will represent the function
+    for (_ <- 1 to bound) {
+      nextState = gen(nextState, TupT1(funType.arg, funType.res))
+      pairs = nextState.asCell :: pairs
+    }
+    // create a relation cell
+    val argT = CellT.fromType1(funType.arg)
+    val resT = CellT.fromType1(funType.res)
+    nextState = nextState.updateArena(_.appendCell(FinSetT(TupleT(Seq(argT, resT)))))
+    val relationCell = nextState.arena.topCell
+    // we just add the pairs, but do not restrict their membership, as the generator is free to produce a set
+    // that is an arbitrary subset of the pairs
+    nextState = nextState.updateArena(_.appendHas(relationCell, pairs: _*))
+    // create a function cell
+    nextState = nextState.updateArena(_.appendCell(CellT.fromType1(funType)))
+    val funCell = nextState.arena.topCell
+    nextState = nextState.updateArena(_.setCdm(funCell, relationCell))
+    // Require that if two arguments belong to the domain, they are distinct.
+    val types = Map("p" -> TupT1(funType.arg, funType.res), "R" -> SetT1(TupT1(funType.arg, funType.res)),
+        "a" -> funType.arg, "b" -> BoolT1())
+    for ((p1, i1) <- pairs.zipWithIndex) {
+      for ((p2, i2) <- pairs.zipWithIndex) {
+        if (i1 < i2) {
+          // get the arguments that are associated with the pairs
+          val a1 = nextState.arena.getHas(p1).head
+          val a2 = nextState.arena.getHas(p2).head
+          // if two pairs belong to the relation, their arguments must be unequal
+          nextState = rewriter.lazyEq.cacheEqConstraints(nextState, Seq((a1, a2)))
+          val not1 = tla
+            .not(tla.in(p1.toNameEx ? "p", relationCell.toNameEx ? "R") ? "b")
+            .typed(types, "b")
+          val not2 = tla
+            .not(tla.in(p2.toNameEx ? "p", relationCell.toNameEx ? "R") ? "b")
+            .typed(types, "b")
+          val neq = tla
+            .not(tla.eql(a1.toNameEx ? "a", a2.toNameEx ? "a") ? "b")
+            .typed(types, "b")
+          rewriter.solverContext.assertGroundExpr(tla.or(not1, not2, neq).typed(BoolT1()))
+        }
+      }
+    }
+    // This will guarantee that we define a function, not an arbitrary relation.
+    // Note that we cannot simply require that all arguments are distinct,
+    // as there may be not enough values in the universe to guarantee that.
+    nextState.setRex(funCell.toNameEx.withTag(Typed(funType)))
+  }
+}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterApalacheGen.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterApalacheGen.scala
@@ -1,0 +1,162 @@
+package at.forsyte.apalache.tla.bmcmt
+
+import at.forsyte.apalache.tla.lir.TypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla._
+import at.forsyte.apalache.tla.lir.oper.ApalacheOper
+import at.forsyte.apalache.tla.lir.{BoolT1, ConstT1, FunT1, IntT1, OperEx, RecT1, SeqT1, SetT1, StrT1, TupT1, Typed}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestSymbStateRewriterApalacheGen extends RewriterBase {
+  private val types = Map("i" -> IntT1(), "I" -> SetT1(IntT1()), "b" -> BoolT1())
+
+  test("""Gen(1) for Int""") {
+    val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(IntT1()))
+
+    val state = new SymbState(gen, arena, Binding())
+    val rewriter = create()
+    val ge10 = ge(state.ex ? "i", int(10))
+      .typed(types, "b")
+    val nextState = rewriter.rewriteUntilDone(state.setRex(ge10))
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(1) for Str""") {
+    val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(StrT1()))
+
+    val state = new SymbState(gen, arena, Binding())
+    val rewriter = create()
+    val eq = eql(state.ex ? "s", str("foo"))
+      .typed(types, "b")
+    val nextState = rewriter.rewriteUntilDone(state.setRex(eq))
+    assert(solverContext.sat())
+    solverContext.push()
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+    solverContext.pop()
+    solverContext.assertGroundExpr(not(nextState.ex ? "b").typed(types, "b"))
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(1) for ConstT1(name)""") {
+    // in the current implementation, ConstT1(PID) is generated the same way as StrT1
+    val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(ConstT1("PID")))
+
+    val state = new SymbState(gen, arena, Binding())
+    val rewriter = create()
+    val eq = eql(state.ex ? "s", str("foo"))
+      .typed(types, "b")
+    val nextState = rewriter.rewriteUntilDone(state.setRex(eq))
+    assert(solverContext.sat())
+    solverContext.push()
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+    solverContext.pop()
+    solverContext.assertGroundExpr(not(nextState.ex ? "b").typed(types, "b"))
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(1) for Bool""") {
+    val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(BoolT1()))
+
+    val state = new SymbState(gen, arena, Binding())
+    val rewriter = create()
+    val nextState = rewriter.rewriteUntilDone(state)
+    assert(solverContext.sat())
+    solverContext.push()
+    // both b and ~b are possible
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+    solverContext.pop()
+    solverContext.assertGroundExpr(not(nextState.ex ? "b").typed(types, "b"))
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(3) = { 1, 2, 3 }""") {
+    val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(SetT1(IntT1())))
+    val eq123 = eql(gen, enumSet(int(1), int(2), int(3)) ? "I").typed(types, "b")
+
+    val state = new SymbState(eq123, arena, Binding())
+    val nextState = create().rewriteUntilDone(state)
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(3) = { }""") {
+    val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(SetT1(IntT1())))
+    val eq123 = eql(gen, enumSet() ? "I").typed(types, "b")
+
+    val state = new SymbState(eq123, arena, Binding())
+    val nextState = create().rewriteUntilDone(state)
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(3) for [i: Int, b: Bool]""") {
+    val recordType = RecT1("i" -> IntT1(), "b" -> BoolT1())
+    val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(recordType))
+    val i_eq_10 = eql(appFun(gen, str("i")) ? "i", int(10)).typed(types, "b")
+
+    val state = new SymbState(i_eq_10, arena, Binding())
+    val nextState = create().rewriteUntilDone(state)
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(3) for <<Int, Bool>>""") {
+    val tupleType = TupT1(IntT1(), BoolT1())
+    val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(tupleType))
+    val i_eq_10 = eql(appFun(gen, int(1)) ? "i", int(10)).typed(types, "b")
+
+    val state = new SymbState(i_eq_10, arena, Binding())
+    val nextState = create().rewriteUntilDone(state)
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+  }
+
+  test("""Gen(4) for Int -> Bool""") {
+    val funType = FunT1(IntT1(), BoolT1())
+    val gen = OperEx(ApalacheOper.gen, int(4).typed())(Typed(funType))
+
+    val state = new SymbState(gen, arena, Binding())
+    val rewriter = create()
+    var nextState = rewriter.rewriteUntilDone(state)
+    val fun = nextState.ex
+    val dom_eq_1_3 = eql(dom(fun) ? "I", enumSet(int(1), int(3)) ? "I")
+      .typed(types, "b")
+    nextState = rewriter.rewriteUntilDone(nextState.setRex(dom_eq_1_3))
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+    // make sure that the function does not return two different results for the argument
+    val neq = not(eql(appFun(fun, int(1)) ? "b", appFun(fun, minus(int(2), int(1)) ? "i") ? "b") ? "b")
+      .typed(types, "b")
+    nextState = rewriter.rewriteUntilDone(nextState.setRex(neq))
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(!solverContext.sat())
+  }
+
+  test("""Gen(4) for Seq(Bool)""") {
+    val seqType = SeqT1(BoolT1())
+    val gen = OperEx(ApalacheOper.gen, int(4).typed())(Typed(seqType))
+
+    val state = new SymbState(gen, arena, Binding())
+    val rewriter = create()
+    var nextState = rewriter.rewriteUntilDone(state)
+    val seq = nextState.ex
+    val dom_eq_123 = eql(dom(seq) ? "I", enumSet(int(1), int(2), int(3)) ? "I")
+      .typed(types, "b")
+    nextState = rewriter.rewriteUntilDone(nextState.setRex(dom_eq_123))
+    assert(solverContext.sat())
+    solverContext.assertGroundExpr(nextState.ex)
+    assert(solverContext.sat())
+
+  }
+}

--- a/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -70,6 +70,7 @@ object StandardLibrary {
         ("TLC", "Print") -> TlcOper.print,
         ("TLC", "PrintT") -> TlcOper.printT,
         ("Apalache", ":=") -> ApalacheOper.assign,
+        ("Apalache", "Gen") -> ApalacheOper.gen,
         ("Apalache", "Skolem") -> ApalacheOper.skolem,
         ("Apalache", "Expand") -> ApalacheOper.expand,
         ("Apalache", "ConstCardinality") -> ApalacheOper.constCard,

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -708,6 +708,12 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         val opsig = OperT1(Seq(FunT1(IntT1(), a), IntT1()), SeqT1(a))
         mkExRefApp(opsig, Seq(fun, len))
 
+      case OperEx(ApalacheOper.gen, bound) =>
+        val a = varPool.fresh
+        // Int => a
+        val opsig = OperT1(Seq(IntT1()), a)
+        mkExRefApp(opsig, Seq(bound))
+
       case OperEx(ApalacheOper.assign, lhs, rhs) =>
         val a = varPool.fresh
         // (a, a) => Bool

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -748,6 +748,13 @@ class TestToEtcExpr extends FunSuite with BeforeAndAfterEach with EtcBuilder {
     assert(expected == gen(ex))
   }
 
+  test("Apalache!Gen") {
+    val typ = parser("Int => a")
+    val expected = mkAppByName(Seq(typ), "x")
+    val ex = OperEx(ApalacheOper.gen, tla.name("x"))
+    assert(expected == gen(ex))
+  }
+
   test("Apalache!Skolem") {
     val typ = parser("Bool => Bool")
     val expected = mkAppByName(Seq(typ), "P")

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
@@ -36,6 +36,19 @@ object ApalacheOper {
   }
 
   /**
+   * A generator of a data structure. Given a positive integer `bound`, and assuming that the type of the operator
+   * application is known, we recursively generate a TLA+ data structure as a tree, whose width is bound by the
+   * number `bound`.
+   */
+  object gen extends ApalacheOper {
+    override def name: String = "Apalache!Gen"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override def precedence: (Int, Int) = (100, 100)
+  }
+
+  /**
    * Skolemization hint. In an expression Skolem(\E x \in S: e), the existential may be skolemized, that is, translated
    * into a constant.
    */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
@@ -122,6 +122,7 @@ object KeraLanguagePred {
         TlaSeqOper.len,
         TlcOper.printT, // TODO: preprocess into NullEx in Keramelizer
         ApalacheOper.skolem,
+        ApalacheOper.gen,
         ApalacheOper.expand,
         ApalacheOper.constCard
         // for the future


### PR DESCRIPTION
This PR closes #622. Perhaps, it also addresses #191, but I am not sure. What happens here:

- Add the operator `Apalache!Gen`. A call to `Gen(n)` produces a data structure of the proper type (basically, a tree) whose elements can also be data structures, and the number of elements is bounded by `n` at every level. For example, `Gen(5)` of type `Set(Int -> Bool)` produces a set of up to 5 functions, whose domains have up to 5 integers.
- Add the command `test <spec> <before> <action> <assertion>` to run a quick test for an action in isolation.
- Add an example that uses both `Gen` and `test` to do something great, see `TestGen.tla`.

This feature requires a proper documentation and probably a tutorial. I feel that we should experiment with it a bit.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
