### PR TITLE
Refactor SMT encoding flag use

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -9,7 +9,6 @@ import at.forsyte.apalache.infra.passes.{PassChainExecutor, PassOptions, TlaModu
 import at.forsyte.apalache.infra.{ExceptionAdapter, FailureMessage, NormalErrorMessage, PassOptionException}
 import at.forsyte.apalache.io.{OutputManager, ReportGenerator}
 import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.imp.passes.ParserModule
 import at.forsyte.apalache.tla.tooling.{ExitCodes, Version}
 import at.forsyte.apalache.tla.tooling.opt.{CheckCmd, ConfigCmd, General, ParseCmd, TestCmd, TypeCheckCmd}
@@ -186,12 +185,6 @@ object Tool extends LazyLogging {
     tuning = overrideProperties(tuning, check.tuningOptions)
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
-    val smtEncoding: SMTEncoding = check.smtEncoding.getOrElse("oopsla19") match {
-      case "arrays"        => arraysEncoding
-      case "oopsla19"      => oopsla19Encoding
-      case oddEncodingType => throw new IllegalArgumentException(s"Unexpected SMT encoding type $oddEncodingType")
-    }
-
     executor.options.set("general.tuning", tuning)
     executor.options.set("parser.filename", check.file.getAbsolutePath)
     if (check.config != "")
@@ -209,7 +202,7 @@ object Tool extends LazyLogging {
     executor.options.set("checker.discardDisabled", check.discardDisabled)
     executor.options.set("checker.noDeadlocks", check.noDeadlocks)
     executor.options.set("checker.algo", check.algo)
-    executor.options.set("checker.smt-encoding", smtEncoding)
+    executor.options.set("checker.smt-encoding", check.smtEncoding)
     executor.options.set("checker.maxError", check.maxError)
     if (check.view != "")
       executor.options.set("checker.view", check.view)

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.infra.passes.{PassChainExecutor, PassOptions, TlaModu
 import at.forsyte.apalache.infra.{ExceptionAdapter, FailureMessage, NormalErrorMessage, PassOptionException}
 import at.forsyte.apalache.io.{OutputManager, ReportGenerator}
 import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.imp.passes.ParserModule
 import at.forsyte.apalache.tla.tooling.{ExitCodes, Version}
 import at.forsyte.apalache.tla.tooling.opt.{CheckCmd, ConfigCmd, General, ParseCmd, TestCmd, TypeCheckCmd}
@@ -185,6 +186,12 @@ object Tool extends LazyLogging {
     tuning = overrideProperties(tuning, check.tuningOptions)
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
+    val smtEncoding: SMTEncoding = check.smtEncoding.getOrElse("oopsla19") match {
+      case "arrays"        => arraysEncoding
+      case "oopsla19"      => oopsla19Encoding
+      case oddEncodingType => throw new IllegalArgumentException(s"Unexpected SMT encoding type $oddEncodingType")
+    }
+
     executor.options.set("general.tuning", tuning)
     executor.options.set("parser.filename", check.file.getAbsolutePath)
     if (check.config != "")
@@ -202,7 +209,7 @@ object Tool extends LazyLogging {
     executor.options.set("checker.discardDisabled", check.discardDisabled)
     executor.options.set("checker.noDeadlocks", check.noDeadlocks)
     executor.options.set("checker.algo", check.algo)
-    executor.options.set("checker.smt-encoding", check.smtEncoding)
+    executor.options.set("checker.smt-encoding", smtEncoding)
     executor.options.set("checker.maxError", check.maxError)
     if (check.view != "")
       executor.options.set("checker.view", check.view)

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -1,7 +1,9 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-import java.io.File
+import at.forsyte.apalache.tla.bmcmt.{SMTEncoding, arraysEncoding, oopsla19Encoding}
+import org.backuity.clist.util.Read
 
+import java.io.File
 import org.backuity.clist.{Command, _}
 
 /**
@@ -11,12 +13,20 @@ import org.backuity.clist.{Command, _}
  */
 class CheckCmd extends Command(name = "check", description = "Check a TLA+ specification") with General {
 
+  // Parses the smtEncoding option
+  implicit val smtEncodingRead: Read[SMTEncoding] =
+    Read.reads[SMTEncoding]("a SMT encoding, either oopsla19 or arrays") {
+      case "arrays"        => arraysEncoding
+      case "oopsla19"      => oopsla19Encoding
+      case oddEncodingType => throw new IllegalArgumentException(s"Unexpected SMT encoding type $oddEncodingType")
+    }
+
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var nworkers: Int = opt[Int](name = "nworkers", default = 1,
       description = "the number of workers for the parallel checker (soon), default: 1")
   var algo: String = opt[String](name = "algo", default = "incremental",
       description = "the search algorithm: offline, incremental, parallel (soon), default: incremental")
-  var smtEncoding: Option[String] = opt[Option[String]](name = "smt-encoding", useEnv = true,
+  var smtEncoding: SMTEncoding = opt[SMTEncoding](name = "smt-encoding", useEnv = true, default = oopsla19Encoding,
       description =
         "the SMT encoding: oopsla19, arrays (experimental), default: oopsla19 (overrides envvar SMT_ENCODING)")
   var config: String = opt[String](name = "config", default = "",

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SMTEncodings.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SMTEncodings.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
-object SMTEncodings extends Enumeration {
-  type SMTEncoding = Value
-  val oopsla19Encoding, arraysEncoding, invalidEncoding = Value
-}
+sealed trait SMTEncoding
+
+case object oopsla19Encoding extends SMTEncoding
+case object arraysEncoding extends SMTEncoding

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SMTEncodings.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SMTEncodings.scala
@@ -1,0 +1,6 @@
+package at.forsyte.apalache.tla.bmcmt
+
+object SMTEncodings extends Enumeration {
+  type SMTEncoding = Value
+  val oopsla19Encoding, arraysEncoding, invalidEncoding = Value
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
@@ -11,7 +11,6 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 /**
  * This class extends SymbStateRewriterImpl with encoding rules for the encoding with SMT arrays.
- * TODO: enforce that _solverContext.config.smtEncoding is correct?
  *
  * @param _solverContext   a fresh solver context that will be populated with constraints
  * @param exprGradeStore   a labeling scheme that associated a grade with each expression;

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -81,7 +81,7 @@ class BoundedCheckerPassImpl @Inject() (val options: PassOptions, hintsStore: Fo
     val tuning = options.getOrElse[Map[String, String]]("general", "tuning", Map[String, String]())
     val debug = options.getOrElse[Boolean]("general", "debug", false)
     val saveDir = options.getOrError[Path]("io", "outdir").toFile
-    val smtEncoding = options.getOrError[SMTEncoding]("checker", "smt-encoding")
+    val smtEncoding = options.getOrElse[SMTEncoding]("checker", "smt-encoding", oopsla19Encoding)
 
     val params = new ModelCheckerParams(input, stepsBound, saveDir, tuning, debug)
     params.discardDisabled = options.getOrElse[Boolean]("checker", "discardDisabled", true)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -81,11 +81,7 @@ class BoundedCheckerPassImpl @Inject() (val options: PassOptions, hintsStore: Fo
     val tuning = options.getOrElse[Map[String, String]]("general", "tuning", Map[String, String]())
     val debug = options.getOrElse[Boolean]("general", "debug", false)
     val saveDir = options.getOrError[Path]("io", "outdir").toFile
-    val smtEncoding = options.get[Option[String]]("checker", "smt-encoding").flatten.getOrElse("oopsla19") match {
-      case "oopsla19"      => oopsla19Encoding
-      case "arrays"        => arraysEncoding
-      case oddEncodingType => throw new IllegalArgumentException(s"Unexpected SMT encoding type $oddEncodingType")
-    }
+    val smtEncoding = options.getOrError[SMTEncoding]("checker", "smt-encoding")
 
     val params = new ModelCheckerParams(input, stepsBound, saveDir, tuning, debug)
     params.discardDisabled = options.getOrElse[Boolean]("checker", "discardDisabled", true)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -3,7 +3,6 @@ package at.forsyte.apalache.tla.bmcmt.passes
 import at.forsyte.apalache.infra.passes.{Pass, PassOptions}
 import at.forsyte.apalache.tla.assignments.ModuleAdapter
 import at.forsyte.apalache.tla.bmcmt.Checker.NoError
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.analyses.{ExprGradeStore, FormulaHintsStore}
 import at.forsyte.apalache.tla.bmcmt.rewriter.{MetricProfilerListener, RewriterConfig}
@@ -81,6 +80,7 @@ class BoundedCheckerPassImpl @Inject() (val options: PassOptions, hintsStore: Fo
     val tuning = options.getOrElse[Map[String, String]]("general", "tuning", Map[String, String]())
     val debug = options.getOrElse[Boolean]("general", "debug", false)
     val saveDir = options.getOrError[Path]("io", "outdir").toFile
+    // TODO: default smtEncoding option is needed here for executions with TestCmd, add encoding option to TestCmd instead
     val smtEncoding = options.getOrElse[SMTEncoding]("checker", "smt-encoding", oopsla19Encoding)
 
     val params = new ModelCheckerParams(input, stepsBound, saveDir, tuning, debug)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunCtorRule.scala
@@ -71,7 +71,7 @@ class FunCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
     def addCellCons(domElem: ArenaCell, relElem: ArenaCell): Unit = {
       val inDomain = tla.apalacheSelectInSet(domElem.toNameEx, domainCell.toNameEx).typed(BoolT1())
       val inRelation = tla.apalacheStoreInSet(relElem.toNameEx, relation.toNameEx).typed(BoolT1())
-      val expr = if (rewriter.solverContext.config.smtEncoding == "arrays") {
+      val expr = if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
         // In the arrays encoding we also need to update the array if inDomain does not hold
         val notInRelation = tla.apalacheStoreNotInSet(relElem.toNameEx, relation.toNameEx).typed(BoolT1())
         tla.ite(inDomain, inRelation, notInRelation).typed(BoolT1())

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.convenience.tla
@@ -321,7 +322,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
             val ite = tla.ite(tla.apalacheSelectInSet(keyCell.toNameEx, dom.toNameEx),
                 tla.apalacheStoreInSet(keyCell.toNameEx, newDom.toNameEx),
                 tla.apalacheStoreNotInSet(keyCell.toNameEx, newDom.toNameEx))
-            val unchangedSet = if (rewriter.solverContext.config.smtEncoding == "arrays") {
+            val unchangedSet = if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
               // In the arrays encoding we need to propagate the SSA representation of the array if nothing changes
               tla.apalacheStoreNotInSet(keyCell.toNameEx, newDom.toNameEx)
             } else {
@@ -454,7 +455,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
           val inSet = tla.ite(tla.apalacheSelectInSet(elemAndSet._1.toNameEx, elemAndSet._2.toNameEx),
               tla.apalacheStoreInSet(picked.toNameEx, resultCell.toNameEx),
               tla.apalacheStoreNotInSet(picked.toNameEx, resultCell.toNameEx))
-          val unchangedSet = if (rewriter.solverContext.config.smtEncoding == "arrays") {
+          val unchangedSet = if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
             // In the arrays encoding we need to propagate the SSA representation of the array if nothing changes
             tla.apalacheStoreNotInSet(picked.toNameEx, resultCell.toNameEx)
           } else {
@@ -615,7 +616,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
       // In the oopsla19 encoding resultSet is initially unconstrained, and thus can contain any combination of elems.
       // To emulate this in the arrays encoding, in which the all sets are initially empty, unconstrained predicates
       // are used to allow the SMT solver to consider all possible combinations of elems.
-      if (rewriter.solverContext.config.smtEncoding == "arrays") {
+      if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
         nextState = nextState.updateArena(_.appendCell(BoolT()))
         val pred = nextState.arena.topCell.toNameEx
         val storeElem = tla.apalacheStoreInSet(elem.toNameEx, resultSet.toNameEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.convenience.tla

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.search
 
 import java.io.File
 import at.forsyte.apalache.tla.bmcmt.CheckerInput
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.search.ModelCheckerParams.InvariantMode.{AfterJoin, BeforeJoin, InvariantMode}
 
 object ModelCheckerParams {
@@ -95,7 +96,7 @@ class ModelCheckerParams(checkerInput: CheckerInput, val stepsBound: Int, val sa
   /**
    * The SMT encoding to be used.
    */
-  var smtEncoding: String = ""
+  var smtEncoding: SMTEncoding = invalidEncoding
 
   // does the transition number satisfy the given filter at the given step?
   def stepMatchesFilter(stepNo: Int, transitionNo: Int): Boolean = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -1,8 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.search
 
 import java.io.File
-import at.forsyte.apalache.tla.bmcmt.CheckerInput
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
+import at.forsyte.apalache.tla.bmcmt.{CheckerInput, SMTEncoding, oopsla19Encoding}
 import at.forsyte.apalache.tla.bmcmt.search.ModelCheckerParams.InvariantMode.{AfterJoin, BeforeJoin, InvariantMode}
 
 object ModelCheckerParams {
@@ -96,7 +95,7 @@ class ModelCheckerParams(checkerInput: CheckerInput, val stepsBound: Int, val sa
   /**
    * The SMT encoding to be used.
    */
-  var smtEncoding: SMTEncoding = invalidEncoding
+  var smtEncoding: SMTEncoding = oopsla19Encoding
 
   // does the transition number satisfy the given filter at the given step?
   def stepMatchesFilter(stepNo: Int, transitionNo: Int): Boolean = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverConfig.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverConfig.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
+import at.forsyte.apalache.tla.bmcmt.{SMTEncoding, oopsla19Encoding}
 
 /**
  * Configuration option to be passed to SolverContext. This class is declared as a case class

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverConfig.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverConfig.scala
@@ -1,5 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
+
 /**
  * Configuration option to be passed to SolverContext. This class is declared as a case class
  * to enable the concise copy syntax of Scala.
@@ -11,12 +13,13 @@ package at.forsyte.apalache.tla.bmcmt.smt
  *
  * @author Igor Konnov, Rodrigo Otoni
  */
-sealed case class SolverConfig(debug: Boolean, profile: Boolean, randomSeed: Int, smtEncoding: String) {}
+sealed case class SolverConfig(debug: Boolean, profile: Boolean, randomSeed: Int, smtEncoding: SMTEncoding) {}
 
 object SolverConfig {
 
   /**
    * Get the default configuration.
    */
-  val default: SolverConfig = new SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = "oopsla19")
+  val default: SolverConfig =
+    new SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding)
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.profiler.{IdleSmtListener, SmtListener}
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, CellT, FinSetT, IntT, PowSetT}
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
 import at.forsyte.apalache.tla.lir.oper._
@@ -47,7 +48,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   }
 
   private def arraysEnabled(): Boolean = {
-    config.smtEncoding == "arrays"
+    config.smtEncoding == arraysEncoding
   }
 
   var level: Int = 0

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -8,7 +8,6 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.profiler.{IdleSmtListener, SmtListener}
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, CellT, FinSetT, IntT, PowSetT}
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
 import at.forsyte.apalache.tla.lir.oper._

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/OfflineExecutionContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/OfflineExecutionContext.scala
@@ -43,7 +43,8 @@ class OfflineExecutionContext(var rewriter: SymbStateRewriter)
     // TODO: issue #105, remove references to SolverContext, so recovery becomes less of a hack
     val newRewriter = rewriter match {
       case _: SymbStateRewriterImplWithArrays => new SymbStateRewriterImplWithArrays(solver, rewriter.exprGradeStore)
-      case _                                  => new SymbStateRewriterImpl(solver, rewriter.exprGradeStore)
+      case _: SymbStateRewriterImpl           => new SymbStateRewriterImpl(solver, rewriter.exprGradeStore)
+      case oddRewriterType                    => throw new IllegalArgumentException(s"Unexpected rewriter of type $oddRewriterType")
     }
     newRewriter.formulaHintsStore = rewriter.formulaHintsStore
     newRewriter.config = rewriter.config

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/EncodingBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/EncodingBase.scala
@@ -1,6 +1,0 @@
-package at.forsyte.apalache.tla.bmcmt
-
-object EncodingBase {
-  val oopsla19EncodingType = "oopsla19"
-  val arraysEncodingType = "arrays"
-}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
@@ -2,30 +2,30 @@ package at.forsyte.apalache.tla.bmcmt
 
 import java.io.{PrintWriter, StringWriter}
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.scalatest.fixture
 
 trait RewriterBase extends fixture.FunSuite {
-  protected type FixtureParam = String
+  protected type FixtureParam = SMTEncoding
 
   protected var solverContext: SolverContext = _
   protected var arena: Arena = _
 
-  protected def create(rewriterType: String): SymbStateRewriter = {
+  protected def create(rewriterType: SMTEncoding): SymbStateRewriter = {
     rewriterType match {
-      case `oopsla19EncodingType` => new SymbStateRewriterAuto(solverContext)
-      case `arraysEncodingType`   => new SymbStateRewriterAutoWithArrays(solverContext)
-      case oddRewriterType        => throw new IllegalArgumentException(s"Unexpected rewriter of type $oddRewriterType")
+      case `oopsla19Encoding` => new SymbStateRewriterAuto(solverContext)
+      case `arraysEncoding`   => new SymbStateRewriterAutoWithArrays(solverContext)
+      case oddRewriterType    => throw new IllegalArgumentException(s"Unexpected rewriter of type $oddRewriterType")
     }
   }
 
-  protected def createWithoutCache(rewriterType: String): SymbStateRewriter = {
+  protected def createWithoutCache(rewriterType: SMTEncoding): SymbStateRewriter = {
     rewriterType match {
-      case `oopsla19EncodingType` => new SymbStateRewriterImpl(solverContext)
-      case `arraysEncodingType`   => new SymbStateRewriterImplWithArrays(solverContext)
+      case `oopsla19Encoding` => new SymbStateRewriterImpl(solverContext)
+      case `arraysEncoding`   => new SymbStateRewriterImplWithArrays(solverContext)
       case oddRewriterType =>
         throw new IllegalArgumentException(s"Unexpected cacheless rewriter of type $oddRewriterType")
     }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.bmcmt
 
 import java.io.{PrintWriter, StringWriter}
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithArrays.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
 import org.scalatest.Outcome

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithArrays.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
@@ -9,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TestArenaWithArrays extends TestArena {
   override protected def withFixture(test: OneArgTest): Outcome = {
-    solver = new Z3SolverContext(SolverConfig.default.copy(debug = true, smtEncoding = arraysEncodingType))
+    solver = new Z3SolverContext(SolverConfig.default.copy(debug = true, smtEncoding = arraysEncoding))
     val result = test()
     solver.dispose()
     result

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithOOPSLA19.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
 import org.scalatest.Outcome

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
@@ -9,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TestArenaWithOOPSLA19 extends TestArena {
   override protected def withFixture(test: OneArgTest): Outcome = {
-    solver = new Z3SolverContext(SolverConfig.default.copy(debug = true, smtEncoding = oopsla19EncodingType))
+    solver = new Z3SolverContext(SolverConfig.default.copy(debug = true, smtEncoding = oopsla19Encoding))
     val result = test()
     solver.dispose()
     result

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, Oracle, OracleFactory}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -33,7 +34,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     state
   }
 
-  test("""CHERRY-PICK {1, 2, 2}""") { rewriterType: String =>
+  test("""CHERRY-PICK {1, 2, 2}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(BoolT1()), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -59,7 +60,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, pickedState, oracle, 2, int(2).typed())
   }
 
-  test("""CHERRY-PICK {<<1, 2>>, <<3, 4>>}""") { rewriterType: String =>
+  test("""CHERRY-PICK {<<1, 2>>, <<3, 4>>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -80,7 +81,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, tuples(1).toNameEx)
   }
 
-  test("""CHERRY-PICK {<<1, <<2, 3>> >>, <<3, <<4, 5>> >>}""") { rewriterType: String =>
+  test("""CHERRY-PICK {<<1, <<2, 3>> >>, <<3, <<4, 5>> >>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -101,7 +102,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, tuples(1).toNameEx)
   }
 
-  test("""CHERRY-PICK-SEQ {<<1, 2>>, <<3, 4>>}""") { rewriterType: String =>
+  test("""CHERRY-PICK-SEQ {<<1, 2>>, <<3, 4>>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(BoolT1()), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -123,7 +124,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, seqs(1).toNameEx)
   }
 
-  test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3, b |-> 4]}""") { rewriterType: String =>
+  test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3, b |-> 4]}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -146,7 +147,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, records(1).toNameEx)
   }
 
-  test("""CHERRY-PICK [a |-> 1, b |-> 2] or [a |-> 3]""") { rewriterType: String =>
+  test("""CHERRY-PICK [a |-> 1, b |-> 2] or [a |-> 3]""") { rewriterType: SMTEncoding =>
     // After switching to Snowcat, we allow sets to mix records of compatible types.
     // The old encoding was always introducing spurious fields for all records, as it was extending the records.
     val rec1 = enumFun(str("a"), int(1), str("b"), int(2))
@@ -173,7 +174,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, rec2Cell.toNameEx)
   }
 
-  test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3]}""") { rewriterType: String =>
+  test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3]}""") { rewriterType: SMTEncoding =>
     // After switching to Snowcat, we allow sets to mix records of compatible types.
     // The old encoding was always introducing spurious fields for all records, as it was extending the records.
     val rec1 = enumFun(str("a"), int(1), str("b"), int(2))
@@ -204,7 +205,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, state.setRex(eq1or2))
   }
 
-  test("""CHERRY-PICK { {1, 2}, {3, 4} }""") { rewriterType: String =>
+  test("""CHERRY-PICK { {1, 2}, {3, 4} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -226,7 +227,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, sets(1).toNameEx)
   }
 
-  test("""CHERRY-PICK { {1, 2}, {} }""") { rewriterType: String =>
+  test("""CHERRY-PICK { {1, 2}, {} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -246,7 +247,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, sets(1).toNameEx)
   }
 
-  test("""CHERRY-PICK { {} }""") { rewriterType: String =>
+  test("""CHERRY-PICK { {} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -265,7 +266,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 0, sets(0).toNameEx)
   }
 
-  test("""CHERRY-PICK { {{1, 2}, {3, 4}}, {{5, 6}} }""") { rewriterType: String =>
+  test("""CHERRY-PICK { {{1, 2}, {3, 4}}, {{5, 6}} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick
@@ -290,7 +291,7 @@ trait TestCherryPick extends RewriterBase with TestingPredefs {
     assertEqWhenChosen(rewriter, state, oracle, 1, sets(1).toNameEx)
   }
 
-  test("""CHERRY-PICK { [x \in {1, 2} |-> 2 + x], [x \in {2, 3} |-> 2 * x] }""") { rewriterType: String =>
+  test("""CHERRY-PICK { [x \in {1, 2} |-> 2 + x], [x \in {2, 3} |-> 2 * x] }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(bool(true).typed(), arena, Binding())
     // introduce an oracle that tells us which element to pick

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, Oracle, OracleFactory}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithArrays.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux._
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithArrays.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux._
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
@@ -17,9 +17,9 @@ class TestRewriterWithArrays
     with TestSymbStateRewriterStr {
   override protected def withFixture(test: OneArgTest): Outcome = {
     solverContext = new PreproSolverContext(new Z3SolverContext(SolverConfig.default.copy(debug = true,
-                smtEncoding = arraysEncodingType)))
+                smtEncoding = arraysEncoding)))
     arena = Arena.create(solverContext)
-    val result = test(arraysEncodingType)
+    val result = test(arraysEncoding)
     solverContext.dispose()
     result
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithOOPSLA19.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux._
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestRewriterWithOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux._
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
@@ -20,9 +20,9 @@ class TestRewriterWithOOPSLA19
     with TestUninterpretedConstOracle {
   override protected def withFixture(test: OneArgTest): Outcome = {
     solverContext = new PreproSolverContext(new Z3SolverContext(SolverConfig.default.copy(debug = true,
-                smtEncoding = oopsla19EncodingType)))
+                smtEncoding = oopsla19Encoding)))
     arena = Arena.create(solverContext)
-    val result = test(oopsla19EncodingType)
+    val result = test(oopsla19Encoding)
     solverContext.dispose()
     result
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerWithOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.analyses.ExprGradeStoreImpl
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import org.junit.runner.RunWith
@@ -11,7 +11,7 @@ import org.scalatest.junit.JUnitRunner
 class TestSeqModelCheckerWithOOPSLA19 extends TestSeqModelCheckerTrait {
   override protected def withFixture(test: OneArgTest): Outcome = {
     val solver = RecordingSolverContext.createZ3(None,
-        SolverConfig(debug = false, profile = false, 0, smtEncoding = oopsla19EncodingType))
+        SolverConfig(debug = false, profile = false, 0, smtEncoding = oopsla19Encoding))
     val rewriter = new SymbStateRewriterImpl(solver, new ExprGradeStoreImpl)
     test(rewriter)
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerWithOOPSLA19.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.analyses.ExprGradeStoreImpl
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import org.junit.runner.RunWith

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir._
@@ -17,7 +18,7 @@ trait TestSymbStateDecoder extends RewriterBase {
       "i_TO_i" -> SetT1(FunT1(IntT1(), IntT1()))
   )
 
-  test("decode bool") { rewriterType: String =>
+  test("decode bool") { rewriterType: SMTEncoding =>
     val originalEx: TlaEx = bool(true).typed()
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -33,7 +34,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("decode int") { rewriterType: String =>
+  test("decode int") { rewriterType: SMTEncoding =>
     val originalEx = int(3).typed()
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -49,7 +50,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("decode str") { rewriterType: String =>
+  test("decode str") { rewriterType: SMTEncoding =>
     val originalEx: TlaEx = str("hello").typed()
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -65,7 +66,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("decode Int set") { rewriterType: String =>
+  test("decode Int set") { rewriterType: SMTEncoding =>
     val originalEx = intSet()
       .typed(types, "I")
     val state = new SymbState(originalEx, arena, Binding())
@@ -78,7 +79,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assert(originalEx == decodedEx)
   }
 
-  test("decode Nat set") { rewriterType: String =>
+  test("decode Nat set") { rewriterType: SMTEncoding =>
     val originalEx = natSet()
       .typed(types, "I")
     val state = new SymbState(originalEx, arena, Binding())
@@ -91,7 +92,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assert(originalEx == decodedEx)
   }
 
-  test("decode set") { rewriterType: String =>
+  test("decode set") { rewriterType: SMTEncoding =>
     val originalEx = enumSet(int(2), int(1), int(2))
       .typed(types, "I")
     val simpleOriginalEx: TlaEx = enumSet(int(1), int(2))
@@ -110,7 +111,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("decode fun set") { rewriterType: String =>
+  test("decode fun set") { rewriterType: SMTEncoding =>
     val domEx = enumSet(int(1), int(2))
       .typed(types, "I")
     val cdmEx = enumSet(int(3), int(4))
@@ -131,7 +132,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("decode SUBSET S") { rewriterType: String =>
+  test("decode SUBSET S") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
       .typed(types, "I")
     val powset = powSet(set)
@@ -146,7 +147,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assert(powset == decodedEx)
   }
 
-  test("decode fun") { rewriterType: String =>
+  test("decode fun") { rewriterType: SMTEncoding =>
     val domEx = enumSet(int(1), int(2))
       .typed(types, "I")
     val funEx = funDef(plus(name("x") ? "i", int(1)) ? "i", name("x") ? "i", domEx)
@@ -168,7 +169,7 @@ trait TestSymbStateDecoder extends RewriterBase {
   }
 
   // See https://github.com/informalsystems/apalache/issues/962
-  test("decode fun does not show duplicate indices") { rewriterType: String =>
+  test("decode fun does not show duplicate indices") { rewriterType: SMTEncoding =>
     // The specified domain includes duplicate values
     val domEx = enumSet(int(1), int(1))
       .typed(types, "I")
@@ -191,7 +192,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("decode statically empty fun") { rewriterType: String =>
+  test("decode statically empty fun") { rewriterType: SMTEncoding =>
     val domEx = enumSet() ? "I"
     val funEx = funDef(plus(name("x") ? "i", int(1)) ? "i", name("x") ? "i", domEx)
       .typed(types, "i_to_i")
@@ -209,7 +210,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eql(decodedEx, funEx).typed(BoolT1())))
   }
 
-  test("decode dynamically empty fun") { rewriterType: String =>
+  test("decode dynamically empty fun") { rewriterType: SMTEncoding =>
     // this domain is not empty at the arena level, but it is in every SMT model
     def dynEmpty(left: BuilderEx): BuilderEx = {
       filter(name("t") ? "i", left, bool(false) ? "b")
@@ -235,7 +236,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eql(decodedEx, funEx).typed(BoolT1())))
   }
 
-  test("decode sequence") { rewriterType: String =>
+  test("decode sequence") { rewriterType: SMTEncoding =>
     val seqEx =
       tuple(int(1), int(2), int(3), int(4))
         .typed(types, "Qi")
@@ -253,7 +254,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assert(expected == decodedEx)
   }
 
-  test("decode tuple") { rewriterType: String =>
+  test("decode tuple") { rewriterType: SMTEncoding =>
     val tupleEx: TlaEx =
       tuple(int(1), int(2), int(3))
         .typed(types, "iii")
@@ -267,7 +268,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assert(tupleEx == decodedEx)
   }
 
-  test("decode record") { rewriterType: String =>
+  test("decode record") { rewriterType: SMTEncoding =>
     val recEx =
       enumFun(str("a"), int(1), str("b"), bool(true))
         .typed(types, "rib")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriter.scala
@@ -1,11 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 trait TestSymbStateRewriter extends RewriterBase {
-  test("SE-SUBST1: x[cell/x] ~~> cell") { rewriterType: String =>
+  test("SE-SUBST1: x[cell/x] ~~> cell") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(UnknownT())
     val cell = arena.topCell
     val binding = Binding("x" -> cell)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.Continue
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.NameEx
@@ -7,7 +8,7 @@ import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 trait TestSymbStateRewriterAction extends RewriterBase {
-  test("""x' is rewritten to the binding of x'""") { rewriterType: String =>
+  test("""x' is rewritten to the binding of x'""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     arena.appendCell(IntT()) // the type finder is strict about unassigned types, so let's create a cell for x'
     val state = new SymbState(tla.prime(NameEx("x")), arena, Binding("x'" -> arena.topCell))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.Continue
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.NameEx

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterApalacheGen.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterApalacheGen.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterApalacheGen.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterApalacheGen.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper
@@ -8,7 +9,7 @@ import at.forsyte.apalache.tla.lir.{BoolT1, ConstT1, FunT1, IntT1, OperEx, RecT1
 trait TestSymbStateRewriterApalacheGen extends RewriterBase {
   private val types = Map("i" -> IntT1(), "I" -> SetT1(IntT1()), "b" -> BoolT1(), "s" -> StrT1())
 
-  test("""Gen(1) for Int""") { rewriterType: String =>
+  test("""Gen(1) for Int""") { rewriterType: SMTEncoding =>
     val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(IntT1()))
 
     val state = new SymbState(gen, arena, Binding())
@@ -21,7 +22,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(1) for Str""") { rewriterType: String =>
+  test("""Gen(1) for Str""") { rewriterType: SMTEncoding =>
     val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(StrT1()))
 
     val state = new SymbState(gen, arena, Binding())
@@ -38,7 +39,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(1) for ConstT1(name)""") { rewriterType: String =>
+  test("""Gen(1) for ConstT1(name)""") { rewriterType: SMTEncoding =>
     // in the current implementation, ConstT1(PID) is generated the same way as StrT1
     val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(ConstT1("PID")))
 
@@ -56,7 +57,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(1) for Bool""") { rewriterType: String =>
+  test("""Gen(1) for Bool""") { rewriterType: SMTEncoding =>
     val gen = OperEx(ApalacheOper.gen, int(1).typed())(Typed(BoolT1()))
 
     val state = new SymbState(gen, arena, Binding())
@@ -72,7 +73,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(3) = { 1, 2, 3 }""") { rewriterType: String =>
+  test("""Gen(3) = { 1, 2, 3 }""") { rewriterType: SMTEncoding =>
     val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(SetT1(IntT1())))
     val eq123 = eql(gen, enumSet(int(1), int(2), int(3)) ? "I").typed(types, "b")
 
@@ -84,7 +85,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(3) = { }""") { rewriterType: String =>
+  test("""Gen(3) = { }""") { rewriterType: SMTEncoding =>
     val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(SetT1(IntT1())))
     val eq123 = eql(gen, enumSet() ? "I").typed(types, "b")
 
@@ -96,7 +97,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(3) for [i: Int, b: Bool]""") { rewriterType: String =>
+  test("""Gen(3) for [i: Int, b: Bool]""") { rewriterType: SMTEncoding =>
     val recordType = RecT1("i" -> IntT1(), "b" -> BoolT1())
     val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(recordType))
     val i_eq_10 = eql(appFun(gen, str("i")) ? "i", int(10)).typed(types, "b")
@@ -109,7 +110,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(3) for <<Int, Bool>>""") { rewriterType: String =>
+  test("""Gen(3) for <<Int, Bool>>""") { rewriterType: SMTEncoding =>
     val tupleType = TupT1(IntT1(), BoolT1())
     val gen = OperEx(ApalacheOper.gen, int(3).typed())(Typed(tupleType))
     val i_eq_10 = eql(appFun(gen, int(1)) ? "i", int(10)).typed(types, "b")
@@ -122,7 +123,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Gen(4) for Int -> Bool""") { rewriterType: String =>
+  test("""Gen(4) for Int -> Bool""") { rewriterType: SMTEncoding =>
     val funType = FunT1(IntT1(), BoolT1())
     val gen = OperEx(ApalacheOper.gen, int(4).typed())(Typed(funType))
 
@@ -144,7 +145,7 @@ trait TestSymbStateRewriterApalacheGen extends RewriterBase {
     assert(!solverContext.sat())
   }
 
-  test("""Gen(4) for Seq(Bool)""") { rewriterType: String =>
+  test("""Gen(4) for Seq(Bool)""") { rewriterType: SMTEncoding =>
     val seqType = SeqT1(BoolT1())
     val gen = OperEx(ApalacheOper.gen, int(4).typed())(Typed(seqType))
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.NoRule
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, FinSetT, IntT}
 import at.forsyte.apalache.tla.lir.TypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.NoRule
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, FinSetT, IntT}
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -24,7 +25,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     xyBinding = Binding("x" -> x, "y" -> y, "S" -> set)
   }
 
-  test("FALSE ~~> $C$0") { rewriterType: String =>
+  test("FALSE ~~> $C$0") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla.bool(false).typed()
     val state = new SymbState(ex, arena, Binding())
@@ -39,7 +40,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("TRUE ~~> $C$1") { rewriterType: String =>
+  test("TRUE ~~> $C$1") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla.bool(true).typed()
     val state = new SymbState(ex, arena, Binding())
@@ -54,7 +55,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("BOOLEAN ~~> c_BOOLEAN") { rewriterType: String =>
+  test("BOOLEAN ~~> c_BOOLEAN") { rewriterType: SMTEncoding =>
     prepareArena()
     val boolset = tla.booleanSet().typed(SetT1(BoolT1()))
     val state = new SymbState(boolset, arena, Binding())
@@ -69,7 +70,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("x => y ~~> ~x \\/ y") { rewriterType: String =>
+  test("x => y ~~> ~x \\/ y") { rewriterType: SMTEncoding =>
     // outside of KerA+, should be handled by Keramelizer and Normalizer
     prepareArena()
     val ex = tla
@@ -79,7 +80,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assert(NoRule() == create(rewriterType).rewriteOnce(state))
   }
 
-  test("x <=> y") { rewriterType: String =>
+  test("x <=> y") { rewriterType: SMTEncoding =>
     // outside of KerA+, should be handled by Keramelizer and Normalizer
     arena = arena.appendCell(BoolT())
     val left = arena.topCell
@@ -92,7 +93,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assert(NoRule() == create(rewriterType).rewriteOnce(state))
   }
 
-  test("""IF-THEN-ELSE with \E: IF \E i \in {}: x' \in {i} THEN x' ELSE 0""") { rewriterType: String =>
+  test("""IF-THEN-ELSE with \E: IF \E i \in {}: x' \in {i} THEN x' ELSE 0""") { rewriterType: SMTEncoding =>
     // this tricky test comes from Bakery, where an assignment is made in one branch of a conjunction
     prepareArena()
     val exists =
@@ -112,7 +113,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("""~c_i ~~> b_new""") { rewriterType: String =>
+  test("""~c_i ~~> b_new""") { rewriterType: SMTEncoding =>
     prepareArena()
     arena = arena.appendCell(BoolT())
     val cell = arena.topCell
@@ -144,7 +145,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""~x ~~> TRUE""") { rewriterType: String =>
+  test("""~x ~~> TRUE""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla
       .not(tla.name("x") ? "b")
@@ -156,7 +157,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(nextState.ex, tla.bool(true)).typed(BoolT1())))
   }
 
-  test("""FALSE = TRUE ~~> FALSE""") { rewriterType: String =>
+  test("""FALSE = TRUE ~~> FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla
       .eql(arena.cellFalse().toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
@@ -170,7 +171,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("""x = TRUE ~~> FALSE when x = FALSE""") { rewriterType: String =>
+  test("""x = TRUE ~~> FALSE when x = FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla
       .eql(tla.name("x") ? "b", tla.bool(true) ? "b")
@@ -183,7 +184,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("""~(x = TRUE) ~~> TRUE when x = FALSE""") { rewriterType: String =>
+  test("""~(x = TRUE) ~~> TRUE when x = FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla
       .not(tla.eql(tla.name("x") ? "b", tla.bool(true)) ? "b")
@@ -198,7 +199,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("""FALSE /\ TRUE ~~> $B$0""") { rewriterType: String =>
+  test("""FALSE /\ TRUE ~~> $B$0""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla
       .and(tla.bool(false), tla.bool(true))
@@ -214,7 +215,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""c_1 /\ c_2 ~~> b_new""") { rewriterType: String =>
+  test("""c_1 /\ c_2 ~~> b_new""") { rewriterType: SMTEncoding =>
     prepareArena()
     arena = arena.appendCell(BoolT())
     val c1 = arena.topCell
@@ -259,7 +260,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""empty \/ ~~> $B$0""") { rewriterType: String =>
+  test("""empty \/ ~~> $B$0""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla.or().typed(BoolT1())
     val state = new SymbState(ex, arena, Binding())
@@ -273,7 +274,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""empty /\ ~~> $B$1""") { rewriterType: String =>
+  test("""empty /\ ~~> $B$1""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla.and().typed(BoolT1())
     val state = new SymbState(ex, arena, Binding())
@@ -287,7 +288,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""FALSE \/ TRUE ~~> $B$1""") { rewriterType: String =>
+  test("""FALSE \/ TRUE ~~> $B$1""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla.or(tla.bool(false), tla.bool(true)).typed(BoolT1())
     val state = new SymbState(ex, arena, Binding())
@@ -301,7 +302,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""c_1 \/ c_2 ~~> b_new""") { rewriterType: String =>
+  test("""c_1 \/ c_2 ~~> b_new""") { rewriterType: SMTEncoding =>
     prepareArena()
     arena = arena.appendCell(BoolT())
     val left = arena.topCell
@@ -339,7 +340,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""~($B$1 = $B$2) ~~> $B$3""") { rewriterType: String =>
+  test("""~($B$1 = $B$2) ~~> $B$3""") { rewriterType: SMTEncoding =>
     prepareArena()
     arena = arena.appendCell(BoolT())
     val left = arena.topCell
@@ -400,7 +401,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""\E x \in {}: TRUE ~~> FALSE""") { rewriterType: String =>
+  test("""\E x \in {}: TRUE ~~> FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
     val ex = tla
       .exists(tla.name("x") ? "i", tla.enumSet() ? "I", tla.bool(true))
@@ -410,7 +411,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assert(arena.cellFalse().toNameEx == nextState.ex)
   }
 
-  test("""\E x \in {1, 2, 3}: x = 2 ~~> $B$k""") { rewriterType: String =>
+  test("""\E x \in {1, 2, 3}: x = 2 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
     val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1()))
     val ex =
@@ -430,7 +431,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
   }
 
   /** Jure, 9.12.19: Why should this throw? */
-  test("""\E x \in {1, 2}: y' := x ~~> 2 assignments, regression""") { rewriterType: String =>
+  test("""\E x \in {1, 2}: y' := x ~~> 2 assignments, regression""") { rewriterType: SMTEncoding =>
     prepareArena()
     val set12 = tla
       .enumSet(tla.int(1), tla.int(2))
@@ -477,7 +478,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""\E x \in {1, 2, 3}: x > 4 ~~> $B$k""") { rewriterType: String =>
+  test("""\E x \in {1, 2, 3}: x > 4 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
     val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1()))
     val ex =
@@ -496,7 +497,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assert(solverContext.sat())
   }
 
-  test("""\E x \in {t \in {1}: FALSE}: x > 4, regression""") { rewriterType: String =>
+  test("""\E x \in {t \in {1}: FALSE}: x > 4, regression""") { rewriterType: SMTEncoding =>
     prepareArena()
     def dynEmpty(left: TlaEx): TlaEx = {
       tla
@@ -519,7 +520,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(tla.not(nextState.ex).typed(BoolT1())))
   }
 
-  test("""skolem: \E i \in Nat: i = 10 /\ x' \in {i}""") { rewriterType: String =>
+  test("""skolem: \E i \in Nat: i = 10 /\ x' \in {i}""") { rewriterType: SMTEncoding =>
     prepareArena()
     // this works for skolem constants only
     val ex =
@@ -543,7 +544,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(eql))
   }
 
-  test("""skolemization over range: \E i \in a..b: i % 3 = 1 /\ x' \in {i}""") { rewriterType: String =>
+  test("""skolemization over range: \E i \in a..b: i % 3 = 1 /\ x' \in {i}""") { rewriterType: SMTEncoding =>
     // this works for skolem constants only
     prepareArena()
     val ex =
@@ -579,7 +580,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
-  test("""\A x \in {1, 2, 3}: x < 10 ~~> $B$k""") { rewriterType: String =>
+  test("""\A x \in {1, 2, 3}: x < 10 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
     val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1()))
     val ex =
@@ -598,7 +599,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
     assertUnsatOrExplain(rewriter, nextState)
   }
 
-  test("""\A x \in {1, 2, 3}: x > 2 ~~> $B$k""") { rewriterType: String =>
+  test("""\A x \in {1, 2, 3}: x > 2 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
     val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1()))
     val ex =

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterChoose.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterChoose.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, TestingPredefs}
@@ -11,7 +12,7 @@ trait TestSymbStateRewriterChoose extends RewriterBase with TestingPredefs {
       "I" -> SetT1(IntT1())
   )
 
-  test("""CHOOSE x \in {1, 2, 3}: x > 1""") { rewriterType: String =>
+  test("""CHOOSE x \in {1, 2, 3}: x > 1""") { rewriterType: SMTEncoding =>
     val ex =
       choose(name("x") ? "i", enumSet(int(1), int(2), int(3)) ? "I", gt(name("x") ? "i", int(1)) ? "b")
         .typed(types, "i")
@@ -40,7 +41,7 @@ trait TestSymbStateRewriterChoose extends RewriterBase with TestingPredefs {
     assertUnsatOrExplain(rewriter, ns)
   }
 
-  test("""CHOOSE x \in {1}: x > 1""") { rewriterType: String =>
+  test("""CHOOSE x \in {1}: x > 1""") { rewriterType: SMTEncoding =>
     val ex = choose(name("x") ? "i", enumSet(int(1)) ? "I", gt(name("x"), int(1)) ? "b")
       .typed(types, "i")
     val state = new SymbState(ex, arena, Binding())
@@ -53,7 +54,7 @@ trait TestSymbStateRewriterChoose extends RewriterBase with TestingPredefs {
   // but this happened to be error-prone and sometimes conflicting with other rules. So, no default values.
   }
 
-  test("""CHOOSE x \in {}: x > 1""") { rewriterType: String =>
+  test("""CHOOSE x \in {}: x > 1""") { rewriterType: SMTEncoding =>
     val ex = choose(name("x") ? "i", enumSet() ? "I", gt(name("x") ? "i", int(1)) ? "b")
       .typed(types, "b")
     val state = new SymbState(ex, arena, Binding())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterChoose.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterChoose.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, TestingPredefs}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -12,7 +13,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
       "O" -> OperT1(Seq(), IntT1())
   )
 
-  test("""IF 3 > 2 THEN 2 < 4 ELSE 5 < 1""") { rewriterType: String =>
+  test("""IF 3 > 2 THEN 2 < 4 ELSE 5 < 1""") { rewriterType: SMTEncoding =>
     val pred = gt(int(3), int(2))
     val e1 = lt(int(2), int(4))
     val e2 = lt(int(5), int(1))
@@ -23,7 +24,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state.setRex(ifThenElse))
   }
 
-  test("""IF 3 < 2 THEN 2 < 4 ELSE 5 < 1""") { rewriterType: String =>
+  test("""IF 3 < 2 THEN 2 < 4 ELSE 5 < 1""") { rewriterType: SMTEncoding =>
     val pred = lt(int(3), int(2))
     val e1 = lt(int(2), int(4))
     val e2 = lt(int(5), int(1))
@@ -34,7 +35,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state.setRex(ifThenElse))
   }
 
-  test("""IF 3 > 2 THEN 4 ELSE 1""") { rewriterType: String =>
+  test("""IF 3 > 2 THEN 4 ELSE 1""") { rewriterType: SMTEncoding =>
     val pred = gt(int(3), int(2))
     val e1 = int(4)
     val e2 = int(1)
@@ -46,7 +47,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""IF 3 < 2 THEN 4 ELSE 1""") { rewriterType: String =>
+  test("""IF 3 < 2 THEN 4 ELSE 1""") { rewriterType: SMTEncoding =>
     val pred = lt(int(3), int(2))
     val e1 = int(4)
     val e2 = int(1)
@@ -58,7 +59,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""IF 3 < 2 THEN {1, 2} ELSE {2, 3} equals {2, 3}""") { rewriterType: String =>
+  test("""IF 3 < 2 THEN {1, 2} ELSE {2, 3} equals {2, 3}""") { rewriterType: SMTEncoding =>
     val pred = lt(int(3), int(2))
     val e1 = enumSet(int(1), int(2))
     val e2 = enumSet(int(2), int(3))
@@ -71,7 +72,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""IF 1 = 1 THEN {2} ELSE {1} ]""") { rewriterType: String =>
+  test("""IF 1 = 1 THEN {2} ELSE {1} ]""") { rewriterType: SMTEncoding =>
     val ifThenElse = ite(eql(int(1), int(1)) ? "b", enumSet(int(2)) ? "I", enumSet(int(1)) ? "I")
     val eq = eql(enumSet(int(2)) ? "I", ifThenElse ? "I")
       .typed(types, "b")
@@ -80,7 +81,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""SE-ITE[5]: IF 2 < 3 THEN {1, 2} ELSE {2, 3} ~~> {1, 2}""") { rewriterType: String =>
+  test("""SE-ITE[5]: IF 2 < 3 THEN {1, 2} ELSE {2, 3} ~~> {1, 2}""") { rewriterType: SMTEncoding =>
     val pred = lt(int(2), int(3))
     val e1 = enumSet(int(1), int(2))
     val e2 = enumSet(int(2), int(3))
@@ -93,7 +94,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""1 + (IF 3 < 2 THEN 4 ELSE 1)""") { rewriterType: String =>
+  test("""1 + (IF 3 < 2 THEN 4 ELSE 1)""") { rewriterType: SMTEncoding =>
     val pred = lt(int(3), int(2))
     val e1 = int(4)
     val e2 = int(1)
@@ -106,7 +107,7 @@ trait TestSymbStateRewriterControl extends RewriterBase with TestingPredefs {
   }
 
   // LET-IN is often used to cache computation results
-  test("""LET A == 1 + 2 IN 1 + A equals 4""") { rewriterType: String =>
+  test("""LET A == 1 + 2 IN 1 + A equals 4""") { rewriterType: SMTEncoding =>
     val decl = declOp("A", plus(int(1), int(2)) ? "i")
       .typedOperDecl(types, "O")
     val let = letIn(plus(int(1), appOp(name("A") ? "O") ? "i") ? "i", decl)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, IntT1, SetT1}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, IntT1, SetT1}
@@ -14,7 +15,7 @@ trait TestSymbStateRewriterExpand extends RewriterBase {
       "i_TO_b" -> SetT1(FunT1(IntT1(), BoolT1()))
   )
 
-  test("""Expand(SUBSET {1, 2})""") { rewriterType: String =>
+  test("""Expand(SUBSET {1, 2})""") { rewriterType: SMTEncoding =>
     val baseset = enumSet(int(1), int(2))
     val expandPowset = apalacheExpand(powSet(baseset ? "I") ? "II")
       .typed(types, "II")
@@ -26,7 +27,7 @@ trait TestSymbStateRewriterExpand extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""Expand([{1, 2, 3} -> {FALSE, TRUE}]) fails as unsupported""") { rewriterType: String =>
+  test("""Expand([{1, 2, 3} -> {FALSE, TRUE}]) fails as unsupported""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2), int(3))
     val codomain = enumSet(bool(false), bool(true))
     val set = apalacheExpand(funSet(domain ? "I", codomain ? "B") ? "i_TO_b")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, TlaEx}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, TlaEx}
@@ -11,7 +12,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
       "I" -> SetT1(IntT1())
   )
 
-  test("""Cardinality({1, 2, 3}) = 3""") { rewriterType: String =>
+  test("""Cardinality({1, 2, 3}) = 3""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(3).map(int): _*)
     val cardinality = card(set ? "I")
       .typed(types, "i")
@@ -22,7 +23,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""Cardinality({1, 2, 2, 2, 3, 3}) = 3""") { rewriterType: String =>
+  test("""Cardinality({1, 2, 2, 2, 3, 3}) = 3""") { rewriterType: SMTEncoding =>
     val set = enumSet(Seq(1, 2, 2, 2, 3, 3).map(int): _*)
     val cardinality = card(set ? "I")
       .typed(types, "i")
@@ -33,7 +34,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""Apalache!ConstCard(Cardinality({1, 2, 3}) >= 3)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({1, 2, 3}) >= 3)""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(3).map(int): _*)
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(3)) ? "b")
       .typed(types, "b")
@@ -46,7 +47,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({1, 2, 3}) >= 4)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({1, 2, 3}) >= 4)""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(3).map(int): _*)
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(4)) ? "b")
       .typed(types, "b")
@@ -59,7 +60,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(!solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({1, 2, 2, 3}) >= 4)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({1, 2, 2, 3}) >= 4)""") { rewriterType: SMTEncoding =>
     val set = enumSet(Seq(1, 2, 2, 3).map(int): _*)
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(4)) ? "b")
       .typed(types, "b")
@@ -72,7 +73,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(!solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({1, 2, 2, 3, 3}) >= 4)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({1, 2, 2, 3, 3}) >= 4)""") { rewriterType: SMTEncoding =>
     val set = enumSet(Seq(1, 2, 2, 3, 3).map(int): _*)
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(4)) ? "b")
       .typed(types, "b")
@@ -85,7 +86,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(!solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({}) >= 0)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({}) >= 0)""") { rewriterType: SMTEncoding =>
     val set = enumSet()
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(0)) ? "b")
       .typed(types, "b")
@@ -98,7 +99,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({}) >= 1)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({}) >= 1)""") { rewriterType: SMTEncoding =>
     val set = enumSet()
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(1)) ? "b")
       .typed(types, "b")
@@ -111,7 +112,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(!solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({x \in {}: FALSE}) >= 0)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({x \in {}: FALSE}) >= 0)""") { rewriterType: SMTEncoding =>
     val set = filter(name("x") ? "i", enumSet() ? "I", bool(false))
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(0)) ? "b")
       .typed(types, "b")
@@ -124,7 +125,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Apalache!ConstCard(Cardinality({x \in {}: FALSE}) >= 1)""") { rewriterType: String =>
+  test("""Apalache!ConstCard(Cardinality({x \in {}: FALSE}) >= 1)""") { rewriterType: SMTEncoding =>
     val set = filter(name("x") ? "i", enumSet() ? "I", bool(false))
     val cardCmp = apalacheConstCard(ge(card(set ? "I") ? "i", int(1)) ? "b")
       .typed(types, "b")
@@ -137,7 +138,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assert(!solverContext.sat())
   }
 
-  test("""Cardinality({1, 2, 3} \ {2}) = 2""") { rewriterType: String =>
+  test("""Cardinality({1, 2, 3} \ {2}) = 2""") { rewriterType: SMTEncoding =>
     def setminus(set: TlaEx, intVal: Int): TlaEx = {
       filter(name("t") ? "i", set ? "I", not(eql(name("t") ? "i", int(intVal)) ? "b") ? "b")
         .typed(types, "I")
@@ -152,7 +153,7 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""IsFiniteSet({1, 2, 3}) = TRUE""") { rewriterType: String =>
+  test("""IsFiniteSet({1, 2, 3}) = TRUE""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(3).map(int): _*)
     val isFiniteSet = isFin(set ? "I")
       .typed(types, "b")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSeq.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSeq.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.FoldSeqRule
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
@@ -8,7 +9,7 @@ import at.forsyte.apalache.tla.lir.oper.ApalacheOper
 
 trait TestSymbStateRewriterFoldSeq extends RewriterBase {
 
-  test("""FoldSeq( LAMBDA x,y: C, v, S ) = C""") { rewriterType: String =>
+  test("""FoldSeq( LAMBDA x,y: C, v, S ) = C""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == 0
     val a = IntT1()
@@ -38,7 +39,7 @@ trait TestSymbStateRewriterFoldSeq extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""FoldSeq( LAMBDA x,y: ..., v, <<>> ) = v""") { rewriterType: String =>
+  test("""FoldSeq( LAMBDA x,y: ..., v, <<>> ) = v""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == 0
     val a = IntT1()
@@ -66,7 +67,7 @@ trait TestSymbStateRewriterFoldSeq extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""FoldSeq( LAMBDA x,y: x + 1, 0, s ) = Card(Len(s))""") { rewriterType: String =>
+  test("""FoldSeq( LAMBDA x,y: x + 1, 0, s ) = Card(Len(s))""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == p + 1
     val a = IntT1()
@@ -96,7 +97,7 @@ trait TestSymbStateRewriterFoldSeq extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""FoldSeq( LAMBDA x,y: x + y, 0, s ) = Sum(s)""") { rewriterType: String =>
+  test("""FoldSeq( LAMBDA x,y: x + y, 0, s ) = Sum(s)""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == p + q
     val a = IntT1()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSeq.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSeq.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.FoldSeqRule
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSet.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.FoldSetRule
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -18,7 +19,7 @@ trait TestSymbStateRewriterFoldSet extends RewriterBase {
       "ibI" -> TupT1(IntT1(), BoolT1(), SetT1(IntT1()))
   )
 
-  test("""FoldSet( LAMBDA x,y: C, v, S ) = C""") { rewriterType: String =>
+  test("""FoldSet( LAMBDA x,y: C, v, S ) = C""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == 0
     val a = IntT1()
@@ -48,7 +49,7 @@ trait TestSymbStateRewriterFoldSet extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""FoldSet( LAMBDA x,y: ..., v, {} ) = v""") { rewriterType: String =>
+  test("""FoldSet( LAMBDA x,y: ..., v, {} ) = v""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == 0
     val a = IntT1()
@@ -75,7 +76,7 @@ trait TestSymbStateRewriterFoldSet extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""FoldSet( LAMBDA x,y: x + 1, 0, S ) = Card(S)""") { rewriterType: String =>
+  test("""FoldSet( LAMBDA x,y: x + 1, 0, S ) = Card(S)""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == p + 1
     val a = IntT1()
@@ -106,7 +107,7 @@ trait TestSymbStateRewriterFoldSet extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""FoldSet( LAMBDA x,y: x + y, 0, S ) = Sum(S)""") { rewriterType: String =>
+  test("""FoldSet( LAMBDA x,y: x + y, 0, S ) = Sum(S)""") { rewriterType: SMTEncoding =>
     // A : (a,b) => a
     // A(p,q) == p + q
     val a = IntT1()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFoldSet.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.FoldSetRule
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -14,7 +15,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
         "b_to_b" -> FunT1(BoolT1(), BoolT1()), "b_TO_b" -> SetT1(FunT1(BoolT1(), BoolT1())),
         "i_to_b_to_b" -> FunT1(IntT1(), FunT1(BoolT1(), BoolT1())))
 
-  test("""[x \in {1,2,3,4} |-> x / 3: ]""") { rewriterType: String =>
+  test("""[x \in {1,2,3,4} |-> x / 3: ]""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(4).map(int): _*)
       .typed(types, "I")
     val mapping = div(name("x") ? "i", int(3))
@@ -42,7 +43,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     }
   }
 
-  test(""" [x \in {1,2,3} |-> IF x = 1 THEN {2} ELSE IF x = 2 THEN {3} ELSE {1} ]""") { rewriterType: String =>
+  test(""" [x \in {1,2,3} |-> IF x = 1 THEN {2} ELSE IF x = 2 THEN {3} ELSE {1} ]""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(3).map(int): _*)
       .typed(types, "I")
 
@@ -68,7 +69,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""[x \in {1,2} |-> {} ][1] = {}""") { rewriterType: String =>
+  test("""[x \in {1,2} |-> {} ][1] = {}""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
       .typed(types, "I")
     val mapping = enumSet()
@@ -96,7 +97,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""[x \in {1,2} |-> IF x = 1 THEN {2} ELSE {1} ][1]""") { rewriterType: String =>
+  test("""[x \in {1,2} |-> IF x = 1 THEN {2} ELSE {1} ][1]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
       .typed(types, "I")
     val mapping = ite(eql(name("x") ? "i", int(1)) ? "b", enumSet(int(2)) ? "I", enumSet(int(1)) ? "I")
@@ -127,7 +128,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
   }
 
   // regression: this test did not work with EWD840
-  test("""[x \in {1,2} |-> ["a" |-> x] ][1]""") { rewriterType: String =>
+  test("""[x \in {1,2} |-> ["a" |-> x] ][1]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
       .typed(types, "I")
     val mapping = enumFun(str("a"), name("x") ? "i")
@@ -157,7 +158,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""f[4]""") { rewriterType: String =>
+  test("""f[4]""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(4).map(int): _*)
       .typed(types, "I")
     val mapping = mult(name("x"), int(3))
@@ -196,7 +197,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     }
   }
 
-  test("""[x \in {1, 2} |-> x][4] ~~> failure!""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> x][4] ~~> failure!""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
       .typed(types, "I")
     val fun = funDef(name("x") ? "i", name("x") ? "i", set)
@@ -223,7 +224,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
   // Raft is directly using f @@ e :> r to construct a function g such as:
   // DOMAIN g = {e} \cup DOMAIN f and g[e] = r and g[a] = f[a] for a \in DOMAIN f
   // It is trivial to implement this extension with our encoding
-  test("""[x \in {1, 2} |-> x] @@ 3 :> 4""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> x] @@ 3 :> 4""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
     val fun = funDef(name("x") ? "i", name("x") ? "i", set ? "I")
     val extFun = atat(fun ? "i_to_i", colonGreater(int(3), int(4)) ? "i_to_i")
@@ -237,7 +238,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, extState.setRex(eq1))
   }
 
-  test("""[x \in {3} |-> {1, x}][3]""") { rewriterType: String =>
+  test("""[x \in {3} |-> {1, x}][3]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(3))
     val mapping = enumSet(int(1), name("x") ? "i")
     val fun = funDef(mapping ? "I", name("x") ? "i", set ? "I")
@@ -251,7 +252,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, state.setRex(appEq))
   }
 
-  test("""[x \in {} |-> x][3]""") { rewriterType: String =>
+  test("""[x \in {} |-> x][3]""") { rewriterType: SMTEncoding =>
     // regression: function application with an empty domain should not crash.
     // The result of this function is undefined in TLA+.
     val fun = funDef(name("x") ? "i", name("x") ? "i", enumSet() ? "I")
@@ -263,7 +264,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assert(solverContext.sat())
   }
 
-  test("""[y \in BOOLEAN |-> ~y] = [x \in BOOLEAN |-> ~x]""") { rewriterType: String =>
+  test("""[y \in BOOLEAN |-> ~y] = [x \in BOOLEAN |-> ~x]""") { rewriterType: SMTEncoding =>
     val fun1 = funDef(not(name("y") ? "b") ? "b", name("y") ? "b", booleanSet() ? "B")
       .typed(types, "b_to_b")
     val fun2 = funDef(not(name("x") ? "b") ? "b", name("x") ? "b", booleanSet() ? "B")
@@ -277,7 +278,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
   }
 
   // a function returning a function
-  test("""[x \in {3} |-> [y \in BOOLEAN |-> ~y]][3]""") { rewriterType: String =>
+  test("""[x \in {3} |-> [y \in BOOLEAN |-> ~y]][3]""") { rewriterType: SMTEncoding =>
     val boolNegFun = funDef(not(name("y") ? "b") ? "b", name("y") ? "b", booleanSet() ? "B")
       .typed(types, "b_to_b")
 
@@ -294,7 +295,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""[x \in {1, 2} |-> IF x = 1 THEN 11 ELSE 2 * x][1]""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> IF x = 1 THEN 11 ELSE 2 * x][1]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
     val pred = eql(name("x") ? "i", int(1))
     val ifThenElse = ite(pred ? "b", int(11), mult(int(2), name("x") ? "i") ? "i")
@@ -308,7 +309,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""[[x \in {1, 2} |-> 2 * x] EXCEPT ![1] = 11]""") { rewriterType: String =>
+  test("""[[x \in {1, 2} |-> 2 * x] EXCEPT ![1] = 11]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2))
     val mapExpr = mult(int(2), name("x") ? "i")
     val fun = funDef(mapExpr ? "i", name("x") ? "i", set ? "I")
@@ -339,7 +340,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, nextState.setRex(resFun1eq11))
   }
 
-  test("""[[x \in {"a", "b"} |-> 3] EXCEPT !["a"] = 11]""") { rewriterType: String =>
+  test("""[[x \in {"a", "b"} |-> 3] EXCEPT !["a"] = 11]""") { rewriterType: SMTEncoding =>
     val set = enumSet(str("a"), str("b"))
     val mapExpr = int(3)
     val fun = funDef(mapExpr ? "i", name("x") ? "s", set ? "S")
@@ -354,7 +355,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, state.setRex(resFun1eq11))
   }
 
-  test("""fun in a set: \E x \in {[y \in BOOLEAN |-> ~y]}: x[FALSE]""") { rewriterType: String =>
+  test("""fun in a set: \E x \in {[y \in BOOLEAN |-> ~y]}: x[FALSE]""") { rewriterType: SMTEncoding =>
     // this test was failing in the buggy implementation with PICK .. FROM and FUN-MERGE
     val fun1 = funDef(not(name("y") ? "b") ? "b", name("y") ? "b", booleanSet() ? "B")
       .typed(types, "b_to_b")
@@ -369,7 +370,7 @@ trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""DOMAIN [x \in {1,2,3} |-> x / 2: ]""") { rewriterType: String =>
+  test("""DOMAIN [x \in {1,2,3} |-> x / 2: ]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2), int(3))
     val mapping = div(name("x"), int(2))
     val fun = funDef(mapping ? "i", name("x") ? "i", set ? "I")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -34,7 +35,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
         "i_to_b_to_b" -> FunT1(IntT1(), FunT1(BoolT1(), BoolT1()))
     )
 
-  test("""[{1, 2, 3} -> {FALSE, TRUE}]""") { rewriterType: String =>
+  test("""[{1, 2, 3} -> {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2), int(3))
     val codomain = enumSet(bool(false), bool(true))
     val fs = funSet(domain ? "I", codomain ? "B")
@@ -61,7 +62,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
     }
   }
 
-  test("""[{1, 2} -> Expand(SUBSET {FALSE, TRUE})]""") { rewriterType: String =>
+  test("""[{1, 2} -> Expand(SUBSET {FALSE, TRUE})]""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2))
     val codomain = apalacheExpand(powSet(enumSet(bool(false), bool(true)) ? "B") ? "BB")
     val fs = funSet(domain ? "I", codomain ? "BB")
@@ -87,7 +88,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // the existential over a function set should work without expanding the powerset!
-  test("""Skolem(\E f \in [{1, 2} -> SUBSET {FALSE, TRUE}]: g' <- f)""") { rewriterType: String =>
+  test("""Skolem(\E f \in [{1, 2} -> SUBSET {FALSE, TRUE}]: g' <- f)""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2)) ? "I"
     val codomain = powSet(enumSet(bool(false), bool(true)) ? "B") ? "BB"
     val pred = assign(prime(name("g") ? "i_to_B") ? "i_to_B", name("f") ? "i_to_B")
@@ -107,7 +108,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // the existential over a function set should work without expanding the powerset!
-  test("""Skolem(\E f \in [{1, 2} -> SUBSET {FALSE}]: f[1] = {TRUE})""") { rewriterType: String =>
+  test("""Skolem(\E f \in [{1, 2} -> SUBSET {FALSE}]: f[1] = {TRUE})""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2)) ? "I"
     val codomain = powSet(enumSet(bool(false)) ? "B") ? "BB"
     val pred = eql(appFun(name("f") ? "i_to_B", int(1)) ? "B", enumSet(bool(true)) ? "B")
@@ -124,7 +125,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // An existential over a function set that returns a function set to a powerset. Does it blow up your mind? :-)
-  test("""Skolem(\E f \in [{1, 2} -> [{3} -> SUBSET {FALSE, TRUE}]]: g' <- f)""") { rewriterType: String =>
+  test("""Skolem(\E f \in [{1, 2} -> [{3} -> SUBSET {FALSE, TRUE}]]: g' <- f)""") { rewriterType: SMTEncoding =>
     val domain1 = enumSet(int(1), int(2))
     val domain2 = enumSet(int(3))
     val codomain2 = powSet(enumSet(bool(false), bool(true)) ? "B") ? "BB"
@@ -148,7 +149,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // this should be fixed by implementing #91
-  test("""[x \in {1, 2} |-> {x = 1}] \in [{1, 2} -> SUBSET {FALSE, TRUE}]""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> {x = 1}] \in [{1, 2} -> SUBSET {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2)) ? "I"
     val codomain = powSet(enumSet(bool(false), bool(true)) ? "B") ? "BB"
     val funset = funSet(domain, codomain) ? "i_to_B"
@@ -160,7 +161,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""[x \in {1, 2} |-> 3] \in [{1, 2} -> {3, 4}]""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> 3] \in [{1, 2} -> {3, 4}]""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2)) ? "I"
     val codomain = enumSet(int(3), int(4)) ? "I"
     val funset = funSet(domain, codomain) ? "i_TO_i"
@@ -173,7 +174,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // this should be redundant in the presence of #91
-  test("""[x \in {0, 1, 2} \ {0} |-> 3] \in [{1, 2} -> {3, 4}]""") { rewriterType: String =>
+  test("""[x \in {0, 1, 2} \ {0} |-> 3] \in [{1, 2} -> {3, 4}]""") { rewriterType: SMTEncoding =>
     // although 0 is in the function domain at the arena level, it does not belong to the set difference
     def setminus(set: TlaEx, intVal: Int): TlaEx = {
       filter(name("t") ? "i", set, not(eql(name("t") ? "i", int(intVal)) ? "b") ? "b")
@@ -199,7 +200,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // this should be fixed by implementing #91
-  test("""[x \in {1, 2} |-> {TRUE}] \in [{1, 2} -> SUBSET {FALSE}]""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> {TRUE}] \in [{1, 2} -> SUBSET {FALSE}]""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2)) ? "I"
     val codomain = powSet(enumSet(bool(false)) ? "B") ? "BB"
     val funset = funSet(domain, codomain)
@@ -217,7 +218,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // this should be fixed by implementing #91
-  test("""[x \in {1, 2} |-> {TRUE}] \in [{1, 2} -> SUBSET {FALSE, TRUE}]""") { rewriterType: String =>
+  test("""[x \in {1, 2} |-> {TRUE}] \in [{1, 2} -> SUBSET {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
     val domain = enumSet(int(1), int(2)) ? "I"
     val codomain = powSet(enumSet(bool(false), bool(true)) ? "B") ? "BB"
     val funset = funSet(domain, codomain)
@@ -234,7 +235,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   // bugfix 27/12/2017
-  test("""SE-FUNSET1: [0..(5 - 1) -> {FALSE, TRUE}]""") { rewriterType: String =>
+  test("""SE-FUNSET1: [0..(5 - 1) -> {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
     val domain = dotdot(int(0), minus(int(5), int(1)) ? "i") ? "I"
     val codomain = enumSet(bool(false), bool(true)) ? "B"
     val fs = funSet(domain, codomain)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -10,7 +11,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
   private val Bool = BoolT1()
   private val IntSet = SetT1(IntT1())
 
-  test("$C$_i: Int = $C$_j: Int") { rewriterType: String =>
+  test("$C$_i: Int = $C$_j: Int") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT())
@@ -50,7 +51,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$Z$Int = $Z$j ~~> $B$k") { rewriterType: String =>
+  test("$Z$Int = $Z$j ~~> $B$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -85,7 +86,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         fail("Unexpected rewriting result")
     }
   }
-  test("$C$_i: Int < $C$_j: Int ~~> valInt(...) < valInt(...)") { rewriterType: String =>
+  test("$C$_i: Int < $C$_j: Int ~~> valInt(...) < valInt(...)") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT())
@@ -115,7 +116,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$C$_i: Int <= $C$_j: Int ~~> valInt(...) <= valInt(...)") { rewriterType: String =>
+  test("$C$_i: Int <= $C$_j: Int ~~> valInt(...) <= valInt(...)") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT())
@@ -145,7 +146,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$C$_i: Int > $C$_j: Int ~~> valInt(...) > valInt(...)") { rewriterType: String =>
+  test("$C$_i: Int > $C$_j: Int ~~> valInt(...) > valInt(...)") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT())
@@ -175,7 +176,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("(composite expressions): 1 + 5 > 6 - 3 ~~> $B$_k") { rewriterType: String =>
+  test("(composite expressions): 1 + 5 > 6 - 3 ~~> $B$_k") { rewriterType: SMTEncoding =>
     val left = plus(int(1), int(5)).typed(IntT1())
     val right = minus(int(6), int(3)).typed(IntT1())
     val state = new SymbState(gt(left, right).typed(BoolT1()), arena, Binding())
@@ -196,7 +197,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$C$_i: Int >= $C$_j: Int ~~> valInt(...) >= valInt(...)") { rewriterType: String =>
+  test("$C$_i: Int >= $C$_j: Int ~~> valInt(...) >= valInt(...)") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT())
@@ -226,7 +227,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("~($Z$Int = $Z$j) ~~> $B$k") { rewriterType: String =>
+  test("~($Z$Int = $Z$j) ~~> $B$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -263,7 +264,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$Z$Int + $Z$j ~~> $Z$k") { rewriterType: String =>
+  test("$Z$Int + $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -291,7 +292,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$Z$Int - $Z$j ~~> $Z$k") { rewriterType: String =>
+  test("$Z$Int - $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -319,7 +320,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("-$Z$j ~~> $Z$k") { rewriterType: String =>
+  test("-$Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     val expr = uminus(leftInt as Int) as Int
@@ -343,7 +344,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$Z$Int * $Z$j ~~> $Z$k") { rewriterType: String =>
+  test("$Z$Int * $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -371,7 +372,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$Z$Int / $Z$j ~~> $Z$k") { rewriterType: String =>
+  test("$Z$Int / $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -399,7 +400,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("$Z$Int % $Z$j ~~> $Z$k") { rewriterType: String =>
+  test("$Z$Int % $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT())
     val leftInt = arena.topCell.toNameEx
     arena = arena.appendCell(IntT())
@@ -427,7 +428,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("""2..5  = {2, 3, 4, 5}""") { rewriterType: String =>
+  test("""2..5  = {2, 3, 4, 5}""") { rewriterType: SMTEncoding =>
     val expected = enumSet(2.until(6).map(int): _*).typed(SetT1(IntT1()))
     val range = dotdot(int(2), int(5)).typed(SetT1(IntT1()))
     val eqExpected = eql(range, expected).typed(BoolT1())
@@ -451,7 +452,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     }
   }
 
-  test("""SE-INT-RNG: 2..(6 - 1)  = {2, 3, 4, 5}""") { rewriterType: String =>
+  test("""SE-INT-RNG: 2..(6 - 1)  = {2, 3, 4, 5}""") { rewriterType: SMTEncoding =>
     val expected = enumSet(2.to(5).map(int): _*).typed(SetT1(IntT1()))
     val range = dotdot(int(2), minus(int(6), int(1)) as Int) as IntSet
     val eqExpected = eql(range, expected).typed(BoolT1())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.PowSetCtor
 import at.forsyte.apalache.tla.bmcmt.types.{FinSetT, IntT, PowSetT}
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -14,7 +15,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
       "b" -> BoolT1()
   )
 
-  test("""SUBSET {1, 2, 3}""") { rewriterType: String =>
+  test("""SUBSET {1, 2, 3}""") { rewriterType: SMTEncoding =>
     val ex = powSet(enumSet(int(1), int(2), int(3)) ? "I")
       .typed(types, "II")
     val state = new SymbState(ex, arena, Binding())
@@ -35,7 +36,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     }
   }
 
-  test("""SE-SUBSET1: {1, 2} \in SUBSET {1, 2, 3}""") { rewriterType: String =>
+  test("""SE-SUBSET1: {1, 2} \in SUBSET {1, 2, 3}""") { rewriterType: SMTEncoding =>
     val set12 = enumSet(int(1), int(2)) ? "I"
     val powset = powSet(enumSet(int(1), int(2), int(3)) ? "I") ? "II"
     val inEx = in(set12, powset)
@@ -44,7 +45,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""SE-SUBSET1: {} \in SUBSET {1, 2, 3}""") { rewriterType: String =>
+  test("""SE-SUBSET1: {} \in SUBSET {1, 2, 3}""") { rewriterType: SMTEncoding =>
     // an empty set requires a type annotation
     val emptySet = enumSet()
       .typed(types, "I")
@@ -55,7 +56,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""SE-SUBSET1: {1, 2, 3} \in SUBSET {1, 2, 3}""") { rewriterType: String =>
+  test("""SE-SUBSET1: {1, 2, 3} \in SUBSET {1, 2, 3}""") { rewriterType: SMTEncoding =>
     val set1to3 = enumSet(int(1), int(2), int(3)) ? "I"
     val powset = powSet(set1to3) ? "II"
     val inEx = in(set1to3, powset)
@@ -64,7 +65,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""SE-SUBSET1: {1, 2, 3, 4} \in SUBSET {1, 2, 3}""") { rewriterType: String =>
+  test("""SE-SUBSET1: {1, 2, 3, 4} \in SUBSET {1, 2, 3}""") { rewriterType: SMTEncoding =>
     def setTo(k: Int) = enumSet(1 to k map int: _*)
 
     val set1to4 = setTo(4) ? "I"
@@ -75,7 +76,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""SE-SUBSET: \E X \in SUBSET {1, 2}: TRUE (sat)""") { rewriterType: String =>
+  test("""SE-SUBSET: \E X \in SUBSET {1, 2}: TRUE (sat)""") { rewriterType: SMTEncoding =>
     // a regression test that failed in the previous versions
     val set = enumSet(int(1), int(2)) ? "I"
     val ex = exists(name("X") ? "I", powSet(set) ? "II", bool(true))
@@ -90,7 +91,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     }
   }
 
-  test("""SE-SUBSET: Skolem(\E X \in SUBSET {1, 2}: TRUE) (sat)""") { rewriterType: String =>
+  test("""SE-SUBSET: Skolem(\E X \in SUBSET {1, 2}: TRUE) (sat)""") { rewriterType: SMTEncoding =>
     // a regression test that failed in the previous versions
     val set = enumSet(int(1), int(2)) ? "I"
     val ex =
@@ -110,7 +111,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     }
   }
 
-  test("""SE-SUBSET: Skolem(\E X \in SUBSET {1, 2}: FALSE (unsat))""") { rewriterType: String =>
+  test("""SE-SUBSET: Skolem(\E X \in SUBSET {1, 2}: FALSE (unsat))""") { rewriterType: SMTEncoding =>
     // a regression test that failed in the previous versions
     val set = enumSet(int(1), int(2)) ? "I"
     val ex =
@@ -131,7 +132,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
     }
   }
 
-  test("""PowSetCtor {1, 2}""") { rewriterType: String =>
+  test("""PowSetCtor {1, 2}""") { rewriterType: SMTEncoding =>
     val baseset = enumSet(int(1), int(2))
       .typed(types, "I")
     val state = new SymbState(baseset, arena, Binding())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.PowSetCtor
 import at.forsyte.apalache.tla.bmcmt.types.{FinSetT, IntT, PowSetT}
 import at.forsyte.apalache.tla.lir.TypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -13,7 +14,7 @@ trait TestSymbStateRewriterRecFun extends RewriterBase with TestingPredefs {
         "i_to_i" -> FunT1(IntT1(), IntT1())
     )
 
-  test("""recursive fun: f[n \in { 1, 2, 3 }] == IF n <= 1 THEN 2 ELSE 2 * f[n - 1]""") { rewriterType: String =>
+  test("""recursive fun: f[n \in { 1, 2, 3 }] == IF n <= 1 THEN 2 ELSE 2 * f[n - 1]""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2), int(3)) ? "I"
     val ref = recFunRef() ? "i_to_i"
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecord.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecord.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, ConstT, FinSetT, IntT, RecordT}
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, NameEx, RecT1, SetT1, StrT1, TupT1}
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
@@ -15,7 +16,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
 
   // As sequences are not distinguishable from tuples, we need a type annotation.
   // In the not so far away future, a type inference engine would tell us, whether to construct a sequence or a tuple
-  test("""<<>> as Seq(Int)""") { rewriterType: String =>
+  test("""<<>> as Seq(Int)""") { rewriterType: SMTEncoding =>
     val tup = tuple()
       .typed(types, "Qi")
 
@@ -33,7 +34,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     }
   }
 
-  test("""<<1, 2, 3>> as Seq(Int)""") { rewriterType: String =>
+  test("""<<1, 2, 3>> as Seq(Int)""") { rewriterType: SMTEncoding =>
     val tup = tuple(1.to(3).map(int): _*)
       .typed(types, "Qi")
 
@@ -51,7 +52,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     }
   }
 
-  test("""(<<3, 4, 5>> as Seq(Int))[2]""") { rewriterType: String =>
+  test("""(<<3, 4, 5>> as Seq(Int))[2]""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(5).map(int): _*)
       .typed(types, "Qi")
 
@@ -71,7 +72,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq3))
   }
 
-  test("""(<<>> as Seq(Int))[1]""") { rewriterType: String =>
+  test("""(<<>> as Seq(Int))[1]""") { rewriterType: SMTEncoding =>
     // regression: <<>>[1] should produce no contradiction, nor throw an exception
     val tup = tuple()
       .typed(types, "Qi")
@@ -82,7 +83,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""Head(<<3, 4, 5>> as Seq(Int))""") { rewriterType: String =>
+  test("""Head(<<3, 4, 5>> as Seq(Int))""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(5).map(int): _*) ? "Qi"
     val seqHead = head(tup) ? "i"
     val eq = eql(seqHead, int(3))
@@ -92,7 +93,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""Len(<<3, 4, 5>> <: Seq(Int))""") { rewriterType: String =>
+  test("""Len(<<3, 4, 5>> <: Seq(Int))""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(5).map(i => int(i)): _*)
       .typed(types, "Qi")
     val seqLen = len(tup) ? "i"
@@ -103,7 +104,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""Tail(<<3, 4, 5>> as Seq(Int))""") { rewriterType: String =>
+  test("""Tail(<<3, 4, 5>> as Seq(Int))""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(5).map(int): _*) ? "Qi"
     val seqTail = tail(tup) ? "Qi"
     val expected = tuple(int(4), int(5)) ? "Qi"
@@ -114,7 +115,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""regression: Tail(<<>> as Seq(Int)) does not unsat and its length is zero""") { rewriterType: String =>
+  test("""regression: Tail(<<>> as Seq(Int)) does not unsat and its length is zero""") { rewriterType: SMTEncoding =>
     val emptyTuple = tuple()
       .typed(types, "Qi")
     val seqTail = tail(emptyTuple)
@@ -126,7 +127,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""SubSeq(S, 2, 4)""") { rewriterType: String =>
+  test("""SubSeq(S, 2, 4)""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(6).map(int): _*)
       .typed(types, "Qi")
     val subseqEx = subseq(tup, int(2), int(3))
@@ -149,7 +150,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq3))
   }
 
-  test("""regression: SubSeq(S, 3, 1) does not unsat and has length 0""") { rewriterType: String =>
+  test("""regression: SubSeq(S, 3, 1) does not unsat and has length 0""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(6).map(int): _*)
       .typed(types, "Qi")
     val subseqEx = subseq(tup, int(3), int(1))
@@ -161,7 +162,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""Append(S, 10)""") { rewriterType: String =>
+  test("""Append(S, 10)""") { rewriterType: SMTEncoding =>
     val tup = tuple(4.to(5).map(int): _*)
       .typed(types, "Qi")
     val seqAppend = append(tup, int(10))
@@ -186,7 +187,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq4))
   }
 
-  test("""Append(SubSeq(S, 2, 3), 10)""") { rewriterType: String =>
+  test("""Append(SubSeq(S, 2, 3), 10)""") { rewriterType: SMTEncoding =>
     val tup = tuple(3.to(6).map(int): _*) ? "Qi"
     val subseqEx = subseq(tup, int(2), int(3)) ? "Qi"
     val seqAppend = append(subseqEx, int(10))
@@ -211,7 +212,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(eq4))
   }
 
-  test("""<<4, 5>> = SubSeq(<<3, 4, 5, 6>>, 2, 3)""") { rewriterType: String =>
+  test("""<<4, 5>> = SubSeq(<<3, 4, 5, 6>>, 2, 3)""") { rewriterType: SMTEncoding =>
     val tup3456 = tuple(3.to(6).map(int): _*) ? "Qi"
     val subseqEx = subseq(tup3456, int(2), int(3)) ? "Qi"
     val tup45 = tuple(4.to(5).map(int): _*) ? "Qi"
@@ -222,7 +223,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""DOMAIN SubSeq(<<3, 4, 5, 6>>, 2, 3) equals {2, 3}""") { rewriterType: String =>
+  test("""DOMAIN SubSeq(<<3, 4, 5, 6>>, 2, 3) equals {2, 3}""") { rewriterType: SMTEncoding =>
     val tup3456 = tuple(3.to(6).map(int): _*) ? "Qi"
     val subseqEx = subseq(tup3456, int(2), int(3)) ? "Qi"
     val domEx = dom(subseqEx) ? "I"
@@ -233,7 +234,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""<<9, 10>> \o SubSeq(S, 2, 3)""") { rewriterType: String =>
+  test("""<<9, 10>> \o SubSeq(S, 2, 3)""") { rewriterType: SMTEncoding =>
     val tup3_6 = tuple(3.to(6).map(int): _*) ? "Qi"
     val subseqRes = subseq(tup3_6, int(2), int(3)) ? "Qi" // <<4, 5>>
     val tup9_10 = tuple(int(9), int(10)) ? "Qi"
@@ -246,7 +247,7 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""regression: <<9, 10>> \o Tail(<<>>) does not unsat""") { rewriterType: String =>
+  test("""regression: <<9, 10>> \o Tail(<<>>) does not unsat""") { rewriterType: SMTEncoding =>
     val t9_10 = tuple(int(9), int(10)) ? "Qi"
     // Tail(<<>>) produces some undefined value. In this case, \o should also produce an undefined value.
     val concatRes = concat(t9_10, tail(tuple() ? "Qi") ? "Qi")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.io.typecheck.parser.DefaultType1Parser
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.io.typecheck.parser.DefaultType1Parser
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -22,7 +23,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   private val intBoolT = parser("<<Int, Bool>>")
   private val intBoolSetT = parser("Set(<<Int, Bool>>)")
 
-  test("""{ x, y, z } ~~> c_set""") { rewriterType: String =>
+  test("""{ x, y, z } ~~> c_set""") { rewriterType: SMTEncoding =>
     val ex = enumSet(name("x") as intT, name("y") as boolT, name("z") as boolT) as boolSetT
     val binding = Binding("x" -> arena.cellFalse(), "y" -> arena.cellTrue(), "z" -> arena.cellFalse())
     val state = new SymbState(ex, arena, binding)
@@ -46,7 +47,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{1, 3, 5} ~~> c_set""") { rewriterType: String =>
+  test("""{1, 3, 5} ~~> c_set""") { rewriterType: SMTEncoding =>
     val ex = enumSet(int(1), int(3), int(5)) as intSetT
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
@@ -63,14 +64,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{} \in {}""") { rewriterType: String =>
+  test("""{} \in {}""") { rewriterType: SMTEncoding =>
     val ex = in(enumSet() as intSetT, enumSet() as int2SetT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val nextState = create(rewriterType).rewriteUntilDone(state)
     assert(nextState.arena.cellFalse().toNameEx == nextState.ex)
   }
 
-  test("""3 \in {1, 3, 5}""") { rewriterType: String =>
+  test("""3 \in {1, 3, 5}""") { rewriterType: SMTEncoding =>
     val ex = in(int(3), enumSet(int(1), int(3), int(5)) as intSetT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -89,7 +90,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{3} \in {{1}, {3}, {5}}""") { rewriterType: String =>
+  test("""{3} \in {{1}, {3}, {5}}""") { rewriterType: SMTEncoding =>
     val ex = in(enumSet(int(3)) as intSetT,
         enumSet(enumSet(int(1)) as intSetT, enumSet(int(3)) as intSetT,
             enumSet(int(5)) as intSetT) as int2SetT) as boolT
@@ -111,7 +112,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""2 \in {1, 3, 5}""") { rewriterType: String =>
+  test("""2 \in {1, 3, 5}""") { rewriterType: SMTEncoding =>
     val ex = in(int(2), enumSet(int(1), int(3), int(5)) as intSetT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -130,7 +131,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""2 \in Int""") { rewriterType: String =>
+  test("""2 \in Int""") { rewriterType: SMTEncoding =>
     val ex = in(int(2), intSet() as intSetT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -139,7 +140,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState)
   }
 
-  test("""2 \in Nat""") { rewriterType: String =>
+  test("""2 \in Nat""") { rewriterType: SMTEncoding =>
     val ex = in(int(2), natSet() as intSetT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -148,7 +149,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState)
   }
 
-  test("""-1 \in Nat""") { rewriterType: String =>
+  test("""-1 \in Nat""") { rewriterType: SMTEncoding =>
     val ex = in(int(-1), natSet() as intSetT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -157,7 +158,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(not(nextState.ex as boolT) as boolT))
   }
 
-  test("""~({} \in {})""") { rewriterType: String =>
+  test("""~({} \in {})""") { rewriterType: SMTEncoding =>
     val ex = not(in(enumSet() as intSetT, enumSet() as int2SetT) as boolT) as boolT
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -172,7 +173,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     solverContext.pop()
   }
 
-  test("""FALSE \in {FALSE, TRUE}""") { rewriterType: String =>
+  test("""FALSE \in {FALSE, TRUE}""") { rewriterType: SMTEncoding =>
     val ex =
       in(bool(false), enumSet(bool(false), bool(true)) as boolSetT) as boolT
     val state = new SymbState(ex, arena, Binding())
@@ -197,7 +198,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""~(FALSE \in {FALSE, TRUE})""") { rewriterType: String =>
+  test("""~(FALSE \in {FALSE, TRUE})""") { rewriterType: SMTEncoding =>
     val ex =
       not(in(bool(false), enumSet(bool(false), bool(true)) as boolSetT) as boolT) as boolT
     val state = new SymbState(ex, arena, Binding())
@@ -216,7 +217,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""c_i \in {TRUE, TRUE}""") { rewriterType: String =>
+  test("""c_i \in {TRUE, TRUE}""") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(BoolT())
     val cell = arena.topCell
     val ex =
@@ -251,7 +252,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""1 \in {1}""") { rewriterType: String =>
+  test("""1 \in {1}""") { rewriterType: SMTEncoding =>
     // regression: there is a special shortcut rule for singleton sets, which had a bug
     val ex = in(int(1), enumSet(int(1)) as intSetT) as boolT
 
@@ -275,7 +276,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""~(Bool \in {TRUE, TRUE})""") { rewriterType: String =>
+  test("""~(Bool \in {TRUE, TRUE})""") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(BoolT())
     val cell = arena.topCell
     val ex =
@@ -304,7 +305,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{{}, {{}, {}}} \in {{}, {{}, {{}, {}}}}""") { rewriterType: String =>
+  test("""{{}, {{}, {}}} \in {{}, {{}, {{}, {}}}}""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     def int2Set() = enumSet() as int2SetT
@@ -336,7 +337,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{{}, {{{}}}} \in {{}, {{}, {{}}}""") { rewriterType: String =>
+  test("""{{}, {{{}}}} \in {{}, {{}, {{}}}""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     def int2Set() = enumSet() as int2SetT
@@ -367,7 +368,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{{}} = {} ~~> (false)""") { rewriterType: String =>
+  test("""{{}} = {} ~~> (false)""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     def int2Set() = enumSet() as int2SetT
@@ -388,7 +389,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{{}, {{}}} = {{}, {{{}}} ~~> (false)""") { rewriterType: String =>
+  test("""{{}, {{}}} = {{}, {{{}}} ~~> (false)""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     def int2Set() = enumSet() as int2SetT
@@ -413,7 +414,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{{}, {{}}} = {{}, {{}} ~~> (true)""") { rewriterType: String =>
+  test("""{{}, {{}}} = {{}, {{}} ~~> (true)""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     def int2Set() = enumSet() as int2SetT
@@ -437,7 +438,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{} = {1} \ {1} ~~> (true)""") { rewriterType: String =>
+  test("""{} = {1} \ {1} ~~> (true)""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     val setOf1 = enumSet(int(1)) as intSetT
@@ -464,7 +465,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""type incorrect { i \in {1}: FALSE } = { b \in {FALSE}: FALSE }""") { rewriterType: String =>
+  test("""type incorrect { i \in {1}: FALSE } = { b \in {FALSE}: FALSE }""") { rewriterType: SMTEncoding =>
     // This test worked in the previous versions.
     // Now we enforce type correctness, and reject this expression right after type checking.
     // Although we keep this test, it cannot originate from a well-typed TLA+ code.
@@ -478,7 +479,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""~({{}, {{}}} = {{}, {{}}})""") { rewriterType: String =>
+  test("""~({{}, {{}}} = {{}, {{}}})""") { rewriterType: SMTEncoding =>
     def intSet() = enumSet() as intSetT
 
     def int2Set() = enumSet() as int2SetT
@@ -500,7 +501,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         fail("Unexpected rewriting result")
     }
   }
-  test("""{x \in {1,2,3,4} : x % 2 = 0} ~~> {2, 4}""") { rewriterType: String =>
+  test("""{x \in {1,2,3,4} : x % 2 = 0} ~~> {2, 4}""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2), int(3), int(4)) as intSetT
     val xMod2 = mod(name("x") as intT, int(2)) as intT
     val pred = eql(xMod2, int(0)) as intT
@@ -519,7 +520,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""2 \in {x \in {1,2,3,4} : x < 3}""") { rewriterType: String =>
+  test("""2 \in {x \in {1,2,3,4} : x < 3}""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(1), int(2), int(3), int(4)) as intSetT
     val pred = lt(name("x") as intT, int(3)) as boolT
     val filteredSet = filter(name("x") as intT, set, pred) as intSetT
@@ -542,7 +543,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{Q \in Expand(SUBSET {1,2,3}) : ~(2 \in Q)}""") { rewriterType: String =>
+  test("""{Q \in Expand(SUBSET {1,2,3}) : ~(2 \in Q)}""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(3).map(int): _*) as intSetT
 
     val predEx = not(in(int(2), name("Q") as intSetT) as boolT) as boolT
@@ -558,7 +559,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     assertTlaExAndRestore(rewriter, nextState.setRex(notInPred))
   }
 
-  test("""\E X \in SUBSET {1} IN {} = {x \in X : [y \in X |-> TRUE][x]}""") { rewriterType: String =>
+  test("""\E X \in SUBSET {1} IN {} = {x \in X : [y \in X |-> TRUE][x]}""") { rewriterType: SMTEncoding =>
     // regression
     val baseSet = enumSet(int(1)) as intSetT
     val pred =
@@ -581,7 +582,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""\E X \in SUBSET {1, 2}: {} = {x \in X : [y \in {1} |-> TRUE][x]}""") { rewriterType: String =>
+  test("""\E X \in SUBSET {1, 2}: {} = {x \in X : [y \in {1} |-> TRUE][x]}""") { rewriterType: SMTEncoding =>
     // regression
     val set1 = enumSet(int(1)) as intSetT
     val pred = appFun(funDef(bool(true), name("y") as intT, set1) as intToBoolT, name("x") as intT) as boolT
@@ -607,7 +608,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""3 \in {x \in {2, 3} : x % 2 = 0}""") { rewriterType: String =>
+  test("""3 \in {x \in {2, 3} : x % 2 = 0}""") { rewriterType: SMTEncoding =>
     val set = enumSet(int(2), int(3)) as intSetT
     val xMod2 = mod(name("x") as intT, int(2)) as intT
     val pred = eql(xMod2, int(0)) as boolT
@@ -631,7 +632,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{ x / 3: x \in {1,2,3,4} }""") { rewriterType: String =>
+  test("""{ x / 3: x \in {1,2,3,4} }""") { rewriterType: SMTEncoding =>
     val set = enumSet(1 to 4 map int: _*) as intSetT
     val mapping = div(name("x") as intT, int(3)) as intT
     val mappedSet = map(mapping, name("x") as intT, set) as intSetT
@@ -648,7 +649,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""0 \in {x / 3: x \in {1,2,3,4}}""") { rewriterType: String =>
+  test("""0 \in {x / 3: x \in {1,2,3,4}}""") { rewriterType: SMTEncoding =>
     val set = enumSet(1 to 4 map int: _*) as intSetT
     val mapping = div(name("x") as intT, int(3)) as intT
     val mappedSet = map(mapping, name("x") as intT, set) as intSetT
@@ -671,7 +672,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""2 \in {x / 3: x \in {1,2,3,4}}""") { rewriterType: String =>
+  test("""2 \in {x / 3: x \in {1,2,3,4}}""") { rewriterType: SMTEncoding =>
     val set = enumSet(1 to 4 map int: _*) as intSetT
     val mapping = div(name("x") as intT, int(3)) as intT
     val mappedSet = map(mapping, name("x") as intT, set) as intSetT
@@ -695,7 +696,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   // type inference would reject this
-  test("""error: {x: x \in Int}""") { rewriterType: String =>
+  test("""error: {x: x \in Int}""") { rewriterType: SMTEncoding =>
     val set = intSet() as intSetT
     val mapSet = map(name("x") as intT, name("x") as intT, set) as intSetT
 
@@ -704,7 +705,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     assertThrows[TlaInputError](rewriter.rewriteUntilDone(state))
   }
 
-  test("""<<2, true>> \in {<<x, y>>: x \in {1,2,3}, y \in {FALSE, TRUE}}""") { rewriterType: String =>
+  test("""<<2, true>> \in {<<x, y>>: x \in {1,2,3}, y \in {FALSE, TRUE}}""") { rewriterType: SMTEncoding =>
     val set123 = enumSet(1 to 3 map int: _*) as intSetT
     val setBool = enumSet(bool(false), bool(true)) as boolSetT
     val mapping = tuple(name("x") as intT, name("y") as boolT) as intBoolT
@@ -728,7 +729,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""<<TRUE>> \in {<<y>>: x \in {1,2} \ {2}, y \in {FALSE, TRUE}}""") { rewriterType: String =>
+  test("""<<TRUE>> \in {<<y>>: x \in {1,2} \ {2}, y \in {FALSE, TRUE}}""") { rewriterType: SMTEncoding =>
     // this expression tests regressions in cached expressions
     // we express {1, 2} \ {2} as a filter, as set difference is not in KerA+
     val set12minus2 =
@@ -759,7 +760,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
 
   // Regression for the issue 365: https://github.com/informalsystems/apalache/issues/365
   test("""MAP: \E S \in SUBSET { [a: "a", b: 1], [a: "a", b: 2] }:  "a" \in { r.a: r \in S }""") {
-    rewriterType: String =>
+    rewriterType: SMTEncoding =>
       // this test reveals a deep bug in the encoding: SUBSET {[a: 1, b: 1], [a: 1, b: 2]} produces a powerset,
       // whose elements are sets that refer to the same cells,
       // namely the cells for the records [a: 1, b: 1] and [a: 1, b: 2].
@@ -802,7 +803,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       assumeTlaEx(rewriter2, state2)
   }
 
-  test("""{1, 3} \cup {3, 4} = {1, 3, 4}""") { rewriterType: String =>
+  test("""{1, 3} \cup {3, 4} = {1, 3, 4}""") { rewriterType: SMTEncoding =>
     val left = enumSet(int(1), int(3)) as intSetT
     val right = enumSet(int(3), int(4)) as intSetT
     val expected = enumSet(int(1), int(3), int(4)) as intSetT
@@ -828,7 +829,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{1, 2} \subseteq {1, 2, 3} ~~> (true)""") { rewriterType: String =>
+  test("""{1, 2} \subseteq {1, 2, 3} ~~> (true)""") { rewriterType: SMTEncoding =>
     val left = enumSet(int(1), int(2)) as intSetT
     val right = enumSet(int(1), int(2), int(3)) as intSetT
     val ex = subseteq(left, right) as boolT
@@ -850,7 +851,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{1, 2, 3} \subseteq {1, 2, 3} ~~> (true)""") { rewriterType: String =>
+  test("""{1, 2, 3} \subseteq {1, 2, 3} ~~> (true)""") { rewriterType: SMTEncoding =>
     val right = enumSet(int(1), int(2), int(3)) as intSetT
     val ex = subseteq(right, right) as boolT
     val state = new SymbState(ex, arena, Binding())
@@ -871,7 +872,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{} \subseteq {1, 2, 3} ~~> (true)""") { rewriterType: String =>
+  test("""{} \subseteq {1, 2, 3} ~~> (true)""") { rewriterType: SMTEncoding =>
     val right = enumSet(int(1), int(2), int(3)) as intSetT
     // an empty set requires a type annotation
     val ex = subseteq(enumSet() as intSetT, right) as boolT
@@ -893,7 +894,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""{1, 4} \subseteq {1, 2, 3} ~~> (false)""") { rewriterType: String =>
+  test("""{1, 4} \subseteq {1, 2, 3} ~~> (false)""") { rewriterType: SMTEncoding =>
     val left = enumSet(int(1), int(4)) as intSetT
     val right = enumSet(int(1), int(2), int(3)) as intSetT
     val ex = subseteq(left, right) as boolT
@@ -915,7 +916,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
-  test("""UNION {{1, 2}, {2,3}} = {1, 2, 3}""") { rewriterType: String =>
+  test("""UNION {{1, 2}, {2,3}} = {1, 2, 3}""") { rewriterType: SMTEncoding =>
     val setOf12 = enumSet(int(1), int(2)) as intSetT
     val setOf23 = enumSet(int(3), int(2)) as intSetT
     val setOf123 = enumSet(int(1), int(2), int(3)) as intSetT

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
@@ -1,11 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, StrT1}
 
 trait TestSymbStateRewriterStr extends RewriterBase {
-  test(""" rewrite "red" """) { rewriterType: String =>
+  test(""" rewrite "red" """) { rewriterType: SMTEncoding =>
     val string = str("red").typed(StrT1())
     val neq = not(eql(str("red"), str("blue")).typed(BoolT1()))
       .typed(BoolT1())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.{BoolT1, StrT1}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.TlcOper

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTlc.scala
@@ -1,12 +1,13 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.TlcOper
 import at.forsyte.apalache.tla.lir._
 
 trait TestSymbStateRewriterTlc extends RewriterBase {
-  test("SE-TLC-PRINT: PRINT(...) -> TRUE") { rewriterType: String =>
+  test("SE-TLC-PRINT: PRINT(...) -> TRUE") { rewriterType: SMTEncoding =>
     // Builder does not have a standard method for TLC!Print, as we do not construct internally
     val print = OperEx(TlcOper.print, int(1).typed(), str("hello").typed())(Typed(StrT1()))
     val state = new SymbState(print, arena, Binding())
@@ -22,7 +23,7 @@ trait TestSymbStateRewriterTlc extends RewriterBase {
     }
   }
 
-  test("SE-TLC-PRINT: PRINTT(...) -> TRUE") { rewriterType: String =>
+  test("SE-TLC-PRINT: PRINTT(...) -> TRUE") { rewriterType: SMTEncoding =>
     // Builder does not have a standard method for TLC!PrintT, as we do not construct internally
     val print = OperEx(TlcOper.printT, str("hello").typed())(Typed(StrT1()))
     val state = new SymbState(print, arena, Binding())
@@ -38,7 +39,7 @@ trait TestSymbStateRewriterTlc extends RewriterBase {
     }
   }
 
-  test("SE-TLC-ASSERT: Assert(TRUE, _) -> reach") { rewriterType: String =>
+  test("SE-TLC-ASSERT: Assert(TRUE, _) -> reach") { rewriterType: SMTEncoding =>
     // Builder does not have a standard method for TLC!Assert, as we do not construct internally
     val assertEx = OperEx(TlcOper.assert, bool(true).typed(), str("oops").typed())(Typed(BoolT1()))
     val state = new SymbState(assertEx, arena, Binding())
@@ -54,7 +55,7 @@ trait TestSymbStateRewriterTlc extends RewriterBase {
     }
   }
 
-  test("SE-TLC-ASSERT: Assert(FALSE, _) -> TRUE") { rewriterType: String =>
+  test("SE-TLC-ASSERT: Assert(FALSE, _) -> TRUE") { rewriterType: SMTEncoding =>
     // Builder does not have a standard method for TLC!Assert, as we do not construct internally
     val assertEx = OperEx(TlcOper.assert, bool(false).typed(), str("oops").typed())(Typed(BoolT1()))
     val state = new SymbState(assertEx, arena, Binding())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, StrT1, TupT1}
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -16,7 +17,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
       "ibI" -> TupT1(IntT1(), BoolT1(), SetT1(IntT1()))
   )
 
-  test("""<<1, FALSE, {2}>>""") { rewriterType: String =>
+  test("""<<1, FALSE, {2}>>""") { rewriterType: SMTEncoding =>
     val tup = tuple(int(1), bool(false), enumSet(int(2)) ? "I")
       .typed(types, "ibI")
 
@@ -25,7 +26,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test(""" <<1, FALSE, {2}>>[2] returns FALSE""") { rewriterType: String =>
+  test(""" <<1, FALSE, {2}>>[2] returns FALSE""") { rewriterType: SMTEncoding =>
     val tup = tuple(int(1), bool(false), enumSet(int(2)) ? "I")
     val tupleAcc = appFun(tup ? "ibI", int(2))
       .typed(types, "b")
@@ -36,7 +37,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
-  test("""{<<1, FALSE>>, <<2, TRUE>>} works""") { rewriterType: String =>
+  test("""{<<1, FALSE>>, <<2, TRUE>>} works""") { rewriterType: SMTEncoding =>
     val tuple1 = tuple(int(1), bool(false))
     val tuple2 = tuple(int(2), bool(true))
     val tupleSet = enumSet(tuple1 ? "ib", tuple2 ? "ib")
@@ -47,7 +48,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
     assert(solverContext.sat())
   }
 
-  test("""~(<<2, FALSE>> = <<2, TRUE>>)""") { rewriterType: String =>
+  test("""~(<<2, FALSE>> = <<2, TRUE>>)""") { rewriterType: SMTEncoding =>
     val tuple1 = tuple(int(2), bool(false))
     val tuple2 = tuple(int(2), bool(true))
     val eq = not(eql(tuple1 ? "ib", tuple2 ? "ib") ? "b")
@@ -58,7 +59,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""<<2, FALSE>> = <<2, FALSE>>""") { rewriterType: String =>
+  test("""<<2, FALSE>> = <<2, FALSE>>""") { rewriterType: SMTEncoding =>
     val tuple1 = tuple(int(2), bool(false))
     val tuple2 = tuple(int(2), bool(false))
     val eq = eql(tuple1 ? "ib", tuple2 ? "ib")
@@ -69,7 +70,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""DOMAIN <<2, FALSE, "c">> = {1, 2, 3}""") { rewriterType: String =>
+  test("""DOMAIN <<2, FALSE, "c">> = {1, 2, 3}""") { rewriterType: SMTEncoding =>
     val tup = tuple(int(2), bool(false), str("c"))
     val set123 = enumSet(1.to(3) map int: _*)
     val eq = eql(dom(tup ? "ibs") ? "I", set123 ? "I")
@@ -79,7 +80,7 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""[ <<1, FALSE>> EXCEPT ![1] = 3 ]""") { rewriterType: String =>
+  test("""[ <<1, FALSE>> EXCEPT ![1] = 3 ]""") { rewriterType: SMTEncoding =>
     val tup = tuple(int(1), bool(false))
     val newTuple = except(tup ? "ib", tuple(int(1)) ? "(i)", int(3))
       .typed(types, "ib")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, StrT1, TupT1}
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.TypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
 import at.forsyte.apalache.tla.lir.TestingPredefs
@@ -7,7 +8,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
-  test("""Propositional Oracle.create""") { rewriterType: String =>
+  test("""Propositional Oracle.create""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -15,7 +16,7 @@ trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
     assert(solverContext.sat())
   }
 
-  test("""Propositional Oracle.whenEqualTo""") { rewriterType: String =>
+  test("""Propositional Oracle.whenEqualTo""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -27,7 +28,7 @@ trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
     assert(!solverContext.sat())
   }
 
-  test("""Propositional Oracle.evalPosition""") { rewriterType: String =>
+  test("""Propositional Oracle.evalPosition""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -39,7 +40,7 @@ trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
     assert(3 == position)
   }
 
-  test("""Propositional Oracle.caseAssertions""") { rewriterType: String =>
+  test("""Propositional Oracle.caseAssertions""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     state = state.updateArena(_.appendCell(BoolT()))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
@@ -1,8 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
-import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
+import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SMTEncoding, SymbState}
 import at.forsyte.apalache.tla.lir.TestingPredefs
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
 import at.forsyte.apalache.tla.lir.TestingPredefs
@@ -7,7 +8,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 trait TestSparseOracle extends RewriterBase with TestingPredefs {
-  test("""Sparse Oracle.create""") { rewriterType: String =>
+  test("""Sparse Oracle.create""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -16,7 +17,7 @@ trait TestSparseOracle extends RewriterBase with TestingPredefs {
     assert(solverContext.sat())
   }
 
-  test("""Sparse Oracle.whenEqualTo""") { rewriterType: String =>
+  test("""Sparse Oracle.whenEqualTo""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -27,7 +28,7 @@ trait TestSparseOracle extends RewriterBase with TestingPredefs {
     assert(solverContext.sat())
   }
 
-  test("""Sparse Oracle.evalPosition""") { rewriterType: String =>
+  test("""Sparse Oracle.evalPosition""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -40,7 +41,7 @@ trait TestSparseOracle extends RewriterBase with TestingPredefs {
     assert(5 == position)
   }
 
-  test("""Sparse Oracle.caseAssertions""") { rewriterType: String =>
+  test("""Sparse Oracle.caseAssertions""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     state = state.updateArena(_.appendCell(BoolT()))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
@@ -1,8 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
-import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
+import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SMTEncoding, SymbState}
 import at.forsyte.apalache.tla.lir.TestingPredefs
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
 import at.forsyte.apalache.tla.lir.TestingPredefs
@@ -7,7 +8,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
-  test("""UninterpretedConst Oracle.create""") { rewriterType: String =>
+  test("""UninterpretedConst Oracle.create""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -15,7 +16,7 @@ trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
     assert(solverContext.sat())
   }
 
-  test("""UninterpretedConst Oracle.whenEqualTo""") { rewriterType: String =>
+  test("""UninterpretedConst Oracle.whenEqualTo""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -27,7 +28,7 @@ trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
     assert(!solverContext.sat())
   }
 
-  test("""UninterpretedConst Oracle.evalPosition""") { rewriterType: String =>
+  test("""UninterpretedConst Oracle.evalPosition""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
@@ -39,7 +40,7 @@ trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
     assert(3 == position)
   }
 
-  test("""UninterpretedConst Oracle.caseAssertions""") { rewriterType: String =>
+  test("""UninterpretedConst Oracle.caseAssertions""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
     var state = new SymbState(tla.bool(true), arena, Binding())
     state = state.updateArena(_.appendCell(BoolT()))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
@@ -1,8 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
-import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
+import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SMTEncoding, SymbState}
 import at.forsyte.apalache.tla.lir.TestingPredefs
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithArrays.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
+import at.forsyte.apalache.tla.bmcmt.arraysEncoding
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithArrays.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
@@ -8,7 +8,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TestRecordingSolverContextWithArrays extends TestRecordingSolverContext {
   override protected def withFixture(test: OneArgTest): Outcome = {
-    solverConfig = SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = arraysEncodingType)
+    solverConfig = SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = arraysEncoding)
     test()
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
+import at.forsyte.apalache.tla.bmcmt.oopsla19Encoding
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
@@ -8,7 +8,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TestRecordingSolverContextWithOOPSLA19 extends TestRecordingSolverContext {
   override protected def withFixture(test: OneArgTest): Outcome = {
-    solverConfig = SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19EncodingType)
+    solverConfig = SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding)
     test()
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
@@ -18,8 +18,8 @@ class TestTransitionExecutorWithIncrementalAndOOPSLA19
     extends TestTransitionExecutorImpl[IncrementalExecutionContextSnapshot]
     with TestFilteredTransitionExecutor[IncrementalExecutionContextSnapshot] {
   override protected def withFixture(test: OneArgTest): Outcome = {
-    val solver = new Z3SolverContext(SolverConfig(debug = false, profile = false, randomSeed = 0,
-            smtEncoding = oopsla19EncodingType))
+    val solver =
+      new Z3SolverContext(SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding))
     val rewriter = new SymbStateRewriterImpl(solver, new ExprGradeStoreImpl())
     val exeCtx = new IncrementalExecutionContext(rewriter)
     try {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndOOPSLA19.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
-import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
+import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl, oopsla19Encoding}
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndOOPSLA19.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
-import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
+import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl, oopsla19Encoding}
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import org.junit.runner.RunWith

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndOOPSLA19.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.EncodingBase._
+import at.forsyte.apalache.tla.bmcmt.SMTEncodings._
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
@@ -17,7 +17,7 @@ import org.scalatest.junit.JUnitRunner
 class TestTransitionExecutorWithOfflineAndOOPSLA19 extends TestTransitionExecutorImpl[OfflineExecutionContextSnapshot] {
   override protected def withFixture(test: OneArgTest): Outcome = {
     val solver = RecordingSolverContext.createZ3(None,
-        SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19EncodingType))
+        SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding))
     val rewriter = new SymbStateRewriterImpl(solver, new ExprGradeStoreImpl())
     val exeCtx = new OfflineExecutionContext(rewriter)
     try {


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

This PR makes the the SMT encoding options global constants (see `SMTEncodings`). The bulk of the changes relates to enabling access to the new global constants. Regarding the use of the correct encoding for symbolic state rewriter instantiations, all such uses are already guarded; every instantiation, current and future, needs to check the encoding flag to select the appropriate rewriter class, so this is a non-issue. Closes #1159.