### PR TITLE
Fix expansion of ~ in configured paths

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix expansion of `~` in configured paths, see #1208

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2436,6 +2436,20 @@ $ test -d ./configured-run-dir
 $ rm -rf ./configured-run-dir ./cli-config.cfg
 ```
 
+### configuration management: tilde is expanded in configured paths
+
+We set `user.home` to the current working directly, so we can test tilde
+expansion in the path without writing outside of the test directory.
+
+```sh
+$ echo "run-dir: ~/run-dir" > .apalache.cfg
+$ JVM_ARGS="-Duser.home=$PWD" apalache-mc check --length=0 Counter.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+$ test -d ./run-dir
+$ rm -rf ./run-dir ./.apalache.cfg
+```
+
 ## server mode
 
 ### server mode: subcommand is not yet implemented

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2441,9 +2441,12 @@ $ rm -rf ./configured-run-dir ./cli-config.cfg
 We set `user.home` to the current working directly, so we can test tilde
 expansion in the path without writing outside of the test directory.
 
+NOTE: We need to set the home to a relative path to the cwd in order to
+ensure the tests also works in the docker container.
+
 ```sh
 $ echo "run-dir: ~/run-dir" > .apalache.cfg
-$ JVM_ARGS="-Duser.home=$PWD" apalache-mc check --length=0 Counter.tla | sed 's/[IEW]@.*//'
+$ JVM_ARGS="-Duser.home=." apalache-mc check --length=0 Counter.tla | sed 's/[IEW]@.*//'
 ...
 EXITCODE: OK
 $ test -d ./run-dir

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -11,7 +11,6 @@ import com.typesafe.config.ConfigObject
 private object Converters {
   import pureconfig.ConvertHelpers._
 
-
   private def expandedFilePath(s: String): Path = {
     Paths.get(if (s.startsWith("~")) s.replaceFirst("~", System.getProperty("user.home")) else s)
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -4,39 +4,24 @@ import pureconfig._
 import pureconfig.generic.auto._
 import java.io.{File}
 import java.nio.file.{Path, Files, Paths}
+import com.typesafe.config.ConfigValueFactory
+import com.typesafe.config.ConfigObject
 
-object Converters {
+// Provides implicit conversions used when deserializing into configurable values.
+private object Converters {
+  import pureconfig.ConvertHelpers._
+
 
   private def expandedFilePath(s: String): Path = {
     Paths.get(if (s.startsWith("~")) s.replaceFirst("~", System.getProperty("user.home")) else s)
   }
 
-  // Value class to allow adding a new implicit for the File
-  case class ExpandedFile(val file: File) extends AnyVal
-
-  object ExpandedFile {
-    def apply(f: File): ExpandedFile = {
-      new ExpandedFile(expandedFilePath(f.toString()).toFile())
-    }
-  }
-
-  // Value class to allow adding a new implicit for Path
-  case class ExpandedPath(val path: Path) extends AnyVal
-
-  object ExpandedPath {
-    def apply(f: Path): ExpandedPath = {
-      new ExpandedPath(expandedFilePath(f.toString()))
-    }
-  }
-
-  // Briniging these implicits in scope lets us override the existing
-  // file deserialization behavior, so we get path expansion in all configured
-  // paths
-  implicit def expandedFileConfigReader: ConfigReader[ExpandedFile] =
-    ConfigReader[File].map(ExpandedFile.apply)
-
-  implicit def expandedPathConfigReader: ConfigReader[ExpandedPath] =
-    ConfigReader[Path].map(ExpandedPath.apply)
+  // Briniging these implicits in scope lets us override the existing File and
+  // Path deserialization behavior, so we get path expansion in all configured
+  // paths.
+  // See https://pureconfig.github.io/docs/overriding-behavior-for-types.html
+  implicit val overridePathReader = ConfigReader.fromString[Path](catchReadError(expandedFilePath))
+  implicit val overrideFileReader = ConfigReader.fromString[File](catchReadError(expandedFilePath(_).toFile()))
 }
 
 /** The configuration values that can be overriden based on CLI arguments */


### PR DESCRIPTION
@Kukovec reported that `~` was not be expanded in configured paths correctly.
Indeed, this was an oversight on my part. I failed to correctly override
pureconfig's reader for `Path` and `File` types. This PR fixes that mistake.

Followup to #1160


<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality