### PR TITLE
Use the latest openjdk version for the runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mvn --batch-mode -DskipTests package
 
 
 # 2. APP IMAGE
-FROM openjdk:9-slim
+FROM openjdk:16-slim
 
 # To prepare the app image, we do the following:
 #
@@ -56,7 +56,7 @@ COPY --from=builder \
 ENV _JAVA_OPTIONS="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
 
 # make apalache-mc available in PATH
-ENV PATH="/usr/local/openjdk-8/bin/:/opt/apalache/bin:${PATH}"
+ENV PATH="/usr/local/openjdk-16/bin/:/opt/apalache/bin:${PATH}"
 
 # TLA parser requires all specification files to be in the same directory
 # We assume the user bind-mounted the spec dir into /var/apalache

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,10 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Changes
+
+* Docker: Use openjdk-16 for the runtime in the app image, see #807
+
 ### Bug fixes
 
 * Printer: replacing '$' and '!' with supported characters, see #574


### PR DESCRIPTION
Prior to this change were were only using JDK 9 for the runtime. Afaict, there's no reason for us to so such an old version.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
