### PR TITLE
Closes #1130:   Improve the format of uninterpreted constants to name_OF_TYPE

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@
 
  * Added bug report templates, see #1094
 
+ * Improve the format of uninterpreted constants to name_OF_TYPE, see #1130
+
 ### Bug fixes
 
  * Remove duplicate function indices when decoding symbolic states, fixes #962

--- a/test/tla/MC3_TwoPhaseUFO.tla
+++ b/test/tla/MC3_TwoPhaseUFO.tla
@@ -1,7 +1,7 @@
 ------------------------ MODULE MC3_TwoPhaseUFO -------------------------------
 \* a fixed instance of TwoPhaseUFO to be checked with Apalache or TLC
 
-Values_RM == { "uval_SORT_RM_r1", "uval_SORT_RM_r2", "uval_SORT_RM_r3" }
+Values_RM == { "r1_OF_SORT_RM", "r2_OF_SORT_RM", "r3_OF_SORT_RM" }
 
 VARIABLES
   \* rmState[rm] is the state of resource manager RM.

--- a/test/tla/ModelVal.tla
+++ b/test/tla/ModelVal.tla
@@ -16,7 +16,7 @@ VARIABLE
   \* @type: Str;
   s
 
-CInit == C = "uval_UT_1" /\ G = "uval_XY_1"
+CInit == C = "1_OF_UT" /\ G = "1_OF_XY"
 
 Init == x = {} /\ z = {G} /\ s = "init"
 

--- a/test/tla/TwoPhaseUFO.tla
+++ b/test/tla/TwoPhaseUFO.tla
@@ -66,10 +66,10 @@ Init ==
   (*************************************************************************)
   (* The initial predicate.                                                *)
   (*************************************************************************)
-  \* uval_SORT_STATE_working is interpreted
+  \* working_OF_SORT_STATE is interpreted
   \* as a distinct constant 'working' of the sort SORT_STATE
-  /\ rmState = [rm \in Values_RM |-> "uval_SORT_STATE_working"]
-  /\ tmState = "uval_SORT_STATE_init"
+  /\ rmState = [rm \in Values_RM |-> "working_OF_SORT_STATE"]
+  /\ tmState = "init_OF_SORT_STATE"
   \*/\ tmPrepared   = {}
   /\ tmPrepared = [rm \in Values_RM |-> FALSE]
   \*/\ msgs = {}
@@ -87,7 +87,7 @@ TMRcvPrepared(rm) ==
   (*************************************************************************)
   (* The TM receives a $"Prepared"$ message from resource manager $rm$.    *)
   (*************************************************************************)
-  /\ tmState = "uval_SORT_STATE_init"
+  /\ tmState = "init_OF_SORT_STATE"
   \*/\ [type |-> "Prepared", rm |-> rm] \in msgs
   /\ msgsPrepared[rm]
   \*/\ tmPrepared' = tmPrepared \union {rm}
@@ -99,11 +99,11 @@ TMCommit ==
   (* The TM commits the transaction; enabled iff the TM is in its initial  *)
   (* state and every RM has sent a $"Prepared"$ message.                   *)
   (*************************************************************************)
-  /\ tmState = "uval_SORT_STATE_init"
+  /\ tmState = "init_OF_SORT_STATE"
   \*/\ tmPrepared = RM
   /\ \A rm \in Values_RM:
         tmPrepared[rm]
-  /\ tmState' = "uval_SORT_STATE_committed"
+  /\ tmState' = "committed_OF_SORT_STATE"
   \*/\ msgs' = msgs \union {[type |-> "Commit"]}
   /\ msgsCommit' = TRUE
   /\ UNCHANGED <<rmState, tmPrepared, msgsPrepared, msgsAbort>>
@@ -112,8 +112,8 @@ TMAbort ==
   (*************************************************************************)
   (* The TM spontaneously aborts the transaction.                          *)
   (*************************************************************************)
