### PR TITLE
Fix #962: Duplicate indices in functions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Remove duplicate function indices when decoding symbolic states, fixes #962


### PR DESCRIPTION
This is towards a fix of #962, which reported functions with duplicate indices appearing in counterexamples.

My current understanding of the root cause of the problem is that this is because the spec in question (https://github.com/informalsystems/modelator/blob/c9b54c1c4cd753af833ae4a16b626e4d3a5cab94/modelator/tests/integration/tla/IBC_ics02.tla) adds duplicate indices to the function in its updates, and we are not currently constructing sets or functions in a way that de-dupes in such cases.

The two small changes currently included in this draft illustrate the problem. The test case added fails prior to the deduplication. However, deduplication in the case of `EXCEPT`-based updates is much more subtle, afaict. I *think* it should be possible in principle, but I'm not clear on the interaction between such deduplication at the time of expression construction and the construction of arenas for the SMT encoding.

So further progress here is blocked on  the following question:

Is the right approach to this problem to add an accumulator into our [`FunExceptRule`](https://github.com/jonathanlorimer/apalache/blob/unstable/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala#L31) that will allow us to de-duplicate indices? Or do we just let those duplicate indices accumulate?

If the latter, we could still strip out the duplicate indices in the report of the counter-example, but perhaps whether we do that should depend on whether or not the duplicate indices impact the complexity of the sat checking?

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
