### PR TITLE
Fix the annotation parser

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,9 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+
+### Bug fixes
+
+* Parser: supporting annotations in multiline comments, see #718
+* Parser: supporting TLA+ identifiers in annotations, see #768
+* Parser: better parser for annotations, see #757

--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -362,16 +362,29 @@ This may change later, when the tlaplus [Issue 578][] is resolved.
 
 ### Multi-line annotations
 
-A type annotation may span over multiple lines. However, you should use
-the `(* ... *)` syntax in this case. An annotation in a series
-of single-line comments is not properly parsed. For example:
+A type annotation may span over multiple lines. You may use both the `(* ...
+*)` syntax as well as the single-line syntax `\* ...`. All three examples below
+are accepted by the parser:
 
 ```tla
-\* @type: Int
-\*          => Bool;
+VARIABLES
+   (*
+    @type: Int
+            => Bool;
+    *)           
+    f,
+    \* @type:
+    \*       Int
+    \*          => Bool;
+    g,
+    \* @type("Int
+    \*          => Bool
+    \*       ")
+    h
 ```
 
-To see progress on this issue, check [Issue 718][].
+Note that the parser removes the leading strings `"    \*"` from the annotations,
+similar to how multiline strings are treated in modern programming languages.
 
 
 [old type annotations]: ../apalache/types-and-annotations.md

--- a/docs/src/adr/004adr-annotations.md
+++ b/docs/src/adr/004adr-annotations.md
@@ -35,28 +35,27 @@ An annotation is a string that follows the grammar (question mark denotes
 optional rules):
 
 ```
-Annotation  ::= '@' javaIdentifier ( '(' ArgList? ')' | ':' inlineArg ';' )?
+Annotation  ::= '@' tlaIdentifier ( '(' ArgList? ')' | ':' inlineArg ';' )?
 ArgList     ::= (Arg) ( ',' Arg )*
-Arg         ::= (string | integer | boolean)
+Arg         ::= (string | integer | boolean | tlaIdentifier)
 inlineArg   ::= <char sequence excluding ';'>
 string      ::= '"' <char sequence> '"'
 integer     ::= '-'? [0-9]+
 boolean     ::= ('false' | 'true')
 ```
 
-Java Language Specification defines how a [Java identifier] looks like.
-The sequence `<char sequence>` is a sequence admitted by [JavaTokenParsers]:
+The sequence `<char sequence>` is a sequence of characters admitted by the TLA+ parser:
 
