### PR TITLE
Use setup-ocaml v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ on: [pull_request]
 
 name: build
 
+# trigger build
+
 jobs:
   build-mdbook:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ on: [pull_request]
 
 name: build
 
-# trigger build
-
 jobs:
   build-mdbook:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,11 +57,6 @@ jobs:
         operating-system: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Cache local opam repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-4.11.0
       - name: Set up opam
         uses: ocaml/setup-ocaml@v2
         with:
@@ -89,11 +84,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache local opam repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-4.11.0
       - name: Set up opam
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,9 @@ jobs:
           path: ~/.opam
           key: ${{ runner.os }}-opam-4.11.0
       - name: Set up opam
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: 4.11.0
+          ocaml-compiler: 4.11.0
       - name: Install mdx
         run: |
           opam pin https://github.com/realworldocaml/mdx.git#e5a86b0b0588d07cabbb3b1bedde84d1ebb35d1b
@@ -95,9 +95,9 @@ jobs:
           path: ~/.opam
           key: ${{ runner.os }}-opam-4.11.0
       - name: Set up opam
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: 4.11.0
+          ocaml-compiler: 4.11.0
       - name: Install mdx
         run: |
           opam pin https://github.com/realworldocaml/mdx.git#e5a86b0b0588d07cabbb3b1bedde84d1ebb35d1b


### PR DESCRIPTION
This should fix the failing MacOS CI builds.

I would like to update the CI pipeline to drop the ocaml/opam dependency all
together (this should be quite easy using a prebuilt mdx), but this fix
should work for now.

This fixes the CI failure for the moment.
-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality