### PR TITLE
Replace \cup with \union in the documentation

### DIFF
--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -202,7 +202,7 @@ of `TPTypeOK` and `Message` to get the idea about the type of `msgs`:
 ```tla
 Message ==
   ({[type |-> t, rm |-> r]: t \in {"Prepared"}, r \in RM }
-   \cup
+   \union
    {[type |-> t] : t \in {"Commit", "Abort"}})
 
 TPTypeOK ==

--- a/docs/src/adr/002adr-types.md
+++ b/docs/src/adr/002adr-types.md
@@ -416,7 +416,7 @@ Init ==
 startSmoking ==
     /\ dealer /= {}
     /\ smokers' = [r \in Ingredients |->
-                    [smoking |-> {r} \cup dealer = Ingredients]]
+                    [smoking |-> {r} \union dealer = Ingredients]]
     /\ dealer' = {}
 
 stopSmoking ==

--- a/docs/src/apalache/types-and-annotations.md
+++ b/docs/src/apalache/types-and-annotations.md
@@ -75,19 +75,19 @@ This approach manages to automatically compute types of many TLA+ expressions.
 However, there a few problematic cases that require type annotations:
 
  1. An empty set ``{}`` gets assigned the type ``Set[Unknown]``. When it is later
- combined with a more precise type, e.g., as in ``{} \cup {1}``, the type finder
+ combined with a more precise type, e.g., as in ``{} \union {1}``, the type finder
  reports a type error. In this case, the user has to write a type annotation.
  For instance, the above-mentioned problematic expression can be fixed as follows:
- ``({} <: {Int}) \cup {1}``.
+ ``({} <: {Int}) \union {1}``.
  1. Similar to an empty set, an empty sequence ``<<>>`` gets assigned the type
   ``Seq[Unknown]``. Hence ``<<>> \o <<1>>`` produces a type error. To resolve this,
   the user has to write a type annotation ``(<<>> <: Seq(Int)) \o <<1>>``.
  1. It is common to mix records that have different sets of fields, e.g.,
   see [Paxos](https://github.com/tlaplus/Examples/tree/master/specifications/Paxos).
   However, our type checker will report a type error on the following expression:
-  ``{[type |-> "1a", bal |-> 1]} \cup {[type |-> "2a", bal |-> 2, val |-> 3]}``.
+  ``{[type |-> "1a", bal |-> 1]} \union {[type |-> "2a", bal |-> 2, val |-> 3]}``.
   To resolve this, the user has to write a type annotation:
-   ``{[type |-> "1a", bal |-> 1] <: MT} \cup {[type |-> "2a", bal |-> 2, val |-> 3]}``,
+   ``{[type |-> "1a", bal |-> 1] <: MT} \union {[type |-> "2a", bal |-> 2, val |-> 3]}``,
    where ``MT`` is defined as ``[type |-> STRING, bal |-> Int, val |-> Int]``.
   The type checker requires that the fields with the same name are assigned
   the same type.

--- a/docs/src/idiomatic/003record-sets.md
+++ b/docs/src/idiomatic/003record-sets.md
@@ -22,10 +22,10 @@ The bellow snippet from [Paxos.tla][] demonstrates this convention:
 ```tla
 \* The set of all possible messages 
 Message ==      [type : {"1a"}, bal : Ballot]
-           \cup [type : {"1b"}, acc : Acceptor, bal : Ballot, 
-                 mbal : Ballot \cup {-1}, mval : Value \cup {None}]
-           \cup [type : {"2a"}, bal : Ballot, val : Value]
-           \cup [type : {"2b"}, acc : Acceptor, bal : Ballot, val : Value]
+           \union [type : {"1b"}, acc : Acceptor, bal : Ballot, 
+                 mbal : Ballot \union {-1}, mval : Value \union {None}]
+           \union [type : {"2a"}, bal : Ballot, val : Value]
+           \union [type : {"2b"}, acc : Acceptor, bal : Ballot, val : Value]
 ```
 
 Ultimately, this approach both disagrees with our interpretation of the purpose of a type-system for TLA+, as well as introduces unsoundness, in the sense that it makes it impossible, at the type-checking level, to detect record-field access violations.
@@ -50,8 +50,8 @@ VARIABLE
 \* Assuming S1: Set(a1), ..., Sn: Set(an) 
 \* @type: Set( [ type: Str, x1: a1, ..., xn: an, ... ] );
 Message ==      [type : {"t1"}, x1: S1, ...]
-           \cup  ...
-           \cup [type : {"tn"}, xn: Sn, ...]
+           \union  ...
+           \union [type : {"tn"}, xn: Sn, ...]
 ...
 
 TypeOk: msgs \subseteq Message
@@ -70,7 +70,7 @@ Messages == [
 This way, `Messages.t1` represents the set of all messages `m`, for which `m.type` would have been equal to "t1" in the original implementation, that is, `[type: {"t1"}, x1: S1, ...]`.
 For example, assume the original specification included
 ```tla
