### PR TITLE
WIP: New approach to rewriting rules

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/BasicOps.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/BasicOps.scala
@@ -1,0 +1,44 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter2
+
+import at.forsyte.apalache.tla.bmcmt._
+import at.forsyte.apalache.tla.bmcmt.types.CellT
+import at.forsyte.apalache.tla.lir.TlaEx
+import at.forsyte.apalache.tla.lir.smt.SmtTools.False
+import scalaz._
+import scalaz.Scalaz._
+
+/**
+ * A collection of common methods for manipulating the internal state
+ */
+object BasicOps {
+  private def safeBind(key: String, value: ArenaCell): RewritingComputation[Unit] = modify { s =>
+    s.copy(binding = Binding(s.binding.toMap + (key -> value)))
+  }
+
+  // Extends the internal binding with key->value
+  def bind(key: String, value: ArenaCell): StateCompWithExceptions[Unit] =
+    EitherT.rightT(safeBind(key, value))
+
+  private def safeAssertGroundExpr(ex: TlaEx): RewritingComputation[Unit] = modify { s =>
+    // xform ex into BoolFormula
+    // proof of concept: every formula is False
+    s.copy(constraints = False() +: s.constraints)
+  }
+
+  // Extends the collection of constraints with the SMT formula represented by ex
+  // Note: A real implementation should not use the BoolT1 fragment of TlaEx as a proxy for
+  // representing SMT constraints.
+  def assertGroundExpr(ex: TlaEx): StateCompWithExceptions[Unit] = EitherT.rightT(safeAssertGroundExpr(ex))
+
+  def safeNewCell(cellType: CellT): RewritingComputation[ArenaCell] = symbState { state =>
+    val newArena = state.arena.appendCell(cellType)
+    (state.copy(arena = newArena), newArena.topCell)
+  }
+
+  // Adds a new cell of the given type to the arena and returns it
+  def newCell(cellType: CellT): StateCompWithExceptions[ArenaCell] = EitherT.rightT(safeNewCell(cellType))
+
+  // Shorthand for State[SymbStateInternal, T] { fn }
+  def symbState[T](fn: RewritingState => (RewritingState, T)): RewritingComputation[T] =
+    State[RewritingState, T] { fn }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/NegationRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/NegationRule.scala
@@ -1,0 +1,49 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter2
+
+import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
+import BasicOps._
+import at.forsyte.apalache.tla.bmcmt.RewriterException
+import at.forsyte.apalache.tla.bmcmt.types.BoolT
+import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import scalaz._
+import scalaz.Scalaz._
+
+/**
+ * An alternate implementation of NegRule
+ */
+class NegationRule(rewriter: Rewriter) extends Rule {
+  // Basic applicability check
+  override def isApplicable(ex: TlaEx): Boolean = ex match {
+    case OperEx(TlaBoolOper.not, _) => true
+    case _                          => false
+  }
+
+  // Rule application. Returns a Right containing the rewritten expression, if ex has the correct shape,
+  // or a Left, containing the appropriate exception
+  override def apply(ex: TlaEx): StateCompWithExceptions[TlaEx] = for {
+    // .point lifts the static transformation into a stateful computation that does not modify the internal
+    // state. Then, fromEither bridges from Either[...] to EitherT[...]
+    // if exOrException(ex) returns a Right, that value is read into inner
+    inner <- EitherT.fromEither(exOrException(ex).point[RewritingComputation])
+    // Then, the inner value is recursively rewritten, using the provided rewriter.
+    newExRewritten <- rewriter.rewriteUntilDone(inner) // "c0"
+    // Next, we prep a fresh BoolT-typed cell ...
+    predCell <- newCell(BoolT())
+    predCellName = predCell.toNameEx // "c1"
+    // ... and add the relevant assertion to the constraints ( -c1 = c0 )
+    _ <- assertGroundExpr(tla.eql(tla.not(predCellName), newExRewritten))
+    // The result, if none of the steps fail with an Exception, is the cell containing the predicate, c1
+    // If, at any point, one of the Either[...] values produced was a Left (= exception),
+    // that value is propagated to the actual final result (i.e. the first exception encountered is "thrown")
+  } yield predCellName
+
+  // Static evaluation of ex as a representation of a TlaOper.not expression.
+  // If ex is equal to (- y), returns Right(y), otherwise returns Left(RewritereException)
+  private def exOrException(ex: TlaEx): Either[Exception, TlaEx] = ex match {
+    case OperEx(TlaBoolOper.not, negEx) => Right(negEx)
+    case badEx =>
+      Left(new RewriterException("%s is not applicable".format(getClass.getSimpleName), badEx))
+  }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/Rewriter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/Rewriter.scala
@@ -1,0 +1,10 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter2
+
+import at.forsyte.apalache.tla.lir.TlaEx
+
+/**
+ * A Rewriter using the new computation framework.
+ */
+trait Rewriter {
+  def rewriteUntilDone(ex: TlaEx): StateCompWithExceptions[TlaEx]
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/RewritingState.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/RewritingState.scala
@@ -1,0 +1,27 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter2
+
+import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
+import at.forsyte.apalache.tla.bmcmt.{Arena, Binding}
+import at.forsyte.apalache.tla.lir.smt.SmtTools.BoolFormula
+
+/**
+ * The internal state of the term rewriting system.
+ *
+ * Each state consists of three components:
+ *   1) An Arena, which keeps track of existing cells and their relations
+ *   2) A Binding, which keeps track of (local) variable assignments
+ *   3) A collection of constraints, which will eventually be passed to an SMT solver
+ *      once rewriting terminates
+ *
+ * Notably, TlaEx expressions are NOT part of the internal state
+ */
+sealed case class RewritingState(arena: Arena, binding: Binding, constraints: Seq[BoolFormula])
+
+object RewritingState {
+  def init: RewritingState =
+    RewritingState(
+        Arena.create(new Z3SolverContext(SolverConfig.default)),
+        Binding(),
+        Seq.empty
+    )
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/Rule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/Rule.scala
@@ -1,0 +1,14 @@
+package at.forsyte.apalache.tla.bmcmt.rewriter2
+
+import at.forsyte.apalache.tla.lir.TlaEx
+
+/**
+ * A rule in the new rewriting system. It can be tested, or applied. In the latter case, it either returns
+ * a TlaEx (rewritten expression) or throws a RewritingException (represented by computation)
+ */
+trait Rule {
+  def isApplicable(ex: TlaEx): Boolean
+
+  def apply(ex: TlaEx): StateCompWithExceptions[TlaEx]
+
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter2/package.scala
@@ -1,0 +1,11 @@
+package at.forsyte.apalache.tla.bmcmt
+
+import scalaz._
+import scalaz.Scalaz._
+
+package object rewriter2 {
+
+  type RewritingComputation[T] = State[RewritingState, T]
+
+  type StateCompWithExceptions[T] = EitherT[Exception, RewritingComputation, T]
+}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterV2.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterV2.scala
@@ -1,0 +1,109 @@
+package at.forsyte.apalache.tla.bmcmt
+
+import at.forsyte.apalache.tla.bmcmt.rewriter2._
+import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatest.junit.JUnitRunner
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.smt.SmtTools.False
+import scalaz._
+import scalaz.Scalaz._
+
+@RunWith(classOf[JUnitRunner])
+class TestRewriterV2 extends FunSuite with BeforeAndAfterEach {
+
+  // Two basic rewriters. dummyrewriter just returns the expression unchanged, but doesn't throw,
+  // while failingrewriter returns an Exception on any input
+  val dummyrewriter = new Rewriter {
+    override def rewriteUntilDone(ex: TlaEx): StateCompWithExceptions[TlaEx] =
+      EitherT.right(ex)
+  }
+
+  val failingrewriter = new Rewriter {
+    override def rewriteUntilDone(ex: TlaEx): StateCompWithExceptions[TlaEx] =
+      EitherT.left(new Exception("Rewriter failed."))
+  }
+
+  // 1 rule instance for each rewriter type
+  val ruleOk = new NegationRule(dummyrewriter)
+  val ruleX = new NegationRule(failingrewriter)
+
+  test("Good rewriter, good shape") {
+    val ex = tla.not(tla.name("x"))
+
+    val initState = RewritingState.init
+
+    val (postState, result) = ruleOk.apply(ex).run(initState)
+
+    // 1 cell was introduced, bindings are empty and 1 constraint (False) was added
+    assert(postState.arena.cellCount == initState.arena.cellCount + 1)
+    assert(postState.binding.toMap.isEmpty)
+    assert(postState.constraints == Seq(False()))
+
+    // the result is a Right (some arbitrary cell name)
+    assert(result.isRight)
+
+  }
+
+  test("Good rewriter, bad shape") {
+    val ex = tla.name("x")
+
+    val initState = RewritingState.init
+
+    val (postState, result) = ruleOk.apply(ex).run(initState)
+
+    // Incompatible shape should have made it so that no part of the rewriting code gets executed, so
+    // postState is initState
+    assert(postState == initState)
+
+    // Moreover, result should wrap a RewriterExpression, since the failure happened at the rule level
+    val assertCond = result match {
+      case -\/(_: RewriterException) => true
+      case _                         => false
+    }
+
+    assert(assertCond)
+  }
+
+  test("Bad rewriter, good shape") {
+    val ex = tla.not(tla.name("x"))
+
+    val initState = RewritingState.init
+
+    val (postState, result) = ruleX.apply(ex).run(initState)
+
+    // Bad rewriter made it so that no part of the rewriting code after the recursive call
+    // to the rewriter gets executed, so the state remains unchanged
+    assert(postState == initState)
+
+    // The result is an Exception, but it's not a RewriterException
+    val assertCond = result match {
+      case -\/(_: RewriterException) => false
+      case -\/(_: Exception)         => true
+      case _                         => false
+    }
+
+    assert(assertCond)
+  }
+
+  test("Bad rewriter, bad shape") {
+    val ex = tla.name("x")
+
+    val initState = RewritingState.init
+
+    val (postState, result) = ruleX.apply(ex).run(initState)
+
+    // Rewriting doesn't happen, so the state is unchanged
+    assert(postState == initState)
+
+    // Bad shape should trigger before the bad rewriter
+    val assertCond = result match {
+      case -\/(_: RewriterException) => true
+      case _                         => false
+    }
+
+    assert(assertCond)
+  }
+}


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

This PR outlines a proof-of-concept alternative implementation of rewriting rules, using `scalaz.State`. It should facilitate discussion regarding the new approach to rewriting, and is not intended to be integrated (in its current form) in the near future. 