### PR TITLE
Add ConfigManager

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,14 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Breaking changes
+
+* The global config file is now named `$HOME/.tlaplus/apalache.cfg`, see #1160
+
+### Features
+
+* Support for a local config file (defaulting to `$PWD/.apalache.cfg`) see #1160
+
 ### Bug fixes
 
 * Fix the use of set union in the array encoding, see #1162

--- a/docs/src/adr/009adr-outputs.md
+++ b/docs/src/adr/009adr-outputs.md
@@ -1,8 +1,9 @@
-# ADR-008: Apalache Outputs
+---
+authors: Jure Kukovec, Shon Feder
+last revised: 2021-12-14
+---
 
-| author                   | revision |
-|--------------------------|---------:|
-| Jure Kukovec, Shon Feder |        2.1 |
+# ADR-008: Apalache Outputs
 
 This ADR documents the various files produced by Apalache, and where they get written to.
 
@@ -67,9 +68,18 @@ following:
 
 ## 4. Global Configuration File
 
-Apalache should define a global configuration file `apalache-global-config`, e.g. in the `<HOME>/.tlaplus` directory, in which users can define the default values of all parameters, including all flags listed in section 1, as well as `out-dir`. The format of the configuration file is an implementation detail and will not be specified here.
+Apalache should define a global configuration file `apalache.cfg`, e.g. in the `<HOME>/.tlaplus` directory, in which users can define the default values of all parameters, including all flags listed in section 1, as well as `out-dir`. The format of the configuration file is an implementation detail and will not be specified here.
+
+Apalache should also look for a local configuration file `.apalache.cfg`, within
+current working directory or its parents. If it finds such file, any configured
+parameters therein will override the parameters from the global config file.
+
 If a parameter is specified in the configuration file, it replaces the default value, but specifying a parameter manually always overrides config defaults.
 In other words, parameter values are determined in the following way, by order of priority:
-  1. If `--<flag>=<value>` is given, use `<value>`, otherwise
-  2. If `apalache-global-config` specifies `<flag>=<CFGvalue>` use `<CFGvalue>`, otherwise 
-  3. Use Apalache defaults.
+
+1. If `--<flag>=<value>` is given, use `<value>`, otherwise
+2. if a local `.apalache.cfg` file is found containing `<flag>: <value>`, then
+    use `<value>`, otherwise
+3. if the global `apalache.cfg` specifies `<flag>=: <value>` use `<value>`,
+    otherwise
+4. Use the defaults specified in the `ApalacheConfig` class.

--- a/docs/src/adr/009adr-outputs.md
+++ b/docs/src/adr/009adr-outputs.md
@@ -78,8 +78,8 @@ If a parameter is specified in the configuration file, it replaces the default v
 In other words, parameter values are determined in the following way, by order of priority:
 
 1. If `--<flag>=<value>` is given, use `<value>`, otherwise
-2. if a local `.apalache.cfg` file is found containing `<flag>: <value>`, then
+2. if a local `.apalache.cfg` file is found (or is specified with the `--config-file` argument) containing `<flag>: <value>`, then
     use `<value>`, otherwise
-3. if the global `apalache.cfg` specifies `<flag>=: <value>` use `<value>`,
+3. if the global `apalache.cfg` specifies `<flag>: <value>` use `<value>`,
     otherwise
 4. Use the defaults specified in the `ApalacheConfig` class.

--- a/docs/src/apalache/config.md
+++ b/docs/src/apalache/config.md
@@ -16,10 +16,10 @@ a later numbered source.
 ## Command line arguments and environment variables
 
 To view the available command line arguments, run Apalache with the `--help`
-flag and consult the section on [Running the Too](./running.md) for more
+flag and consult the section on [Running the Tool](./running.md) for more
 details.
 
-*Some* parameters configurable the command are also configurable via environment
+*Some* parameters configurable via the command line are also configurable via environment
 variables. These parameters are noted in the CLI's inline help. If a parameter
 is configured both through a CLI argument and an environment variable, then the
 CLI argument always takes precedence. 

--- a/docs/src/apalache/config.md
+++ b/docs/src/apalache/config.md
@@ -1,23 +1,72 @@
-# Apalache global configuration file
-Apalache allows you to specify certain parameters, governing outputs produced by it, as described in [ADR-009](../adr/009adr-outputs.md).
+# Apalache configuration
 
-You can create a global configuration file named `apalache-global-config.yml` in `$HOME/.tlaplus/` and populate it with values for the following flags, in YAML format:
-  - `out-dir` (String): The value of `out-dir` defines a path to the directory,
-  in which all Apalache runs write their outputs. Each run will produce a unique
-  subdirectory inside `out-dir` using the following convention:
-  `<SPECNAME>_yyyy-MM-dd_HH-mm-ss_<UNIQUEID>`. The use of `~` in the path
-  specification is permitted. The directory path need not already exist.
-  Example value: `'~/apalache-out'`.
-  If this value is not defined in `apalache-global-config.yml`, Apalache will, for each individual run, define it to be equal to `CWD/_apalache-out/`, where `CWD` is the current working directory.
-  - `profiling` (Bool): This flag governs the creation of `profile-rules.txt` used in [profiling](profiling.md). The file is only created if `profiling` is set to `True`.  Setting `profiling` to `False` is incompatible with the `--smtprof` flag.
-  The default is `False`.
-  - `write-intermediate` (Bool): This Boolean flag governs the creation of intermediate outputs. If set to `True`, apalache will produce an `intermediate` subdirectory in the run directory and output the state of the module after each pass.
-  The default is `False`.
+Apalache supports configuration of some parameters governing its behavior.
 
+Application configuration is loaded from the following four sources:
 
-Example of a valid `apalache-global-config.yml`:
+1. Command line arguments
+2. Environment variables
+3. A local configuration file
+4. The global configuration file
+
+The order of precedence of the sources follows their numbering: i.e., and any
+configuration set in an earlier numbered source overrides a configuration set in
+a later numbered source.
+
+## Command line arguments and environment variables
+
+To view the available command line arguments, run Apalache with the `--help`
+flag and consult the section on [Running the Too](./running.md) for more
+details.
+
+*Some* parameters configurable the command are also configurable via environment
+variables. These parameters are noted in the CLI's inline help. If a parameter
+is configured both through a CLI argument and an environment variable, then the
+CLI argument always takes precedence. 
+
+## Configuration files
+
+### File format and supported parameters
+
+Local configuration files support JSON and the JSON superset
+[HOCON](https://github.com/lightbend/config/blob/master/HOCON.md).
+
+Here's an example of a valid configuration for the currently 
+supported parameters, along with their default values: 
+
+```yaml
+# Directory in which to write all log files and records of each run
+out-dir: "${PWD}/_apalache-out"
+
+# Whether or not to write additional files, that report on intermediate
+# processing steps
+write-intermediate: false
+
+# Whether or not to write the SMT profiling file
+profiling: false
+
+# Fixed directory into which generated files are written (absent by default)
+# run-dir: ~/my-run-dir
 ```
-out-dir: '~/apalache-out'
-profiling: True
-write-intermediate: True
-```
+
+A `~` found at the beginning of a file path will expanded into the value set for
+the user's home directory.
+
+Details on the effect of these parameters can be found in [Running the
+Too](./running.md).
+
+### Local configuration file
+
+You can specify a local configuration file explicitly via the `config-file`
+command line argument. If this is not provided, then Apalache will look for the
+nearest `.apalache.cfg` file, beginning in the current working directory and
+searching up through its parents.
+
+Parameters configured in the local configuration file will be overridden by
+values set via CLI arguments or environment variables, and will override
+parameters configured via the global configuration file.
+
+### Global configuration file
+
+The final fallback for configuration parameters is the global configuration file
+named `$HOME/.tlaplus/apalache.cfg`.

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -11,10 +11,13 @@ The model checker can be run as follows:
 ```bash
 $ apalache check [--config=filename] [--init=Init] [--cinit=ConstInit] \
     [--next=Next] [--inv=Inv] [--length=10] [--algo=(incremental|offline)] \
-    [--discard-disabled] [--no-deadlock] [--tuning=filename] [--tune-here=options] \
+    [--discard-disabled] [--no-deadlock] \
+    [--tuning=filename] [--tune-here=options] \
     [--smt-encoding=(oopsla19|arrays)] \
     [--out-dir=./path/to/dir] \
     [--write-intermediate=(true|false)] \
+    [--config-file=./path/to/file] \
+    [--profiling=false] \
     <myspec>.tla
 ```
 
@@ -32,7 +35,7 @@ The arguments are as follows:
     - `--algo` lets you to choose the search algorithm: `incremental` is using the incremental SMT solver, `offline` is
       using the non-incremental
       (offline) SMT solver
-    - `smt-encoding` lets you choose how the SMT instances are encoded: `oopsla19` (default) uses QF_UFNIA, and
+    - `--smt-encoding` lets you choose how the SMT instances are encoded: `oopsla19` (default) uses QF_UFNIA, and
       `arrays` (experimental) uses arrays with extensionality. This parameter can also be set via the
       `SMT_ENCODING` environment variable. See the [alternative SMT encoding using arrays] for details.
     - `--discard-disabled` does a pre-check on transitions and discard the disabled ones at every step. If you know that
@@ -50,6 +53,13 @@ The arguments are as follows:
       [Detailed output](#detailed-output). *`false` by default*
     - `--run-dir=DIRECTORY` write all outputs directly into the specified
       `DIRECTORY`
+    - `--config-file` a file to use for loading configuration parameters. This
+      will prevent Apalache from looking for any local `.apalache.cfg` file.
+    - `--profiling` (Bool): This flag governs the creation of `profile-rules.txt`
+      used in [profiling](profiling.md). The file is only created if `profiling`
+      is set to `True`.  Setting `profiling` to `False` is incompatible with the
+      `--smtprof` flag. The default is `False`.
+
 
       The options that are passed with the option `--tuning-options`
       have priority over the options that are passed with the option `--tuning`.
@@ -242,12 +252,38 @@ the [TLA+ Community Modules](https://github.com/tlaplus/CommunityModules).
 
 ## Detailed output
 
-The tool will display only important messages on stdout, but a detailed log can be found in `detailed.log`.
+The location for detailed output is determined by the value of the `out-dir`
+parameter, which specifies the path to a directory into which all Apalache
+runs write their outputs (see [configuration instructions](config.md). 
 
-Additionally, if the flag `--write-intermediate=true` is set or this option is
-enabled in the `apalache-global-config.yml` (see [configuration
-instructions](config.md)) each pass of the model checker produces an
-intermediate TLA+ file in the run-specific directory:
+Each run will produce a unique subdirectory inside its "namespace", derived from
+the file name of the specification, using the following convention
+`yyyy-MM-ddTHH-mm-ss_<UNIQUEID>`. 
+
+For an example, consider using the default location of the `run-dir` for a run of
+Apalache on a spec named `test.tla`. This will create a directory structuring matching following pattern:
+
+```
+./_apalache-out/
+└── test.tla
+    └── 2021-11-05T22-54-55_810261790529975561
+```
+
+The default value for the `out-dir` is the `_apalahce-out` directory in the
+current working directly. The subdirectory `test.tla` is derived from the name
+of the spec on which the tool was run, and the run-specific subdirectory
+`2021-11-05T22-54-55_810261790529975561` gives a unique location to write the
+all the outputs produced by the run.
+
+The tool only writes important messages on stdout, but a detailed log can be
+found in the `detailed.log` in the run-specific subdirectory.
+
+The directory also includes a file `run.txt`, reporting the command line
+arguments used during the run.
+
+Additionally, if the parameter `write-intermediate` is set to `true` (see
+[configuration instructions](config.md)) each pass of the model checker produces
+an intermediate TLA+ file in the run-specific subdirectory:
 
 - File `out-parser.tla` is produced as a result of parsing and importing into the intermediate representation, Apalache
   TLA IR.

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -269,7 +269,7 @@ Apalache on a spec named `test.tla`. This will create a directory structuring ma
     └── 2021-11-05T22-54-55_810261790529975561
 ```
 
-The default value for the `out-dir` is the `_apalahce-out` directory in the
+The default value for the `out-dir` is the `_apalache-out` directory in the
 current working directly. The subdirectory `test.tla` is derived from the name
 of the spec on which the tool was run, and the run-specific subdirectory
 `2021-11-05T22-54-55_810261790529975561` gives a unique location to write the
@@ -283,7 +283,7 @@ arguments used during the run.
 
 Additionally, if the parameter `write-intermediate` is set to `true` (see
 [configuration instructions](config.md)) each pass of the model checker produces
-an intermediate TLA+ file in the run-specific subdirectory:
+intermediate TLA+ files in the run-specific subdirectory:
 
 - File `out-parser.tla` is produced as a result of parsing and importing into the intermediate representation, Apalache
   TLA IR.

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.tooling.opt
 
 import org.backuity.clist.{Command, _}
+import java.io.File
 
 /**
  * This command initiates the 'config' command line.
@@ -12,4 +13,7 @@ class ConfigCmd extends Command(name = "config", description = "Configure Apalac
   var submitStats: Option[Boolean] = opt[Option[Boolean]](name = "enable-stats",
       description = "Let Apalache submit usage statistics to tlapl.us\n"
         + "(shared with TLC and TLA+ Toolbox)\nSee: https://apalache.informal.systems/docs/apalache/statistics.html")
+
+  // Used for application (esp. output) configuration
+  def file = new File("config")
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-import at.forsyte.apalache.io.{OutputManagerConfig, OutputManager}
+import at.forsyte.apalache.io.CliConfig
 
 import java.io.File
 import org.backuity.clist._
@@ -13,21 +13,26 @@ import at.forsyte.apalache.io.OutputManager
  *
  * @author Igor Konnov
  */
-trait General extends Command with OutputManagerConfig {
+trait General extends Command with CliConfig {
+  // TODO Fix excessively long strings
+  var configFile = opt[Option[File]](
+      description =
+        "configuration to read from (JSON and HOCON formats supported). Overrides any local .aplache.cfg files. (overrides envvar CONFIG_FILE)",
+      useEnv = true)
   var debug = opt[Boolean](description = "extensive logging in detailed.log and log.smt, default: false")
   var smtprof = opt[Boolean](description = "profile SMT constraints in log.smt, default: false")
-  var profiling = opt[Option[Boolean]](name = OutputManager.Names.ProfilingFlag,
+  var profiling = opt[Option[Boolean]](
       description =
         s"write general profiling data to profile-rules.txt in the run directory, default: false (overrides envvar PROFILING)",
       useEnv = true)
-  var outDir = opt[Option[File]](name = OutputManager.Names.OutdirNameInCfg,
+  var outDir = opt[Option[File]](
       description = "where all output files will be written, default: ./_apalache-out (overrides envvar OUT_DIR)",
       useEnv = true)
   var runDir = opt[Option[File]](
       description =
         "additional directory wherein output files for this run will be written directly, default: none (overrides envvar RUN_DIR)",
       useEnv = true)
-  var writeIntermediate = opt[Option[Boolean]](name = OutputManager.Names.IntermediateFlag,
+  var writeIntermediate = opt[Option[Boolean]](
       description =
         "write intermediate output files to `out-dir`, default: false (overrides envvar WRITE_INTERMEDIATE)",
       useEnv = true)

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2395,3 +2395,43 @@ MC.out
 run.txt
 $ rm -rf ./test-out-dir ./test-run-dir
 ```
+
+## configuration management
+
+### configuration management: read run-dir from local `.apalache.cfg`
+
+```sh
+$ echo "run-dir: ./configured-run-dir" > .apalache.cfg
+$ apalache-mc check --length=0 Counter.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+$ ls ./configured-run-dir | ./sort.sh
+detailed.log
+run.txt
+$ rm -rf ./configured-run-dir ./.apalache.cfg
+```
+
+### configuration management: CLI config file overrides local `.apalache.cfg`
+
+```sh
+$ echo "run-dir: ./to-override-dir" > .apalache.cfg
+$ echo "run-dir: ./configured-run-dir" > cli-config.cfg
+$ apalache-mc check --config-file=cli-config.cfg --length=0 Counter.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+$ ! test -d ./to-override-dir
+$ test -d ./configured-run-dir
+$ rm -rf ./configured-run-dir ./.apalache.cfg ./cli-config.cfg
+```
+
+### configuration management: CLI argument overrides config-file
+
+```sh
+$ echo "run-dir: ./to-override-dir" > cli-config.cfg
+$ apalache-mc check --config-file=cli-config.cfg --run-dir=./configured-run-dir --length=0 Counter.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+$ ! test -d ./to-override-dir
+$ test -d ./configured-run-dir
+$ rm -rf ./configured-run-dir ./cli-config.cfg
+```

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -528,7 +528,7 @@ class SymbStateRewriterImpl(private var _solverContext: SolverContext,
   }
 
   override def flushStatistics(): Unit = {
-    statListener.locator.writeStats("profile-rules.txt")
+    statListener.locator.writeStats()
   }
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
@@ -26,23 +26,21 @@ class RuleStatLocator {
 
   def getStats = SortedMap(ruleStats.toSeq: _*)
 
-  def writeStats(filename: String): Unit =
-    OutputManager.doIfFlag(OutputManager.Names.ProfilingFlag) {
-      OutputManager.withWriterInRunDir(filename) { writer =>
-        writer.println("Rule profiling statistics")
-        val hrule = List.fill(80)('-').mkString
-        writer.println(hrule)
+  def writeStats(): Unit =
+    OutputManager.withProfilingWriter { writer =>
+      writer.println("Rule profiling statistics")
+      val hrule = List.fill(80)('-').mkString
+      writer.println(hrule)
+      writer.println(
+        "%20s %9s %9s %9s %9s %9s"
+          .format("name", "calls", "cells", "smt-consts", "smt-asserts", "smt-avg-size"))
+      writer.println(hrule)
+      val stats = ruleStats.values.toSeq.sortWith(_.nCalls > _.nCalls)
+      for (rs <- stats) {
         writer.println(
-            "%20s %9s %9s %9s %9s %9s"
-              .format("name", "calls", "cells", "smt-consts", "smt-asserts", "smt-avg-size"))
-        writer.println(hrule)
-        val stats = ruleStats.values.toSeq.sortWith(_.nCalls > _.nCalls)
-        for (rs <- stats) {
-          writer.println(
-              "%-20s %9d %9d %9d %9d %9d"
-                .format(rs.ruleName, rs.nCalls, rs.nCellsSelf, rs.nSmtConstsSelf, rs.nSmtAssertsSelf,
+          "%-20s %9d %9d %9d %9d %9d"
+            .format(rs.ruleName, rs.nCalls, rs.nCellsSelf, rs.nSmtConstsSelf, rs.nSmtAssertsSelf,
                     rs.smtAssertsSizeAvg))
-        }
       }
     }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
@@ -32,15 +32,15 @@ class RuleStatLocator {
       val hrule = List.fill(80)('-').mkString
       writer.println(hrule)
       writer.println(
-        "%20s %9s %9s %9s %9s %9s"
-          .format("name", "calls", "cells", "smt-consts", "smt-asserts", "smt-avg-size"))
+          "%20s %9s %9s %9s %9s %9s"
+            .format("name", "calls", "cells", "smt-consts", "smt-asserts", "smt-avg-size"))
       writer.println(hrule)
       val stats = ruleStats.values.toSeq.sortWith(_.nCalls > _.nCalls)
       for (rs <- stats) {
         writer.println(
-          "%-20s %9d %9d %9d %9d %9d"
-            .format(rs.ruleName, rs.nCalls, rs.nCellsSelf, rs.nSmtConstsSelf, rs.nSmtAssertsSelf,
-                    rs.smtAssertsSizeAvg))
+            "%-20s %9d %9d %9d %9d %9d"
+              .format(rs.ruleName, rs.nCalls, rs.nCellsSelf, rs.nSmtConstsSelf, rs.nSmtAssertsSelf,
+                  rs.smtAssertsSizeAvg))
       }
     }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/RewriterConfig.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/RewriterConfig.scala
@@ -16,6 +16,10 @@ class RewriterConfig {
    * If true, for A /\ B, check satisfiability of A with SMT and only if it is true, rewrite B.
    */
   var lazyCircuit = false
+
+  /**
+   * If true, then write profiling report */
+  var profilingReport = false
 }
 
 object RewriterConfig {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/RewriterConfig.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/RewriterConfig.scala
@@ -16,11 +16,6 @@ class RewriterConfig {
    * If true, for A /\ B, check satisfiability of A with SMT and only if it is true, rewrite B.
    */
   var lazyCircuit = false
-
-  /**
-   * If true, then write profiling report
-   */
-  var profilingReport = false
 }
 
 object RewriterConfig {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/RewriterConfig.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/RewriterConfig.scala
@@ -18,7 +18,8 @@ class RewriterConfig {
   var lazyCircuit = false
 
   /**
-   * If true, then write profiling report */
+   * If true, then write profiling report
+   */
   var profilingReport = false
 }
 

--- a/tla-io/pom.xml
+++ b/tla-io/pom.xml
@@ -41,6 +41,12 @@
             <artifactId>scala-parser-combinators_${scalaBinaryVersion}</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.pureconfig</groupId>
+            <artifactId>pureconfig_${scalaBinaryVersion}</artifactId>
+            <version>0.17.1</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
         <dependency>
             <groupId>org.yaml</groupId>

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -53,12 +53,9 @@ trait CliConfig {
 
 /** The application's configurable values, along with their base defaults */
 case class ApalacheConfig(
-  file: Option[File] = None,
-  outDir: File = new File(System.getProperty("user.dir"), "_apalache-out"),
-  runDir: Option[File] = None,
-  configFile: Option[File] = None,
-  writeIntermediate: Boolean = false,
-  profiling: Boolean = false
+    file: Option[File] = None, outDir: File = new File(System.getProperty("user.dir"), "_apalache-out"),
+    runDir: Option[File] = None, configFile: Option[File] = None, writeIntermediate: Boolean = false,
+    profiling: Boolean = false
 )
 
 case class ConfigManager(cmd: CliConfig) {
@@ -101,18 +98,18 @@ case class ConfigManager(cmd: CliConfig) {
 
     localConfig
       .getOrElse(ConfigSource.empty)
-    // `withFallback` supplies configuration sources that only apply if the preceding configs aren't set
+      // `withFallback` supplies configuration sources that only apply if the preceding configs aren't set
       .withFallback(globalConfig.optional)
       .load[ApalacheConfig]
       .map(cfg =>
         // TODO Is there no better way than hardcoding these overrides?
         cfg.copy(
-          file = Some(cmd.file),
-          outDir = cmd.outDir.getOrElse(cfg.outDir),
-          runDir = cmd.runDir.orElse(cfg.runDir),
-          configFile = cmd.configFile.orElse(cfg.configFile),
-          writeIntermediate = cmd.writeIntermediate.getOrElse(cfg.writeIntermediate),
-          profiling = cmd.profiling.getOrElse(cfg.profiling)
+            file = Some(cmd.file),
+            outDir = cmd.outDir.getOrElse(cfg.outDir),
+            runDir = cmd.runDir.orElse(cfg.runDir),
+            configFile = cmd.configFile.orElse(cfg.configFile),
+            writeIntermediate = cmd.writeIntermediate.getOrElse(cfg.writeIntermediate),
+            profiling = cmd.profiling.getOrElse(cfg.profiling)
         )
       )
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -1,10 +1,49 @@
+package at.forsyte.apalache.io
+
 import pureconfig._
 import pureconfig.generic.auto._
 import java.io.{File}
 import java.nio.file.{Path, Files, Paths}
 
+object Converters {
+
+  private def expandedFilePath(s: String): Path = {
+    Paths.get(if (s.startsWith("~")) s.replaceFirst("~", System.getProperty("user.home")) else s)
+  }
+
+  // Value class to allow adding a new implicit for the File
+  case class ExpandedFile(val file: File) extends AnyVal
+
+  object ExpandedFile {
+    def apply(f: File): ExpandedFile = {
+      new ExpandedFile(expandedFilePath(f.toString()).toFile())
+    }
+  }
+
+  // Value class to allow adding a new implicit for Path
+  case class ExpandedPath(val path: Path) extends AnyVal
+
+  object ExpandedPath {
+    def apply(f: Path): ExpandedPath = {
+      new ExpandedPath(expandedFilePath(f.toString()))
+    }
+  }
+
+  // Briniging these implicits in scope lets us override the existing
+  // file deserialization behavior, so we get path expansion in all configured
+  // paths
+  implicit def expandedFileConfigReader: ConfigReader[ExpandedFile] =
+    ConfigReader[File].map(ExpandedFile.apply)
+
+  implicit def expandedPathConfigReader: ConfigReader[ExpandedPath] =
+    ConfigReader[Path].map(ExpandedPath.apply)
+}
+
 /** The configuration values that can be overriden based on CLI arguments */
 trait CliConfig {
+
+  /** Input file */
+  def file: File
   def outDir: Option[File]
   def runDir: Option[File]
   def writeIntermediate: Option[Boolean]
@@ -12,10 +51,14 @@ trait CliConfig {
   def configFile: Option[File]
 }
 
-/** The applications configurable values, along with their base defaults */
-case class ApalacheConfigs(
-    outDir: Option[File] = None, runDir: Option[File] = None, configFile: Option[File] = None,
-    writeIntermediate: Boolean = false, profiling: Boolean = false
+/** The application's configurable values, along with their base defaults */
+case class ApalacheConfig(
+  file: Option[File] = None,
+  outDir: File = new File(System.getProperty("user.dir"), "_apalache-out"),
+  runDir: Option[File] = None,
+  configFile: Option[File] = None,
+  writeIntermediate: Boolean = false,
+  profiling: Boolean = false
 )
 
 case class ConfigManager(cmd: CliConfig) {
@@ -23,17 +66,20 @@ case class ConfigManager(cmd: CliConfig) {
   val APALACHE_CFG = "aplache.cfg"
   val DOT_APALACHE_CFG = "." + APALACHE_CFG
 
-  // Recursively search parents of given, looking for .apalache.cfg file
+  import Converters._
+
+  // Recursively search parents of given `dir`, looking for .apalache.cfg file
   private def findLocalConfig(dir: Path): Option[ConfigObjectSource] = {
     val localCfg = dir.resolve(DOT_APALACHE_CFG)
     if (Files.exists(localCfg)) {
       Some(ConfigSource.file(localCfg))
     } else {
-      findLocalConfig(dir.getParent)
+      Option(dir.getParent).flatMap(findLocalConfig)
     }
   }
 
   private def localConfig(): Option[ConfigObjectSource] = {
+    // TODO Ensure an error is raised if config file is specifid in cmd but file cannot be loaded!
     cmd.configFile.map(ConfigSource.file).orElse(findLocalConfig(Paths.get(".").toAbsolutePath()))
   }
 
@@ -48,24 +94,37 @@ case class ConfigManager(cmd: CliConfig) {
    * 4. Globacl config file
    * 5. `ApalacheConfig` defaults (as specified in the case class definition)
    */
-  def load(): ConfigReader.Result[ApalacheConfigs] = {
+  def load(): ConfigReader.Result[ApalacheConfig] = {
+
     val home = System.getProperty("user.home")
     val globalConfig = ConfigSource.file(Paths.get(home, TLA_PLUS_DIR, APALACHE_CFG))
+
     localConfig
       .getOrElse(ConfigSource.empty)
-      .optional
-      // `withFallback` supplies configuration sources that only apply if the preceding configs aren't set
+    // `withFallback` supplies configuration sources that only apply if the preceding configs aren't set
       .withFallback(globalConfig.optional)
-      .load[ApalacheConfigs]
+      .load[ApalacheConfig]
       .map(cfg =>
         // TODO Is there no better way than hardcoding these overrides?
         cfg.copy(
-            outDir = cmd.outDir.orElse(cfg.outDir),
-            runDir = cmd.runDir.orElse(cfg.runDir),
-            configFile = cmd.configFile.orElse(cfg.configFile),
-            writeIntermediate = cmd.writeIntermediate.getOrElse(cfg.writeIntermediate),
-            profiling = cmd.profiling.getOrElse(cfg.profiling)
+          file = Some(cmd.file),
+          outDir = cmd.outDir.getOrElse(cfg.outDir),
+          runDir = cmd.runDir.orElse(cfg.runDir),
+          configFile = cmd.configFile.orElse(cfg.configFile),
+          writeIntermediate = cmd.writeIntermediate.getOrElse(cfg.writeIntermediate),
+          profiling = cmd.profiling.getOrElse(cfg.profiling)
         )
       )
+  }
+}
+
+object ConfigManager {
+
+  /** Load the application configuration, or raise a configuration error */
+  def apply(cmd: CliConfig): ApalacheConfig = {
+    new ConfigManager(cmd).load() match {
+      case Left(err)  => throw new ConfigurationError(err.toString())
+      case Right(cfg) => cfg
+    }
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -76,7 +76,6 @@ case class ConfigManager(cmd: CliConfig) {
   }
 
   private def localConfig(): Option[ConfigObjectSource] = {
-    // TODO Ensure an error is raised if config file is specifid in cmd but file cannot be loaded!
     cmd.configFile.map(ConfigSource.file).orElse(findLocalConfig(Paths.get(".").toAbsolutePath()))
   }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -1,0 +1,71 @@
+import pureconfig._
+import pureconfig.generic.auto._
+import java.io.{File}
+import java.nio.file.{Path, Files, Paths}
+
+/** The configuration values that can be overriden based on CLI arguments */
+trait CliConfig {
+  def outDir: Option[File]
+  def runDir: Option[File]
+  def writeIntermediate: Option[Boolean]
+  def profiling: Option[Boolean]
+  def configFile: Option[File]
+}
+
+/** The applications configurable values, along with their base defaults */
+case class ApalacheConfigs(
+    outDir: Option[File] = None, runDir: Option[File] = None, configFile: Option[File] = None,
+    writeIntermediate: Boolean = false, profiling: Boolean = false
+)
+
+case class ConfigManager(cmd: CliConfig) {
+  val TLA_PLUS_DIR = ".tlaplus"
+  val APALACHE_CFG = "aplache.cfg"
+  val DOT_APALACHE_CFG = "." + APALACHE_CFG
+
+  // Recursively search parents of given, looking for .apalache.cfg file
+  private def findLocalConfig(dir: Path): Option[ConfigObjectSource] = {
+    val localCfg = dir.resolve(DOT_APALACHE_CFG)
+    if (Files.exists(localCfg)) {
+      Some(ConfigSource.file(localCfg))
+    } else {
+      findLocalConfig(dir.getParent)
+    }
+  }
+
+  private def localConfig(): Option[ConfigObjectSource] = {
+    cmd.configFile.map(ConfigSource.file).orElse(findLocalConfig(Paths.get(".").toAbsolutePath()))
+  }
+
+  /**
+   * Load the application configuration from all sources supported by apalache
+   *
+   * The following precedence is maintained, wherein lower numbered items override highest numbered items:
+   *
+   * 1. CLI arguments
+   * 2. Environment variables (Overiding is taken care of by CLI parsing library)
+   * 3. Local config file
+   * 4. Globacl config file
+   * 5. `ApalacheConfig` defaults (as specified in the case class definition)
+   */
+  def load(): ConfigReader.Result[ApalacheConfigs] = {
+    val home = System.getProperty("user.home")
+    val globalConfig = ConfigSource.file(Paths.get(home, TLA_PLUS_DIR, APALACHE_CFG))
+    localConfig
+      .getOrElse(ConfigSource.empty)
+      .optional
+      // `withFallback` supplies configuration sources that only apply if the preceding configs aren't set
+      .withFallback(globalConfig.optional)
+      .load[ApalacheConfigs]
+      .map(cfg =>
+        // TODO Is there no better way than hardcoding these overrides?
+        cfg.copy(
+            outDir = cmd.outDir.orElse(cfg.outDir),
+            runDir = cmd.runDir.orElse(cfg.runDir),
+            configFile = cmd.configFile.orElse(cfg.configFile),
+            writeIntermediate = cmd.writeIntermediate.getOrElse(cfg.writeIntermediate),
+            profiling = cmd.profiling.getOrElse(cfg.profiling)
+        )
+      )
+  }
+}

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -60,7 +60,7 @@ case class ApalacheConfig(
 
 case class ConfigManager(cmd: CliConfig) {
   val TLA_PLUS_DIR = ".tlaplus"
-  val APALACHE_CFG = "aplache.cfg"
+  val APALACHE_CFG = "apalache.cfg"
   val DOT_APALACHE_CFG = "." + APALACHE_CFG
 
   import Converters._

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -59,9 +59,9 @@ case class ApalacheConfig(
 )
 
 case class ConfigManager(cmd: CliConfig) {
-  val TLA_PLUS_DIR = ".tlaplus"
-  val APALACHE_CFG = "apalache.cfg"
-  val DOT_APALACHE_CFG = "." + APALACHE_CFG
+  private val TLA_PLUS_DIR = ".tlaplus"
+  private val APALACHE_CFG = "apalache.cfg"
+  private val DOT_APALACHE_CFG = "." + APALACHE_CFG
 
   import Converters._
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -23,7 +23,7 @@ object OutputManager extends LazyLogging {
   import Names._
 
   // TODO RM once OutputManager isn't a singleton
-  private var cfgOpt: Option[ApalacheConfig] = None
+  private var cfg: ApalacheConfig = ApalacheConfig()
   // outDirOpt is stored as an expanded and absolute path
   private var outDirOpt: Option[Path] = None
   // This should only be set if the IntermediateFlag is true
@@ -84,11 +84,6 @@ object OutputManager extends LazyLogging {
     runDirOpt.getOrElse(throw new IllegalStateException("run directory does not exist"))
   }
 
-  // Private accessor for accessing configuration settings
-  private def cfg: ApalacheConfig = {
-    cfgOpt.getOrElse(throw new IllegalStateException("OutputManager is not configured"))
-  }
-
   // The intermdiate output directory in the configured custom
   // run directory
   private def customIntermediateRunDir: Option[Path] = {
@@ -120,7 +115,8 @@ object OutputManager extends LazyLogging {
    * over the configuration file
    */
   def configure(config: ApalacheConfig): Unit = {
-    cfgOpt = Some(config)
+    // Replace the default config used for initialiation with the config loaded on startup
+    cfg = config
 
     val fileName = cfg.file
       .getOrElse(throw new IllegalStateException("OutputManager configured without file"))

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -114,6 +114,7 @@ object OutputManager extends LazyLogging {
       ensureDirExists(dir)
     }
   }
+
   /**
    * Configure OutputManager, with cli configuration taking precedence
    * over the configuration file
@@ -121,8 +122,7 @@ object OutputManager extends LazyLogging {
   def configure(config: ApalacheConfig): Unit = {
     cfgOpt = Some(config)
 
-    val fileName = cfg
-      .file
+    val fileName = cfg.file
       .getOrElse(throw new IllegalStateException("OutputManager configured without file"))
       .getName
 
@@ -214,7 +214,8 @@ object OutputManager extends LazyLogging {
   }
 
   /**
-   * Conditionally write into "profile-rules.txt", depending on whether the `profiling` config is set */
+   * Conditionally write into "profile-rules.txt", depending on whether the `profiling` config is set
+   */
   def withProfilingWriter(f: PrintWriter => Unit): Boolean = {
     if (cfg.profiling) {
       withWriterInRunDir("profile-rules.txt")(f)


### PR DESCRIPTION
Closes #1069

This adds the configuration management component, based around `PureConfig`,
decided for in #1156:

## Changes:

- [x] Add dependency on `PureConfig`
- [x] Specify `ApalacheConfigs` trait (extending `OutputManagerConfig`) to serve
      as the collection of loadable application configurations.
- [x] Add new `ConfigManager(cli: CliArgs)` class as a sibling of `OutputManager`
- [x] Look for a local config file `.apalache.cfg`, starting from the cwd, and climbing up through parent dirs.
- [x] Factor out all configuration from `OutputManager`, removing the
      `syncFromCli` method.

## Routine:
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality