### PR TITLE
One-line comments in types

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@
 ### Features
 
  * apalache quits with a non-zero exit code on counterexample or error, see #249
+ * type checker: supporting one-line comments in types, see #773
 
 ### Bug fixes
 
@@ -28,3 +29,4 @@
 ### Changes
 
  * Builds: removed scoverage from maven, to improve build times
+ * Docs: updated ADR002 and HOWTO on type annotations to explain comments

--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -225,6 +225,7 @@ an incorrect field access. We probably will introduce more precise types for
 records later. See [Issue 401][].
 
 
+<a id="funAsSeq"></a>
 ## Recipe 5: functions as sequences
 
 Check the example [Queens.tla][] from the repository of TLA+ examples.  It has
@@ -345,22 +346,7 @@ minimizing the burden of specification maintenance. When you add one more field
 to the record type, it suffices to change the definition of the type alias,
 instead of changing the record type everywhere.
 
-
-## Known issues
-
-### Annotations of LOCAL operators
-
-In contrast to all other cases, a local operator definition does require
-a type annotation before the keyword `LOCAL`, not after it. For example:
-
-```tla
-\* @type: Int => Int;
-LOCAL LocalInc(x) == x + 1
-```
-
-This may change later, when the tlaplus [Issue 578][] is resolved.
-
-### Multi-line annotations
+## Recipe 7: Multi-line annotations
 
 A type annotation may span over multiple lines. You may use both the `(* ...
 *)` syntax as well as the single-line syntax `\* ...`. All three examples below
@@ -384,7 +370,52 @@ VARIABLES
 ```
 
 Note that the parser removes the leading strings `"    \*"` from the annotations,
-similar to how multiline strings are treated in modern programming languages.
+similar to how multi-line strings are treated in modern programming languages.
+
+## Recipe 8: Comments in annotations
+
+Sometimes, it helps to document the meaning of type components. Consider the following
+example from [Recipe 5](#funAsSeq):
+
+```tla
+\* @type: (Seq(Int), Int, Int) => Bool;
+Attacks(queens,i,j)
+```
+
+If you think that an explanation of the arguments would help, you can do that as follows:
+
+```tla
+(*
+  @type:
+    (
+      // the column of an n-th queen, for n in the sequence domain
+      Seq(Int),
+      // the index (line number) of the first queen
+      Int,
+      // the index (line number) of the second queen
+      Int
+    ) => Bool;
+*)
+Attacks(queens,i,j)
+```
+
+You don't have to do that, but if you feel that types can also help you in documenting
+your specification, you have this option.
+
+
+## Known issues
+
+### Annotations of LOCAL operators
+
+In contrast to all other cases, a local operator definition does require
+a type annotation before the keyword `LOCAL`, not after it. For example:
+
+```tla
+\* @type: Int => Int;
+LOCAL LocalInc(x) == x + 1
+```
+
+This may change later, when the tlaplus [Issue 578][] is resolved.
 
 
 [old type annotations]: ../apalache/types-and-annotations.md

--- a/docs/src/adr/002adr-types.md
+++ b/docs/src/adr/002adr-types.md
@@ -2,7 +2,7 @@
 
 | authors                                | revision |
 | -------------------------------------- | --------:|
-| Shon Feder, Igor Konnov, Jure Kukovec  |        3 |
+| Shon Feder, Igor Konnov, Jure Kukovec  |        4 |
 
 This is a follow up of
 [RFC-001](https://github.com/informalsystems/apalache/blob/unstable/docs/internal/rfc/001rfc-types.md), which discusses
@@ -123,7 +123,29 @@ This rule binds a type (produced by `T`) to a name (produced by `typeConst`). As
 of `typeConst`, the name should be an identifier in the upper case. The type checker should use the bound type instead
 of the constant type. For examples, see [Section 2.4](#useTypeAlias).
 
-### 1.3. Discussion
+<a id="comments"></a>
+### 1.3. Comments inside types
+
+When you introduce records that have dozens of fields, it is useful to explain
+those fields right in the type annotations. For that reason, the type lexer
+supports one-line comments right in the type definitions. The following
+text presents a type definition that contains comments:
+
+```
+// packets are stored in a set
+Set([
+  // unique sequence number
+  seqno: Int,
+  // payload hash
+  payloadHash: Str
+])
+```
+
+The parser only supports one-line comments that starts with `//`. Since type
+annotations are currently written inside TLA+ comments, we feel that more
+complex comments would complicate the matters.
+
+### 1.4. Discussion
 
 Our type grammar presents a minimal type system that, in our understanding,
 captures all interesting cases that occur in practice. Obviously, this type
@@ -202,7 +224,7 @@ assumptions, the user merely states the variable types and the *type checker*
 has a simple job of checking type consistency and finding the types of the
 expressions.
 
-# useTuseT 2.2. Annotating Operators
+## 2.2. Annotating operators
 
 Again, write a type annotation `@type: <your type>;` in a comment that precedes the operator declaration. For example:
 

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
@@ -177,6 +177,20 @@ class TestDefaultType1Parser extends FunSuite with Checkers with TlaType1Gen {
     assert(SetT1(ConstT1("ENTRY")) == result)
   }
 
+  test("one-line comments") {
+    val text =
+      """
+        |Set([
+        |  // this comment explains something about tags
+        |  tag: Str,
+        |  // this comment explains something about values
+        |  value: Int
+        |])
+        |""".stripMargin
+    val result = DefaultType1Parser.parseType(text)
+    assert(SetT1(RecT1("tag" -> StrT1(), "value" -> IntT1())) == result)
+  }
+
   test("no crashes: either parse, or raise an error") {
     check({
       forAll(alphaStr) { str =>


### PR DESCRIPTION
Closes #773. This PR introduces one-line comments in the type grammar, in order to comment on long records, e.g.

```tla
(*
  @type:
    (
      // the column of an n-th queen, for n in the sequence domain
      Seq(Int),
      // the index (line number) of the first queen
      Int,
      // the index (line number) of the second queen
      Int
    ) => Bool;
*)
Attacks(queens,i,j)
```

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
