### PR TITLE
Update all docker container references to point to GitHub container registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           opam pin https://github.com/realworldocaml/mdx.git#e5a86b0b0588d07cabbb3b1bedde84d1ebb35d1b
       - name: Build the docker image
-        run: docker build -t apalache/mc:ci .
+        run: docker build -t informalsystems/apalache:ci .
       - name: Run integration tests in docker container
         run: ./test/run-integration
         env:

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ course].
 
 ## Releases
 
-Check the [releases page][].
+Check the [releases page][] for our latest release.
 
-For a stable release, we recommend that you run the latest docker image
-`apalache/mc:latest` or checkout the source code from our latest release tag.
+For a stable release, we recommend that you pull the latest docker image with
+`docker pull ghcr.io/informalsystems/apalache:unstable`, use the jar from the
+most recent release, or checkout the source code from the most recent release
+tag.
 
-To try the latest cool features, check out the [unstable branch][].
+To try the latest cool features, check out the head of the [unstable branch][].
 
 For more information on installation options, see [the
 manual][user-manual-installation].

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,4 +17,8 @@
 
 ### Features
 
- * Enumerated files containing intermediate module states, see #993
+* Enumerated files containing intermediate module states, see #993
+
+### Delivery
+
+* Move docker containers to the GitHub container registry, see #1013

--- a/docs/src/apalache/installation/docker.md
+++ b/docs/src/apalache/installation/docker.md
@@ -8,7 +8,7 @@ All dependencies are already installed in docker. However, you have to install d
 To get the latest Apalache image, issue the command:
 
 ```bash
-docker pull apalache/mc
+docker pull ghcr.io/informalsystems/apalache
 ```
 
 ## Running the docker image
@@ -16,7 +16,7 @@ docker pull apalache/mc
 To run an Apalache image, issue the command:
 
 ```bash
-$ docker run --rm -v <your-spec-directory>:/var/apalache apalache/mc <args>
+$ docker run --rm -v <your-spec-directory>:/var/apalache informalsystems/apalache <args>
 ```
 
 The following docker parameters are used:
@@ -31,8 +31,8 @@ The following docker parameters are used:
 
   When using SELinux, you might have to use the modified form of `-v` option:
     `-v <your-spec-directory>:/var/apalache:z`
-- `apalache/mc` is the APALACHE docker image name. By default, the `latest` stable
-  version is used; you can also refer to a specific tool version, e.g., `apalache/mc:0.6.0` or `apalache/mc:unstable`
+- `informalsystems/apalache` is the APALACHE docker image name. By default, the `latest` stable
+  version is used; you can also refer to a specific tool version, e.g., `informalsystems/apalache:0.6.0` or `informalsystems/apalache:unstable`
 - `<args>` are the tool arguments as described in [Running the Tool](../running.md).
 
 We provide a convenience wrapper for this docker command in
@@ -58,11 +58,11 @@ Apalache in docker while sharing the working directory:
 
 ###### using the latest stable
 
-$ alias apalache='docker run --rm -v $(pwd):/var/apalache apalache/mc'
+$ alias apalache='docker run --rm -v $(pwd):/var/apalache informalsystems/apalache'
 
 ###### using the latest unstable
 
-$ alias apalache='docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable'
+$ alias apalache='docker run --rm -v $(pwd):/var/apalache informalsystems/apalache:unstable'
 ```
 
 ## Using the unstable version of Apalache
@@ -75,25 +75,25 @@ log](https://github.com/informalsystems/apalache/blob/unstable/CHANGES.md) and
 on the unstable branch for the description of the newest features. **We
 recommend using the unstable version if you want to try all the exciting new
 features of Apalache. But be warned: It is called "unstable" for a reason**. To
-use `unstable`, just type `apalache/mc:unstable` instead of `apalache/mc`
+use `unstable`, just type `informalsystems/apalache:unstable` instead of `informalsystems/apalache`
 everywhere.
 
 Do not forget to pull the docker image from time to time:
 
 ```bash
-docker pull apalache/mc:unstable
+docker pull ghcr.io/informalsystems/apalache:unstable
 ```
 
 Run it with the following command:
 
 ```bash
-$ docker run --rm -v <your-spec-directory>:/var/apalache apalache/mc:unstable <args>
+$ docker run --rm -v <your-spec-directory>:/var/apalache informalsystems/apalache:unstable <args>
 ```
 
 To create an alias pointing to the `unstable` version:
 
 ```bash
-$ alias apalache='docker run --rm -v $(pwd):/var/apalache apalache/mc:unstable'
+$ alias apalache='docker run --rm -v $(pwd):/var/apalache informalsystems/apalache:unstable'
 ```
 
 ## Building an image

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -60,7 +60,7 @@ If you are running Apalache via docker directly (instead of using the script in
 environment variable to the docker container:
 
 ```sh
-$ JVM_ARGS="-Xmx1G" docker run -e JVM_ARGS --rm -v <your-spec-directory>:/var/apalache apalache/mc <args>
+$ JVM_ARGS="-Xmx1G" docker run -e JVM_ARGS --rm -v <your-spec-directory>:/var/apalache informalsystems/apalache <args>
 ```
 
 To track memory usage with: `jcmd <pid> VM.native_memory summary`, you can set

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -14,9 +14,9 @@ if [ -z "$APALACHE_TAG" ]
 then
     >&2 echo "# No docker image supplied. Defaulting to '$default_tag'"
     >&2 echo "# To run a specific docker tag set APALACHE_TAG."
-    img="apalache/mc:${default_tag}"
+    img="informalsystems/apalache:${default_tag}"
 else
-    img="apalache/mc:${APALACHE_TAG}"
+    img="informalsystems/apalache:${APALACHE_TAG}"
 fi
 
 cmd="docker run -e TLA_PATH -e JVM_ARGS --rm -v $(pwd):/var/apalache ${img} ${@}"


### PR DESCRIPTION
Followup to #1011

This updates documentation and scripts to use the new docker tagging scheme
required by our move from docker hub to the github container registry.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality