### PR TITLE
Remove non-existent Typing.tla file

### DIFF
--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -23,7 +23,6 @@
             <outputDirectory>tla2sany/StandardModules/</outputDirectory>
             <includes>
                 <include>Apalache.tla</include>
-                <include>Typing.tla</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
Removes the non-existent `Typing.tla` from `assembly/pom.xml`

This was ditched long ago.