### PR TITLE
Allow supplying the JVM args when running Apalache

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,12 +12,12 @@
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Documentation
 
- * RFC006 on unit testing: see #741
+* RFC006 on unit testing: see #741
 
 ### Features
 
- * apalache quits with a non-zero exit code on counterexample or error, see #249
- * type checker: supporting one-line comments in types, see #773
+* apalache quits with a non-zero exit code on counterexample or error, see #249
+* type checker: supporting one-line comments in types, see #773
 
 ### Bug fixes
 
@@ -32,5 +32,6 @@
 
 ### Changes
 
- * Builds: removed scoverage from maven, to improve build times
- * Docs: updated ADR002 and HOWTO on type annotations to explain comments
+* Builds: removed scoverage from maven, to improve build times
+* Docs: updated ADR002 and HOWTO on type annotations to explain comments
+* CLI: Users can set JVM args via the JVM_ARGS env var, see #790

--- a/bin/apalache-mc
+++ b/bin/apalache-mc
@@ -44,11 +44,14 @@ else
     TLA_PATH="$TLA_LIB:$TLA_PATH"
 fi
 
-# 1. The maximum heap size, Z3 will use much more as a native library.
-JVM_ARGS="-Xmx4096m"
+JVM_ARGS=${JVM_ARGS:-""}
 
-# uncomment to track memory usage with: jcmd <pid> VM.native_memory summary
-#JVM_ARGS="${JVM_ARGS} -XX:NativeMemoryTracking=summary"
+# Check of the heap size is already set
+if ! [[ "$JVM_ARGS" =~ -Xmx ]]
+then
+    # If not, set our default heap size
+    JVM_ARGS="${JVM_ARGS} -Xmx4096m"
+fi
 
 JVM_ARGS="$JVM_ARGS -DTLA-Library=$TLA_PATH"
 

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -43,6 +43,24 @@ The arguments are as follows:
 If an initialization predicate, transition predicate, or invariant is specified both in the configuration file, and on
 the command line, the command line parameters take precedence over those in the configuration file.
 
+### Supplying JVM arguments
+
+You can supply JVM argument to be used when running Apalache by setting the
+environment variable `JVM_ARGS`. For example, to change the JVM heap size from
+the default (`4096m`) to `1G` invoke Apalache as follows:
+
+```sh
+JVM_ARGS="-Xmx1G" apalache-mc <args>
+```
+
+If you are running Apalache via docker directly (instead of using the script in
+`$APALACHE_HOME/script/run-docker.sh`), you'll also need to expose the
+environment variable to the docker container:
+
+```sh
+$ JVM_ARGS="-Xmx1G" docker run -e JVM_ARGS --rm -v <your-spec-directory>:/var/apalache apalache/mc <args>
+```
+
 ### Bounded model checking
 
 By default, Apalache performs *bounded model checking*, that is, it encodes a symbolic execution of length `k` and an

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -61,6 +61,12 @@ environment variable to the docker container:
 $ JVM_ARGS="-Xmx1G" docker run -e JVM_ARGS --rm -v <your-spec-directory>:/var/apalache apalache/mc <args>
 ```
 
+To track memory usage with: `jcmd <pid> VM.native_memory summary`, you can set
+
+```
+JVM_ARGS="-XX:NativeMemoryTracking=summary"
+```
+
 ### Bounded model checking
 
 By default, Apalache performs *bounded model checking*, that is, it encodes a symbolic execution of length `k` and an

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -19,6 +19,6 @@ else
     img="apalache/mc:${APALACHE_TAG}"
 fi
 
-cmd="docker run -e TLA_PATH --rm -v $(pwd):/var/apalache ${img} ${@}"
+cmd="docker run -e TLA_PATH -e JVM_ARGS --rm -v $(pwd):/var/apalache ${img} ${@}"
 >&2 echo "# running command: ${cmd}"
 $cmd

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -94,6 +94,28 @@ $ apalache-mc help
 EXITCODE: OK
 ```
 
+### executable responds to JVM_ARGS environment variable
+
+We can set some JVM args and still have the default max heap size supplied. (Note we also trim out the `TLA_Library` argument, since is environment sensitive and makes the tests unstable.)
+
+```sh
+$ JVM_ARGS="-Xms1m -XX:+UseSerialGC" apalache-mc version | sed 's/-DTLA-Library.*//'
+...
+# JVM args: -Xms1m -XX:+UseSerialGC -Xmx4096m
+...
+EXITCODE: OK
+```
+
+If we set the max heap size (with `-Xmx`) it will override the default max heap size:
+
+```sh
+$ JVM_ARGS="-Xmx16m" apalache-mc version | sed 's/-DTLA-Library.*//'
+...
+# JVM args: -Xmx16m
+...
+EXITCODE: OK
+```
+
 ## running the parse command
 
 This command parses a TLA+ specification with the SANY parser.


### PR DESCRIPTION
Closes #790

This change alters the runner script to allow users to tune the JVM when running
Apalache. The runner script now appends its args whatever is already in the
JVM_ARGS environment variable. If a max heapsize is set by the user, it lets
that take precedence. 

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality