### PR TITLE
Fix #860: Unhandled exception when type-checking incorrect annotation syntax for operators

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Bug fixes
 
 * Fix unhandled errors on non-existent record field access, see #874
+* Fix unhandled `MatchError` on invalid operator type annotations, see #919

--- a/test/tla/Bug832.tla
+++ b/test/tla/Bug832.tla
@@ -1,0 +1,9 @@
+------------------- MODULE Bug832 -----------------------
+
+\* @type: () => (Bool, Bool);
+Example ==
+  <<TRUE, FALSE>>
+
+============================================================
+\* Modification History
+\* Created Tue Jul 20 15:01:16 2021 by Shon Feder

--- a/test/tla/Bug860.tla
+++ b/test/tla/Bug860.tla
@@ -1,0 +1,9 @@
+------------------------------------ MODULE Bug860 -----------------------------
+\* Snowcat was raising an MatchError when handling multi-argument operator
+\* annotations that misused ->in place of =>.
+\*
+\* See https://github.com/informalsystems/apalache/issues/860
+
+\* @type: (Int, Int) -> Bool;
+Op(n, m) == TRUE
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1793,6 +1793,21 @@ Type checker [OK]
 EXITCODE: OK
 ```
 
+### typecheck bug #860
+
+Unhandled exception thrown when type-checking a spec that uses the wrong
+annotation syntax for operators.
+
+See https://github.com/informalsystems/apalache/issues/860
+
+```sh
+$ apalache-mc typecheck Bug860.tla | sed 's/[IEW]@.*//'
+...
+Type checker [OK]
+...
+EXITCODE: OK
+```
+
 ## Running the config command
 
 ### config --enable-stats=false
@@ -1814,4 +1829,3 @@ Statistics collection is ON.
 ...
 EXITCODE: OK
 ```
-

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1820,7 +1820,7 @@ See https://github.com/informalsystems/apalache/issues/832
 $ apalache-mc typecheck Bug832.tla | sed 's/[IEW]@.*//'
 ...
 Parsing error in the type annotation:  () => (Bool, Bool)
-Typing input error: Parser error in type annotation of View1: '->' expected but ) found
+Typing input error: Parser error in type annotation of Example: '->' expected but ) found
 ...
 EXITCODE: ERROR (255)
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1809,6 +1809,22 @@ Typing input error: Parser error in type annotation of Op: '=>' expected but -> 
 EXITCODE: ERROR (255)
 ```
 
+### typecheck bug #832
+
+Unhandled exception thrown due to incorrect annotation of a tuple return
+type.
+
+See https://github.com/informalsystems/apalache/issues/832
+
+```sh
+$ apalache-mc typecheck Bug832.tla | sed 's/[IEW]@.*//'
+...
+Parsing error in the type annotation:  () => (Bool, Bool)
+Typing input error: Parser error in type annotation of View1: '->' expected but ) found
+...
+EXITCODE: ERROR (255)
+```
+
 ## Running the config command
 
 ### config --enable-stats=false

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1803,9 +1803,10 @@ See https://github.com/informalsystems/apalache/issues/860
 ```sh
 $ apalache-mc typecheck Bug860.tla | sed 's/[IEW]@.*//'
 ...
-Type checker [OK]
+Parsing error in the type annotation:  (Int, Int) -> Bool
+Typing input error: Parser error in type annotation of Op: '=>' expected but -> found
 ...
-EXITCODE: OK
+EXITCODE: ERROR (255)
 ```
 
 ## Running the config command

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
@@ -16,7 +16,7 @@ import scala.util.parsing.input.NoPosition
  * <p><b>Warning:</b> Avoid using this object directly. Rather use Type1ParserFactory.</p>
  *
  * @see at.forsyte.apalache.tla.typecheck.Type1ParserFactory
- * @author Igor Konnov
+ * @author Igor Konnov, Shon Feder
  */
 object DefaultType1Parser extends Parsers with Type1Parser {
   override type Elem = Type1Token

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
@@ -82,21 +82,22 @@ object DefaultType1Parser extends Parsers with Type1Parser {
 
   // functions are tricky, as they start as other expressions, so we have to distinguish them by RIGHT_ARROW
   private def function: Parser[TlaType1] = {
-    (noFunExpr ~ RIGHT_ARROW() ~ typeExpr) ^^ {
-      case source ~ _ ~ target => FunT1(source, target)
+    (noFunExpr ~ RIGHT_ARROW() ~ typeExpr) ^^ { case source ~ _ ~ target =>
+      FunT1(source, target)
     }
   }
 
   private def operator: Parser[TlaType1] = {
-    (operatorArgs ~ DOUBLE_RIGHT_ARROW() ~ typeExpr) ^^ {
-      case args ~ _ ~ result => OperT1(args, result)
+    (operatorArgs ~ DOUBLE_RIGHT_ARROW() ~ typeExpr) ^^ { case args ~ _ ~ result =>
+      OperT1(args, result)
     }
   }
 
   // Operator arguments can be of the form (), (type), or (type, ..., type)
   private def operatorArgs: Parser[List[TlaType1]] = {
     (LPAREN() ~ repsep(typeExpr, COMMA()) ~ RPAREN() | noFunExpr) ^^ {
-      case _ ~ list ~ _ => list.asInstanceOf[List[TlaType1]] // No idea why this cast is needed :(
+      case _ ~ list ~ _ =>
+        list.asInstanceOf[List[TlaType1]] // No idea why this cast is needed :(
       case typ: TlaType1 => List(typ)
     }
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
@@ -64,36 +64,48 @@ object DefaultType1Parser extends Parsers with Type1Parser {
   }
 
   private def typeExpr: Parser[TlaType1] = {
-    // functions are tricky, as they start as other expressions, so we have to distinguish them by RIGHT_ARROW
-    (noFunExpr ~ opt((RIGHT_ARROW() | DOUBLE_RIGHT_ARROW()) ~ typeExpr)) ^^ {
-      case (lhs :: Nil) ~ Some(RIGHT_ARROW() ~ rhs)   => FunT1(lhs, rhs)
-      case (lhs :: Nil) ~ None                        => lhs
-      case args ~ Some(DOUBLE_RIGHT_ARROW() ~ result) => OperT1(args, result)
-    }
+    (operator | function | noFunExpr)
   }
 
   // A type expression. We wrap it with a list, as (type, ..., type) may start an operator type
-  private def noFunExpr: Parser[List[TlaType1]] = {
+  private def noFunExpr: Parser[TlaType1] = {
     (INT() | REAL() | BOOL() | STR() | typeVar | typeConst
       | set | seq | tuple | sparseTuple
       | record | parenExpr) ^^ {
-      case INT()        => List(IntT1())
-      case REAL()       => List(RealT1())
-      case BOOL()       => List(BoolT1())
-      case STR()        => List(StrT1())
-      case tt: TlaType1 => List(tt)
-      case lst: List[TlaType1] =>
-        lst
+      case INT()        => IntT1()
+      case REAL()       => RealT1()
+      case BOOL()       => BoolT1()
+      case STR()        => StrT1()
+      case tt: TlaType1 => tt
     }
   }
 
-  // A type or partial type in parenthesis.
-  // We can have: (), (type), or (type, ..., type). All of them work as a left-hand side of an operator type.
-  // Additionally, (type) may just wrap a type such as in (A -> B) -> C.
-  // Thus, return a list here, and resolve it in the rules above.
-  private def parenExpr: Parser[List[TlaType1]] = {
-    (LPAREN() ~ repsep(typeExpr, COMMA()) ~ RPAREN()) ^^ { case _ ~ list ~ _ =>
-      list
+  // functions are tricky, as they start as other expressions, so we have to distinguish them by RIGHT_ARROW
+  private def function: Parser[TlaType1] = {
+    (noFunExpr ~ RIGHT_ARROW() ~ typeExpr) ^^ {
+      case source ~ _ ~ target => FunT1(source, target)
+    }
+  }
+
+  private def operator: Parser[TlaType1] = {
+    (operatorArgs ~ DOUBLE_RIGHT_ARROW() ~ typeExpr) ^^ {
+      case args ~ _ ~ result => OperT1(args, result)
+    }
+  }
+
+  // Operator arguments can be of the form (), (type), or (type, ..., type)
+  private def operatorArgs: Parser[List[TlaType1]] = {
+    (LPAREN() ~ repsep(typeExpr, COMMA()) ~ RPAREN() | noFunExpr) ^^ {
+      case _ ~ list ~ _ => list.asInstanceOf[List[TlaType1]] // No idea why this cast is needed :(
+      case typ: TlaType1 => List(typ)
+    }
+  }
+
+  // A type in parenthesis.
+  // Parens may be used to wrap a type, such as in (A -> B) -> C.
+  private def parenExpr: Parser[TlaType1] = {
+    (LPAREN() ~ typeExpr ~ RPAREN()) ^^ { case _ ~ typ ~ _ =>
+      typ
     }
   }
 


### PR DESCRIPTION
Closes #860



This introduces a slight refactoring of the type annotation parser,
reducing the complexity of the top-level `typeExpr` parser, and
eliminating the ambiguity that was leading to the `MatchError` reported
in #860.

The principle changes are

- factoring the function and operator parsing into separate combinators
- differentiating a type expression wrapped in parentheses from the
  parentheses wrapped list of type expressions that are unique to
  operator arguments.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality