### PR TITLE
closes #748: no exception on `Cardinality(a..b) > i`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@
 
 ### Bug fixes
 * Type checker: Showing an error on missing annotations CONSTANTs or VARIABLEs, see #705
+* Model checker: Fix an exception on `Cardinality(a..b) > i`, see #748
 
 ### Changed
 


### PR DESCRIPTION
Closes #748. That was a coding bug. Additionally, `ExprOptimizer` transforms `Cardinality(a..b)` to `b - a + 1`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
