### PR TITLE
Type functions in builder

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/Applicative.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/Applicative.scala
@@ -1,0 +1,44 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.values._
+
+// Several types in TT1 describe objects with the same kind of functionality: application
+// Instead of case-splitting in matching, we can simply view each type, for which this is the
+// case as a pair of two values: (fromT, toT) [Applicative],
+// describing the required argument type and the type of the object after application respectively.
+// For records and tuples, we additionally take an index hint as an argument, because
+// the codomain type may depend on the argument
+sealed case class Applicative(fromT: TlaType1, toT: TlaType1)
+
+object Applicative {
+  def asInstanceOfApplicative(tt1: TlaType1, argHint: TlaEx): Option[Applicative] =
+    tt1 match {
+      // A function T1 -> T2 application takes a T1 argument and returns a T2 value
+      case FunT1(domT, cdmT) => Some(Applicative(domT, cdmT))
+      // A record [ s2: T1, s2: T2, ... ] application takes a Str argument and returns
+      // a value of type Ti, which depends on the argument value (not just type)
+      case RecT1(fieldTypes) =>
+        argHint match {
+          case ValEx(TlaStr(s)) => Some(Applicative(StrT1(), fieldTypes(s)))
+          case _                => None
+        }
+      // A sequence Seq(T) application takes an Int argument and returns a T value
+      case SeqT1(t) => Some(Applicative(IntT1(), t))
+      // Sparse tuples are similar to records
+      case SparseTupT1(indexTypes) =>
+        argHint match {
+          case ValEx(TlaInt(i)) => Some(Applicative(IntT1(), indexTypes(i.toInt)))
+          case _                => None
+        }
+      // Tuples are similar to records
+      case TupT1(tupArgs @ _*) =>
+        argHint match {
+          case ValEx(TlaInt(i)) =>
+            val j = (i - 1).toInt // TLA is 1-indexed, indexedSeq is 0-indexed
+            Some(Applicative(IntT1(), tupArgs.toIndexedSeq(j)))
+          case _ => None
+        }
+      case _ => None
+    }
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/ArithOp.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/ArithOp.scala
@@ -1,0 +1,13 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir.IntT1
+import at.forsyte.apalache.tla.lir.oper.TlaArithOper
+
+object ArithOp {
+  def plusCmp: pureTypeComputation = {
+    case Seq(IntT1(), IntT1()) => IntT1()
+    case args =>
+      throwMsg(s"${TlaArithOper.plus.name} expects arguments of type (Int,Int), found: (${args.mkString(",")})")
+  }
+
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/BoolOp.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/BoolOp.scala
@@ -1,0 +1,14 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir.BoolT1
+import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
+
+object BoolOp {
+  def andCmp: pureTypeComputation = { args =>
+    if (args.forall(_ == BoolT1()))
+      BoolT1()
+    else
+      throwMsg(s"${TlaBoolOper.and.name} expects arguments of type (Bool*), found: (${args.mkString(",")})")
+  }
+
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/BuildInstruction.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/BuildInstruction.scala
@@ -5,7 +5,10 @@ import at.forsyte.apalache.tla.lir.oper.TlaOper
 
 sealed case class BuildInstruction(oper: TlaOper, typeCmp: typeComputation) {
   def build(args: TlaEx*): TlaEx = {
-    val typeTag = Typed(typeCmp(args))
-    OperEx(oper, args: _*)(typeTag)
+    typeCmp(args) match {
+      case Left(err) => throw err
+      case Right(typeRes) =>
+        OperEx(oper, args: _*)(Typed(typeRes))
+    }
   }
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/BuildInstruction.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/BuildInstruction.scala
@@ -1,0 +1,11 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, Typed}
+import at.forsyte.apalache.tla.lir.oper.TlaOper
+
+sealed case class BuildInstruction(oper: TlaOper, typeCmp: typeComputation) {
+  def build(args: TlaEx*): TlaEx = {
+    val typeTag = Typed(typeCmp(args))
+    OperEx(oper, args: _*)(typeTag)
+  }
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/FunOp.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/FunOp.scala
@@ -1,0 +1,99 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir.{OperEx, SeqT1, TlaEx, TlaType1, TupT1}
+import at.forsyte.apalache.tla.lir.oper.TlaFunOper
+import at.forsyte.apalache.tla.typecheck.etc.Substitution
+
+object FunOp {
+  def tupCmp: pureTypeComputation = {
+    TupT1(_: _*)
+  }
+
+  // Assume nonempty
+  def seqCmp: pureTypeComputation = {
+    case Nil =>
+      throwMsg("Unable to determine sequence element type for empty sequence.")
+    case h +: t if t.forall(_ == h) => SeqT1(h)
+    case args =>
+      throwMsg(s"Sequence expects arguments of type (T*), found: (${args.mkString(",")})")
+
+  }
+
+  def exceptCmp: typeComputation = { args =>
+    val nArgs = args.length
+    assert(nArgs >= 3 && nArgs % 2 == 1)
+    // Each row lists all of the arguments that define one update,
+    val argumentRows = args.zipWithIndex collect {
+      case (OperEx(TlaFunOper.tuple, tupArgs @ _*), i) if i % 2 == 1 =>
+        tupArgs
+    }
+
+    // Ensure that all of the arguments are uniformly sized
+    val rowSizes = (argumentRows map {
+      _.length
+    }).toSet
+    assert(rowSizes.size == 1)
+
+    // The first argument is the applicative (fn/rec/seq/tup), the other even positions hold
+    // the updates in the final codomain
+    val applicativeCand +: codomainArgs = args.zipWithIndex collect {
+      case (ex, i) if i % 2 == 0 =>
+        ex
+    }
+
+    // The arguments match the signature of (multi-level) except, if the argument types consecutively unify
+    // with the appropriate layer of applicativeCand.type
+    def matchUpdateWithArgChain(guidingType: TlaType1, rowArgTypes: Seq[TlaEx], updateType: TlaType1,
+        subst: Substitution = Substitution.empty): Option[(Substitution, TlaType1)] =
+      rowArgTypes match {
+        case Nil =>
+          // If we've run out of arguments, guidingType has been peeled until the update layer
+          // It must unify with the updateType
+          singleUnification(guidingType, updateType)
+        case headEx +: tailExs =>
+          for {
+            // Otherwise, `guidingType` must be some form of Applicative(fromT, toT).
+            // As headEx is the argument at the current depth, its value gives us a hint for tuples/records.
+            Applicative(fromT, toT) <- Applicative.asInstanceOfApplicative(guidingType, argHint = headEx)
+            // The toT type, in the case of multi-level EXCEPT may be another applicative, so
+            // we recurse with it over the other arguments given by tailExs.
+            (subst1, _) <- matchUpdateWithArgChain(toT, tailExs, updateType, subst)
+            // Lastly, the type of headEx must unify with the domain type at the current layer, fromT
+            (subst2, _) <- singleUnification(TlaType1.fromTypeTag(headEx.typeTag), fromT, subst1)
+            // If this process fails to unify at any step, we get None, otherwise we
+            // have shown type compliance with guidingType at this layer (which may morph slightly under
+            // the computed substitution)
+          } yield (subst2, subst2.subRec(guidingType))
+      }
+
+    // We now analyze each update point in sequence.
+    // A point is a pair (a,b), where a is a sequence of arguments to the Applicative of each layer
+    // and b is the final codomain update.
+    val finalMatch =
+      argumentRows
+        .zip(codomainArgs)
+        .foldLeft(
+            // the starting type for the result of except is the type of the 1st argument,
+            // i.e. the object being updated
+            Option((Substitution.empty, TlaType1.fromTypeTag(applicativeCand.typeTag)))
+        ) {
+          // For each point, we use matchUpdateWithArgChain to see if the given arguments/codomain value
+          // unify with the type of the object being updated
+          case (Some((subst, partialUnifApplicativeType)), (rowExs, codomainEx)) =>
+            matchUpdateWithArgChain(
+                partialUnifApplicativeType,
+                rowExs,
+                TlaType1.fromTypeTag(codomainEx.typeTag),
+                subst
+            )
+          case _ => None
+        }
+    // Finally, we drop the substitution, as it is no longer needed
+    finalMatch map { _._2 } match {
+      case Some(tt) => tt
+      case _        => throwMsg(s"Arguments passed to ${TlaFunOper.except.name} have incompatible types.")
+    }
+
+  }
+
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/TypeCalculatingBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/TypeCalculatingBuilder.scala
@@ -1,0 +1,29 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaBoolOper, TlaFunOper, TlaOper}
+
+object TypeCalculatingBuilder {
+
+  def plus(x: TlaEx, y: TlaEx): TlaEx =
+    BuildInstruction(TlaArithOper.plus, ArithOp.plusCmp).build(x, y)
+
+  def and(args: TlaEx*): TlaEx =
+    BuildInstruction(TlaBoolOper.and, BoolOp.andCmp).build(args: _*)
+
+  def except(applicative: TlaEx, key1: TlaEx, val1: TlaEx, keysAndVals: TlaEx*) =
+    BuildInstruction(TlaFunOper.except, FunOp.exceptCmp).build(applicative +: key1 +: val1 +: keysAndVals: _*)
+
+  def seq(head: TlaEx, tail: TlaEx*) =
+    BuildInstruction(TlaFunOper.tuple, FunOp.seqCmp).build(head +: tail: _*)
+
+  def emptySeq(seqElemType: TlaType1) =
+    OperEx(TlaFunOper.tuple)(Typed(SeqT1(seqElemType)))
+
+  def tuple(args: TlaEx*) =
+    BuildInstruction(TlaFunOper.tuple, FunOp.tupCmp).build(args: _*)
+
+  def emptyTup() =
+    OperEx(TlaFunOper.tuple)(Typed(TupT1()))
+
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecmp/package.scala
@@ -1,0 +1,25 @@
+package at.forsyte.apalache.tla
+
+import at.forsyte.apalache.tla.lir.{TlaEx, TlaType1, TypingException}
+import at.forsyte.apalache.tla.typecheck.etc.{Substitution, TypeUnifier}
+
+package object typecmp {
+  type typeComputationReturn = Either[TypingException, TlaType1]
+  type typeComputation = Seq[TlaEx] => typeComputationReturn
+  type pureTypeComputation = Seq[TlaType1] => typeComputationReturn
+
+  implicit def fromPure(cmp: pureTypeComputation): typeComputation = { args =>
+    cmp(args map { ex => TlaType1.fromTypeTag(ex.typeTag) })
+  }
+
+  implicit def liftRet(tt: TlaType1): typeComputationReturn = Right(tt)
+
+  def throwMsg(msg: String): typeComputationReturn = Left(new TypingException(msg))
+
+  // Performs unificaiton on 2 types with a fresh unifier
+  def singleUnification(
+      lhs: TlaType1, rhs: TlaType1, subst: Substitution = Substitution.empty
+  ): Option[(Substitution, TlaType1)] = {
+    (new TypeUnifier).unify(subst, lhs, rhs)
+  }
+}

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecmp/TestTCB.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecmp/TestTCB.scala
@@ -1,0 +1,106 @@
+package at.forsyte.apalache.tla.typecmp
+
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaBoolOper, TlaFunOper, TlaOper}
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestTCB extends FunSuite with BeforeAndAfter {
+
+  test("Plus") {
+    val plus = ArithOp.plusCmp
+
+    val args = Seq(
+        TlaInt(1),
+        TlaInt(1)
+    ) map { ValEx(_)(Typed(IntT1())) }
+
+    val res = plus(args)
+
+    assert(res.contains(IntT1()))
+
+    val utArgs = Seq(
+        TlaInt(1),
+        TlaInt(1)
+    ) map { ValEx(_)(Untyped()) }
+
+    assertThrows[TypingException] {
+      plus(utArgs)
+    }
+
+    val badArgs = Seq(
+        ValEx(TlaInt(1))(Typed(IntT1())),
+        ValEx(TlaStr("a"))(Typed(StrT1()))
+    )
+
+    val badRes = plus(badArgs)
+
+    assert(badRes.isLeft)
+
+    val tooManyArgs = Seq(
+        TlaInt(1),
+        TlaInt(1),
+        TlaInt(1)
+    ) map { ValEx(_)(Typed(IntT1())) }
+
+    val tooManyRes = plus(tooManyArgs)
+
+    assert(tooManyRes.isLeft)
+  }
+
+  test("And") {
+    val and = BoolOp.andCmp
+    val args = Seq(
+        TlaBool(true),
+        TlaBool(true),
+        TlaBool(true),
+        TlaBool(true)
+    ) map { ValEx(_)(Typed(BoolT1())) }
+
+    val res = and(args)
+    val res2 = and(args.take(2))
+
+    assert(res.contains(BoolT1()))
+    assert(res2.contains(BoolT1()))
+
+    val utArgs = Seq(
+        TlaBool(true),
+        TlaBool(true)
+    ) map { ValEx(_)(Untyped()) }
+
+    assertThrows[TypingException] {
+      and(utArgs)
+    }
+
+    val badArgs = Seq(
+        ValEx(TlaBool(true))(Typed(BoolT1())),
+        ValEx(TlaStr("a"))(Typed(StrT1()))
+    )
+
+    val badRes = and(badArgs)
+
+    assert(badRes.isLeft)
+
+  }
+
+  test("Except") {
+    val except = FunOp.exceptCmp
+
+    val recType = RecT1("y" -> IntT1())
+    val recExceptArgs = Seq(
+        NameEx("x")(Typed(recType)),
+        OperEx(
+            TlaFunOper.tuple,
+            ValEx(TlaStr("y"))(Typed(StrT1()))
+        )(Typed(TupT1(StrT1()))),
+        NameEx("z")(Typed(IntT1()))
+    )
+
+    val resRec = except(recExceptArgs)
+    assert(resRec.contains(recType))
+  }
+
+}


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

Experimental builder:
Instead of using a schema-based approach, each (TNT) operator is associated with a type-computation function, that synthesizes a return type from input types (or, in rare cases, using value hints).