-  - Any character except double quotes, control characters or backslash `\`
+  - Any ASCII character except double quotes, control characters or backslash `\`
   - A backslash followed by another backslash, a single or double quote,
-    or one of the letters `b`, `f`, `n`, `r` or `t`
-  - `\` followed by u followed by four hexadecimal digits
+    or one of the letters `f`, `n`, `r` or `t`.
 
 **Examples.** The following strings are examples of syntactically correct
 annotations:
 
  1. `@tailrec`
  1. `@type("(Int, Int) => Int")`
+ 1. `@require(Init)`
  1. `@type: (Int, Int) => Int ;`
  1. `@random(true)`
  1. `@deprecated("Use operator Foo instead")`
@@ -68,6 +67,28 @@ example 3 is not following the syntax of Java annotations. We have introduced
 this format for one-argument annotations, especially, for type annotations.
 Its purpose is to reduce the visual clutter in annotations that accept a string
 as their only argument.
+
+Currently, annotations are written in comments that precede a definition (see
+the explanation below). String arguments can span over multiple lines. For instance,
+the following examples demonstrate valid annotations inside TLA+ comments:
+
+```tla
+(*
+  @type: Int
+            => Int
+  ;
+ *)
+
+\* @type: Int
+\*           => Int
+\* ;
+
+\* @hal_msg("Sorry,
+\*           I
+\*           CAN
+\*           do that,
+\*           Dave")
+```
 
 ## 3. An annotated specification
 

--- a/test/tla/TestAnnotations.tla
+++ b/test/tla/TestAnnotations.tla
@@ -1,0 +1,38 @@
+---------------------- MODULE TestAnnotations ---------------------------------
+\* test several tricky annotations
+
+VARIABLES
+    \* See issue #718
+    \*
+    \* @typeAlias: ELEM =
+    \*             Int;
+    \* @type:
+    \*   Set(
+    \*        ELEM
+    \*      );
+    \*
+    \* See issue #757
+    \* packetCommitments' = [packetCommitments EXCEPT
+    \*    ![upcomingEvent.chain] = @ \ {upcomingEvent.packet}]
+    S
+
+Init ==
+    S = {}
+
+Next ==
+    S' = {1}
+
+Inv ==
+    2 \notin S
+    
+\* Unit tests as proposed in RFC006
+\*
+\* We can use identifiers, see issue #768
+\*
+\* @require(Init)
+\* @ensure(Assertion)
+\* @testAction(5)
+Test ==
+    Next
+
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1293,3 +1293,33 @@ Typing input error: Expected a type annotation for VARIABLE x
 EXITCODE: ERROR (99)
 ```
 
+### typecheck TestAnnotations.tla
+
+```sh
+$ apalache-mc typecheck TestAnnotations.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeCheckerSnowcat
+ > Running Snowcat .::.
+ > Your types are great!
+ > All expressions are typed
+...
+Type checker [OK]
+...
+EXITCODE: OK
+```
+
+### typecheck schroedinger_cat.tla
+
+```sh
+$ apalache-mc typecheck schroedinger_cat.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeCheckerSnowcat
+ > Running Snowcat .::.
+ > Your types are great!
+ > All expressions are typed
+...
+Type checker [OK]
+...
+EXITCODE: OK
+```
+

--- a/test/tla/schroedinger_cat.tla
+++ b/test/tla/schroedinger_cat.tla
@@ -1,5 +1,8 @@
 ------------------------- MODULE schroedinger_cat ----------------------------
-VARIABLE state
+VARIABLE
+    \* @type: Str;
+    state
+
 Init == state = "ALIVE"
 Next == state' = state \/ state' = "DEAD"
 Inv == state = "ALIVE"

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationArg.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationArg.scala
@@ -10,6 +10,10 @@ object AnnotationArg {
     AnnotationStr(text)
   }
 
+  def mkIdent(name: String): AnnotationArg = {
+    AnnotationIdent(name)
+  }
+
   def mkInt(i: Int): AnnotationInt = {
     AnnotationInt(i)
   }
@@ -26,6 +30,15 @@ object AnnotationArg {
  */
 case class AnnotationStr(text: String) extends AnnotationArg {
   override def toString: String = '"' + text + '"'
+}
+
+/**
+ * An identifier argument.
+ *
+ * @param name the name of an identifier.
+ */
+case class AnnotationIdent(name: String) extends AnnotationArg {
+  override def toString: String = name
 }
 
 /**

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
@@ -1,63 +1,118 @@
 package at.forsyte.apalache.io.annotations
 
-import scala.util.parsing.combinator.JavaTokenParsers
+import at.forsyte.apalache.io.annotations.parser.{
+  AT_IDENT, AnnotationLexer, AnnotationToken, AnnotationTokenReader, BOOLEAN, COMMA, DOT, IDENT, INLINE_STRING, LPAREN,
+  NUMBER, RPAREN, STRING
+}
+
 import java.io.{Reader, StringReader}
+import scala.util.parsing.combinator.Parsers
 
 /**
  * A parser for TLA+ annotations. Use the object TlaAnnotationParser to parser the input.
  *
  * @author Igor Konnov
  */
-class AnnotationParser extends JavaTokenParsers {
-  def expr: Parser[Any] = "@" ~ ident ~ opt(argsInParentheses | argAfterColon) ^^ {
-    case _ ~ name ~ None =>
+class AnnotationParser extends Parsers {
+  override type Elem = AnnotationToken
+
+  def annotationsInText: Parser[List[Annotation]] = rep(junk) ~ repsep(isolatedAnnotation, rep(junk)) ^^ {
+    case _ ~ annotations =>
+      annotations
+  }
+
+  def isolatedAnnotation: Parser[Annotation] = atIdent ~ opt(argsInParentheses | argAfterColon) ^^ {
+    case name ~ None =>
       Annotation(name)
 
-    case _ ~ name ~ Some(args) =>
+    case name ~ Some(args) =>
       Annotation(name, args: _*)
   }
 
-  def argsInParentheses: Parser[List[AnnotationArg]] = "(" ~ repsep(arg, ",") ~ ")" ^^ { case _ ~ args ~ _ =>
-    args
+  // As annotations are embedded in text comments, the lexer may recognize some character sequences as tokens.
+  // It's OK, we will ignore them.
+  private def junk: Parser[String] =
+    (ident | string | inlineString | number | boolean | COMMA() | DOT() | LPAREN() | RPAREN()) ^^ { _ =>
+      ""
+    }
+
+  def argsInParentheses: Parser[List[AnnotationArg]] = LPAREN() ~ repsep(arg, COMMA()) ~ RPAREN() ^^ {
+    case _ ~ args ~ _ =>
+      args
   }
 
-  def argAfterColon: Parser[List[AnnotationArg]] = ":" ~ nonSemiString ~ ";" ^^ { case _ ~ str ~ _ =>
+  def argAfterColon: Parser[List[AnnotationArg]] = inlineString ^^ { str =>
     List(AnnotationStr(str))
   }
 
-  def arg: Parser[AnnotationArg] = stringArg | intArg | boolArg
+  def arg: Parser[AnnotationArg] = stringArg | intArg | boolArg | identArg
 
-  def stringArg: Parser[AnnotationStr] = stringLiteral ^^ { str =>
-    AnnotationStr(str.slice(1, str.length - 1))
+  def stringArg: Parser[AnnotationStr] = string ^^ { str =>
+    AnnotationStr(str)
   }
 
-  def intArg: Parser[AnnotationInt] = wholeNumber ^^ { str =>
-    AnnotationInt(str.toInt)
+  def inlineStringArg: Parser[AnnotationStr] = inlineString ^^ { str =>
+    AnnotationStr(str)
   }
 
-  def boolArg: Parser[AnnotationBool] = ident ^^ {
-    case "true"  => AnnotationBool(true)
-    case "false" => AnnotationBool(false)
+  def identArg: Parser[AnnotationIdent] = ident ^^ { name =>
+    AnnotationIdent(name)
   }
 
-  def nonSemiString: Parser[String] = """[^;]*""".r
+  def intArg: Parser[AnnotationInt] = number ^^ { num =>
+    AnnotationInt(num)
+  }
+
+  def boolArg: Parser[AnnotationBool] = boolean ^^ { b =>
+    AnnotationBool(b)
+  }
+
+  private def ident: Parser[String] = {
+    accept("identifier", { case IDENT(name) => name })
+  }
+
+  private def atIdent: Parser[String] = {
+    accept("@identifier", { case AT_IDENT(name) => name })
+  }
+
+  private def number: Parser[Int] = {
+    accept("number", { case NUMBER(i) => i })
+  }
+
+  private def string: Parser[String] = {
+    accept("string", { case STRING(s) => s })
+  }
+
+  private def inlineString: Parser[String] = {
+    accept("inlineString", { case INLINE_STRING(s) => s })
+  }
+
+  private def boolean: Parser[Boolean] = {
+    accept("boolean", { case BOOLEAN(b) => b })
+  }
 }
 
 object AnnotationParser {
   abstract class Result
-  case class Success(annotation: Annotation, length: Int) extends Result
+
+  case class Success(annotation: List[Annotation]) extends Result
+
   case class Failure(message: String) extends Result
 
   private val parser: AnnotationParser = new AnnotationParser
 
   def parse(reader: Reader): Result = {
-    parser.parse(parser.expr, reader) match {
-      case parser.Success(annotation: Annotation, rest) =>
-        Success(annotation, rest.offset)
+    val tokenReader = new AnnotationTokenReader(AnnotationLexer(reader))
+    parser.annotationsInText(tokenReader) match {
+      case parser.Success(annotations: List[Annotation], _) =>
+        Success(annotations)
+
       case parser.Success(res, _) =>
-        Failure("Expected annotation, found: " + res)
+        Failure("Expected a list of annotations, found: " + res)
+
       case parser.Failure(msg, _) => Failure(msg)
-      case parser.Error(msg, _)   => Failure(msg)
+
+      case parser.Error(msg, _) => Failure(msg)
     }
   }
 

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
@@ -1,0 +1,126 @@
+package at.forsyte.apalache.io.annotations.parser
+
+import at.forsyte.apalache.io.annotations.AnnotationParserError
+
+import java.io.Reader
+import scala.util.matching.Regex
+import scala.util.parsing.combinator.RegexParsers
+
+/**
+ * <p>A lexer for annotations that are hidden in TLA+ comments.
+ * Since the annotations are hidden in comments, it is tricky to parse comments like that.
+ * Internally, the lexer is producing junk tokens and then filtering them out.
+ * </p>
+ *
+ * @author Igor Konnov
+ */
+object AnnotationLexer extends RegexParsers {
+  override def skipWhitespace: Boolean = true
+
+  override val whiteSpace: Regex = """([ \t\r\f\n]+|\\\*|\(\*|\*\))""".r
+
+  /**
+   * Parse the input stream and return the list of tokens. Although collecting the list of all tokens in memory is
+   * not optimal, streams of tokens produced from comments are supposed to be small.
+   *
+   * @param reader a Java reader
+   * @return the list of parsed tokens
+   * @throws AnnotationParserError when the lexer finds an error
+   */
+  def apply(reader: Reader): Seq[AnnotationToken] = parseAll(program, reader) match {
+    case Success(result, _) =>
+      result
+
+    case NoSuccess(msg, _) =>
+      // we ignore the position, as it is the position that is relative to a comment
+      throw new AnnotationParserError(msg)
+  }
+
+  def program: Parser[Seq[AnnotationToken]] = {
+    skip ~> rep(token <~ skip) <~ eof ^^ { tokens => tokens.filter(_ != JUNK()) }
+  }
+
+  def eof: Parser[String] = "\\z".r | failure("unexpected character")
+
+  def token: Parser[AnnotationToken] =
+    positioned(
+        leftParen | rightParen | comma | dot | boolean | atIdentifier | identifier | number | string | inline_string | junk
+    ) ///
+
+  def skip: Parser[Unit] = rep(whiteSpace) ^^^ Unit
+
+  def linefeed: Parser[Unit] = "\n" ^^^ Unit
+
+  private def identifier: Parser[IDENT] = {
+    "[a-zA-Z_][a-zA-Z0-9_]*".r ^^ { name => IDENT(name) }
+  }
+
+  private def atIdentifier: Parser[AT_IDENT] = {
+    "@[a-zA-Z_][a-zA-Z0-9_]*".r ^^ { name => AT_IDENT(name.substring(1)) }
+  }
+
+  private def string: Parser[STRING] = {
+    """"[a-zA-Z0-9_~!@#\\$%^&*\-+=|(){}\[\],:;`'<>.?/ \t\r\f\n]*"""".r ^^ { name =>
+      STRING(removeLeadingCommentsAndControlChars(name.substring(1, name.length - 1)))
+    }
+  }
+
+  private def inline_string: Parser[INLINE_STRING] = {
+    """:[a-zA-Z0-9_~!@#\\$%^&*\-+=|(){}\[\],:`'<>.?/ \t\r\f\n]*;""".r ^^ { name =>
+      INLINE_STRING(removeLeadingCommentsAndControlChars(name.substring(1, name.length - 1)))
+    }
+  }
+
+  /**
+   * <p>It is not uncommon to write multiline strings in annotations. Since these strings are written in comments,
+   * it should be possible to write them like:</p>
+   *
+   * <pre>
+   *
+   * \* @type: Int
+   * \*          => Int;
+   * \*
+   * \* @type("Int
+   * \*          => Int")
+   * </pre>
+   *
+   * <p>This method removes the leading "\*" from a multiline string. Additionally, it replaces with a space
+   * a group of carriage returns, form feeds, line feeds, and tabs.</p>
+   *
+   * @param text text to preprocess
+   * @return text without leading "\*" and ASCII control characters
+   */
+  private def removeLeadingCommentsAndControlChars(text: String): String = {
+    text.replaceAll("""\n[ \t\r\f]*\\\*""", "").replaceAll("[\n\t\r\f]*", "")
+  }
+
+  private def number: Parser[NUMBER] = {
+    "(|-)[0-9][0-9]*".r ^^ { value => NUMBER(value.toInt) }
+  }
+
+  private def boolean: Parser[BOOLEAN] = {
+    "(FALSE|TRUE|false|true|False|True)".r ^^ { value => BOOLEAN(value.toBoolean) }
+  }
+
+  private def leftParen: Parser[LPAREN] = {
+    "(" ^^ (_ => LPAREN())
+  }
+
+  private def rightParen: Parser[RPAREN] = {
+    ")" ^^ (_ => RPAREN())
+  }
+
+  private def comma: Parser[COMMA] = {
+    "," ^^ (_ => COMMA())
+  }
+
+  private def dot: Parser[DOT] = {
+    "." ^^ (_ => DOT())
+  }
+
+  // Whatever is not recognized as a token above, should be treated as junk.
+  // We take care of not consuming the character '@' as junk, if it is followed by a letter or underscore.
+  private def junk: Parser[JUNK] = {
+    "(@[^a-zA-Z_]|[^@]+)".r ^^ { _ => JUNK() }
+  }
+}

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationTokenReader.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationTokenReader.scala
@@ -1,0 +1,13 @@
+package at.forsyte.apalache.io.annotations.parser
+
+import scala.util.parsing.input.{NoPosition, Position, Reader}
+
+class AnnotationTokenReader(tokens: Seq[AnnotationToken]) extends Reader[AnnotationToken] {
+  override def first: AnnotationToken = tokens.head
+
+  override def atEnd: Boolean = tokens.isEmpty
+
+  override def pos: Position = if (tokens.isEmpty) NoPosition else tokens.head.pos
+
+  override def rest: Reader[AnnotationToken] = new AnnotationTokenReader(tokens.tail)
+}

--- a/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/parser/tokens.scala
+++ b/tla-import/src/main/scala/at/forsyte/apalache/io/annotations/parser/tokens.scala
@@ -1,0 +1,78 @@
+package at.forsyte.apalache.io.annotations.parser
+
+import scala.util.parsing.input.Positional
+
+/**
+ * A token that can be used in annotation.
+ */
+sealed trait AnnotationToken extends Positional
+
+/**
+ * Arbitrary text that could be used outside of an annotation.
+ * The lexer may produce such tokens internally, but it never gives them to the API user.
+ */
+case class JUNK() extends AnnotationToken {}
+
+/**
+ * An identifier
+ *
+ * @param name the name associated with the identifier
+ */
+case class IDENT(name: String) extends AnnotationToken {}
+
+/**
+ * Annotation name that start with "@". We introduce a special token for that instead of using
+ * a token for "@" and IDENT. The reason is that we want to ignore standalone "@" in the parser.
+ * See: https://github.com/informalsystems/apalache/issues/757
+ *
+ * @param name the name associated with the identifier
+ */
+case class AT_IDENT(name: String) extends AnnotationToken {}
+
+/**
+ * A string according to the TLA+ syntax, that is a sequence of characters between quotes, "...".
+ *
+ * @param text the contents of the string
+ */
+case class STRING(text: String) extends AnnotationToken {}
+
+/**
+ * A string that appears between ":" and ";".
+ *
+ * @param text the contents of the string
+ */
+case class INLINE_STRING(text: String) extends AnnotationToken {}
+
+/**
+ * A number
+ *
+ * @param num the value of the number
+ */
+case class NUMBER(num: Int) extends AnnotationToken {}
+
+/**
+ * A Boolean value, FALSE or TRUE.
+ *
+ * @param bool string representation of a Boolean value: "FALSE" or "TRUE"
+ */
+case class BOOLEAN(bool: Boolean) extends AnnotationToken {}
+
+/**
+ * Comma ",".
+ */
+case class COMMA() extends AnnotationToken {}
+
+/**
+ * Dot ".". We don't really use dots, but they are useful, e.g., for parsing 1.23.
+ */
+case class DOT() extends AnnotationToken {}
+
+/**
+ * Left parenthesis "(".
+ */
+case class LPAREN() extends AnnotationToken {}
+
+/**
+ * Right parenthesis ")".
+ */
+case class RPAREN() extends AnnotationToken {}

--- a/tla-import/src/test/scala/at/forsyte/apalache/io/annotations/parser/TestAnnotationLexer.scala
+++ b/tla-import/src/test/scala/at/forsyte/apalache/io/annotations/parser/TestAnnotationLexer.scala
@@ -1,0 +1,104 @@
+package at.forsyte.apalache.io.annotations.parser
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import java.io.StringReader
+
+/**
+ * Tests for the TLC configuration parser. As the lexer does not know the syntactic structure of annotations,
+ * it may produce additional tokens that have to be resolved by the parser.
+ *
+ * @author Igor Konnov
+ */
+@RunWith(classOf[JUnitRunner])
+class TestAnnotationLexer extends FunSuite {
+  test("empty") {
+    val text = "   "
+    val output = AnnotationLexer.apply(new StringReader(text))
+    assert(output.isEmpty)
+  }
+
+  test("@test") {
+    val text = "(*  @test *)"
+    val output = AnnotationLexer.apply(new StringReader(text))
+    assert(List(AT_IDENT("test")) == output)
+  }
+
+  test("@test(123, TRUE)") {
+    val text = "  @test(123, TRUE) "
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(AT_IDENT("test"), LPAREN(), NUMBER(123), COMMA(), BOOLEAN(true), RPAREN())
+    assert(expected == output)
+  }
+
+  test("an annotation surrounded by some text") {
+    val text = """\* example by foo@example.org: @test(123, TRUE) the rest is junk. :-)"""
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected =
+      List(IDENT("example"), IDENT("by"), IDENT("foo"), AT_IDENT("example"), DOT(), IDENT("org"), AT_IDENT("test"),
+          LPAREN(), NUMBER(123), COMMA(), BOOLEAN(true), RPAREN(), IDENT("the"), IDENT("rest"), IDENT("is"),
+          IDENT("junk"), DOT())
+    assert(expected == output)
+  }
+
+  test("identifier argument") {
+    val text = """@foo(Bar)"""
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(AT_IDENT("foo"), LPAREN(), IDENT("Bar"), RPAREN())
+    assert(expected == output)
+  }
+
+  test("string argument") {
+    val text = """@foo("one", "two")"""
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected =
+      List(AT_IDENT("foo"), LPAREN(), STRING("one"), COMMA(), STRING("two"), RPAREN())
+    assert(expected == output)
+  }
+
+  test("inline string argument") {
+    val text = """@baz: one;"""
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(AT_IDENT("baz"), INLINE_STRING(" one"))
+    assert(expected == output)
+  }
+
+  test("mismatch in a string") {
+    val text = """ 1.3 " zzz """
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(NUMBER(1), DOT(), NUMBER(3))
+    assert(expected == output)
+  }
+
+  test("annotation with comments inside") {
+    // It should be possible to write a multiline string using the ":...;" syntax.
+    // As such a string would be inside a TLA+ comment, we have to remove the leading comment characters.
+    val text =
+      """\* @type: Int
+      |\*          => Int;""".stripMargin
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(AT_IDENT("type"), INLINE_STRING(" Int          => Int"))
+    assert(expected == output)
+  }
+
+  test("quoted string with comments inside") {
+    // It should be also possible to write multiline strings in quotes.
+    val text =
+      """\* @type("Int
+        |\*          => Int")"""".stripMargin
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(AT_IDENT("type"), LPAREN(), STRING("Int          => Int"), RPAREN())
+    assert(expected == output)
+  }
+
+  test("annotation with ASCII codes") {
+    // a sequence of control characters is replaced with a single space
+    val text =
+      "\\* @type: Int \t\f\r\n => Int;".stripMargin
+    val output = AnnotationLexer.apply(new StringReader(text)).toList
+    val expected = List(AT_IDENT("type"), INLINE_STRING(" Int  => Int"))
+    assert(expected == output)
+  }
+}


### PR DESCRIPTION
This PR contains a rewrite of the annotation parser. Hence it:
 - closes #718: by supporting multi-line annotations that are written with the `\*` syntax,
 - closes #757: by parsing annotations more precisely and ignoring unimportant parts of comments,
 - closes #768: by allowing for TLA+ identifiers as arguments for annotations.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
