### PR TITLE
closes #925: fix infinite recursion in the type unifier

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,5 +12,6 @@
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Bug fixes
 
+* Fix infinite recursion in the type unifier, see #925
 * Fix unhandled errors on non-existent record field access, see #874
 * Fix unhandled `MatchError` on invalid operator type annotations, see #919

--- a/test/tla/Bug925.tla
+++ b/test/tla/Bug925.tla
@@ -1,0 +1,10 @@
+------------------- MODULE Bug925 -----------------------
+\* a regression test for the bug found in the type unifier
+
+EXTENDS Integers, FiniteSets
+
+\* @type: (a) => [f: Set(a)];
+Optional(x) == [f |-> x]
+
+
+============================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1825,6 +1825,21 @@ Typing input error: Parser error in type annotation of Example: '->' expected bu
 EXITCODE: ERROR (255)
 ```
 
+### typecheck bug #925
+
+Type unification should not recurse infinitely.
+
+See: https://github.com/informalsystems/apalache/issues/925
+
+```sh
+$ apalache-mc typecheck Bug925.tla | sed 's/[IEW]@.*//'
+...
+[Bug925.tla:7:1-7:24]: Expected ((b) => [f: Set(b)]) in Optional. Found: ((a) => [f: a])
+[Bug925.tla:7:1-7:24]: Error when computing the type of Optional
+...
+EXITCODE: ERROR (255)
+```
+
 ## Running the config command
 
 ### config --enable-stats=false

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
@@ -3,14 +3,15 @@ package at.forsyte.apalache.tla.typecheck.etc
 import at.forsyte.apalache.tla.lir.{
   BoolT1, ConstT1, FunT1, IntT1, OperT1, RealT1, RecT1, SeqT1, SetT1, SparseTupT1, StrT1, TlaType1, TupT1, VarT1
 }
-import at.forsyte.apalache.tla.typecheck._
 import at.forsyte.apalache.tla.typecheck.etc.TypeUnifier.CycleDetected
 
 import scala.collection.immutable.SortedMap
 
 /**
  * <p>A unification solver for the TlaType1 system. Note that our subtyping relation unifies records
- * and sparse tuples with a different number of fields. It does so by extending the key set, not by shrinking it.</p>
+ * and sparse tuples with a different number of fields. It does so by extending the key set, not by shrinking it.
+ * This unifier is a quick prototype. We should probably use a more efficient and more robust algorithm from a textbook.
+ * </p>
  *
  * <p>This class is not designed for concurrency. Use different instances in different threads.</p>
  *
@@ -81,6 +82,10 @@ class TypeUnifier {
       case (c @ ConstT1(lname), ConstT1(rname)) =>
         // uninterpreted constant types must have the same name
         if (lname != rname) None else Some(c)
+
+      case (lvar @ VarT1(lname), VarT1(rname)) if lname == rname =>
+        // if it is the same variable, do not recurse, but just return the result
+        Some(lvar)
 
       // variables contribute to the solutions
       case (VarT1(lname), rvar @ VarT1(rname)) =>

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeUnifier.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeUnifier.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
-import at.forsyte.apalache.tla.lir.{BoolT1, ConstT1, FunT1, IntT1, OperT1, RealT1, SetT1, StrT1, VarT1}
+import at.forsyte.apalache.tla.lir.{BoolT1, ConstT1, FunT1, IntT1, OperT1, RealT1, RecT1, SetT1, StrT1, VarT1}
 import at.forsyte.apalache.io.typecheck.parser.{DefaultType1Parser, Type1Parser}
 import org.junit.runner.RunWith
 import org.scalatest.easymock.EasyMockSugar
@@ -176,5 +176,12 @@ class TestTypeUnifier extends FunSuite with EasyMockSugar with BeforeAndAfterEac
   test("cycle detection") {
     val expectedSubstitution = Substitution(0 -> VarT1("a"), 1 -> VarT1("a"))
     assert(unifier.unify(Substitution(0 -> VarT1("b"), 1 -> VarT1("a")), VarT1("a"), VarT1("b")).isEmpty)
+  }
+
+  // regression
+  test("no stack overflow #925") {
+    val oper1 = OperT1(Seq(VarT1("a")), RecT1("f" -> VarT1("a")))
+    val oper2 = OperT1(Seq(VarT1("a")), RecT1("f" -> SetT1(VarT1("a"))))
+    assert(unifier.unify(Substitution(), oper1, oper2).isEmpty)
   }
 }


### PR DESCRIPTION
Fix infinite recursion in the type unifier

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
