### PR TITLE
Remove homebrew update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,6 @@ jobs:
         with:
           path: ~/.opam
           key: ${{ runner.os }}-opam-4.11.0
-      - name: Update brew
-        run: |
-          brew update
       - name: Set up opam
         uses: avsm/setup-ocaml@v1
         with:


### PR DESCRIPTION
This should be resolved in our github action setup now, and removing
the update will shave 50s or so off our macos builds.