-Messages == [type: {"t1"}, x: {1,2,3}] \cup [type: {"t2"}, y:{"a","b","c"}]
+Messages == [type: {"t1"}, x: {1,2,3}] \union [type: {"t2"}, y:{"a","b","c"}]
 ```
 that is, defined two types of messages: "t1", with an integer-valued field "x" and "t2" with a string-valued field "y". The type of any `m \in Messages` would have been `[type: Str, x: Int, y: Str]` in the old approach.
 The rewritten version would be:

--- a/docs/src/idiomatic/MsgSetNew.tla
+++ b/docs/src/idiomatic/MsgSetNew.tla
@@ -25,7 +25,7 @@ Init ==
 
 \* @type: ([x: Int]) => Bool; 
 SendInt(m) == 
-    msgs' = [msgs EXCEPT !.int = msgs.int \cup {m}]
+    msgs' = [msgs EXCEPT !.int = msgs.int \union {m}]
 
 \* @type: ([x: Int]) => Bool; 
 RmInt(m) == 
@@ -33,7 +33,7 @@ RmInt(m) ==
 
 \* @type: ([y: Str]) => Bool;
 SendStr(m) == 
-    msgs' = [msgs EXCEPT !.str = msgs.str \cup {m}]
+    msgs' = [msgs EXCEPT !.str = msgs.str \union {m}]
 
 \* @type: ([x: Int]) => Bool; 
 RmStr(m) == 

--- a/docs/src/idiomatic/MsgSetOld.tla
+++ b/docs/src/idiomatic/MsgSetOld.tla
@@ -13,14 +13,14 @@ Ints == {1,2,3}
 Strs == {"a","b","c"}
 
 \* @type: () => Set([ type: Str, x: Int, y: Str ] );
-Messages == [ type: {"int"}, x: Ints ] \cup [ type: {"str"}, y: Strs ]
+Messages == [ type: {"int"}, x: Ints ] \union [ type: {"str"}, y: Strs ]
 
 Init == 
     /\ msgs = {}
     /\ found3 = FALSE
     /\ foundC = FALSE
 
-Send(m) == msgs' = msgs \cup {m}
+Send(m) == msgs' = msgs \union {m}
 Rm(m) == msgs' = msgs \ {m}
 
 AddIntMsg == 

--- a/docs/src/specs/search/ParBMC.tla
+++ b/docs/src/specs/search/ParBMC.tla
@@ -45,10 +45,10 @@ BadExes == { <<0, 1, 2, 1, 2>> }
 \* a worker's workerState
 WorkerStates ==
     [type: {"idle", "error", "noerror", "deadlock"}]
-        \cup
+        \union
         \* the process is checking, whether a transition tr is feasible
     [type: {"exploring"}, tr: Transitions]
-        \cup
+        \union
         \* the process is checking, whether the invariant holds true for a prefix
     [type: {"proving"}, prefix: Seq(SUBSET Transitions)]
 
@@ -119,7 +119,7 @@ CheckOneTransition(w) ==
         /\ runningTrans' = [runningTrans EXCEPT ![workerState[w].tr] = outcome]
         /\ workerState' = [workerState EXCEPT ![w] = [type |-> "idle"]]
         /\  IF outcome = "enabled"
-            THEN unsafePrefixes' = unsafePrefixes \cup { Append(runningPrefix, {workerState[w].tr}) } 
+            THEN unsafePrefixes' = unsafePrefixes \union { Append(runningPrefix, {workerState[w].tr}) }
             ELSE UNCHANGED unsafePrefixes
     /\ UNCHANGED <<depth, runningPrefix, slowPrefixes>>
     
@@ -147,7 +147,7 @@ FindSlowPrefixes ==
     LET timedOut == {tr \in Transitions: runningTrans[tr] = "timeout"} IN
         IF timedOut = {}
         THEN slowPrefixes
-        ELSE slowPrefixes \cup { Append(runningPrefix, {tr}): tr \in timedOut }
+        ELSE slowPrefixes \union { Append(runningPrefix, {tr}): tr \in timedOut }
 
 \* all transitions at the current depth have been explored, move on
 IncreaseDepth == 

--- a/docs/src/tutorials/TwoPhase.tla
+++ b/docs/src/tutorials/TwoPhase.tla
@@ -54,7 +54,7 @@ Message ==
   (* be received by all RMs.  The set $msgs$ contains just a single copy   *)
   (* of such a message.                                                    *)
   (*************************************************************************)
-  [type : {"Prepared"}, rm : RM]  \cup  [type : {"Commit", "Abort"}]
+  [type : {"Prepared"}, rm : RM]  \union  [type : {"Commit", "Abort"}]
    
 TPTypeOK ==  
   (*************************************************************************)
@@ -84,7 +84,7 @@ TMRcvPrepared(rm) ==
   (*************************************************************************)
   /\ tmState = "init"
   /\ [type |-> "Prepared", rm |-> rm] \in msgs
-  /\ tmPrepared' = tmPrepared \cup {rm}
+  /\ tmPrepared' = tmPrepared \union {rm}
   /\ UNCHANGED <<rmState, tmState, msgs>>
 
 TMCommit ==
@@ -95,7 +95,7 @@ TMCommit ==
   /\ tmState = "init"
   /\ tmPrepared = RM
   /\ tmState' = "committed"
-  /\ msgs' = msgs \cup {[type |-> "Commit"]}
+  /\ msgs' = msgs \union {[type |-> "Commit"]}
   /\ UNCHANGED <<rmState, tmPrepared>>
 
 TMAbort ==
@@ -104,7 +104,7 @@ TMAbort ==
   (*************************************************************************)
   /\ tmState = "init"
   /\ tmState' = "aborted"
-  /\ msgs' = msgs \cup {[type |-> "Abort"]}
+  /\ msgs' = msgs \union {[type |-> "Abort"]}
   /\ UNCHANGED <<rmState, tmPrepared>>
 
 RMPrepare(rm) == 
@@ -113,7 +113,7 @@ RMPrepare(rm) ==
   (*************************************************************************)
   /\ rmState[rm] = "working"
   /\ rmState' = [rmState EXCEPT ![rm] = "prepared"]
-  /\ msgs' = msgs \cup {[type |-> "Prepared", rm |-> rm]}
+  /\ msgs' = msgs \union {[type |-> "Prepared", rm |-> rm]}
   /\ UNCHANGED <<tmState, tmPrepared>>
   
 RMChooseToAbort(rm) ==

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -56,7 +56,7 @@ CONSTANT RM \* The set of resource managers
 
 Message ==
   ...
-  [type : {"Prepared"}, rm : RM]  \cup  [type : {"Commit", "Abort"}]
+  [type : {"Prepared"}, rm : RM]  \union  [type : {"Commit", "Abort"}]
 ```
 
 Indeed, we have not introduced a type annotation for the constant `RM`, so the
@@ -212,7 +212,7 @@ Let's look at the definitions of `Messages` and `TPTypeOK`:
 ```tla
 Message ==
   ...
-  [type : {"Prepared"}, rm : RM]  \cup  [type : {"Commit", "Abort"}]
+  [type : {"Prepared"}, rm : RM]  \union  [type : {"Commit", "Abort"}]
 
 TPTypeOK ==  
   ...  


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~~Tests added for any new code~~
- [ ] ~~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~~
- [ ] ~~Documentation added for any new functionality~~
- [ ] ~~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~~

Updates the use of TLA+ set union operator in the documentation. Closes #974.