### PR TITLE
Add IR operators for compound set update

### DIFF
--- a/docs/src/adr/011adr-smt-arrays.md
+++ b/docs/src/adr/011adr-smt-arrays.md
@@ -157,8 +157,7 @@ The following changes will be made to implement the new encoding of sets:
   - The `storeInSetOneStep` and `storeInSetLastStep` IR operators, encoding a sequence of `store`
     operations into a single clause, are used to more efficiently encode array updates dealing
     with many elements. Their benefit stand from avoiding the declaration of many intermediary
-    arrays. They represent a shift in the mechanical way in which set updates are done in the
-    OOPSLA'19 encoding, and thus should only be used in the new encoding.
+    arrays.
   - Cases for `FinSetT` and `PowSetT` will be added to `getOrMkCellSort`, as these types are no
     longer represented by uninterpreted constants.
   - `cellCache` will be changed to contain a list of cells, in order to handle the effects of

--- a/docs/src/adr/011adr-smt-arrays.md
+++ b/docs/src/adr/011adr-smt-arrays.md
@@ -140,7 +140,7 @@ The following changes will be made to implement the new encoding of sets:
   `PreproSolverContext`, to represent the array operations.
   - The `selectInSet` IR operator represents the SMT `select`.
   - The `storeInSet` IR operator represents the SMT `store`.
-  - The `storeInSetOneStep` and `storeInSetLastStep` IR operators represent a compound SMT `store`.
+  - The `chain` and `assignChain` IR operators represent compound SMT operations.
   - The `unchangedSet` IR operator represents an equality between the current and new SSA array
     representations. This is required to constraint the array representation as it evolves. It is
     important to note that this operator assumes that all arrays are initially empty, so an element
@@ -154,10 +154,10 @@ The following changes will be made to implement the new encoding of sets:
     and `getInPred`, will not be applied to the new encoding. Cases for the new IR operators will 
     be added to `toExpr`, which will default to `TlaSetOper.in` and `TlaSetOper.notin` for the 
     existing encoding.
-  - The `storeInSetOneStep` and `storeInSetLastStep` IR operators, encoding a sequence of `store`
-    operations into a single clause, are used to more efficiently encode array updates dealing
-    with many elements. Their benefit stand from avoiding the declaration of many intermediary
-    arrays.
+  - The `chain` and `assignChain` IR operators encode a sequence of SMT operations into a single
+    clause. They can be used to efficiently encode compound `store` operations when many elements
+    need to be added a set, by avoiding the declaration of intermediary arrays. In addition to
+    `store`, they can also be used to compound other operations, such as arithmetic ones.
   - Cases for `FinSetT` and `PowSetT` will be added to `getOrMkCellSort`, as these types are no
     longer represented by uninterpreted constants.
   - `cellCache` will be changed to contain a list of cells, in order to handle the effects of

--- a/docs/src/adr/011adr-smt-arrays.md
+++ b/docs/src/adr/011adr-smt-arrays.md
@@ -136,10 +136,11 @@ The following changes will be made to implement the new encoding of sets:
     elements will remain unchanged.
 - In class `SymbStateRewriterImplWithArrays`, add the new rules to `ruleLookupTable` by overriding
   the entries to their older versions.
-- Add three new Apalache IR operators in `ApalacheOper`, `Builder`, `ConstSimplifierForSmt`, and 
+- Add five new Apalache IR operators in `ApalacheOper`, `Builder`, `ConstSimplifierForSmt`, and 
   `PreproSolverContext`, to represent the array operations.
   - The `selectInSet` IR operator represents the SMT `select`.
   - The `storeInSet` IR operator represents the SMT `store`.
+  - The `storeInSetOneStep` and `storeInSetLastStep` IR operators represent a compound SMT `store`.
   - The `unchangedSet` IR operator represents an equality between the current and new SSA array
     representations. This is required to constraint the array representation as it evolves. It is
     important to note that this operator assumes that all arrays are initially empty, so an element
@@ -153,6 +154,11 @@ The following changes will be made to implement the new encoding of sets:
     and `getInPred`, will not be applied to the new encoding. Cases for the new IR operators will 
     be added to `toExpr`, which will default to `TlaSetOper.in` and `TlaSetOper.notin` for the 
     existing encoding.
+  - The `storeInSetOneStep` and `storeInSetLastStep` IR operators, encoding a sequence of `store`
+    operations into a single clause, are used to more efficiently encode array updates dealing
+    with many elements. Their benefit stand from avoiding the declaration of many intermediary
+    arrays. They represent a shift in the mechanical way in which set updates are done in the
+    OOPSLA'19 encoding, and thus should only be used in the new encoding.
   - Cases for `FinSetT` and `PowSetT` will be added to `getOrMkCellSort`, as these types are no
     longer represented by uninterpreted constants.
   - `cellCache` will be changed to contain a list of cells, in order to handle the effects of

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
@@ -35,6 +35,8 @@ class SymbStateRewriterImplWithArrays(_solverContext: SolverContext,
         // sets
         key(tla.in(tla.name("x"), tla.name("S")))
           -> List(new SetInRuleWithArrays(this)), // TODO: add support for funSet later
+        key(tla.apalacheSelectInSet(tla.name("x"), tla.name("S")))
+          -> List(new SetInRule(this)),
         key(tla.subseteq(tla.name("x"), tla.name("S")))
           -> List(new SetInclusionRuleWithArrays(this))
         // TODO: consider copying one array and storing the edges of the other in SetCupRule

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
@@ -36,7 +36,7 @@ class SymbStateRewriterImplWithArrays(_solverContext: SolverContext,
         key(tla.in(tla.name("x"), tla.name("S")))
           -> List(new SetInRuleWithArrays(this)), // TODO: add support for funSet later
         key(tla.apalacheSelectInSet(tla.name("x"), tla.name("S")))
-          -> List(new SetInRule(this)),
+          -> List(new SetInRuleWithArrays(this)),
         key(tla.subseteq(tla.name("x"), tla.name("S")))
           -> List(new SetInclusionRuleWithArrays(this))
         // TODO: consider copying one array and storing the edges of the other in SetCupRule

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -70,7 +70,9 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       OperEx(op, name, transform(true)(set), transform(false)(pred))(tag)
 
     case ex @ OperEx(op, elem, set)
-        if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet || op == TlaSetOper.notin || op == ApalacheOper.storeNotInSet =>
+        if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet ||
+          op == ApalacheOper.storeInSetOneStep || op == ApalacheOper.storeInSetLastStep || op == TlaSetOper.notin ||
+          op == ApalacheOper.storeNotInSet =>
       // when checking e \in S or e \notin S, we can keep S unexpanded, but e should be expanded
       val tag = ex.typeTag
       OperEx(op, transform(true)(elem), transform(false)(set))(tag)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -70,9 +70,7 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       OperEx(op, name, transform(true)(set), transform(false)(pred))(tag)
 
     case ex @ OperEx(op, elem, set)
-        if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet ||
-          op == ApalacheOper.storeInSetOneStep || op == ApalacheOper.storeInSetLastStep || op == TlaSetOper.notin ||
-          op == ApalacheOper.storeNotInSet =>
+        if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet || op == TlaSetOper.notin || op == ApalacheOper.storeNotInSet =>
       // when checking e \in S or e \notin S, we can keep S unexpanded, but e should be expanded
       val tag = ex.typeTag
       OperEx(op, transform(true)(elem), transform(false)(set))(tag)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntRangeCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntRangeCache.scala
@@ -1,10 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt.caches
 
-import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
+import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell, arraysEncoding}
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.{FinSetT, IntT}
+import at.forsyte.apalache.tla.lir.{BuilderEx, ValEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.values.TlaBool
 
 /**
  * Cache tuple domains as well as ranges a..b.
@@ -35,7 +37,23 @@ class IntRangeCache(solverContext: SolverContext, intValueCache: IntValueCache)
     val set = arena.topCell
     arena = arena.appendHas(set, cells: _*)
     // force that every element is in the set
-    solverContext.assertGroundExpr(tla.and(cells.map(c => tla.apalacheStoreInSet(c.toNameEx, set.toNameEx)): _*))
+    if (solverContext.config.smtEncoding == arraysEncoding) {
+      def addCons(cells: Seq[ArenaCell]): BuilderEx = {
+        val c = cells.head
+
+        cells.tail match {
+          case Seq() => tla.apalacheStoreInSetOneStep(c.toNameEx, set.toNameEx, ValEx(TlaBool(true)))
+          case tail  => tla.apalacheStoreInSetOneStep(c.toNameEx, addCons(tail), ValEx(TlaBool(true)))
+        }
+      }
+
+      if (cells.nonEmpty) {
+        val cons = addCons(cells)
+        solverContext.assertGroundExpr(tla.apalacheStoreInSetLastStep(set.toNameEx, cons))
+      }
+    } else {
+      solverContext.assertGroundExpr(tla.and(cells.map(c => tla.apalacheStoreInSet(c.toNameEx, set.toNameEx)): _*))
+    }
     (arena, set)
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntRangeCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/IntRangeCache.scala
@@ -3,10 +3,9 @@ package at.forsyte.apalache.tla.bmcmt.caches
 import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.{FinSetT, IntT}
-import at.forsyte.apalache.tla.lir.{BuilderEx, ValEx}
+import at.forsyte.apalache.tla.lir.BuilderEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
-import at.forsyte.apalache.tla.lir.values.TlaBool
 
 /**
  * Cache tuple domains as well as ranges a..b.
@@ -38,17 +37,18 @@ class IntRangeCache(solverContext: SolverContext, intValueCache: IntValueCache)
     arena = arena.appendHas(set, cells: _*)
     // force that every element is in the set
     if (cells.nonEmpty) {
-      def addCons(cells: Seq[ArenaCell]): BuilderEx = {
+      def consChain(cells: Seq[ArenaCell]): BuilderEx = {
         val cell = cells.head
+        val inSet = tla.apalacheStoreInSet(cell.toNameEx, set.toNameEx)
 
         cells.tail match {
-          case Seq() => tla.apalacheStoreInSetOneStep(cell.toNameEx, set.toNameEx, ValEx(TlaBool(true)))
-          case tail  => tla.apalacheStoreInSetOneStep(cell.toNameEx, addCons(tail), ValEx(TlaBool(true)))
+          case Seq() => tla.apalacheChain(inSet, set.toNameEx)
+          case tail  => tla.apalacheChain(inSet, consChain(tail))
         }
       }
 
-      val cons = addCons(cells)
-      solverContext.assertGroundExpr(tla.apalacheStoreInSetLastStep(set.toNameEx, cons))
+      val cons = consChain(cells)
+      solverContext.assertGroundExpr(tla.apalacheAssignChain(set.toNameEx, cons))
     }
     (arena, set)
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
@@ -54,6 +54,7 @@ class ConstSimplifierForSmt extends ConstSimplifierBase {
 
     // same as tla.in and tla.notin
     case ex @ (OperEx(ApalacheOper.selectInSet, _*) | OperEx(ApalacheOper.storeInSet, _*) |
+        OperEx(ApalacheOper.storeInSetOneStep, _*) | OperEx(ApalacheOper.storeInSetLastStep, _*) |
         OperEx(ApalacheOper.storeNotInSet, _*)) =>
       ex
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
@@ -49,13 +49,8 @@ class ConstSimplifierForSmt extends ConstSimplifierBase {
       }
 
     // do not go in tla.in and tla.notin, as it breaks down our SMT encoding
-    case ex @ (OperEx(TlaSetOper.in, _*) | OperEx(TlaSetOper.notin, _*)) =>
-      ex
-
-    // same as tla.in and tla.notin
-    case ex @ (OperEx(ApalacheOper.selectInSet, _*) | OperEx(ApalacheOper.storeInSet, _*) |
-        OperEx(ApalacheOper.storeInSetOneStep, _*) | OperEx(ApalacheOper.storeInSetLastStep, _*) |
-        OperEx(ApalacheOper.storeNotInSet, _*)) =>
+    case ex @ (OperEx(TlaSetOper.in, _*) | OperEx(TlaSetOper.notin, _*) | OperEx(ApalacheOper.selectInSet, _*) |
+        OperEx(ApalacheOper.storeInSet, _*) | OperEx(ApalacheOper.storeNotInSet, _*)) =>
       ex
 
     // using isTrueConst and isFalseConst that are more precise than those of ConstSimplifierBase

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunCtorRule.scala
@@ -71,12 +71,15 @@ class FunCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
     def addCellCons(domElem: ArenaCell, relElem: ArenaCell): Unit = {
       val inDomain = tla.apalacheSelectInSet(domElem.toNameEx, domainCell.toNameEx).typed(BoolT1())
       val inRelation = tla.apalacheStoreInSet(relElem.toNameEx, relation.toNameEx).typed(BoolT1())
-      val expr = if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
-        // In the arrays encoding we also need to update the array if inDomain does not hold
-        val notInRelation = tla.apalacheStoreNotInSet(relElem.toNameEx, relation.toNameEx).typed(BoolT1())
-        tla.ite(inDomain, inRelation, notInRelation).typed(BoolT1())
-      } else {
-        tla.equiv(inDomain, inRelation).typed(BoolT1())
+      val expr = rewriter.solverContext.config.smtEncoding match {
+        case `arraysEncoding` =>
+          // In the arrays encoding we also need to update the array if inDomain does not hold
+          val notInRelation = tla.apalacheStoreNotInSet(relElem.toNameEx, relation.toNameEx).typed(BoolT1())
+          tla.ite(inDomain, inRelation, notInRelation).typed(BoolT1())
+        case `oopsla19Encoding` =>
+          tla.equiv(inDomain, inRelation).typed(BoolT1())
+        case oddEncodingType =>
+          throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
       }
       rewriter.solverContext.assertGroundExpr(expr)
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -53,51 +53,37 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
         nextState = nextState.updateArena(_.appendHas(newSetCell, allDistinct: _*))
 
         // require each cell to be in in the union iff it is exactly in its origin set
-        def addOnlyCellCons(thisSet: ArenaCell, thisElem: ArenaCell): Unit = {
-          val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, thisSet.toNameEx)
-          val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          rewriter.solverContext.assertGroundExpr(tla.ite(inThis, inCup, notInCup))
-        }
-
-        def addOnlyCellConsSeq(thisSet: ArenaCell, elems: Seq[ArenaCell]): Unit = {
-          def addCons(thisSet: ArenaCell, elems: Seq[ArenaCell]): BuilderEx = {
-            val thisElem = elems.head
-            val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, thisSet.toNameEx)
-            elems.tail match {
-              case Seq() => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, newSetCell.toNameEx, inThis)
-              case tail  => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, addCons(thisSet, tail), inThis)
-            }
-          }
-
+        def addOnlyCellCons(thisSet: ArenaCell, elems: Seq[ArenaCell]): Unit = {
           if (elems.nonEmpty) {
+            def addCons(thisSet: ArenaCell, elems: Seq[ArenaCell]): BuilderEx = {
+              val thisElem = elems.head
+              val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, thisSet.toNameEx)
+
+              elems.tail match {
+                case Seq() => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, newSetCell.toNameEx, inThis)
+                case tail  => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, addCons(thisSet, tail), inThis)
+              }
+            }
+
             val cons = addCons(thisSet, elems)
             rewriter.solverContext.assertGroundExpr(tla.apalacheStoreInSetLastStep(newSetCell.toNameEx, cons))
           }
         }
 
-        def addEitherCellCons(thisElem: ArenaCell): Unit = {
-          val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, leftSetCell.toNameEx)
-          val inOther = tla.apalacheSelectInSet(thisElem.toNameEx, rightSetCell.toNameEx)
-          val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          rewriter.solverContext.assertGroundExpr(tla.ite(tla.or(inThis, inOther), inCup, notInCup))
-        }
-
-        def addEitherCellConsSeq(elems: Seq[ArenaCell]): Unit = {
-          def addCons(elems: Seq[ArenaCell]): BuilderEx = {
-            val thisElem = elems.head
-            val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, leftSetCell.toNameEx)
-            val inOther = tla.apalacheSelectInSet(thisElem.toNameEx, rightSetCell.toNameEx)
-            val inThisOrOther = tla.or(inThis, inOther)
-
-            elems.tail match {
-              case Seq() => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, newSetCell.toNameEx, inThisOrOther)
-              case tail  => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, addCons(tail), inThisOrOther)
-            }
-          }
-
+        def addEitherCellCons(elems: Seq[ArenaCell]): Unit = {
           if (elems.nonEmpty) {
+            def addCons(elems: Seq[ArenaCell]): BuilderEx = {
+              val thisElem = elems.head
+              val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, leftSetCell.toNameEx)
+              val inOther = tla.apalacheSelectInSet(thisElem.toNameEx, rightSetCell.toNameEx)
+              val inThisOrOther = tla.or(inThis, inOther)
+
+              elems.tail match {
+                case Seq() => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, newSetCell.toNameEx, inThisOrOther)
+                case tail  => tla.apalacheStoreInSetOneStep(thisElem.toNameEx, addCons(tail), inThisOrOther)
+              }
+            }
+
             val cons = addCons(elems)
             rewriter.solverContext.assertGroundExpr(tla.apalacheStoreInSetLastStep(newSetCell.toNameEx, cons))
           }
@@ -111,15 +97,9 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
 //        val eqState = rewriter.lazyEq.cacheEqConstraints(rightState.setArena(arena), prodIter.toSeq)
         // bugfix: we have to compare the elements in both sets and thus to introduce a quadratic number of constraints
         // add SMT constraints
-        if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
-          addOnlyCellConsSeq(leftSetCell, onlyLeft.toSeq)
-          addOnlyCellConsSeq(rightSetCell, onlyRight.toSeq)
-          addEitherCellConsSeq(common.toSeq)
-        } else {
-          onlyLeft foreach (addOnlyCellCons(leftSetCell, _))
-          onlyRight foreach (addOnlyCellCons(rightSetCell, _))
-          common foreach addEitherCellCons
-        }
+        addOnlyCellCons(leftSetCell, onlyLeft.toSeq)
+        addOnlyCellCons(rightSetCell, onlyRight.toSeq)
+        addEitherCellCons(common.toSeq)
 
         // that's it
         nextState.setRex(newSetCell.toNameEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
@@ -59,54 +59,34 @@ class SetUnionRule(rewriter: SymbStateRewriter) extends RewritingRule {
           //
           // This approach is more expensive at the rewriting phase, but it produces O(n) constraints in SMT,
           // in contrast to the old approach with equalities and uninterpreted functions, which required O(n^2) constraints.
-          def addOneElemCons(elemCell: ArenaCell): Unit = {
-            def isPointedBySet(set: ArenaCell, setElems: Set[ArenaCell]): Boolean = setElems.contains(elemCell)
-            val pointingSets = (sets.zip(elemsOfSets) filter (isPointedBySet _).tupled) map (_._1)
-            def inPointingSet(set: ArenaCell) = {
-              // this is sound, because we have generated element equalities
-              // and thus can use congruence of in(...) for free
-              tla.and(tla.apalacheSelectInSet(set.toNameEx, topSetCell.toNameEx),
-                  tla.apalacheSelectInSet(elemCell.toNameEx, set.toNameEx))
-            }
-
-            val existsIncludingSet = tla.or(pointingSets map inPointingSet: _*)
-            val inUnionSet = tla.apalacheStoreInSet(elemCell.toNameEx, newSetCell.toNameEx)
-            val notInUnionSet = tla.apalacheStoreNotInSet(elemCell.toNameEx, newSetCell.toNameEx)
-            val ite = tla.ite(existsIncludingSet, inUnionSet, notInUnionSet)
-            rewriter.solverContext.assertGroundExpr(ite)
-          }
-
-          def addOneElemConsSeq(elemsCells: Seq[ArenaCell]): Unit = {
-            def addCons(elemsCells: Seq[ArenaCell]): BuilderEx = {
-              val elemCell = elemsCells.head
-              def isPointedBySet(set: ArenaCell, setElems: Set[ArenaCell]): Boolean = setElems.contains(elemCell)
-              val pointingSets = (sets.zip(elemsOfSets) filter (isPointedBySet _).tupled) map (_._1)
-              def inPointingSet(set: ArenaCell) = {
-                // this is sound, because we have generated element equalities
-                // and thus can use congruence of in(...) for free
-                tla.and(tla.apalacheSelectInSet(set.toNameEx, topSetCell.toNameEx),
-                    tla.apalacheSelectInSet(elemCell.toNameEx, set.toNameEx))
-              }
-              val existsIncludingSet = tla.or(pointingSets map inPointingSet: _*)
-
-              elemsCells.tail match {
-                case Seq() => tla.apalacheStoreInSetOneStep(elemCell.toNameEx, newSetCell.toNameEx, existsIncludingSet)
-                case tail  => tla.apalacheStoreInSetOneStep(elemCell.toNameEx, addCons(tail), existsIncludingSet)
-              }
-            }
-
+          def addOneElemCons(elemsCells: Seq[ArenaCell]): Unit = {
             if (elemsCells.nonEmpty) {
+              def addCons(elemsCells: Seq[ArenaCell]): BuilderEx = {
+                val elemCell = elemsCells.head
+                def isPointedBySet(set: ArenaCell, setElems: Set[ArenaCell]): Boolean = setElems.contains(elemCell)
+                val pointingSets = (sets.zip(elemsOfSets) filter (isPointedBySet _).tupled) map (_._1)
+                def inPointingSet(set: ArenaCell) = {
+                  // this is sound, because we have generated element equalities
+                  // and thus can use congruence of in(...) for free
+                  tla.and(tla.apalacheSelectInSet(set.toNameEx, topSetCell.toNameEx),
+                      tla.apalacheSelectInSet(elemCell.toNameEx, set.toNameEx))
+                }
+                val existsIncludingSet = tla.or(pointingSets map inPointingSet: _*)
+
+                elemsCells.tail match {
+                  case Seq() =>
+                    tla.apalacheStoreInSetOneStep(elemCell.toNameEx, newSetCell.toNameEx, existsIncludingSet)
+                  case tail => tla.apalacheStoreInSetOneStep(elemCell.toNameEx, addCons(tail), existsIncludingSet)
+                }
+              }
+
               val cons = addCons(elemsCells)
               rewriter.solverContext.assertGroundExpr(tla.apalacheStoreInSetLastStep(newSetCell.toNameEx, cons))
             }
           }
 
           // add SMT constraints
-          if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
-            addOneElemConsSeq(unionOfSets.toSeq)
-          } else {
-            unionOfSets foreach addOneElemCons
-          }
+          addOneElemCons(unionOfSets.toSeq)
 
           // that's it
           nextState.setRex(newSetCell.toNameEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -321,11 +321,14 @@ class CherryPick(rewriter: SymbStateRewriter) {
             val ite = tla.ite(tla.apalacheSelectInSet(keyCell.toNameEx, dom.toNameEx),
                 tla.apalacheStoreInSet(keyCell.toNameEx, newDom.toNameEx),
                 tla.apalacheStoreNotInSet(keyCell.toNameEx, newDom.toNameEx))
-            val unchangedSet = if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
-              // In the arrays encoding we need to propagate the SSA representation of the array if nothing changes
-              tla.apalacheStoreNotInSet(keyCell.toNameEx, newDom.toNameEx)
-            } else {
-              tla.bool(true)
+            val unchangedSet = rewriter.solverContext.config.smtEncoding match {
+              case `arraysEncoding` =>
+                // In the arrays encoding we need to propagate the SSA representation of the array if nothing changes
+                tla.apalacheStoreNotInSet(keyCell.toNameEx, newDom.toNameEx)
+              case `oopsla19Encoding` =>
+                tla.bool(true)
+              case oddEncodingType =>
+                throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
             }
             rewriter.solverContext.assertGroundExpr(tla.ite(oracle.whenEqualTo(nextState, no), ite, unchangedSet))
           } else {
@@ -454,11 +457,14 @@ class CherryPick(rewriter: SymbStateRewriter) {
           val inSet = tla.ite(tla.apalacheSelectInSet(elemAndSet._1.toNameEx, elemAndSet._2.toNameEx),
               tla.apalacheStoreInSet(picked.toNameEx, resultCell.toNameEx),
               tla.apalacheStoreNotInSet(picked.toNameEx, resultCell.toNameEx))
-          val unchangedSet = if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
-            // In the arrays encoding we need to propagate the SSA representation of the array if nothing changes
-            tla.apalacheStoreNotInSet(picked.toNameEx, resultCell.toNameEx)
-          } else {
-            tla.bool(true)
+          val unchangedSet = rewriter.solverContext.config.smtEncoding match {
+            case `arraysEncoding` =>
+              // In the arrays encoding we need to propagate the SSA representation of the array if nothing changes
+              tla.apalacheStoreNotInSet(picked.toNameEx, resultCell.toNameEx)
+            case `oopsla19Encoding` =>
+              tla.bool(true)
+            case oddEncodingType =>
+              throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
           }
           (inSet, unchangedSet)
         } else {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.values.TlaBool
-import at.forsyte.apalache.tla.lir.{MalformedSepecificationError, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.{BuilderEx, MalformedSepecificationError, TlaEx, ValEx}
 
 import scala.collection.immutable.SortedMap
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler
@@ -612,22 +612,33 @@ class CherryPick(rewriter: SymbStateRewriter) {
 
     // if resultSet has an element, then it must be also in baseSet
     def inResultIfInBase(elem: ArenaCell): Unit = {
-      // In the oopsla19 encoding resultSet is initially unconstrained, and thus can contain any combination of elems.
-      // To emulate this in the arrays encoding, in which the all sets are initially empty, unconstrained predicates
-      // are used to allow the SMT solver to consider all possible combinations of elems.
-      if (rewriter.solverContext.config.smtEncoding == arraysEncoding) {
-        nextState = nextState.updateArena(_.appendCell(BoolT()))
-        val pred = nextState.arena.topCell.toNameEx
-        val storeElem = tla.apalacheStoreInSet(elem.toNameEx, resultSet.toNameEx)
-        val notStoreElem = tla.apalacheStoreNotInSet(elem.toNameEx, resultSet.toNameEx)
-        rewriter.solverContext.assertGroundExpr(tla.ite(pred, storeElem, notStoreElem))
-      }
-
       val inResult = tla.apalacheSelectInSet(elem.toNameEx, resultSet.toNameEx)
       val inBase = tla.apalacheSelectInSet(elem.toNameEx, baseSet.toNameEx)
       rewriter.solverContext.assertGroundExpr(tla.impl(inResult, inBase))
     }
 
+    // In the oopsla19 encoding resultSet is initially unconstrained, and thus can contain any combination of elems.
+    // To emulate this in the arrays encoding, in which the all sets are initially empty, unconstrained predicates
+    // are used to allow the SMT solver to consider all possible combinations of elems.
+    def unconstrainElems(elems: Seq[ArenaCell]): Unit = {
+      def addCons(elems: Seq[ArenaCell]): BuilderEx = {
+        val elem = elems.head
+        nextState = nextState.updateArena(_.appendCell(BoolT()))
+        val pred = nextState.arena.topCell.toNameEx
+
+        elems.tail match {
+          case Seq() => tla.apalacheStoreInSetOneStep(elem.toNameEx, resultSet.toNameEx, pred)
+          case tail  => tla.apalacheStoreInSetOneStep(elem.toNameEx, addCons(tail), pred)
+        }
+      }
+
+      if (elems.nonEmpty & rewriter.solverContext.config.smtEncoding == arraysEncoding) {
+        val cons = addCons(elems)
+        rewriter.solverContext.assertGroundExpr(tla.apalacheStoreInSetLastStep(resultSet.toNameEx, cons))
+      }
+    }
+
+    unconstrainElems(elems)
     elems foreach inResultIfInBase
     rewriter.solverContext.log("; } PICK %s FROM %s".format(resultType, set))
     nextState.setRex(resultSet.toNameEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/PreproSolverContext.scala
@@ -74,7 +74,9 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
         }
 
       case OperEx(op, NameEx(left), NameEx(right))
-          if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet || op == ApalacheOper.storeNotInSet =>
+          if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet ||
+            op == ApalacheOper.storeInSetOneStep || op == ApalacheOper.storeInSetLastStep ||
+            op == ApalacheOper.storeNotInSet =>
         // in and not(notin), the latter is transformed by simplifier
         if (ArenaCell.isValidName(left) && ArenaCell.isValidName(right)) {
           cache.put((left, right), PreproInEntry(true))
@@ -140,6 +142,18 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
           case None         => ex
         }
 
+      case OperEx(ApalacheOper.storeInSetOneStep, NameEx(left), NameEx(right)) =>
+        cache.get((left, right)) match {
+          case Some(cached) => cached.asTlaEx(negate = false)
+          case None         => ex
+        }
+
+      case OperEx(ApalacheOper.storeInSetLastStep, NameEx(left), NameEx(right)) =>
+        cache.get((left, right)) match {
+          case Some(cached) => cached.asTlaEx(negate = false)
+          case None         => ex
+        }
+
       case OperEx(TlaSetOper.notin, NameEx(left), NameEx(right)) =>
         cache.get((left, right)) match {
           case Some(cached) => cached.asTlaEx(negate = true)
@@ -153,6 +167,7 @@ class PreproSolverContext(context: SolverContext) extends SolverContext {
         }
 
       case OperEx(TlaSetOper.in, _*) | OperEx(ApalacheOper.selectInSet, _*) | OperEx(ApalacheOper.storeInSet, _*) |
+          OperEx(ApalacheOper.storeInSetOneStep, _*) | OperEx(ApalacheOper.storeInSetLastStep, _*) |
           OperEx(TlaSetOper.notin, _*) | OperEx(ApalacheOper.storeNotInSet, _*) =>
         // do not preprocess these expressions, as we have to find sorts from the names
         ex

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -30,10 +30,11 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case set @ NameEx(_) =>
-            val falseInSet = in(arena.cellFalse().toNameEx as boolT, set as boolSetT) as boolT
+            val falseInSet = apalacheSelectInSet(arena.cellFalse().toNameEx as boolT, set as boolSetT) as boolT
             solverContext.assertGroundExpr(falseInSet)
             assert(solverContext.sat())
-            val notTrueInSet = not(in(arena.cellTrue().toNameEx as boolT, set as boolSetT) as boolT) as boolT
+            val notTrueInSet =
+              not(apalacheSelectInSet(arena.cellTrue().toNameEx as boolT, set as boolSetT) as boolT) as boolT
             solverContext.assertGroundExpr(notTrueInSet)
             assert(!solverContext.sat())
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -604,16 +604,16 @@ class Builder {
     BuilderOper(ApalacheOper.storeInSet, elem, set)
   }
 
-  def apalacheStoreInSetOneStep(elem: BuilderEx, set: BuilderEx, cond: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.storeInSetOneStep, elem, set, cond)
-  }
-
-  def apalacheStoreInSetLastStep(elem: BuilderEx, set: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.storeInSetLastStep, elem, set)
-  }
-
   def apalacheStoreNotInSet(elem: BuilderEx, set: BuilderEx): BuilderEx = {
     BuilderOper(ApalacheOper.storeNotInSet, elem, set)
+  }
+
+  def apalacheChain(op: BuilderEx, tail: BuilderEx, cond: BuilderEx = bool(true)): BuilderEx = {
+    BuilderOper(ApalacheOper.chain, op, tail, cond)
+  }
+
+  def apalacheAssignChain(elem: BuilderEx, chain: BuilderEx): BuilderEx = {
+    BuilderOper(ApalacheOper.assignChain, elem, chain)
   }
 
   private val m_nameMap: Map[String, TlaOper] =

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -604,6 +604,14 @@ class Builder {
     BuilderOper(ApalacheOper.storeInSet, elem, set)
   }
 
+  def apalacheStoreInSetOneStep(elem: BuilderEx, set: BuilderEx, cond: BuilderEx): BuilderEx = {
+    BuilderOper(ApalacheOper.storeInSetOneStep, elem, set, cond)
+  }
+
+  def apalacheStoreInSetLastStep(elem: BuilderEx, set: BuilderEx): BuilderEx = {
+    BuilderOper(ApalacheOper.storeInSetLastStep, elem, set)
+  }
+
   def apalacheStoreNotInSet(elem: BuilderEx, set: BuilderEx): BuilderEx = {
     BuilderOper(ApalacheOper.storeNotInSet, elem, set)
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
@@ -194,6 +194,30 @@ object ApalacheOper {
   }
 
   /**
+   * The storeInSetOneStep operator is a variant of storeInSet.
+   * It signals a step in a sequence of operations enforcing set membership.
+   */
+  object storeInSetOneStep extends ApalacheOper {
+    override def name: String = "Apalache!StoreInSetOneStep"
+
+    override def arity: OperArity = FixedArity(3)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+   * The storeInSetLastStep operator is a variant of storeInSet.
+   * It signals the last step in a sequence of operations enforcing set membership.
+   */
+  object storeInSetLastStep extends ApalacheOper {
+    override def name: String = "Apalache!StoreInSetLastStep"
+
+    override def arity: OperArity = FixedArity(2)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
    * The storeNotInSet operator is a variant of storeInSet.
    * It signals that the negation of set membership should be enforced.
    */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
@@ -194,23 +194,11 @@ object ApalacheOper {
   }
 
   /**
-   * The storeInSetOneStep operator is a variant of storeInSet.
-   * It signals a step in a sequence of operations enforcing set membership.
+   * The storeNotInSet operator is a variant of storeInSet.
+   * It signals that the negation of set membership should be enforced.
    */
-  object storeInSetOneStep extends ApalacheOper {
-    override def name: String = "Apalache!StoreInSetOneStep"
-
-    override def arity: OperArity = FixedArity(3)
-
-    override def precedence: (Int, Int) = (5, 5)
-  }
-
-  /**
-   * The storeInSetLastStep operator is a variant of storeInSet.
-   * It signals the last step in a sequence of operations enforcing set membership.
-   */
-  object storeInSetLastStep extends ApalacheOper {
-    override def name: String = "Apalache!StoreInSetLastStep"
+  object storeNotInSet extends ApalacheOper {
+    override def name: String = "Apalache!UnchangedSet"
 
     override def arity: OperArity = FixedArity(2)
 
@@ -218,11 +206,22 @@ object ApalacheOper {
   }
 
   /**
-   * The storeNotInSet operator is a variant of storeInSet.
-   * It signals that the negation of set membership should be enforced.
+   * The chain operator allows the chaining of individual operations.
+   * It can improve solver performance by eliminating intermediary declarations.
    */
-  object storeNotInSet extends ApalacheOper {
-    override def name: String = "Apalache!UnchangedSet"
+  object chain extends ApalacheOper {
+    override def name: String = "Apalache!Chain"
+
+    override def arity: OperArity = FixedArity(3)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+   * The assignChain operator assigns the result of a chain of operations to an element.
+   */
+  object assignChain extends ApalacheOper {
+    override def name: String = "Apalache!AssignChain"
 
     override def arity: OperArity = FixedArity(2)
 


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

This PR adds two new IR operators, `storeInSetOneStep` and `storeInSetLastStep`, which are variants of `storeInSet`. The existing store operator updates one entry of a SMT array. The new operators, which need to be used in conjunction, allow for the update of an arbitrary number of entries to be encoded into a single clause, thus avoiding the creation of unnecessary intermediary arrays. These new operators are intended to be used only for sequences of updates, thus the `storeInSet` operator remains useful for single updates. Closes #1171.

The arrays encoding will change from
```
(assert (= ite cond_1 (= (set_1 (store set_0 elem_1 true))) (= (set_1 set_0))))
(assert (= ite cond_2 (= (set_2 (store set_1 elem_2 true))) (= (set_2 set_1))))
(assert (= ite cond_3 (= (set_3 (store set_2 elem_3 true))) (= (set_3 set_2))))
```
to
```
(assert (= (set_1 (store (store (store set_0 elem_1 cond_1) elem_2 cond_2) elem_3 cond_3))))
```
\
To avoid having different compound set update operations depending on the encoding, the oopsla19 encoding will also use the new IR operators. Adding elements to a set will change from
```
(assert (= ite cond_1 (elem1_in_set) (not elem1_in_set)))
(assert (= ite cond_2 (elem2_in_set) (not elem2_in_set)))
(assert (= ite cond_3 (elem3_in_set) (not elem3_in_set)))
```
to
```
(assert (and (= cond_1 elem1_in_set) (= cond_2 elem2_in_set) (= cond_3 elem3_in_set)))
```
In `(= cond elem_in_set)`, if `cond` evaluates to `true` the expression is simplified to `elem_in_set`.