### PR TITLE
Add user error for non-existent record field access

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix unhandled errors on non-existent record field access, see #874

--- a/docs/src/lang/records.md
+++ b/docs/src/lang/records.md
@@ -65,6 +65,13 @@ and `[type |-> "B", b |-> TRUE]` have the joint type:
   [type: Str, a: Int, b: Bool]
 ```
 
+If your spec tries to access a field on a record without that field, Apalache
+will fail with the following error:
+
+```
+Access to non-existent record field ...
+```
+
 ----------------------------------------------------------------------------
 
 ## Operators

--- a/test/tla/Bug874.tla
+++ b/test/tla/Bug874.tla
@@ -1,0 +1,10 @@
+------------------- MODULE Bug874 -----------------------
+
+
+Init == FALSE = [a |-> 2].b
+
+Next == TRUE
+
+============================================================
+\* Modification History
+\* Created Thu Jul 22 16:26:49 2021 by Shon Feder

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1414,6 +1414,22 @@ The outcome is: Error
 EXITCODE: ERROR (12)
 ```
 
+### check bug #874
+
+Unhandled `IllegalArgumentException` when accessing a non-existent field on a
+record.
+
+See https://github.com/informalsystems/apalache/issues/874
+
+```sh
+$ apalache-mc check Bug874.tla | sed 's/[IEW]@.*//'
+...
+Found 20 error(s)
+The outcome is: Error
+...
+EXITCODE: ERROR (12)
+```
+
 ## running the typecheck command
 
 ### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1424,10 +1424,9 @@ See https://github.com/informalsystems/apalache/issues/874
 ```sh
 $ apalache-mc check Bug874.tla | sed 's/[IEW]@.*//'
 ...
-Found 20 error(s)
-The outcome is: Error
+Bug874.tla:4:17-4:27: Input error (see the manual): Access to non-existent record field b in (["a" ↦ 2])["b"]
 ...
-EXITCODE: ERROR (12)
+EXITCODE: ERROR (255)
 ```
 
 ## running the typecheck command

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -43,7 +43,7 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
       }
       found match {
         case Some(pair) => pair(1) // get the value
-        case _          => {
+        case _ => {
           val msg = s"Access to non-existent record field $accessedKey in ${expr}"
           throw new TlaInputError(msg, Some(expr.ID))
         }


### PR DESCRIPTION
Fixes #874

The fix is achieved by replacing the `IllegalArgumentException` with the more
fitting `TlaInputError`. The new error includes the offending record access, and
source location. See the included integration test for an example.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality