### PR TITLE
fix the typo in typeAlias and add a warning on multiline comments

### DIFF
--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -319,7 +319,7 @@ We can do that by declaring a type alias as follows:
 
 ```tla
 CONSTANTS
-    \* @typeAlias PERSONS = Set(PERSON);
+    \* @typeAlias: PERSONS = Set(PERSON);
     \* @type: PERSONS;
     Missionaries,
     \* @type: PERSONS;
@@ -348,6 +348,8 @@ instead of changing the record type everywhere.
 
 ## Known issues
 
+### Annotations of LOCAL operators
+
 In contrast to all other cases, a local operator definition does require
 a type annotation before the keyword `LOCAL`, not after it. For example:
 
@@ -357,6 +359,19 @@ LOCAL LocalInc(x) == x + 1
 ```
 
 This may change later, when the tlaplus [Issue 578][] is resolved.
+
+### Multi-line annotations
+
+A type annotation may span over multiple lines. However, you should use
+the `(* ... *)` syntax in this case. An annotation in a series
+of single-line comments is not properly parsed. For example:
+
+```tla
+\* @type: Int
+\*          => Bool;
+```
+
+To see progress on this issue, check [Issue 718][].
 
 
 [old type annotations]: ../apalache/types-and-annotations.md
@@ -371,4 +386,5 @@ This may change later, when the tlaplus [Issue 578][] is resolved.
 [Specifying Systems]: http://lamport.azurewebsites.net/tla/book.html?back-link=learning.html#book
 [Issue 401]: https://github.com/informalsystems/apalache/issues/401
 [Issue 578]: https://github.com/tlaplus/tlaplus/issues/578
+[Issue 718]: https://github.com/informalsystems/apalache/issues/718
 [MissionariesAndCannibals.tla]: https://github.com/tlaplus/Examples/blob/master/specifications/MissionariesAndCannibals/MissionariesAndCannibals.tla

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -80,6 +80,11 @@ identifier `RM`. We used the one-line TLA+ comment: `\* @type: ...;`.
 Alternatively, we could use the multi-line comment: `(* @type: Set(Str); *)`.
 Importantly, the type annotation should end with a semi-colon: `;`.
 
+**Warning**. If you want to write a type annotation on multiple lines, write it
+in a multi-line comment `(* ... *)` instead of starting multiple lines with a
+single-line comment `\* ...`. See [issue
+718](https://github.com/informalsystems/apalache/issues/718).
+
 ## Step 3: Running Snowcat again
 
 Having introduced the type annotation for `RM`, let's run the type checker again:


### PR DESCRIPTION
A few fixes in the documentation after the bugs found by @istoilkovska 

- [ ] ~Tests added for any new code~
- [ ] ~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
