### PR TITLE
closes #987: use SortedMap.keySet instead of SortedMap.keys

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,7 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+
+### Bug fixes
+
+* Heisenbug caused by EXCEPT on records, which used unsorted keys, see #987

--- a/test/tla/RecordExcept987.tla
+++ b/test/tla/RecordExcept987.tla
@@ -1,0 +1,46 @@
+----------------------------- MODULE RecordExcept987 ------------------------
+EXTENDS Integers
+
+VARIABLES
+    (*
+      @typeAlias: R = [
+         id: Str,
+         name: Str,
+         oneMoreField: Bool,
+         age: Int,
+         isShadow: Bool,
+         isAllow: Bool
+      ];
+      @type: Set(R);
+    *)
+    recs,
+    \* @type: Bool;
+    ok
+
+Init ==
+  /\ ok = TRUE
+  /\ recs = { }
+
+Next ==
+  /\ ok' = \A r \in recs:
+        r.age < 15
+  /\ \/ LET nr == [name |-> "foo",
+                   age |-> 10,
+                   isShadow |-> TRUE,
+                   id |-> "111",
+                   isAllow |-> FALSE,
+                   oneMoreField |-> TRUE
+                   ]
+       IN
+       recs' = recs \union { nr }
+    \/ \E r \in recs:
+        LET nr == [r EXCEPT !.age = @ + 1] IN
+        /\ recs' = (recs \union {nr}) \ {r}
+        /\ nr /= r
+    \/ UNCHANGED recs
+
+Inv ==
+    \A r \in recs:
+        r.age < 15
+
+=============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1050,9 +1050,8 @@ EXITCODE: OK
 ### check Bug914 succeeds
 
 Regression test for https://github.com/informalsystems/apalache/issues/914
-In the earlier version, we expected the model checker to complain about mismatching
-record types. In the latest version, this bug disappeared, due to the changes
-in the type checker.
+In the earlier version, we expected the model checker to complain about mismatching record types. In the latest version,
+this bug disappeared, due to the changes in the type checker.
 
 ```sh
 $ apalache-mc check Bug914.tla | sed 's/I@.*//'
@@ -1060,11 +1059,21 @@ $ apalache-mc check Bug914.tla | sed 's/I@.*//'
 EXITCODE: OK
 ```
 
+### check RecordExcept987 succeeds
+
+Regression test for https://github.com/informalsystems/apalache/issues/987
+We should always use sorted keys on record types.
+
+```sh
+$ apalache-mc check Bug987.tla | sed 's/I@.*//'
+...
+EXITCODE: OK
+```
+
 ## configure the check command
 
-Testing various flags that are set via command-line options and the TLC
-configuration file. The CLI has priority over the TLC config. So we have to
-test that it all works together.
+Testing various flags that are set via command-line options and the TLC configuration file. The CLI has priority over
+the TLC config. So we have to test that it all works together.
 
 ### configure default Init and Next
 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1049,9 +1049,10 @@ EXITCODE: OK
 
 ### check Bug914 succeeds
 
-Regression test for https://github.com/informalsystems/apalache/issues/914
-In the earlier version, we expected the model checker to complain about mismatching record types. In the latest version,
-this bug disappeared, due to the changes in the type checker.
+Regression test for https://github.com/informalsystems/apalache/issues/914 In
+the earlier version, we expected the model checker to complain about
+mismatching record types. In the latest version, this bug disappeared, due to
+the changes in the type checker.
 
 ```sh
 $ apalache-mc check Bug914.tla | sed 's/I@.*//'
@@ -1065,15 +1066,16 @@ Regression test for https://github.com/informalsystems/apalache/issues/987
 We should always use sorted keys on record types.
 
 ```sh
-$ apalache-mc check Bug987.tla | sed 's/I@.*//'
+$ apalache-mc check RecordExcept987.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
 ```
 
 ## configure the check command
 
-Testing various flags that are set via command-line options and the TLC configuration file. The CLI has priority over
-the TLC config. So we have to test that it all works together.
+Testing various flags that are set via command-line options and the TLC
+configuration file. The CLI has priority over the TLC config. So we have to
+test that it all works together.
 
 ### configure default Init and Next
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -143,7 +143,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
       }
     }
 
-    for ((key, cell) <- recType.fieldTypes.keys.zip(nextState.arena.getHas(oldRecord))) {
+    for ((key, cell) <- recType.fieldTypes.keySet.zip(nextState.arena.getHas(oldRecord))) {
       nextState = nextState.updateArena(_.appendHasNoSmt(newRecord, updateOrKeep(key, cell)))
     }
 


### PR DESCRIPTION
closes #987

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
