### PR TITLE
bugfix for the empty function in the ITF writer

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+ * Fix the ITF writer on empty functions, see #1232

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/ItfCounterexampleWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/ItfCounterexampleWriter.scala
@@ -118,6 +118,10 @@ class ItfCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
     case e @ OperEx(TlcOper.atat, _, _) =>
       ujson.Obj("#map" -> collectFun(e))
 
+    // the degenerate case of an empty function [ x \in {} |-> x ]
+    case e @ OperEx(TlaFunOper.funDef, _, _, OperEx(TlaSetOper.enumSet)) =>
+      ujson.Obj("#map" -> ujson.Arr())
+
     case e =>
       throw new IllegalArgumentException("Unexpected expression in an ITF counterexample: " + e)
   }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestItfCounterexampleWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestItfCounterexampleWriter.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.io.lir
 
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
@@ -70,8 +71,10 @@ class TestItfCounterexampleWriter extends FunSuite {
         TlaVarDecl("d")(Typed(intSet)),
         TlaVarDecl("e")(Typed(fooBar)),
         TlaVarDecl("f")(Typed(intAndStr)),
-        TlaVarDecl("g")(Typed(intToStr))
+        TlaVarDecl("g")(Typed(intToStr)),
+        TlaVarDecl("h")(Typed(intToStr))
     )
+
     compareJson(
         TlaModule("test", decls),
         List(
@@ -97,7 +100,11 @@ class TestItfCounterexampleWriter extends FunSuite {
                     "g" -> atat(colonGreater(int(1), str("a")) as intToStr,
                         atat(colonGreater(int(2), str("b")) as intToStr,
                             colonGreater(int(3), str("c")) as intToStr) as intToStr)
-                      .as(intToStr)
+                      .as(intToStr),
+                    // [ x \in {} |-> x ]
+                    // technically, this expression is not type-correct
+                    "h" -> funDef(name("x").typed(IntT1()), name("x").typed(IntT1()), enumSet().typed(SetT1(StrT1())))
+                      .typed(intToStr)
                 ))
         ),
         """{
@@ -106,7 +113,7 @@ class TestItfCounterexampleWriter extends FunSuite {
         |    "format-description": "https://apalache.informal.systems/docs/adr/015adr-trace.html",
         |    "description": "Created by Apalache"
         |  },
-        |  "vars": [ "a", "b", "c", "d", "e", "f", "g" ],
+        |  "vars": [ "a", "b", "c", "d", "e", "f", "g", "h" ],
         |  "states": [
         |    {
         |      "#meta": { "index": 0 },
@@ -116,7 +123,8 @@ class TestItfCounterexampleWriter extends FunSuite {
         |      "d": { "#set": [ 5, 6 ] },
         |      "e": { "foo": 3, "bar": true },
         |      "f": { "#tup": [ 7, "myStr" ] },
-        |      "g": { "#map": [[1, "a"], [2, "b"], [3, "c"]] }
+        |      "g": { "#map": [[1, "a"], [2, "b"], [3, "c"]] },
+        |      "h": { "#map": [] }
         |    }
         |  ]
         |}""".stripMargin


### PR DESCRIPTION
A quickfix introduced by a bug in the ITF counterexample writer

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
