### PR TITLE
Use doubles to calculate constant exponentiation

### DIFF
--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -103,20 +103,19 @@ abstract class ConstSimplifierBase {
     // Try to evaluante constant exponentiation
     case ex @ OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) =>
       if (power < 0) {
-        throw new TlaInputError(s"Negative power at ${ex.toString}")
-      } else if (!power.isValidInt) {
-        throw new TlaInputError(
-            s"Power of ${power} is bigger than the max allowed of ${Int.MaxValue} at ${ex.toString}")
+        throw new TlaInputError(s"Negative power at ${ex}")
       } else {
         try {
-          // This can take a long time for big base values i.e. 2147484647 ^ 1100000
-          // Maybe we should consider implementing a timeout
-          ValEx(TlaInt(base.pow(power.toInt)))(intTag)
+          // Use doubles to calculate since they have a reasonable size limit
+          val pow = Math.pow(base.toDouble, power.toDouble)
+          val powAsBigInt = BigDecimal(pow).setScale(0, BigDecimal.RoundingMode.DOWN).toBigInt()
+          ValEx(TlaInt(powAsBigInt))(intTag)
         } catch {
-          case _: ArithmeticException =>
-            throw new TlaInputError(s"The result of ${ex.toString} exceedes the limit of 2^${Int.MaxValue}")
+          case _: NumberFormatException =>
+            throw new TlaInputError(s"The result of ${ex.toString} exceedes the limit of ${Double.MaxValue}")
         }
       }
+
     // x ^ 0 = 1
     case OperEx(TlaArithOper.exp, leftEx, ValEx(TlaInt(right))) if (right == 0) => ValEx(TlaInt(1))(intTag)
     // x ^ 1 = x

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -200,8 +200,8 @@ class TestConstSimplifier extends FunSuite with BeforeAndAfterEach with Checkers
 
   // Since exponential operators are highly value dependent due to precision and sizes, let's use unit tests
   test("simplifies expoents when values are usual") {
-    val base: BigInt = 8888888
-    val power: Int = 400
+    val base: BigInt = Int.MaxValue * 2
+    val power: Int = 10
     val expression = tla.exp(tla.int(base), tla.int(power)) as IntT1()
     val result = simplifier.simplify(expression)
 
@@ -216,7 +216,7 @@ class TestConstSimplifier extends FunSuite with BeforeAndAfterEach with Checkers
       simplifier.simplify(expression)
     }
 
-    thrown.getMessage shouldBe ("Power of 2147484647 is bigger than the max allowed of 2147483647 at 8888888 ^ 2147484647")
+    thrown.getMessage shouldBe ("The result of 8888888 ^ 2147484647 exceedes the limit of 1.7976931348623157E308")
   }
 
   test("raises error when result would be too big") {
@@ -227,7 +227,7 @@ class TestConstSimplifier extends FunSuite with BeforeAndAfterEach with Checkers
       simplifier.simplify(expression)
     }
 
-    thrown.getMessage shouldBe ("The result of 2147483647 ^ 2103446789 exceedes the limit of 2^2147483647")
+    thrown.getMessage shouldBe ("The result of 2147483647 ^ 2103446789 exceedes the limit of 1.7976931348623157E308")
   }
 
   test("simplifies logical expressions that result in TRUE") {


### PR DESCRIPTION
Hello :octocat: 

This fixes a problem in out test suite where scalacheck would generate expressions with exponentiation of big numbers and make some tests really slow. This happens because we began using `BigInt.pow` for all scenarios in https://github.com/informalsystems/apalache/pull/1191 and `BigInt.pow` has a huge size limit, therefore trying to compute giant operations. `Math.pow` uses doubles and has a much more reasonable size limit, ensuring any combination of numbers is computable in feasible time.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
