### PR TITLE
closes #762: create $HOME/.tlaplus if it does not exist

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+ * The command `config --enable-stats=true` creates `$HOME/.tlaplus` if needed, see #762

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -354,7 +354,11 @@ object Tool extends App with LazyLogging {
   private def configure(config: ConfigCmd): Unit = {
     config.submitStats match {
       case Some(isEnabled) =>
-        if (configDirExistsOrCreated()) {
+        val warning = "Unable to update statistics configuration. The other features will keep working."
+
+        if (!configDirExistsOrCreated()) {
+          logger.warn(warning)
+        } else {
           val statCollector = new ExecutionStatisticsCollector()
           // protect against potential exceptions in the tla2tools code
           try {
@@ -370,9 +374,10 @@ object Tool extends App with LazyLogging {
           } catch {
             case e: Exception =>
               logger.warn(e.getMessage)
-              logger.warn(s"Unable to update statistics configuration. The other features will keep working.")
+              logger.warn(warning)
           }
         }
+
       case None =>
         ()
     }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -390,7 +390,7 @@ object Tool extends App with LazyLogging {
       } catch {
         case e: Exception =>
           logger.warn(e.getMessage)
-          logger.warn(s"Unable to create the directory $configDir. The statistics will not be collected.")
+          logger.warn(s"Unable to create the directory $configDir.")
           false
       }
     }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1293,3 +1293,25 @@ Typing input error: Expected a type annotation for VARIABLE x
 EXITCODE: ERROR (99)
 ```
 
+## Running the config command
+
+### config --enable-stats=false
+
+```sh
+$ apalache-mc config --enable-stats=false | sed 's/[IEW]@.*//'
+...
+Statistics collection is OFF.
+...
+EXITCODE: OK
+```
+
+### config --enable-stats=true
+
+```sh
+$ apalache-mc config --enable-stats=true | sed 's/[IEW]@.*//'
+...
+Statistics collection is ON.
+...
+EXITCODE: OK
+```
+


### PR DESCRIPTION
This PR fixes bug #762. It creates the directory `$HOME/.tlaplus` if such a directory does not exist. Also, this PR adds exception processing around the statistics collector.

PS: I will create a PR in tlaplus to create the directory in tla2tools too, as it is an obvious issue.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
