### PR TITLE
Fix output format detection

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,7 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix regression that broken requested output file format detection in parser
+  output, see #1079

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,5 +12,5 @@
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
 ### Bug fixes
 
-* Fix regression that broken requested output file format detection in parser
-  output, see #1079
+* Fix regression breaking `--output` file format detection in parser command, see
+  #1079

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -166,24 +166,46 @@ EXITCODE: OK
 
 ### parse --output=annotations.tla Annotations succeeds
 
+And also check that it actually parses into TLA (see #1079)
+
 ```sh
 $ apalache-mc parse --output=output.tla Annotations.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
-...
-$ test -s output.tla
+$ cat output.tla | head
+----- MODULE /home/sf/Sync/informal-systems/apalache/apalache-core/test/tla/Annotations -----
+
+EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache
+
+CONSTANT
+  (*
+    @type: Int;
+  *)
+  N
+
 $ rm output.tla
 ```
 
 ### parse --output=annotations.json Annotations succeeds
 
+And also check that it actually parses into JSON (see #1079)
+
 ```sh
 $ apalache-mc parse --output=output.json Annotations.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
-$ test -s output.json
+$ cat output.json | head
+{
+  "name": "ApalacheIR",
+  "version": "1.0",
+  "description": "https://apalache.informal.systems/docs/adr/005adr-json.html",
+  "modules": [
+    {
+      "kind": "TlaModule",
+      "name": "/home/sf/Sync/informal-systems/apalache/apalache-core/test/tla/Annotation",
+      "declarations": [
+        {
 $ rm output.json
-...
 ```
 
 ### parse FormulaRefs fails

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -173,7 +173,7 @@ $ apalache-mc parse --output=output.tla Annotations.tla | sed 's/I@.*//'
 ...
 EXITCODE: OK
 $ cat output.tla | head
------ MODULE /home/sf/Sync/informal-systems/apalache/apalache-core/test/tla/Annotations -----
+-------------------------------- MODULE output --------------------------------
 
 EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache
 
@@ -202,7 +202,7 @@ $ cat output.json | head
   "modules": [
     {
       "kind": "TlaModule",
-      "name": "/home/sf/Sync/informal-systems/apalache/apalache-core/test/tla/Annotation",
+      "name": "output",
       "declarations": [
         {
 $ rm output.json

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -87,15 +87,15 @@ class SanyParserPassImpl @Inject() (
           val outfileName = outfile.toString()
 
           if (outfileName.toLowerCase.endsWith(".tla")) {
-            val moduleName = outfileName.substring(0, filename.length - ".tla".length)
+            val moduleName = outfileName.substring(0, outfileName.length - ".tla".length)
             writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
                 Some(outfile))
           } else if (outfileName.toLowerCase.endsWith(".json")) {
-            val moduleName = outfileName.substring(0, filename.length - ".json".length)
+            val moduleName = outfileName.substring(0, outfileName.length - ".json".length)
             writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
                 Some(outfile))
           } else {
-            logger.error(s"  > Unrecognized file format: $filename. Supported formats: .tla and .json")
+            logger.error(s"  > Unrecognized file format: $outfileName. Supported formats: .tla and .json")
           }
 
           if (options.getOrElse[Boolean]("general", "debug", false)) {

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -84,13 +84,14 @@ class SanyParserPassImpl @Inject() (
         // write parser output to specified destination, if requested
         options.get[String]("parser", "output").foreach { output =>
           val outfile = new File(output)
+          val outfileName = outfile.toString()
 
-          if (outfile.toString.toLowerCase.endsWith(".tla")) {
-            val moduleName = filename.substring(0, filename.length - ".tla".length)
+          if (outfileName.toLowerCase.endsWith(".tla")) {
+            val moduleName = outfileName.substring(0, filename.length - ".tla".length)
             writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
                 Some(outfile))
-          } else if (outfile.toString.toLowerCase.endsWith(".json")) {
-            val moduleName = filename.substring(0, filename.length - ".json".length)
+          } else if (outfileName.toLowerCase.endsWith(".json")) {
+            val moduleName = outfileName.substring(0, filename.length - ".json".length)
             writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
                 Some(outfile))
           } else {

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -83,16 +83,16 @@ class SanyParserPassImpl @Inject() (
 
         // write parser output to specified destination, if requested
         options.get[String]("parser", "output").foreach { output =>
-          val file = new File(output)
+          val outfile = new File(output)
 
-          if (filename.toLowerCase.endsWith(".tla")) {
+          if (outfile.toString.toLowerCase.endsWith(".tla")) {
             val moduleName = filename.substring(0, filename.length - ".tla".length)
             writerFactory.writeModuleToTla(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
-                Some(file))
-          } else if (filename.toLowerCase.endsWith(".json")) {
+                Some(outfile))
+          } else if (outfile.toString.toLowerCase.endsWith(".json")) {
             val moduleName = filename.substring(0, filename.length - ".json".length)
             writerFactory.writeModuleToJson(rootModule.get.copy(name = moduleName), TlaWriter.STANDARD_MODULES,
-                Some(file))
+                Some(outfile))
           } else {
             logger.error(s"  > Unrecognized file format: $filename. Supported formats: .tla and .json")
           }


### PR DESCRIPTION
Followup to #1073

That fix introduced *another* regression test, which caused the of the
parser to always go to TLA. :(

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality