### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,9 @@ jobs:
         with:
           path: ~/.opam
           key: ${{ runner.os }}-opam-4.11.0
+      - name: Update brew
+        run: |
+          brew update
       - name: Set up opam
         uses: avsm/setup-ocaml@v1
         with:


### PR DESCRIPTION
Due either to a [homebrew update](https://brew.sh/2021/04/12/homebrew-3.1.0/) or a [bintray outage](https://status.bintray.com/), the part of our macos integration tests that depends on homebrew broke. Adding a step to update homebrew fixes this.