### PR TITLE
Document the `TypeAliases` operator convention

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * Docker: Use openjdk-16 for the runtime in the app image, see #807
+* Documentation: Introduce TypeAlises operator convention, see #808
 
 ### Bug fixes
 

--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -299,10 +299,16 @@ This time the type checker can find the types of all expressions:
 <a id="typeAliases"></a>
 ## Recipe 6: type aliases
 
-Check the example [MissionariesAndCannibals.tla][] from the repository of TLA+
-examples. 
+Type aliases can be used to provide a concise label for complex types, or to
+clarify the intended meaning of a simple types in the given context. 
 
-We can annotate constants as follows:
+Type aliases are declared with the `@typeAlias` annotation, as follows:
+
+```tla
+\* @typeAlias: ALIAS = <type>;
+```
+
+For example, suppose we have annotated some constants as follows:
 
 ```tla
 CONSTANTS
@@ -313,26 +319,28 @@ CONSTANTS
 ```
 
 If we continue annotating other declarations in the specification, we will see
-that the type `Set(PERSON)` is used quite a lot. Would not it be great to
-introduce a shortcut for this type?
+that the type `Set(PERSON)` is used frequently. Type aliases let us provide a 
+shortcut.
 
-We can do that by declaring a type alias as follows:
+By convention, we introduce all type aliases by annotating an operator called
+`<PREFIX>TypeAliases`, where the `<PREFIX>` is replaced with a unique prefix to 
+prevent name clashes. In the [MissionariesAndCannibals.tla][] example, we have
+
+```tla
+\* @typeAlias: PERSONS = Set(PERSON);
+MCTypeAliases = TRUE
+```
+
+Having defined the type alias, we can use it in other definitions anywhere else 
+in the file:
 
 ```tla
 CONSTANTS
-    \* @typeAlias: PERSONS = Set(PERSON);
     \* @type: PERSONS;
     Missionaries,
     \* @type: PERSONS;
     Cannibals 
-```
 
-The basic rule is that we can introduce a type alias with `@typeAlias` in the
-same place, where we can write a `@type` annotation. For more precise rules,
-check [ADR002][].  Having defined the type alias, we can use it in the later
-definitions:
-
-```tla
 VARIABLES
     \* @type: Str;
     bank_of_boat,
@@ -340,11 +348,13 @@ VARIABLES
     who_is_on_bank 
 ```
 
-Surely, we did not gain much by writing `PERSONS` instead of `Set(PERSON)`.  If
-your specification has complex types, e.g., records, aliases may help you in
+Surely, we did not gain much by writing `PERSONS` instead of `Set(PERSON)`.  But
+if your specification has complex types (e.g., records), aliases may help you in
 minimizing the burden of specification maintenance. When you add one more field
 to the record type, it suffices to change the definition of the type alias,
 instead of changing the record type everywhere.
+
+For more details on the design and usage, see [ADR002][].
 
 ## Recipe 7: Multi-line annotations
 

--- a/docs/src/adr/002adr-types.md
+++ b/docs/src/adr/002adr-types.md
@@ -317,11 +317,14 @@ The type checker uses the type annotation to refine the type of an empty set
 
 ### 2.4. Introducing and using type aliases
 
-A type alias is introduced with the annotation `@typeAlias: ...;`. See the example below:
+A type alias is introduced with the annotation `@typeAlias: <ALIAS> = <Type>;` 
+on a dummy operator called `<PREFIX>TypeAliases`. For example:
 
 ```tla
+\* @typeAlias: ENTRY = [a: Int, b: Bool];
+EXTypeAliases = TRUE
+
 VARIABLE
-    \* @typeAlias: ENTRY = [a: Int, b: Bool];
     \* @type: Set(ENTRY);
     msgs
 
@@ -330,14 +333,21 @@ Foo(ms, m) ==
     msgs' = ms \union {m}
 ```
 
-You have to follow three rules:
+The use of the dummy operator is a convention followed to simplify reasoning
+about where type aliases belong, and to ensure all aliases are located in one
+place. The `<PREFIX>` convention protects against name clashes when the  module
+is extended or instantiated.
+
+The actual rules around the placement of the `@typeAlias` annotation allows more
+flexibility:
 
 1. You can define a type alias with `@typeAlias` anywhere you can define a `@type`.
 
 1. The names of type aliases must be unique in a module.
 
-1. There is no scoping for aliases within a module. Even if an alias is defined deep in a tree of LET-IN definitions, it
-   can be references at any level in the module.
+1. There is no scoping for aliases within a module. Even if an alias is defined
+   deep in a tree of LET-IN definitions, it can be references at any level in
+   the module.
 
 ## 3. Example
 

--- a/test/tla/MissionariesAndCannibalsTyped.tla
+++ b/test/tla/MissionariesAndCannibalsTyped.tla
@@ -35,7 +35,7 @@ EXTENDS Integers, FiniteSets
 (***************************************************************************)
 
 \* @typeAlias: PERSONS = Set(PERSON);
-MCTypeAliases = TRUE
+MCTypeAliases == TRUE
 
 (***************************************************************************)
 (* Next comes the declaration of the sets of missionaries and cannibals.   *)

--- a/test/tla/MissionariesAndCannibalsTyped.tla
+++ b/test/tla/MissionariesAndCannibalsTyped.tla
@@ -28,10 +28,19 @@
 EXTENDS Integers, FiniteSets
 
 (***************************************************************************)
+(* The MCTypeAliases operator lets us group all type aliases together.     *)
+(* This makes it easy to rever to the defined aliases and the unique MC    *)
+(* prefix protects against name clashes if this module is extended or      *)
+(* instantiated.                                                           *)
+(***************************************************************************)
+
+\* @typeAlias: PERSONS = Set(PERSON);
+MCTypeAliases = TRUE
+
+(***************************************************************************)
 (* Next comes the declaration of the sets of missionaries and cannibals.   *)
 (***************************************************************************)
 CONSTANTS
-    \* @typeAlias: PERSONS = Set(PERSON);
     \* @type: PERSONS;
     Missionaries,
     \* @type: PERSONS;


### PR DESCRIPTION
The motivation for this change is given in the documentation. In brief,
this convention makes it easier for users to reason about where type
aliases should go, and prevents against name clashes that can lead
aliases to disappear.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
