### PR TITLE
remove scoverage from maven builds

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,7 @@
 ### Bug fixes
 
  * The command `config --enable-stats=true` creates `$HOME/.tlaplus` if needed, see #762
+
+### Changes
+
+ * Builds: removed scoverage from maven, to improve build times

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,6 @@
         <scalaVersion>2.12.12</scalaVersion>
         <scalaBinaryVersion>2.12</scalaBinaryVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scoverage.plugin.version>1.4.1</scoverage.plugin.version>
-        <scoverage.aggregate>true</scoverage.aggregate>
         <logback.version>1.2.3</logback.version>
         <spotless.version>2.10.3</spotless.version>
     </properties>
@@ -241,24 +239,6 @@
                     </configuration>
                 </plugin>
 
-                <plugin>
-                    <groupId>org.scoverage</groupId>
-                    <artifactId>scoverage-maven-plugin</artifactId>
-                    <version>${scoverage.plugin.version}</version>
-                    <configuration>
-                        <scalaVersion>${scalaBinaryVersion}</scalaVersion>
-                        <!-- other parameters -->
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>report</goal> <!-- or integration-check -->
-                            </goals>
-                            <phase>prepare-package</phase> <!-- or any other phase -->
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Code formatting plugin
                      See
                      https://github.com/diffplug/spotless/tree/main/plugin-maven
@@ -386,46 +366,7 @@
                     <rules><dependencyConvergence /></rules>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>org.scoverage</groupId>
-                <artifactId>scoverage-maven-plugin</artifactId>
-                <version>${scoverage.plugin.version}</version>
-                <configuration>
-                    <scalaVersion>${scalaBinaryVersion}</scalaVersion>
-                    <!-- other parameters -->
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>report</goal> <!-- or integration-check -->
-                        </goals>
-                        <phase>prepare-package</phase> <!-- or any other phase -->
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.scoverage</groupId>
-                <artifactId>scoverage-maven-plugin</artifactId>
-                <version>${scoverage.plugin.version}</version>
-                <configuration>
-                    <aggregate>true</aggregate>
-                    <highlighting>true</highlighting>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report</report>  <!-- integration-report, report-only -->
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-        </plugins>
-    </reporting>
 
 </project>


### PR DESCRIPTION
I think I have enough watching maven building things 3 times to get scoverage reports, which we have not been reading for years. We should integrate coverage into CI, which is planned for #373, but we should not impede builds on user machines.

Here is what I have on my machine:

```
# with scoverage
mvn clean && mvn package  -Dmaven.test.skip=true
# 4 min 25 sec
# without scoverage
mvn clean && mvn package  -Dmaven.test.skip=true
# 2 min 03 sec
```

Looks like a good improvement :P

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
