### PR TITLE
Closes 705: error on missing annotations

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,9 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+* Type checker: Showing an error on an annotation for a CONSTANT or VARIABLE, see #705
+
 ### Changed
 
 * IR: simplified `SimpleFormalParam` and `OperFormalParam` into `OperParam`, see #656

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,7 +11,7 @@
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Bug fixes
-* Type checker: Showing an error on an annotation for a CONSTANT or VARIABLE, see #705
+* Type checker: Showing an error on missing annotations CONSTANTs or VARIABLEs, see #705
 
 ### Changed
 

--- a/test/tla/UntypedConst.tla
+++ b/test/tla/UntypedConst.tla
@@ -1,0 +1,18 @@
+------------------------ MODULE UntypedConst ----------------------------------
+\* typecheck should complain about a missing annotation
+EXTENDS Integers
+
+CONSTANT
+    \* N is missing a type annotation
+    N
+
+VARIABLE
+    \* @type: Int;
+    x
+
+Init ==
+    x = N
+
+Next ==
+    x' = x + 1
+===============================================================================

--- a/test/tla/UntypedVar.tla
+++ b/test/tla/UntypedVar.tla
@@ -1,0 +1,18 @@
+------------------------ MODULE UntypedVar ------------------------------------
+\* typecheck should complain about a missing annotation
+EXTENDS Integers
+
+CONSTANT
+    \* @type: Int;
+    N
+
+VARIABLE
+    \* N is missing a type annotation
+    x
+
+Init ==
+    x = N
+
+Next ==
+    x' = x + 1
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1253,3 +1253,27 @@ Type checker [OK]
 EXITCODE: OK
 ```
 
+### typecheck UntypedConst.tla
+
+```sh
+$ apalache-mc typecheck UntypedConst.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeCheckerSnowcat
+ > Running Snowcat .::.
+Typing input error: Expected a type annotation for CONSTANT N
+...
+EXITCODE: ERROR (99)
+```
+
+### typecheck UntypedVar.tla
+
+```sh
+$ apalache-mc typecheck UntypedVar.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeCheckerSnowcat
+ > Running Snowcat .::.
+Typing input error: Expected a type annotation for VARIABLE x
+...
+EXITCODE: ERROR (99)
+```
+

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1156,11 +1156,9 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck Channel.tla | sed 's/[IEW]@.*//'
 ...
-[Channel.tla:8:20-8:23]: Undefined name chan. Introduce a type annotation.
+Typing input error: Expected a type annotation for VARIABLE chan
 ...
-Type checker [FAILED]
-...
-EXITCODE: OK
+EXITCODE: ERROR (99)
 ```
 
 ### typecheck ChannelTyped.tla


### PR DESCRIPTION
This PR closes issue #705. The type checker complains about a missing annotation for a constant or a variable, instead of showing an error later.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
