### PR TITLE
Add server subcommand

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
@@ -1,0 +1,12 @@
+package at.forsyte.apalache.tla.tooling.opt
+
+import java.io.File
+
+import org.backuity.clist.Command
+
+class ServerCmd
+    extends Command(name = "server", description = "Run apalache in server mode (not yet supported)") with General {
+
+  // Dummy file used for application (esp. output) configuration
+  def file = new File("server")
+}

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2435,3 +2435,15 @@ $ ! test -d ./to-override-dir
 $ test -d ./configured-run-dir
 $ rm -rf ./configured-run-dir ./cli-config.cfg
 ```
+
+## server mode
+
+### server mode: subcommand is not yet implemented
+
+```sh
+$ apalache-mc server | sed 's/[IEW]@.*//'
+...
+Server mode is not yet implemented!
+...
+EXITCODE: ERROR (255)
+```


### PR DESCRIPTION
Closes #1115

This just adds the boilerplate to plumb in a the new `server` subcommand, and
run it through the integration tests.

I'm not updating the docs ore lease notes at this point, because the cli subcommand is just a dummy at this point.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)