### PR TITLE
Make target dir in release script

### DIFF
--- a/script/release-publish.sh
+++ b/script/release-publish.sh
@@ -54,6 +54,9 @@ fi
 
 TAG_NAME="v${VERSION}"
 
+# Ensure target directory exists
+mkdir -p target
+
 # Package the artifacts
 # The archives without version suffix support stable links to the latest version.
 # See https://github.com/informalsystems/apalache/issues/716


### PR DESCRIPTION
We've had a couple release pipeline failures because this directory
didn't exist. This change ensures it does exist.

