### PR TITLE
Replace implactions by ITE in array updates in set union rule

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Bug fixes
 
 * Fix the use of set minus in the array encoding, see #1152
+* Fix the use of set union in the array encoding, see #1162

--- a/test/tla/SetAddDel.tla
+++ b/test/tla/SetAddDel.tla
@@ -1,0 +1,40 @@
+---------------------------- MODULE SetAddDel --------------------------
+\* A regression test for the use of set union, see:
+\* https://github.com/informalsystems/apalache/issues/1162
+
+\* In this parametric example we have N values, and a set variable, initially empty.
+\* At each step we can add one element to the set, or remove one element from the set.
+\* The invariant specifies that the set is not complete,
+\* i.e., we ask whether a state where the set contains all the values is reachable.
+\* This final configuration is reachable in exactly N steps.
+\*
+\* Andrey Kuprianov and Shon Feder, 2020
+
+EXTENDS FiniteSets, Naturals
+
+CONSTANT
+  \* @type: Set(Int);
+  Values
+
+VARIABLE
+  \* @type: Set(Int);
+  set
+
+CInit == Values = 0..6
+
+Init ==
+  set = {}
+
+AddOne ==
+  \E x \in (Values \ set) : set' = set \union {x}
+
+DelOne ==
+  \E x \in set : set' = set \ {x}
+
+Next ==
+ \/ AddOne
+ \/ DelOne
+
+Inv == set /= Values
+
+=============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1131,6 +1131,17 @@ $ apalache-mc check --inv=Inv --length=6 --cinit=CInit SetSndRcv.tla | sed 's/I@
 EXITCODE: OK
 ```
 
+### check SetAddDel succeeds (array-encoding)
+
+Regression test for https://github.com/informalsystems/apalache/issues/1162
+Sets should not become unconstrained when union is performed.
+
+```sh
+$ apalache-mc check --inv=Inv --length=6 --cinit=CInit SetAddDel.tla | sed 's/I@.*//'
+...
+EXITCODE: OK
+```
+
 ## configure the check command
 
 Testing various flags that are set via command-line options and the TLC configuration file. The CLI has priority over

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -56,14 +56,16 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
         def addOnlyCellCons(thisSet: ArenaCell, thisElem: ArenaCell): Unit = {
           val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, thisSet.toNameEx)
           val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          rewriter.solverContext.assertGroundExpr(tla.equiv(inCup, inThis))
+          val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
+          rewriter.solverContext.assertGroundExpr(tla.ite(inThis, inCup, notInCup))
         }
 
         def addEitherCellCons(thisElem: ArenaCell): Unit = {
           val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, leftSetCell.toNameEx)
           val inOther = tla.apalacheSelectInSet(thisElem.toNameEx, rightSetCell.toNameEx)
           val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          rewriter.solverContext.assertGroundExpr(tla.equiv(inCup, tla.or(inThis, inOther)))
+          val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
+          rewriter.solverContext.assertGroundExpr(tla.ite(tla.or(inThis, inOther), inCup, notInCup))
         }
 
         // new implementation: as we are not using uninterpreted functions anymore, we do not have to care about


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

It seems that the only remaining incorrect use of implications when dealing with SMT arrays is in set union rule, which is fixed by this PR. Occurrences of implications in rules not yet supported by the arrays encoding will be looked at when these rules are reworked. Closes #1162.