### PR TITLE
Fix regression #1072 - parse output file not being created

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix regression breaking behavior of `--output` flag, see #1072, #1073

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -280,7 +280,17 @@ In this case, Apalache performs the following steps:
    into [Apalache IR](https://github.com/informalsystems/apalache/blob/master/tlair/src/main/scala/at/forsyte/apalache/tla/lir/package.scala)
    .
 
-1. It pretty-prints the IR into `out-parser.tla`, see [Detailed output](#detailed).
+1. If the `--write-intermediate` flag is given, it pretty-prints the IR into
+   `00_OutParser.json` and `00_OutParser.tla` in the output directory (see [Detailed output](#detailed)).
+
+You can also write output to a specified location by using the `--output` flag.
+E.g.,
+
+```bash
+$ apalache parse --output=result.json <myspec>.tla
+```
+
+will write the IR to the file `result.json`.
 
 [alternative SMT encoding using arrays]: ../adr/011adr-smt-arrays.md
 [Enumeration of counterexamples]: ./enumeration.md

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -55,16 +55,10 @@ object Tool extends LazyLogging {
   private def outputAndLogConfig(runDirNamePrefix: String, cmd: General): Unit = {
     OutputManager.configure(cmd)
     OutputManager.createRunDirectory(runDirNamePrefix)
-    OutputManager.runDirPathOpt.foreach { runDir =>
-      println(s"Output directory: ${runDir.toFile}")
-      val outFile = new File(runDir.toFile, OutputManager.Names.RunFile)
-      val writer = new PrintWriter(new FileWriter(outFile, false))
-      try {
-        writer.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
-      } finally {
-        writer.close()
-      }
-    }
+    OutputManager.runDirPathOpt.foreach{d => println(s"Output directory: ${d.toAbsolutePath()}")}
+    OutputManager.withWriterRelativeToRunDir(OutputManager.Names.RunFile)(
+      _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
+    )
     // force our programmatic logback configuration, as the autoconfiguration works unpredictably
     new LogbackConfigurator(OutputManager.runDirPathOpt).configureDefaultContext()
     // TODO: update workers when the multicore branch is integrated

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -161,7 +161,7 @@ object Tool extends LazyLogging {
     logger.info("Parse " + parse.file)
 
     executor.options.set("parser.filename", parse.file.getAbsolutePath)
-    executor.options.set("parser.output", parse.output)
+    parse.output.foreach(executor.options.set("parser.output", _))
 
     // NOTE Must go after all other options are set due to side-effecting
     // behavior of current OutmputManager configuration

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -55,9 +55,9 @@ object Tool extends LazyLogging {
   private def outputAndLogConfig(runDirNamePrefix: String, cmd: General): Unit = {
     OutputManager.configure(cmd)
     OutputManager.createRunDirectory(runDirNamePrefix)
-    OutputManager.runDirPathOpt.foreach{d => println(s"Output directory: ${d.toAbsolutePath()}")}
+    OutputManager.runDirPathOpt.foreach { d => println(s"Output directory: ${d.toAbsolutePath()}") }
     OutputManager.withWriterRelativeToRunDir(OutputManager.Names.RunFile)(
-      _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
+        _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
     )
     // force our programmatic logback configuration, as the autoconfiguration works unpredictably
     new LogbackConfigurator(OutputManager.runDirPathOpt).configureDefaultContext()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -12,7 +12,7 @@ import org.backuity.clist.{Command, _}
 class ParseCmd extends Command(name = "parse", description = "Parse a TLA+ specification and quit") with General {
 
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
-  var output: String = opt[String](name = "output", default = "",
+  var output: Option[String] = opt[Option[String]](name = "output",
       description = "filename where to output the parsed source (.tla or .json),\n" +
         "default: None")
 }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2081,5 +2081,7 @@ $ rm -rf ./test-out-dir
 
 ```sh
 $ apalache-mc check --out-dir=./test-out-dir --profiling=true --length=0 Counter.tla | sed 's/[IEW]@.*//' && test -s ./test-out-dir/*/profile-rules.txt
+...
+EXITCODE: OK
 $ rm -rf ./test-out-dir
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -181,8 +181,8 @@ $ rm output.tla
 $ apalache-mc parse --output=output.json Annotations.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
-$ test -s output.tla
-$ rm output.tla
+$ test -s output.json
+$ rm output.json
 ...
 ```
 
@@ -2002,7 +2002,9 @@ EXITCODE: OK
 ### set out-dir by CLI flag
 
 ```sh
-$ apalache-mc check --out-dir=./test-out-dir --length=0 Counter.tla &> /dev/null && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+$ apalache-mc check --out-dir=./test-out-dir --length=0 Counter.tla | sed 's/[IEW]@.*//' && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+...
+EXITCODE: OK
 detailed.log
 log0.smt
 run.txt
@@ -2012,7 +2014,9 @@ $ rm -rf ./test-out-dir
 ### set out-dir by envvar
 
 ```sh
-$ OUT_DIR=./test-out-dir apalache-mc check --length=0 Counter.tla &> /dev/null && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+$ OUT_DIR=./test-out-dir apalache-mc check --length=0 Counter.tla | sed 's/[IEW]@.*//' && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+...
+EXITCODE: OK
 detailed.log
 log0.smt
 run.txt
@@ -2022,7 +2026,9 @@ $ rm -rf ./test-out-dir
 ### setting out-dir by CLI flag overrides the envvar
 
 ```sh
-$ OUT_DIR=./not-here apalache-mc check --out-dir=./test-out-dir --length=0 Counter.tla &> /dev/null && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+$ OUT_DIR=./not-here apalache-mc check --out-dir=./test-out-dir --length=0 Counter.tla | sed 's/[IEW]@.*//' && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+...
+EXITCODE: OK
 detailed.log
 log0.smt
 run.txt
@@ -2032,7 +2038,9 @@ $ rm -rf ./test-out-dir
 ### write-intermediate files
 
 ```sh
-$ apalache-mc check --out-dir=./test-out-dir --write-intermediate=true --length=0 Counter.tla &> /dev/null && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+$ apalache-mc check --out-dir=./test-out-dir --write-intermediate=true --length=0 Counter.tla | sed 's/[IEW]@.*//' && find ./test-out-dir -type f -exec basename {} \; | ./sort.sh
+...
+EXITCODE: OK
 00_OutParser.json
 00_OutParser.tla
 01_out-post-TypeCheckerSnowcat.json
@@ -2072,6 +2080,6 @@ $ rm -rf ./test-out-dir
 ### use the --profiling flag to write profile-rules.txt
 
 ```sh
-$ apalache-mc check --out-dir=./test-out-dir --profiling=true --length=0 Counter.tla &> /dev/null && test -s ./test-out-dir/*/profile-rules.txt
+$ apalache-mc check --out-dir=./test-out-dir --profiling=true --length=0 Counter.tla | sed 's/[IEW]@.*//' && test -s ./test-out-dir/*/profile-rules.txt
 $ rm -rf ./test-out-dir
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -171,6 +171,8 @@ $ apalache-mc parse --output=output.tla Annotations.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
 ...
+$ test -s output.tla
+$ rm output.tla
 ```
 
 ### parse --output=annotations.json Annotations succeeds
@@ -179,6 +181,8 @@ EXITCODE: OK
 $ apalache-mc parse --output=output.json Annotations.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
+$ test -s output.tla
+$ rm output.tla
 ...
 ```
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -174,7 +174,7 @@ object OutputManager {
     printWriter(Paths.get(base), fileParts: _*)
   }
 
-  /**  Apply f to the writer w, being sure to close w */
+  /** Apply f to the writer w, being sure to close w */
   private def withWriter(f: PrintWriter => Unit)(w: PrintWriter) = {
     try {
       f(w)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -152,32 +152,34 @@ object OutputManager {
       runDirOpt = Some(rundir)
     }
 
-  /**  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file */
+  /** Create a PrintWriter to the file formed by appending `fileParts` to the `base` file */
   def printWriter(base: File, fileParts: String*): PrintWriter = {
     val file = fileParts.foldLeft(base)((file, part) => new File(file, part))
     new PrintWriter(new FileWriter(file))
   }
 
-  /**  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file */
+  /** Create a PrintWriter to the file formed by appending `fileParts` to the `base` file */
   def printWriter(base: Path, fileParts: String*): PrintWriter = {
     printWriter(base.toFile(), fileParts: _*)
   }
 
-  /**  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file
+  /**
+   *  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file
    *
    * E.g., to create a writer to the file `foo/bar/bas.json`:
    *
-   *    val w = printWriter("foo", "bar", "baz.json") */
+   *    val w = printWriter("foo", "bar", "baz.json")
+   */
   def printWriter(base: String, fileParts: String*): PrintWriter = {
     printWriter(Paths.get(base), fileParts: _*)
   }
 
-  /**  Create a PrintWriter to the file formed by appending the `parts` to the `outDir` */
+  /** Create a PrintWriter to the file formed by appending the `parts` to the `outDir` */
   def writerRelativeToOutDir(parts: String*): PrintWriter = {
     printWriter(outDir, parts: _*)
   }
 
-  /**  Create a PrintWriter to the file formed by appending the `parts` to the intermediate output dir */
+  /** Create a PrintWriter to the file formed by appending the `parts` to the intermediate output dir */
   def writerRelativeToIntermediateDir(parts: String*): PrintWriter = {
     printWriter(outDir, (Names.IntermediateFoldername :: parts.toList): _*)
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -198,7 +198,7 @@ object OutputManager {
    *
    * @param parts path parts describing a path relative to the intermediate directory (all parents must exist)
    * @param f a function that will be applied to the the PrintWriter, if the `IntermediateFlag` is set.
-   * @returns `true` if the `IntermediateFlag` is set the output is written, otherwise `false`
+   * @return `true` if the `IntermediateFlag` is set the output is written, otherwise `false`
    * If the IntermediateFlag is true, then this applies `f` to the PrintWriter
    * created by appending the `parts` to the intermediate output dir, and returns `true`. Otherwise, it is false
    */

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -190,11 +190,11 @@ object OutputManager {
    */
   def withWriterRelativeToIntermediateDir(parts: String*)(f: PrintWriter => Unit): Boolean = {
     if (flags(Names.IntermediateFlag)) {
-      val intermediateDir = new File(outDir.toFile(), Names.IntermediateFoldername)
+      val intermediateDir = new File(runDirOpt.get.toFile(), Names.IntermediateFoldername)
       if (!intermediateDir.exists()) {
         intermediateDir.mkdir()
       }
-      f(printWriter(intermediateDir))
+      f(printWriter(intermediateDir, parts: _*))
       true
     } else {
       false

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -53,10 +53,12 @@ object OutputManager extends LazyLogging {
     runDirPathOpt.map(_.resolve(Names.IntermediateFoldername))
   }
 
-  /**  The intermediate output directory as a File, if it exists
+  /**
+   *  The intermediate output directory as a File, if it exists
    *
    * @return `Some(dir)` if `dir` is the intermediate output directory and it
-   * exists or can be created. Otherwise `false`*/
+   * exists or can be created. Otherwise `false`
+   */
   def intermediateDirFile: Option[File] = {
     intermediateDirPathOpt
       .map(_.toFile)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -174,9 +174,23 @@ object OutputManager {
     printWriter(Paths.get(base), fileParts: _*)
   }
 
+  /**  Apply f to the writer w, being sure to close w */
+  private def withWriter(f: PrintWriter => Unit)(w: PrintWriter) = {
+    try {
+      f(w)
+    } finally {
+      w.close()
+    }
+  }
+
+  def withWriterToFile(file: File)(f: PrintWriter => Unit): Unit = {
+    withWriter(f)(printWriter(file))
+  }
+
   /** Applies `f` to a PrintWriter created by appending the `parts` to the `runDir` */
   def withWriterRelativeToRunDir(parts: String*)(f: PrintWriter => Unit): Unit = {
-    f(printWriter(outDir, parts: _*))
+    val w = printWriter(runDirOpt.get, parts: _*)
+    withWriter(f)(w)
   }
 
   /**
@@ -194,7 +208,7 @@ object OutputManager {
       if (!intermediateDir.exists()) {
         intermediateDir.mkdir()
       }
-      f(printWriter(intermediateDir, parts: _*))
+      withWriter(f)(printWriter(intermediateDir, parts: _*))
       true
     } else {
       false

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -48,10 +48,15 @@ object OutputManager extends LazyLogging {
   /** Accessor, read-only */
   def runDirPathOpt: Option[Path] = runDirOpt
 
+  /** Construct the path to the intermediate output directory */
   def intermediateDirPathOpt: Option[Path] = {
     runDirPathOpt.map(_.resolve(Names.IntermediateFoldername))
   }
 
+  /**  The intermediate output directory as a File, if it exists
+   *
+   * @return `Some(dir)` if `dir` is the intermediate output directory and it
+   * exists or can be created. Otherwise `false`*/
   def intermediateDirFile: Option[File] = {
     intermediateDirPathOpt
       .map(_.toFile)
@@ -207,7 +212,7 @@ object OutputManager extends LazyLogging {
    * Conditionally applies a function to a PrintWriter constructed relative to the intermediate directory
    *
    * @param parts path parts describing a path relative to the intermediate directory (all parents must exist)
-   * @param f a function that will be applied to the the PrintWriter, if the `IntermediateFlag` is set.
+   * @param f a function that will be applied to the `PrintWriter`, if the `IntermediateFlag` is set.
    * @return `true` if the `IntermediateFlag` is true, and `f` can be applied to the PrintWriter
    *        created by appending the `parts` to the intermediate output dir. Otherwise, `false`.
    */
@@ -216,15 +221,15 @@ object OutputManager extends LazyLogging {
       false
     } else {
       intermediateDirFile match {
-        case None => {
-          val dirName = intermediateDirPathOpt.getOrElse("")
-          logger.error(
-              s"Unable to find or create intermdediate output directory ${dirName}. Intermediate output will not be written.")
-          false
-        }
         case Some(dir) => {
           withWriter(f)(printWriter(dir, parts: _*))
           true
+        }
+        case None => {
+          val dirName = intermediateDirPathOpt.getOrElse("")
+          logger.error(
+              s"Unable to find or create intermediate output directory ${dirName}. Intermediate output will not be written.")
+          false
         }
       }
     }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -174,13 +174,31 @@ object OutputManager {
     printWriter(Paths.get(base), fileParts: _*)
   }
 
-  /** Create a PrintWriter to the file formed by appending the `parts` to the `outDir` */
-  def writerRelativeToOutDir(parts: String*): PrintWriter = {
-    printWriter(outDir, parts: _*)
+  /** Applies `f` to a PrintWriter created by appending the `parts` to the `runDir` */
+  def withWriterRelativeToRunDir(parts: String*)(f: PrintWriter => Unit): Unit = {
+    f(printWriter(outDir, parts: _*))
   }
 
-  /** Create a PrintWriter to the file formed by appending the `parts` to the intermediate output dir */
-  def writerRelativeToIntermediateDir(parts: String*): PrintWriter = {
-    printWriter(outDir, (Names.IntermediateFoldername :: parts.toList): _*)
+  /**
+   * Conditionally applies a function to a PrintWriter constructed relative to the intermediate directory
+   *
+   * @param parts path parts describing a path relative to the intermediate directory (all parents must exist)
+   * @param f a function that will be applied to the the PrintWriter, if the `IntermediateFlag` is set.
+   * @returns `true` if the `IntermediateFlag` is set the output is written, otherwise `false`
+   * If the IntermediateFlag is true, then this applies `f` to the PrintWriter
+   * created by appending the `parts` to the intermediate output dir, and returns `true`. Otherwise, it is false
+   */
+  def withWriterRelativeToIntermediateDir(parts: String*)(f: PrintWriter => Unit): Boolean = {
+    if (flags(Names.IntermediateFlag)) {
+      val intermediateDir = new File(outDir.toFile(), Names.IntermediateFoldername)
+      if (!intermediateDir.exists()) {
+        intermediateDir.mkdir()
+      }
+      f(printWriter(intermediateDir))
+      true
+    } else {
+      false
+    }
+
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -7,6 +7,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import org.yaml.snakeyaml.Yaml
+import java.io.{PrintWriter, FileWriter}
 
 trait OutputManagerConfig {
   // TODO def debug : Boolean
@@ -150,4 +151,34 @@ object OutputManager {
       val rundir = Files.createTempDirectory(outDir, s"${specName}_${nicedate}T${nicetime}_")
       runDirOpt = Some(rundir)
     }
+
+  /**  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file */
+  def printWriter(base: File, fileParts: String*): PrintWriter = {
+    val file = fileParts.foldLeft(base)((file, part) => new File(file, part))
+    new PrintWriter(new FileWriter(file))
+  }
+
+  /**  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file */
+  def printWriter(base: Path, fileParts: String*): PrintWriter = {
+    printWriter(base.toFile(), fileParts: _*)
+  }
+
+  /**  Create a PrintWriter to the file formed by appending `fileParts` to the `base` file
+   *
+   * E.g., to create a writer to the file `foo/bar/bas.json`:
+   *
+   *    val w = printWriter("foo", "bar", "baz.json") */
+  def printWriter(base: String, fileParts: String*): PrintWriter = {
+    printWriter(Paths.get(base), fileParts: _*)
+  }
+
+  /**  Create a PrintWriter to the file formed by appending the `parts` to the `outDir` */
+  def writerRelativeToOutDir(parts: String*): PrintWriter = {
+    printWriter(outDir, parts: _*)
+  }
+
+  /**  Create a PrintWriter to the file formed by appending the `parts` to the intermediate output dir */
+  def writerRelativeToIntermediateDir(parts: String*): PrintWriter = {
+    printWriter(outDir, (Names.IntermediateFoldername :: parts.toList): _*)
+  }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
@@ -54,7 +54,7 @@ trait TlaWriterFactory {
    *        from the module name)
    */
   def writeModuleToTla(
-    module: TlaModule, extendedModuleNames: List[String], writer: Option[PrintWriter]
+      module: TlaModule, extendedModuleNames: List[String], writer: Option[PrintWriter]
   ): Unit =
     writeModuleWithFormatWriter(".tla", createTlaWriter, writer)(module, extendedModuleNames)
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
@@ -46,7 +46,7 @@ trait TlaWriterFactory {
 
     writer match {
       case Some(w) => writef(w)
-      case None    => OutputManager.withWriterRelativeToRunDir(module.name + extension)(writef)
+      case None    => OutputManager.withWriterRelativeToIntermediateDir(module.name + extension)(writef)
     }
   }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
@@ -37,11 +37,16 @@ trait TlaWriterFactory {
   )(
       module: TlaModule, extendedModuleNames: List[String]
   ): Unit = {
-    val w = writer.getOrElse(OutputManager.writerRelativeToIntermediateDir(module.name + extension))
-    try {
-      createWriter(w).write(module, extendedModuleNames)
-    } finally {
-      w.close()
+    val writef: PrintWriter => Unit = w =>
+      try {
+        createWriter(w).write(module, extendedModuleNames)
+      } finally {
+        w.close()
+      }
+
+    writer match {
+      case Some(w) => writef(w)
+      case None    => OutputManager.withWriterRelativeToRunDir(module.name + extension)(writef)
     }
   }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -82,16 +82,17 @@ class SanyParserPassImpl @Inject() (
         writerFactory.writeModuleAllFormats(rootModule.get.copy(name = "00_OutParser"), TlaWriter.STANDARD_MODULES)
 
         // write parser output to specified destination, if requested
-        options.get[String]("parser", "output").foreach {
-          output =>
+        options.get[String]("parser", "output").foreach { output =>
           val writer = OutputManager.printWriter(output)
 
           if (filename.toLowerCase.endsWith(".tla")) {
             val moduleName = filename.substring(0, filename.length - ".tla".length)
-            writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES, Some(writer))
+            writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
+                Some(writer))
           } else if (filename.toLowerCase.endsWith(".json")) {
             val moduleName = filename.substring(0, filename.length - ".json".length)
-            writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES, Some(writer))
+            writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
+                Some(writer))
           } else {
             logger.error(s"  > Unrecognized file format: $filename. Supported formats: .tla and .json")
           }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -83,16 +83,16 @@ class SanyParserPassImpl @Inject() (
 
         // write parser output to specified destination, if requested
         options.get[String]("parser", "output").foreach { output =>
-          val writer = OutputManager.printWriter(output)
+          val file = new File(output)
 
           if (filename.toLowerCase.endsWith(".tla")) {
             val moduleName = filename.substring(0, filename.length - ".tla".length)
             writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
-                Some(writer))
+                Some(file))
           } else if (filename.toLowerCase.endsWith(".json")) {
             val moduleName = filename.substring(0, filename.length - ".json".length)
             writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
-                Some(writer))
+                Some(file))
           } else {
             logger.error(s"  > Unrecognized file format: $filename. Supported formats: .tla and .json")
           }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -81,19 +81,17 @@ class SanyParserPassImpl @Inject() (
         // save the output
         writerFactory.writeModuleAllFormats(rootModule.get.copy(name = "00_OutParser"), TlaWriter.STANDARD_MODULES)
 
-        // Jure: @Igor: Can we remove this below?
         // write parser output to specified destination, if requested
-        val output = options.getOrElse[String]("parser", "output", "")
-        if (output.nonEmpty) {
-          val outputFile = new File(output)
-          val filename = outputFile.getName
+        options.get[String]("parser", "output").foreach {
+          output =>
+          val writer = OutputManager.printWriter(output)
 
           if (filename.toLowerCase.endsWith(".tla")) {
             val moduleName = filename.substring(0, filename.length - ".tla".length)
-            writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES)
+            writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES, Some(writer))
           } else if (filename.toLowerCase.endsWith(".json")) {
             val moduleName = filename.substring(0, filename.length - ".json".length)
-            writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES)
+            writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES, Some(writer))
           } else {
             logger.error(s"  > Unrecognized file format: $filename. Supported formats: .tla and .json")
           }


### PR DESCRIPTION
Closes #1072

Follow up to #1025, which caused a regression in the handling of the `--output` flag. Instead of writing the specified file, as it used (and as it seems it should), it was only writing to the `intermediate` subdirectory of the run directory, and then only when the `--write-intermediate` flag was also given.

This restores the previous behavior. I think the guiding principle for this kind of UI decision re: output files might be something like:

- Files that we generate automatically during runs should only ever be written to the rundir
- But if we are allowing users to get specific information out of apalche written to a file, then we should allow them to specify any file that for this output that is convenient for their process.

This PR also introduces a few utilities to the OutputManager to support the fix.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality