### PR TITLE
New test scenarios for Normalizer

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Bug fixes
 
 * Fix the use of set union in the array encoding, see #1162
+* Fix preprocesor's normalization of negated temporal formulas and negated `LET .. IN` expressions, see #1165

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
@@ -193,14 +193,16 @@ class Normalizer(tracker: TransformationTracker) extends TlaExTransformation {
       }
 
     case letIn @ LetInEx(body, defs @ _*) =>
+      // always normalize the bodies of the definitions
+      def transformDef(decl: TlaOperDecl): TlaOperDecl = decl.copy(body = transform(decl.body))
+      val normalizedDefs = defs map transformDef
+
       if (neg) {
         // a negation of the let body
-        nnfLetIn(neg, body, defs)
+        nnfLetIn(neg, body, normalizedDefs)
       } else {
-        // no negation, simply normalize the body and the bodies of the definitions
-        def transformDef(decl: TlaOperDecl): TlaOperDecl = decl.copy(body = transform(decl.body))
-
-        LetInEx(transform(body), defs map transformDef: _*)(letIn.typeTag)
+        // no negation, simply normalize the body
+        LetInEx(transform(body), normalizedDefs: _*)(letIn.typeTag)
       }
 
     case ex @ OperEx(oper, args @ _*) =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
@@ -159,9 +159,9 @@ class Normalizer(tracker: TransformationTracker) extends TlaExTransformation {
 
     case ex @ OperEx(TlaTempOper.box, args @ _*) =>
       if (!neg) {
-        OperEx(TlaTempOper.box, args map nnf(true): _*)(ex.typeTag)
+        OperEx(TlaTempOper.box, args map transform: _*)(ex.typeTag)
       } else {
-        OperEx(TlaTempOper.diamond, args map transform: _*)(ex.typeTag)
+        OperEx(TlaTempOper.diamond, args map nnf(true): _*)(ex.typeTag)
       }
 
     case ex @ OperEx(TlaTempOper.leadsTo, args @ _*) =>

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -237,18 +237,39 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
 
   test("""unchanged cases""") {
     val expressions = List(
-        // x ~> y
-        tla.leadsTo(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()
-        // TODO: Add remaining unchanged scenarios
+        // x ~> y and negation
+        tla.leadsTo(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1(),
+        tla.not(tla.leadsTo(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1(),
+        // x -+-> y and negation
+        tla.guarantees(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1(),
+        tla.not(tla.guarantees(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1(),
+        // WF_<x>(y) and negation
+        tla.WF(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1(),
+        tla.not(tla.WF(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1(),
+        // SF_<x>(y) and negation
+        tla.SF(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1(),
+        tla.not(tla.SF(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1(),
+        // \E x \in s . y
+        tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.name("y") as BoolT1()) as BoolT1(),
+        // \A x \in s . y
+        tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.name("y") as BoolT1()) as BoolT1(),
+        // x < y
+        tla.lt(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1(),
+        // x <= y
+        tla.le(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1(),
+        // x > y
+        tla.gt(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1(),
+        // x >= y
+        tla.ge(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1(),
+        // x = y
+        tla.eql(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1(),
+        // x \in s
+        tla.in(tla.name("x") as BoolT1(), tla.name("s") as SetT1(BoolT1())) as BoolT1()
     )
 
     expressions.foreach({ expression =>
       val output = normalizer.apply(expression)
       assert(expression == output)
-
-      val negatedExpression = tla.not(expression) as BoolT1()
-      val negatedOutput = normalizer.apply(negatedExpression)
-      assert(negatedExpression == negatedOutput)
     })
   }
 }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -246,13 +246,12 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
     assert(expected == output)
   }
 
-  test("""~ (LET x = ~FALSE IN ~x ~~> LET x = ~FALSE IN x)""") {
+  test("""~ (LET x = ~FALSE IN ~x ~~> LET x = TRUE IN x)""") {
     val decl = tla.declOp("x", tla.not(tla.bool(false)) as BoolT1()) as BoolT1()
     val input = tla.not(tla.letIn(tla.not(tla.name("x") as BoolT1()) as BoolT1(), decl) as BoolT1()) as BoolT1()
     val output = normalizer.apply(input)
-    println(output)
 
-    val expectedDecl = tla.declOp("x", tla.not(tla.bool(false)) as BoolT1()) as BoolT1()
+    val expectedDecl = tla.declOp("x", tla.bool(true)) as BoolT1()
     val expected =
       tla.letIn(tla.name("x") as BoolT1(), expectedDecl) as BoolT1()
     assert(expected == output)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -38,6 +38,30 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
     assert(expected == output)
   }
 
+  test("""~ IF x THEN y ELSE z ~~> IF x THEN ~y ELSE ~z""") {
+    val input = tla
+      .not(
+          tla.ite(
+              tla.name("x") ? "b",
+              tla.name("y") ? "b",
+              tla.name("z") ? "b"
+          ) ? "b"
+      )
+      .typed(types, "b")
+
+    val output = normalizer.apply(input)
+
+    val expected = tla
+      .ite(
+          tla.name("x") ? "b",
+          tla.not(tla.name("y") ? "b") ? "b",
+          tla.not(tla.name("z") ? "b") ? "b"
+      )
+      .typed(types, "b")
+
+    assert(expected == output)
+  }
+
   test("""~(x /\ y) ~~> ~x \/ ~y""") {
     val input =
       tla
@@ -63,4 +87,32 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
         .typed(types, "b")
     assert(expected == output)
   }
+
+  test("""x => y ~~> ~x \/ y""") {}
+
+  test("""~ (x => y) ~~> x /\ ~y""") {}
+
+  test("""(~FALSE <=> x) ~~> TRUE <=> x""") {}
+
+  test("""~ (~FALSE <=> x) ~~> TRUE \neq x""") {}
+
+  test("""~ \E x \in s . y ~~> \A x \in s . ~y""") {}
+
+  test("""~ \A x \in s . y ~~> \E x \in s . ~y""") {}
+
+  test("""~ (x < y) ~~> x >= y""") {}
+
+  test("""~ (x <= y) ~~> x > y""") {}
+
+  test("""~ (x > y) ~~> x <= y""") {}
+
+  test("""~ (x >= y) ~~> x < y""") {}
+
+  test("""~(x \neq y) ~~> x <=> y""") {}
+
+  test("""~(~FALSE \in s) ~~> ~(TRUE \in s)""") {}
+
+  test("""~<>x ~~> []~x""") {}
+
+  test("""~[]x ~~> <>x""") {}
 }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -1,6 +1,8 @@
 package at.forsyte.apalache.tla.pp
 
 import at.forsyte.apalache.tla.lir.BoolT1
+import at.forsyte.apalache.tla.lir.SetT1
+import at.forsyte.apalache.tla.lir.IntT1
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -18,8 +20,6 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
     normalizer = new Normalizer(new IdleTracker())
   }
 
-  // TODO: we need a complete coverage. Schedule for #649.
-
   test("""~FALSE ~~> TRUE""") {
     val input = tla
       .not(tla.bool(true))
@@ -31,7 +31,7 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
 
   test("""~~x ~~> x""") {
     val input = tla
-      .not(tla.not(tla.name("x") ? "b") ? "b")
+      .not(tla.not(tla.name("x") as BoolT1()) as BoolT1())
       .typed(types, "b")
     val output = normalizer.apply(input)
     val expected = tla.name("x").typed(BoolT1())
@@ -42,22 +42,20 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
     val input = tla
       .not(
           tla.ite(
-              tla.name("x") ? "b",
-              tla.name("y") ? "b",
-              tla.name("z") ? "b"
-          ) ? "b"
-      )
-      .typed(types, "b")
+              tla.name("x") as BoolT1(),
+              tla.name("y") as BoolT1(),
+              tla.name("z") as BoolT1()
+          ) as BoolT1()
+      ) as BoolT1()
 
     val output = normalizer.apply(input)
 
     val expected = tla
       .ite(
-          tla.name("x") ? "b",
-          tla.not(tla.name("y") ? "b") ? "b",
-          tla.not(tla.name("z") ? "b") ? "b"
-      )
-      .typed(types, "b")
+          tla.name("x") as BoolT1(),
+          tla.not(tla.name("y") as BoolT1()) as BoolT1(),
+          tla.not(tla.name("z") as BoolT1()) as BoolT1()
+      ) as BoolT1()
 
     assert(expected == output)
   }
@@ -65,12 +63,12 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
   test("""~(x /\ y) ~~> ~x \/ ~y""") {
     val input =
       tla
-        .not(tla.and(tla.name("x") ? "b", tla.name("y") ? "b") ? "b")
+        .not(tla.and(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1())
         .typed(types, "b")
     val output = normalizer.apply(input)
     val expected =
       tla
-        .or(tla.not(tla.name("x") ? "b") ? "b", tla.not(tla.name("y") ? "b") ? "b")
+        .or(tla.not(tla.name("x") as BoolT1()) as BoolT1(), tla.not(tla.name("y") as BoolT1()) as BoolT1())
         .typed(types, "b")
     assert(expected == output)
   }
@@ -78,41 +76,159 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
   test("""~(x \/ y) ~~> ~x /\ ~y""") {
     val input =
       tla
-        .not(tla.or(tla.name("x") ? "b", tla.name("y") ? "b") ? "b")
+        .not(tla.or(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1())
         .typed(types, "b")
     val output = normalizer.apply(input)
     val expected =
       tla
-        .and(tla.not(tla.name("x") ? "b") ? "b", tla.not(tla.name("y") ? "b") ? "b")
+        .and(tla.not(tla.name("x") as BoolT1()) as BoolT1(), tla.not(tla.name("y") as BoolT1()) as BoolT1())
         .typed(types, "b")
     assert(expected == output)
   }
 
-  test("""x => y ~~> ~x \/ y""") {}
+  test("""x => y ~~> ~x \/ y""") {
+    val input =
+      tla.impl(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla
+        .or(tla.not(tla.name("x") as BoolT1()) as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ (x => y) ~~> x /\ ~y""") {}
+  test("""~ (x => y) ~~> x /\ ~y""") {
+    val input =
+      tla.not(tla.impl(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla
+        .and(tla.name("x") as BoolT1(), tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""(~FALSE <=> x) ~~> TRUE <=> x""") {}
+  test("""(~FALSE <=> x) ~~> TRUE = x""") {
+    val input =
+      tla.equiv(tla.not(tla.bool(false)) as BoolT1(), tla.name("x") as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.eql(tla.bool(true), tla.name("x") as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ (~FALSE <=> x) ~~> TRUE \neq x""") {}
+  test("""~ (~FALSE <=> x) ~~> TRUE /= x""") {
+    val input =
+      tla
+        .not(tla.equiv(tla.not(tla.bool(false)) as BoolT1(), tla.name("x") as BoolT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.neql(tla.bool(true), tla.name("x") as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ \E x \in s . y ~~> \A x \in s . ~y""") {}
+  test("""~ \E x \in s . y ~~> \A x \in s . ~y""") {
+    val input =
+      tla.not(tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ \A x \in s . y ~~> \E x \in s . ~y""") {}
+  test("""~ \A x \in s . y ~~> \E x \in s . ~y""") {
+    val input =
+      tla.not(tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ (x < y) ~~> x >= y""") {}
+  test("""~ (x < y) ~~> x >= y""") {
+    val input =
+      tla.not(tla.lt(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.ge(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ (x <= y) ~~> x > y""") {}
+  test("""~ (x <= y) ~~> x > y""") {
+    val input =
+      tla.not(tla.le(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.gt(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ (x > y) ~~> x <= y""") {}
+  test("""~ (x > y) ~~> x <= y""") {
+    val input =
+      tla.not(tla.gt(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.le(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~ (x >= y) ~~> x < y""") {}
+  test("""~ (x >= y) ~~> x < y""") {
+    val input =
+      tla.not(tla.ge(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.lt(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~(x \neq y) ~~> x <=> y""") {}
+  test("""~(x /= y) ~~> x = y""") {
+    val input =
+      tla.not(tla.neql(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.eql(tla.name("x") as IntT1(), tla.name("y") as IntT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~(~FALSE \in s) ~~> ~(TRUE \in s)""") {}
+  test("""~(~FALSE \in s) ~~> ~(TRUE \in s)""") {
+    val input =
+      tla.not(tla.in(tla.not(tla.bool(false)) as BoolT1(), tla.name("s") as SetT1(IntT1())) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.not(tla.in(tla.bool(true), tla.name("s") as SetT1(IntT1())) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~<>x ~~> []~x""") {}
+  test("""~<>x ~~> []~x""") {
+    val input =
+      tla.not(tla.diamond(tla.name("x") as BoolT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.box(tla.not(tla.name("x") as BoolT1()) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
 
-  test("""~[]x ~~> <>x""") {}
+  test("""~[]x ~~> <>~x""") {
+    val input =
+      tla.not(tla.box(tla.name("x") as BoolT1()) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.diamond(tla.not(tla.name("x") as BoolT1()) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
+
+  test("""unchanged cases""") {
+    val expressions = List(
+      // x ~> y
+      tla.leadsTo(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1(),
+      // TODO: Add remaining unchanged scenarios
+    )
+
+    expressions.foreach({ expression =>
+                          val output = normalizer.apply(expression)
+                          assert(expression == output)
+
+                          val negatedExpression = tla.not(expression) as BoolT1()
+                          val negatedOutput = normalizer.apply(negatedExpression)
+                          assert(negatedExpression == negatedOutput)
+                        })
+  }
 }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -127,19 +127,23 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
 
   test("""~ \E x \in s . y ~~> \A x \in s . ~y""") {
     val input =
-      tla.not(tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+      tla.not(tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()),
+              tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
     val output = normalizer.apply(input)
     val expected =
-      tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+      tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()),
+          tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
     assert(expected == output)
   }
 
   test("""~ \A x \in s . y ~~> \E x \in s . ~y""") {
     val input =
-      tla.not(tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+      tla.not(tla.forall(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()),
+              tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
     val output = normalizer.apply(input)
     val expected =
-      tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()), tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
+      tla.exists(tla.name("x") as BoolT1(), tla.name("s") as SetT1(IntT1()),
+          tla.not(tla.name("y") as BoolT1()) as BoolT1()) as BoolT1()
     assert(expected == output)
   }
 
@@ -217,18 +221,18 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
 
   test("""unchanged cases""") {
     val expressions = List(
-      // x ~> y
-      tla.leadsTo(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1(),
-      // TODO: Add remaining unchanged scenarios
+        // x ~> y
+        tla.leadsTo(tla.name("x") as BoolT1(), tla.name("y") as BoolT1()) as BoolT1()
+        // TODO: Add remaining unchanged scenarios
     )
 
     expressions.foreach({ expression =>
-                          val output = normalizer.apply(expression)
-                          assert(expression == output)
+      val output = normalizer.apply(expression)
+      assert(expression == output)
 
-                          val negatedExpression = tla.not(expression) as BoolT1()
-                          val negatedOutput = normalizer.apply(negatedExpression)
-                          assert(negatedExpression == negatedOutput)
-                        })
+      val negatedExpression = tla.not(expression) as BoolT1()
+      val negatedOutput = normalizer.apply(negatedExpression)
+      assert(negatedExpression == negatedOutput)
+    })
   }
 }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -235,6 +235,29 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
     assert(expected == output)
   }
 
+  test("""LET x = ~FALSE IN ~~x ~~> LET x = TRUE IN x""") {
+    val decl = tla.declOp("x", tla.not(tla.bool(false)) as BoolT1()) as BoolT1()
+    val input = tla.letIn(tla.not(tla.not(tla.name("x") as BoolT1()) as BoolT1()) as BoolT1(), decl) as BoolT1()
+    val output = normalizer.apply(input)
+
+    val expectedDecl = tla.declOp("x", tla.bool(true)) as BoolT1()
+    val expected =
+      tla.letIn(tla.name("x") as BoolT1(), expectedDecl) as BoolT1()
+    assert(expected == output)
+  }
+
+  test("""~ (LET x = ~FALSE IN ~x ~~> LET x = ~FALSE IN x)""") {
+    val decl = tla.declOp("x", tla.not(tla.bool(false)) as BoolT1()) as BoolT1()
+    val input = tla.not(tla.letIn(tla.not(tla.name("x") as BoolT1()) as BoolT1(), decl) as BoolT1()) as BoolT1()
+    val output = normalizer.apply(input)
+    println(output)
+
+    val expectedDecl = tla.declOp("x", tla.not(tla.bool(false)) as BoolT1()) as BoolT1()
+    val expected =
+      tla.letIn(tla.name("x") as BoolT1(), expectedDecl) as BoolT1()
+    assert(expected == output)
+  }
+
   test("""unchanged cases""") {
     val expressions = List(
         // x ~> y and negation

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestNormalizer.scala
@@ -194,10 +194,26 @@ class TestNormalizer extends FunSuite with BeforeAndAfterEach {
 
   test("""~(~FALSE \in s) ~~> ~(TRUE \in s)""") {
     val input =
-      tla.not(tla.in(tla.not(tla.bool(false)) as BoolT1(), tla.name("s") as SetT1(IntT1())) as BoolT1()) as BoolT1()
+      tla.not(tla.in(tla.not(tla.bool(false)) as BoolT1(), tla.name("s") as SetT1(BoolT1())) as BoolT1()) as BoolT1()
     val output = normalizer.apply(input)
     val expected =
-      tla.not(tla.in(tla.bool(true), tla.name("s") as SetT1(IntT1())) as BoolT1()) as BoolT1()
+      tla.not(tla.in(tla.bool(true), tla.name("s") as SetT1(BoolT1())) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
+
+  test("""(~FALSE \notin s) ~~> ~(TRUE \in s)""") {
+    val input =
+      tla.notin(tla.not(tla.bool(false)) as BoolT1(), tla.name("s") as SetT1(BoolT1())) as BoolT1()
+    val output = normalizer.apply(input)
+    val expected =
+      tla.not(tla.in(tla.bool(true), tla.name("s") as SetT1(BoolT1())) as BoolT1()) as BoolT1()
+    assert(expected == output)
+  }
+
+  test("""lab(a) :: ~FALSE ~~> lab(a) :: TRUE""") {
+    val input = tla.label(tla.not(tla.bool(false)) as BoolT1(), "lab", "a") as BoolT1()
+    val output = normalizer.apply(input)
+    val expected = tla.label(tla.bool(true), "lab", "a") as BoolT1()
     assert(expected == output)
   }
 


### PR DESCRIPTION
Hello :octocat: 

Here are some new tests for the normalizer, which currently has poor coverage as stated in https://github.com/informalsystems/apalache/issues/649. Scenarios that have some change in the expression are covered with individual tests, while expressions that should be left unchanged are all covered in a single test.

This also fixes a bug were temporal expressions with negated `\box` operators were being incorrectly normalized (see [discussion](https://github.com/informalsystems/apalache/pull/1165#discussion_r767738234)), and a bug where declarations inside negated `LET` expressions were not being normalized at all.

Fixes https://github.com/informalsystems/apalache/issues/649