-  /\ tmState = "uval_SORT_STATE_init"
-  /\ tmState' = "uval_SORT_STATE_aborted"
+  /\ tmState = "init_OF_SORT_STATE"
+  /\ tmState' = "aborted_OF_SORT_STATE"
   \*/\ msgs' = msgs \union {[type |-> "Abort"]}
   /\ msgsAbort' = TRUE
   /\ UNCHANGED <<rmState, tmPrepared, msgsPrepared, msgsCommit>>
@@ -123,8 +123,8 @@ RMPrepare(rm) ==
   (*************************************************************************)
   (* Resource manager $rm$ prepares.                                       *)
   (*************************************************************************)
-  /\ rmState[rm] = "uval_SORT_STATE_working"
-  /\ rmState' = [rmState EXCEPT ![rm] = "uval_SORT_STATE_prepared"]
+  /\ rmState[rm] = "working_OF_SORT_STATE"
+  /\ rmState' = [rmState EXCEPT ![rm] = "prepared_OF_SORT_STATE"]
   \*/\ msgs' = msgs \union {[type |-> "Prepared", rm |-> rm]}
   /\ msgsPrepared' = [ msgsPrepared EXCEPT ![rm] = TRUE ]
   /\ UNCHANGED <<tmState, tmPrepared, msgsAbort, msgsCommit>>
@@ -135,8 +135,8 @@ RMChooseToAbort(rm) ==
   (* Resource manager $rm$ spontaneously decides to abort.  As noted       *)
   (* above, $rm$ does not send any message in our simplified spec.         *)
   (*************************************************************************)
-  /\ rmState[rm] = "uval_SORT_STATE_working"
-  /\ rmState' = [rmState EXCEPT ![rm] = "uval_SORT_STATE_aborted"]
+  /\ rmState[rm] = "working_OF_SORT_STATE"
+  /\ rmState' = [rmState EXCEPT ![rm] = "aborted_OF_SORT_STATE"]
   /\ UNCHANGED <<tmState, tmPrepared, msgsPrepared, msgsCommit, msgsAbort>>
 
 \* @type: (SORT_RM) => Bool;
@@ -146,7 +146,7 @@ RMRcvCommitMsg(rm) ==
   (*************************************************************************)
   \*/\ [type |-> "Commit"] \in msgs
   /\ msgsCommit
-  /\ rmState' = [rmState EXCEPT ![rm] = "uval_SORT_STATE_committed"]
+  /\ rmState' = [rmState EXCEPT ![rm] = "committed_OF_SORT_STATE"]
   /\ UNCHANGED <<tmState, tmPrepared, msgsPrepared, msgsCommit, msgsAbort>>
 
 \* @type: (SORT_RM) => Bool;
@@ -156,7 +156,7 @@ RMRcvAbortMsg(rm) ==
   (*************************************************************************)
   \*/\ [type |-> "Abort"] \in msgs
   /\ msgsAbort
-  /\ rmState' = [rmState EXCEPT ![rm] = "uval_SORT_STATE_aborted"]
+  /\ rmState' = [rmState EXCEPT ![rm] = "aborted_OF_SORT_STATE"]
   /\ UNCHANGED <<tmState, tmPrepared, msgsPrepared, msgsCommit, msgsAbort>>
 
 Next ==
@@ -181,8 +181,8 @@ TCConsistent ==
   (*************************************************************************)
   \*\A rm1, rm2 \in RM :
   \A rm1, rm2 \in Values_RM :
