### PR TITLE
Fix build config to allow skipping tests

### DIFF
--- a/tla-pp/pom.xml
+++ b/tla-pp/pom.xml
@@ -14,6 +14,28 @@
     <name>tla-pp</name>
     <url>https://github.com/informalsystems/apalache</url>
 
+    <profiles>
+        <!-- Workaround to allow a test-only internal dependency without breaking maven.test.skip -->
+        <!-- See https://issues.apache.org/jira/browse/MJAR-138?focusedCommentId=16160394&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16160394 -->
+        <profile>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>at.forsyte.apalache</groupId>
+                    <artifactId>tlair</artifactId>
+                    <version>${project.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>at.forsyte.apalache</groupId>
@@ -63,13 +85,6 @@
         <dependency>
             <groupId>org.scalacheck</groupId>
             <artifactId>scalacheck_${scalaBinaryVersion}</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>at.forsyte.apalache</groupId>
-            <artifactId>tlair</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Closes #1219 

51228a7 had the unintended consequence of triggering the maven/surefire
design bug reported in https://issues.apache.org/jira/browse/MJAR-138.

The effect of this was to break some of our build targets that skip
tests by setting `maven.test.skip=true`, because it would not build the
tlair jar when tests were skipped, but would then still require that the
jar be present to compile.

This fix implemented the workaround described at
https://issues.apache.org/jira/browse/MJAR-138?focusedCommentId=16160394&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16160394
-- namely, we add a maven profile that only includes the dependency when
`mavne.test.skip=false`.

-------

<!-- Please ensure that your PR includes the following, as needed -->