### PR TITLE
closes #1136: translate a^b for non-constants

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,7 +18,9 @@
 
 ### Bug fixes
 
-* Remove duplicate function indices when decoding symbolic states, fixes #962
+ * Remove duplicate function indices when decoding symbolic states, fixes #962
+
+ * Translate `a^b` for non-constant `a` and `b`, fixes #1136
 
 ### Refactoring
 

--- a/test/tla/Bug1136.tla
+++ b/test/tla/Bug1136.tla
@@ -1,0 +1,28 @@
+-------------------------------- MODULE Bug1136 -------------------------------
+\* a regression test for a^b, see:
+\* https://github.com/informalsystems/apalache/issues/1136
+
+EXTENDS Integers
+
+VARIABLES
+    \* @type: Int;
+    base,
+    \* @type: Int;
+    power,
+    \* @type: Int;
+    exp
+
+Init ==
+    /\ base = 3
+    /\ power = 1
+    /\ exp = 3
+
+Next ==
+    /\ power' = power + 1
+    /\ exp' = exp * base
+    /\ UNCHANGED base
+
+Inv ==
+    exp = base^power
+    
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1602,6 +1602,14 @@ $ apalache-mc check --inv=Inv --length=1 PolyFold.tla | sed 's/[IEW]@.*//'
 EXITCODE: OK
 ```
 
+### check Bug1136.tla reports no error: regression for #1136
+
+```sh
+$ apalache-mc check --inv=Inv Bug1136.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ## running the typecheck command
 
 ### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -732,6 +732,12 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         val mod = z3context.mkMod(le.asInstanceOf[IntExpr], re.asInstanceOf[IntExpr])
         (mod.asInstanceOf[ExprSort], 1 + ln + rn)
 
+      case OperEx(TlaArithOper.exp, left, right) =>
+        val (le, ln) = toArithExpr(left)
+        val (re, rn) = toArithExpr(right)
+        val mod = z3context.mkPower(le.asInstanceOf[IntExpr], re.asInstanceOf[IntExpr])
+        (mod.asInstanceOf[ExprSort], 1 + ln + rn)
+
       case OperEx(TlaArithOper.uminus, subex) =>
         val (e, n) = toArithExpr(subex)
         val minus = z3context.mkUnaryMinus(e.asInstanceOf[IntExpr])


### PR DESCRIPTION
closes #1136. Simply translate it in `Z3SolverContext`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
