### PR TITLE
Fix #830: produce no log on the help message

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,10 @@
 
 * Checker: enumerating multiple counterexamples, see #542 and #827
 
+### Bug fixes
+
+* Tool: no empty log on help message, see #830
+
 ### Documentation
 
 * links to ADR005

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -59,8 +59,6 @@ object Tool extends LazyLogging {
    */
   def run(args: Array[String]): Int = {
     printHeaderAndStatsConfig()
-    // force our programmatic logback configuration, as the autoconfiguration works unpredictably
-    new LogbackConfigurator().configureDefaultContext()
 
     // first, call the arguments parser, which can also handle the standard commands such as version
     val command =
@@ -76,6 +74,8 @@ object Tool extends LazyLogging {
     } else {
       // One of our commands. Print the header and measure time
       val startTime = LocalDateTime.now()
+      // force our programmatic logback configuration, as the autoconfiguration works unpredictably
+      new LogbackConfigurator().configureDefaultContext()
 
       try {
         command match {


### PR DESCRIPTION
Closes #830.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
