### PR TITLE
Closes 876: parse error on TLAPS syntax

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 ### Bug fixes
 
 * Tool: no empty log on help message, see #830
+* Parser: parse error on TLAPS syntax such as `Inv!2`, see #876
 
 ### Documentation
 

--- a/test/tla/FormulaRefs.tla
+++ b/test/tla/FormulaRefs.tla
@@ -1,0 +1,36 @@
+------------------------------ MODULE FormulaRefs -----------------------------
+\* A test for the subformula syntax e.g., A!2.
+\* Apalache should show a parse error.
+EXTENDS Integers
+
+VARIABLES
+    \* @type: Int;
+    x
+
+A ==
+    /\ x > 3
+    /\ x > 2
+
+B(y) ==
+    /\ y > 3
+    /\ y > 2
+
+Init ==
+    x = 2
+
+Next ==
+    x' = x
+
+Inv1 ==
+    A!1
+
+Inv2 ==
+    A!2
+
+Inv4 ==
+    B(x)!1
+
+Inv5 ==
+    B(x)!2
+
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -182,10 +182,18 @@ EXITCODE: OK
 ...
 ```
 
+### parse FormulaRefs fails
+
+```sh
+$ apalache-mc parse FormulaRefs.tla | sed 's/I@.*//'
+...
+EXITCODE: ERROR (255)
+...
+```
+
 ### test TestGen finds an example
 
-This simple test demonstrates how to test a spec by isolating the input with
-generators.
+This simple test demonstrates how to test a spec by isolating the input with generators.
 
 ```sh
 $ apalache-mc test TestGen.tla Prepare Test Assertion | sed 's/I@.*//'

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
@@ -353,8 +353,12 @@ class OpApplTranslator(
             mkPairsCtorBuiltin(TlaSetOper.recSet, node)
 
           case "$Nop" =>
-            // typically, an expression related to TLAPS is marked with $Nop
-            NullEx // we cannot do much here, but hope that the expression will never reach the model checker
+            // Typically, this is an expression related to TLAPS, e.g., `A!2`.
+            // Throw an exception right away.
+            // Otherwise, a null expression may pop up later in the pipeline, e.g., see #876
+            val loc = node.getLocation
+            val msg = s"${loc}: Found TLAPS syntax. Comment it out or rewrite it."
+            throw new SanyImporterException(msg)
 
           case _ =>
             throw new SanyImporterException("Unsupported operator: " + opcode)

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1549,6 +1549,22 @@ class TestSanyImporter extends FunSuite with BeforeAndAfter {
       }
   }
 
+  test("subformulas") {
+    // TLA+ allows the user to refer to subformulas. We should show an error on that syntax.
+    val text =
+      """---- MODULE subformulas ----
+        |A ==
+        |  /\ 1 = 2
+        |  /\ 2 = 2
+        |B == A!2
+        |================================
+        |""".stripMargin
+
+    assertThrows[SanyImporterException] {
+      sanyImporter.loadFromSource("subformulas", Source.fromString(text))
+    }
+  }
+
   test("LAMBDA") {
     val text =
       """---- MODULE lambda ----


### PR DESCRIPTION
Closes #876. Instead of producing a null expression, throw a parse error.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
