### PR TITLE
Add workflow to publish docker images to GitHub

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,3 +32,9 @@
 - The workflow builds the release artifact(s), tags the release commit created
   in the `prepare-release` workflow, and publishes the release to GitHub's
   release artifact store.
+
+## [./container.yml](./container.yml)
+
+- Triggered by publishing releases or merging into the `unstable` branch
+- The workflow builds the docker container defined in the
+  [`/Dockerfile`](../../Dockerfile) and publishes it to GitHub Packages.

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,54 @@
+# This workflow builds and publishes a docker container to the GitHub registry.
+# It is only triggered on merges into the unstable branch, and we assume that
+# any commit merged into the trunk has passed CI is safe to release.
+
+# Adapted from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+
+name: docker-container
+
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - unstable
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: apalache/mc
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # See https://github.com/docker/metadata-action#tags-input for the default
+      # tags that are extracted this way. It includes tags for semver releases
+      # and any branches into unstable
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes #1008

Introduces a CI workflow to build and publish docker containers to [our GitHub Packages](https://github.com/orgs/informalsystems/packages?repo_name=apalache).

Once this is working, I'll do a followup to document the location change.