### PR TITLE
Fixes type synchronization after inlining

### DIFF
--- a/test/tla/Poly1107.tla
+++ b/test/tla/Poly1107.tla
@@ -1,0 +1,37 @@
+---------- MODULE Poly1107 ----------
+
+EXTENDS Integers, Apalache
+
+\* @type: (a) => a -> Int;
+MkFun(p) == [ x \in {p} |-> 1 ]
+
+\* @type: (a -> Int, a -> Int) => a -> Int;
+F1 (+) F2  ==
+  LET 
+    D1 == DOMAIN F1
+    D2 == DOMAIN F2
+  IN [e \in D1 \union D2 |->
+      (IF e \in D1 THEN F1[e] ELSE 0)
+    + (IF e \in D2 THEN F2[e] ELSE 0) ]
+
+\* @type: (Set(a -> Int)) => a -> Int;
+BigPlus(S) ==
+  LET 
+    NotInfix(F1,F2) == F1 (+) F2
+  IN FoldSet( NotInfix, [ x \in {} |-> 1 ], S )
+
+TestBigPlus == 
+  LET 
+    A1 == MkFun(1)
+    A2 == MkFun(2)
+  IN LET
+    R ==  BigPlus({A1,A2})
+  IN R = [x \in {1,2} |-> 1]
+
+Init == TRUE
+
+Next == TRUE
+
+Inv == TestBigPlus
+
+====================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2075,6 +2075,23 @@ Type checker [OK]
 EXITCODE: OK
 ```
 
+### typecheck Poly1107.tla
+
+Regression test for principal types in let definitions.
+
+```sh
+$ apalache-mc typecheck Poly1107.tla | sed 's/[IEW]@.*//'
+...
+PASS #1: TypeCheckerSnowcat
+ > Running Snowcat .::.
+ > Your types are great!
+ > All expressions are typed
+...
+Type checker [OK]
+...
+EXITCODE: OK
+```
+
 ## Running the config command
 
 ### config --enable-stats=false

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/LambdaTypeInliner.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/LambdaTypeInliner.scala
@@ -63,7 +63,7 @@ class LambdaTypeInliner(tracker: TransformationTracker) extends TlaExTransformat
         (withNew, partialNoop && newBody.ID == d.body.ID)
       }
 
-      if (letInBody.eqTyped(newBody) && noop)
+      if (letInBody.ID == newBody.ID && noop)
         letInEx
       else
         LetInEx(newBody, newDefs: _*)(newBody.typeTag)


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

Inlining was performing type substitution only on the body of a declaration, which caused the type tag of a polymorphic declaration to potentially desync from the types used inside the body, whenever that operator was instantiated with another polymorphic operator.

Followup to #1104. 
Closes #1088