### PR TITLE
Fix #914

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Bug fixes
 
  * Fix the profiler, see #963
+ * Handle exceptions in record update edge case, see #917

--- a/docs/src/apalache/known-issues.md
+++ b/docs/src/apalache/known-issues.md
@@ -11,6 +11,53 @@ Deadlock detection is imprecise. It may report false negatives, see [Issue
 
 **Planned fix:** [Issue 712][]
 
+## Updating records with excess fields
+
+Given a record with a type declaration specifying `n` fields, if that record is
+given more than `n` fields and the specification includes an `EXCEPT` expression
+that updates the record, Apalache may be unable to check the specification.
+
+In the following example, the variable `m` is given the type of a record with
+`1` field (namely `a`), but it is then assigned to a record with `2` fields
+(namely `a` and `foo`).
+
+```tla
+VARIABLE
+  \* @type: [a: Int];
+  m
+
+Init == m = [a |-> 0, foo |-> TRUE]
+
+Next ==
+   \/ m' = m
+   \/ m' = [m EXCEPT !.a = 0]
+```
+
+Given the current (unsound) typing discipline Apalache uses for records, this
+specification is not considered incorrectly typed. However, due to the update
+using `EXCEPT` in the `Next` operator, the specification cannot be checked.
+
+**Affected versions:** <= 0.15.x
+
+**Planned fix:** [Issue 401][]
+
+### Workaround
+
+Add the `foo` field to the variable's type signature:
+
+```tla
+VARIABLE
+  \* @type: [a: Int, foo: Bool];
+  m
+
+Init == m = [a |-> 0, foo |-> TRUE]
+
+Next ==
+   \/ m' = m
+   \/ m' = [m EXCEPT !.a = 0]
+```
+
 
 [Issue 711]: https://github.com/informalsystems/apalache/issues/711
 [Issue 712]: https://github.com/informalsystems/apalache/issues/712
+[Issue 401]: https://github.com/informalsystems/apalache/issues/401

--- a/test/tla/Bug914.tla
+++ b/test/tla/Bug914.tla
@@ -1,0 +1,17 @@
+-------------------------------- MODULE Bug914 --------------------------------
+
+\* Minimal reproduction for https://github.com/informalsystems/apalache/issues/914
+
+VARIABLE
+  (* A set of empty records
+    @type:  Set([]);
+  *)
+  msgs
+
+Init == msgs = {}
+
+Next ==
+  \/ msgs' = {[ foo |-> FALSE ]}
+  \/ \E m \in msgs: msgs' = {[ m EXCEPT !.foo = TRUE ]}
+
+================================================================================

--- a/test/tla/Bug914.tla
+++ b/test/tla/Bug914.tla
@@ -1,17 +1,24 @@
 -------------------------------- MODULE Bug914 --------------------------------
 
 \* Minimal reproduction for https://github.com/informalsystems/apalache/issues/914
+\*
+\* The crash occurs when the the number of fields added to the record in `msgs'` in
+\* the first disjunct of `Next` are greater than the number of fields declared for
+\* the record in the type annotation of `msgs`.
+\*
+\* The selection of a set of empty records is just the minimal case in which this
+\* numerical difference between the declared fields and the assigned fields can be
+\* triggerd. I.e., this is not targeting a problem wherein the set of empty records
+\* is an edge case.
 
 VARIABLE
-  (* A set of empty records
-    @type:  Set([]);
-  *)
-  msgs
+  \* @type: [];
+  m
 
-Init == msgs = {}
+Init == m = [foo |-> TRUE]
 
 Next ==
-  \/ msgs' = {[ foo |-> FALSE ]}
-  \/ \E m \in msgs: msgs' = {[ m EXCEPT !.foo = TRUE ]}
+   \/ m' = [m EXCEPT !.foo = TRUE]
+   \/ m' = [m EXCEPT !.foo = TRUE]
 
 ================================================================================

--- a/test/tla/Bug914.tla
+++ b/test/tla/Bug914.tla
@@ -18,7 +18,7 @@ VARIABLE
 Init == m = [foo |-> TRUE]
 
 Next ==
-   \/ m' = [m EXCEPT !.foo = TRUE]
+   \/ m' = m
    \/ m' = [m EXCEPT !.foo = TRUE]
 
 ================================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1054,9 +1054,7 @@ Regression test for https://github.com/informalsystems/apalache/issues/914
 ```sh
 $ apalache-mc check Bug914.tla | sed 's/I@.*//'
 ...
-The outcome is: NoError
-...
-EXITCODE: OK
+EXITCODE: ERROR (255)
 ```
 
 ## configure the check command

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1047,6 +1047,18 @@ The outcome is: NoError
 EXITCODE: OK
 ```
 
+### check Bug914 succeeds
+
+Regression test for https://github.com/informalsystems/apalache/issues/914
+
+```sh
+$ apalache-mc check Bug914.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+EXITCODE: OK
+```
+
 ## configure the check command
 
 Testing various flags that are set via command-line options and the TLC

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -435,13 +435,13 @@ class LazyEquality(rewriter: SymbStateRewriter)
       // Our typing rules on records allow records with a subset of the fields in a type
       // which means the function from fields in a record type to elements in an instance
       // of that type are partial.
-      val leftElemOpt : Option[ArenaCell] = leftElems.lift(leftIndex)
-      val rightElemOpt :  Option[ArenaCell] = rightElems.lift(rightIndex)
+      val leftElemOpt: Option[ArenaCell] = leftElems.lift(leftIndex)
+      val rightElemOpt: Option[ArenaCell] = rightElems.lift(rightIndex)
 
       (leftElemOpt, rightElemOpt) match {
         // Neither record has the key indicated by its type
         case (None, None) => tla.bool(true)
-        case (Some(leftElem), Some(rightElem)) =>  {
+        case (Some(leftElem), Some(rightElem)) => {
           newState = cacheOneEqConstraint(newState, leftElem, rightElem)
           val (newArena, keyCell) = rewriter.strValueCache.getOrCreate(newState.arena, key)
           newState = newState.setArena(newArena)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -236,11 +236,14 @@ class CherryPick(rewriter: SymbStateRewriter) {
         } catch {
           case _: IndexOutOfBoundsException =>
             // TODO Remove once sound record typing is implemented
-            val url = "https://apalache.informal.systems/docs/apalache/known-issues.html#updating-records-with-excess-fields"
+            val url =
+              "https://apalache.informal.systems/docs/apalache/known-issues.html#updating-records-with-excess-fields"
             val msg = s"""|An updated record has more fields than its declared type:
                           |A record with the inferred type `${thisRecT.toTlaType1}` has been updated with
                           |the key `${key}` in an `EXCEPT` expression and the updated record has more fields
-                          |than are specified in its type annotation. For details see $url""".stripMargin.linesIterator.mkString(" ").trim
+                          |than are specified in its type annotation. For details see $url""".stripMargin.linesIterator
+              .mkString(" ")
+              .trim
             throw new MalformedSepecificationError(msg)
         }
       } else {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -236,10 +236,11 @@ class CherryPick(rewriter: SymbStateRewriter) {
         } catch {
           case _: IndexOutOfBoundsException =>
             // TODO Remove once sound record typing is implemented
+            val url = "https://apalache.informal.systems/docs/apalache/known-issues.html#updating-records-with-excess-fields"
             val msg = s"""|An updated record has more fields than its declared type:
                           |A record with the inferred type `${thisRecT.toTlaType1}` has been updated with
-                          |the key `${key}` in an `EXCEPT` expression and this record has more fields
-                          |than its declared type. For details see TODO""".stripMargin.linesIterator.mkString(" ").trim
+                          |the key `${key}` in an `EXCEPT` expression and the updated record has more fields
+                          |than are specified in its type annotation. For details see $url""".stripMargin.linesIterator.mkString(" ").trim
             throw new MalformedSepecificationError(msg)
         }
       } else {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.{NameEx, NullEx, TlaEx, ValEx}
 
 import scala.collection.immutable.SortedMap
+import at.forsyte.apalache.tla.lir.MalformedSepecificationError
 
 /**
  * An element picket that allows us:
@@ -228,9 +229,19 @@ class CherryPick(rewriter: SymbStateRewriter) {
     def getKeyOrDefault(record: ArenaCell, key: String): ArenaCell = {
       val thisRecT = record.cellType.asInstanceOf[RecordT]
       if (thisRecT.fields.contains(key)) {
-        // this record has the key
         val keyIndex = findKeyIndex(thisRecT, key)
-        newState.arena.getHas(record)(keyIndex)
+        val edges = newState.arena.getHas(record)
+        try {
+          edges(keyIndex)
+        } catch {
+          case _: IndexOutOfBoundsException =>
+            // TODO Remove once sound record typing is implemented
+            val msg = s"""|An updated record has more fields than its declared type:
+                          |A record with the inferred type `${thisRecT.toTlaType1}` has been updated with
+                          |the key `${key}` in an `EXCEPT` expression and this record has more fields
+                          |than its declared type. For details see TODO""".stripMargin.linesIterator.mkString(" ").trim
+            throw new MalformedSepecificationError(msg)
+        }
       } else {
         // This record does not have the key, but it was mixed with other records and produced a more general type.
         // Return a default value. As we are iterating over fields of commonRecordT, we will always find a value.


### PR DESCRIPTION
This is an exploratory fix for #914. It does avoid the traceback reported there, but then just yields another out of bounds error later on in the same spec:

```
Step 1: picking a transition out of 4 transition(s)               I@07:53:08.564
State 2: Checking 2 state invariants                              I@07:53:08.597
State 2: Checking 1 state invariants                              I@07:53:09.271
State 2: Checking 3 state invariants                              I@07:53:09.354
(Please report an issue at: [https://github.com/informalsystems/apalache/issues],java.lang.IndexOutOfBoundsException: 5)
Unhandled exception                                               E@07:53:09.631
java.lang.IndexOutOfBoundsException: 5
	at scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:67)
	at scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:65)
	at scala.collection.immutable.List.apply(List.scala:91)
	at at.forsyte.apalache.tla.bmcmt.SymbStateDecoder.eachField$1(SymbStateDecoder.scala:204)
	at at.forsyte.apalache.tla.bmcmt.SymbStateDecoder.$anonfun$decodeCellToTlaEx$10(SymbStateDecoder.scala:209)
	at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
	at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
	at scala.collection.immutable.List.foldLeft(List.scala:91)
	at at.forsyte.apalache.tla.bmcmt.SymbStateDecoder.decodeCellToTlaEx(SymbStateDecoder.scala:209)
	at at.forsyte.apalache.tla.bmcmt.SymbStateDecoder.$anonfun$decodeStateVariables$1(SymbStateDecoder.scala:68)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
	at scala.collection.immutable.HashMap$HashMap1.foreach(HashMap.scala:400)
	at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:728)
	at scala.collection.TraversableLike.map(TraversableLike.scala:286)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at at.forsyte.apalache.tla.bmcmt.SymbStateDecoder.decodeStateVariables(SymbStateDecoder.scala:68)
	at at.forsyte.apalache.tla.bmcmt.trex.TransitionExecutorImpl.decodePair$1(TransitionExecutorImpl.scala:307)
	at at.forsyte.apalache.tla.bmcmt.trex.TransitionExecutorImpl.$anonfun$decodedExecution$1(TransitionExecutorImpl.scala:311)
	at scala.collection.immutable.List.map(List.scala:297)
	at at.forsyte.apalache.tla.bmcmt.trex.TransitionExecutorImpl.decodedExecution(TransitionExecutorImpl.scala:311)
	at at.forsyte.apalache.tla.bmcmt.trex.FilteredTransitionExecutor.decodedExecution(FilteredTransitionExecutor.scala:150)
	at at.forsyte.apalache.tla.bmcmt.trex.ConstrainedTransitionExecutor.decodedExecution(ConstrainedTransitionExecutor.scala:106)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.dumpCounterexample(SeqModelChecker.scala:400)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.$anonfun$checkInvariants$2(SeqModelChecker.scala:272)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.$anonfun$checkInvariants$2$adapted(SeqModelChecker.scala:255)
	at scala.collection.TraversableLike$WithFilter.$anonfun$foreach$1(TraversableLike.scala:985)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:984)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.checkInvariants(SeqModelChecker.scala:255)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.$anonfun$prepareTransitionsAndCheckInvariants$6(SeqModelChecker.scala:177)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.$anonfun$prepareTransitionsAndCheckInvariants$6$adapted(SeqModelChecker.scala:141)
	at scala.collection.TraversableLike$WithFilter.$anonfun$foreach$1(TraversableLike.scala:985)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:984)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.prepareTransitionsAndCheckInvariants(SeqModelChecker.scala:141)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.makeStep(SeqModelChecker.scala:63)
	at at.forsyte.apalache.tla.bmcmt.SeqModelChecker.run(SeqModelChecker.scala:51)
	at at.forsyte.apalache.tla.bmcmt.passes.BoundedCheckerPassImpl.runIncrementalChecker(BoundedCheckerPassImpl.scala:131)
	at at.forsyte.apalache.tla.bmcmt.passes.BoundedCheckerPassImpl.execute(BoundedCheckerPassImpl.scala:98)
	at at.forsyte.apalache.infra.passes.PassChainExecutor.exec$1(PassChainExecutor.scala:22)
	at at.forsyte.apalache.infra.passes.PassChainExecutor.run(PassChainExecutor.scala:37)
	at at.forsyte.apalache.tla.Tool$.runCheck(Tool.scala:187)
	at at.forsyte.apalache.tla.Tool$.$anonfun$run$3(Tool.scala:95)
	at at.forsyte.apalache.tla.Tool$.handleExceptions(Tool.scala:322)
	at at.forsyte.apalache.tla.Tool$.run(Tool.scala:95)
	at at.forsyte.apalache.tla.Tool$.main(Tool.scala:45)
	at at.forsyte.apalache.tla.Tool.main(Tool.scala)
It took me 0 days  0 hours  0 min  7 sec                          I@07:53:09.632
Total time: 7.85 sec                                              I@07:53:09.632
EXITCODE: ERROR (255)
```

I think this confirms my suspicion that we need fix higher up, and that something has gone wrong with the alignment of types and terms at this point in the bmcmt operation.

I'm mostly opening this PR as a way to further the conversation.