### PR TITLE
closes #746: pretty printer outputs EXCEPT correctly

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@
 * Parser: supporting TLA+ identifiers in annotations, see #768
 * Parser: better parser for annotations, see #757
 * Parser: fixed two bugs in the declaration sorter, see #645 and #758
+* Printer: fixed the output for EXCEPT, see #746
 * The command `config --enable-stats=true` creates `$HOME/.tlaplus` if needed, see #762
 
 ### Changes

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/io/TestPrettyWriter.scala
@@ -597,10 +597,21 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
 
   test("a one-line EXCEPT") {
     val writer = new PrettyWriter(printWriter, 80)
-    val expr = except(name("f"), name("k"), name("v"))
+    // recall that EXCEPT indices are always wrapped in a tuple
+    val expr = except(name("f"), tuple(name("k")), name("v"))
     writer.write(expr)
     printWriter.flush()
     val expected = """[ f EXCEPT ![k] = v ]""".stripMargin
+    assert(expected == stringWriter.toString)
+  }
+
+  test("a two-argument EXCEPT") {
+    val writer = new PrettyWriter(printWriter, 80)
+    // recall that EXCEPT indices are always wrapped in a tuple
+    val expr = except(name("f"), tuple(name("i"), name("k")), name("v"))
+    writer.write(expr)
+    printWriter.flush()
+    val expected = """[ f EXCEPT ![i, k] = v ]""".stripMargin
     assert(expected == stringWriter.toString)
   }
 
@@ -608,7 +619,7 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = except(
         name("verylongname1"),
-        name("verylongname2"),
+        tuple(name("verylongname2")),
         name("verylongname3")
     ) ///
 
@@ -626,9 +637,9 @@ class TestPrettyWriter extends FunSuite with BeforeAndAfterEach {
     val writer = new PrettyWriter(printWriter, 40)
     val expr = except(
         name("verylongname1"),
-        name("verylongname2"),
+        tuple(name("verylongname2")),
         name("verylongname3"),
-        name("verylongname4"),
+        tuple(name("verylongname4")),
         name("verylongname5")
     ) ///
 


### PR DESCRIPTION
closes #746. Subj.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
