### PR TITLE
Add type information to overriding error message

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,7 @@
 ### Features
 
 * Checker: support for action invariants, see #801
+
+### Improvements
+
+* Add type information to overriding error, see #823

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
@@ -28,7 +28,16 @@ class ConstAndDefRewriter(tracker: TransformationTracker) extends TlaModuleTrans
           logger.error("  > If you need support for n-ary CONSTANTS, write a feature request.")
           throw new OverridingError(msg, overridingDef.body)
         } else if (d.typeTag != overridingDef.body.typeTag) {
-          val msg = s"The types of ${d.name} and ${overridingDef.name} do not match."
+          val dTypeString = d.typeTag match {
+            case Typed(tt) => tt.toString
+            case Untyped() => d.typeTag.toString
+          };
+          val overridingDefTypeString = overridingDef.body.typeTag match {
+            case Typed(tt) => tt.toString
+            case Untyped() => d.typeTag.toString
+          };
+          val msg =
+            s"The types of ${d.name} (${dTypeString}) and ${overridingDef.name} (${overridingDefTypeString}) do not match."
           logger.error(msg)
           throw new OverridingError(msg, overridingDef.body)
         } else {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
@@ -30,11 +30,11 @@ class ConstAndDefRewriter(tracker: TransformationTracker) extends TlaModuleTrans
         } else if (d.typeTag != overridingDef.body.typeTag) {
           val dTypeString = d.typeTag match {
             case Typed(tt) => tt.toString
-            case Untyped() => d.typeTag.toString
+            case Untyped() => "Untyped"
           };
           val overridingDefTypeString = overridingDef.body.typeTag match {
             case Typed(tt) => tt.toString
-            case Untyped() => d.typeTag.toString
+            case Untyped() => "Untyped"
           };
           val msg =
             s"The types of ${d.name} (${dTypeString}) and ${overridingDef.name} (${overridingDefTypeString}) do not match."


### PR DESCRIPTION
This PR fixes #823 by adding type information into the overriding error message in the event of a type mismatch.

- [ ] ~~Tests added for any new code~~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~~Documentation added for any new functionality~~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