-       ~ /\ rmState[rm1] = "uval_SORT_STATE_aborted"
-         /\ rmState[rm2] = "uval_SORT_STATE_committed"
+       ~ /\ rmState[rm1] = "aborted_OF_SORT_STATE"
+         /\ rmState[rm2] = "committed_OF_SORT_STATE"
 ==============================================================================
 
 =============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1584,6 +1584,16 @@ $ apalache-mc check --cinit=CInit --inv=Inv ModelValFail.tla | sed 's/[IEW]@.*//
 EXITCODE: ERROR (12)
 ```
 
+### check MC3_TwoPhaseUFO.tla succeeds with model values
+
+Test that advanced use of model values is working.
+
+```sh
+$ apalache-mc check --inv=TCConsistent MC3_TwoPhaseUFO.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check PolyFold.tla reports no error: regression for #1085
 
 ```sh

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/ModelValueHandler.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/ModelValueHandler.scala
@@ -9,37 +9,49 @@ import scala.util.matching.Regex
  * types (and SMT sorts) are unique and they are incomparable with regular strings of with other
  * model values of a different type.
  *
- * Each model value follows the pattern
- *  [PREFIX]_[TYPE]_[INDEX]
- * where:
- *  - PREFIX is a prefix shared by, and identifying, all model values.
- *  - TYPE is the type of this particular model value. e.g., a value [PREFIX]_XYZ_[INDEX] has the uninterpreted type XYZ
- *  - INDEX is a unique identifier within the model value type. Its actual value is unimportant, however,
- *  model values with different indices are unequal by definition
+ * Each model value follows the pattern: `[NAME]_OF_[TYPE]`, where:
+ *
+ *  - NAME is a unique identifier within the model value type. Its actual value is unimportant.
+ *  - TYPE is the type of this particular model value. e.g., a value foo_OF_XYZ has the uninterpreted type XYZ.
+ *
+ *  Model values that are constructed with different identifiers are not equal to one another.
+ *
+ *  @author Jure Kukovec
  */
 object ModelValueHandler {
-  val PREFIX: String = "uval"
+
+  /**
+   * The name that is designated for string, in contrast to model values.
+   */
   val STRING_TYPE: String = "str"
-  private val matchRegex: Regex = (s"${PREFIX}_([A-Z_][A-Z0-9_]*)_([a-zA-Z0-9]+)").r
+  private val matchRegex: Regex = raw"([a-zA-Z0-9_]+)_OF_([A-Z_][A-Z0-9_]*)".r
 
   /**
    * Returns the type of `s`.
    * If `s` follows the pattern for model values, its type is `ConstT1(_)`, otherwise is
    * is a regular string.
    */
-  def modelValueOrString(s: String): TlaType1 =
+  def modelValueOrString(s: String): TlaType1 = {
     typeAndIndex(s).map(_._1).getOrElse(StrT1())
+  }
 
   /**
    * Attempts to extract the type and index from thew pattern. If None, the value `s` is not a model value,
    * but a regular string.
    */
-  def typeAndIndex(s: String): Option[(ConstT1, String)] =
-    matchRegex.findFirstMatchIn(s).map(regexMatch => (ConstT1(regexMatch.group(1)), regexMatch.group(2)))
+  def typeAndIndex(s: String): Option[(ConstT1, String)] = {
+    s match {
+      case matchRegex(name, sort) => Some(ConstT1(sort), name)
+      case _                      => None
+    }
+  }
 
   /**
    * Synthesizes a model value string from its components.
    */
-  def construct(typeAndIndex: (String, String)): String =
-    s"${PREFIX}_${typeAndIndex._1}_${typeAndIndex._2}"
+  def construct(typeAndName: (String, String)): String = {
+    val tp = typeAndName._1
+    val name = typeAndName._2
+    s"${name}_OF_$tp"
+  }
 }

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestModelValueHandler.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestModelValueHandler.scala
@@ -7,12 +7,11 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestModelValueHandler extends FunSuite {
-  val prefix = ModelValueHandler.PREFIX
   test("Pattern matching") {
     val s1 = "string"
-    val s2 = s"${prefix}_A_1"
-    val s3 = s"${prefix}_B_1"
-    val s4 = s"${prefix}_lowercase_1"
+    val s2 = "1_OF_A"
+    val s3 = "1_OF_B"
+    val s4 = "1_OF_lowercase"
 
     val f = ModelValueHandler.modelValueOrString _
 
@@ -40,11 +39,11 @@ class TestModelValueHandler extends FunSuite {
     )
 
     val values = Seq(
-        "A_1",
-        "A_2",
-        "B_one",
-        "B_two"
-    ) map { s => s"${prefix}_$s" }
+        ("A", "1"),
+        ("A", "2"),
+        ("B", "one"),
+        ("B", "two")
+    ) map { p => s"${p._2}_OF_${p._1}" }
 
     assert(
         values.forall(v => ti(v).map(x => ctr((x._1.name, x._2))).contains(v))


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
