### PR TITLE
Fix exponentiation inconsistency

### DIFF
--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -106,15 +106,15 @@ abstract class ConstSimplifierBase {
         throw new TlaInputError(s"Negative power at ${ex}")
       }
       if (!power.isValidInt) {
-          throw new TlaInputError(s"The power at ${ex.toString} exceedes the limit of ${Int.MaxValue}")
+        throw new TlaInputError(s"The power at ${ex.toString} exceedes the limit of ${Int.MaxValue}")
       } else {
-          // Use doubles to calculate since they have a reasonable size limit
-          val estimatedPow = Math.pow(base.toDouble, power.toDouble)
-          if (estimatedPow < Double.MinValue || estimatedPow > Double.MaxValue) {
-              throw new TlaInputError(s"The result of ${ex.toString} exceedes the limit of ${Double.MaxValue}")
-          }
-          val pow = base.pow(power.toInt)
-          ValEx(TlaInt(pow))(intTag)
+        // Use doubles to calculate since they have a reasonable size limit
+        val estimatedPow = Math.pow(base.toDouble, power.toDouble)
+        if (estimatedPow < Double.MinValue || estimatedPow > Double.MaxValue) {
+          throw new TlaInputError(s"The result of ${ex.toString} exceedes the limit of ${Double.MaxValue}")
+        }
+        val pow = base.pow(power.toInt)
+        ValEx(TlaInt(pow))(intTag)
       }
 
     // x ^ 0 = 1

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -104,16 +104,17 @@ abstract class ConstSimplifierBase {
     case ex @ OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) =>
       if (power < 0) {
         throw new TlaInputError(s"Negative power at ${ex}")
+      }
+      if (!power.isValidInt) {
+          throw new TlaInputError(s"The power at ${ex.toString} exceedes the limit of ${Int.MaxValue}")
       } else {
-        try {
           // Use doubles to calculate since they have a reasonable size limit
-          val pow = Math.pow(base.toDouble, power.toDouble)
-          val powAsBigInt = BigDecimal(pow).setScale(0, BigDecimal.RoundingMode.DOWN).toBigInt()
-          ValEx(TlaInt(powAsBigInt))(intTag)
-        } catch {
-          case _: NumberFormatException =>
-            throw new TlaInputError(s"The result of ${ex.toString} exceedes the limit of ${Double.MaxValue}")
-        }
+          val estimatedPow = Math.pow(base.toDouble, power.toDouble)
+          if (estimatedPow < Double.MinValue || estimatedPow > Double.MaxValue) {
+              throw new TlaInputError(s"The result of ${ex.toString} exceedes the limit of ${Double.MaxValue}")
+          }
+          val pow = base.pow(power.toInt)
+          ValEx(TlaInt(pow))(intTag)
       }
 
     // x ^ 0 = 1

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -216,7 +216,7 @@ class TestConstSimplifier extends FunSuite with BeforeAndAfterEach with Checkers
       simplifier.simplify(expression)
     }
 
-    thrown.getMessage shouldBe ("The result of 8888888 ^ 2147484647 exceedes the limit of 1.7976931348623157E308")
+    thrown.getMessage shouldBe ("The power at 8888888 ^ 2147484647 exceedes the limit of 2147483647")
   }
 
   test("raises error when result would be too big") {


### PR DESCRIPTION
Hello :octocat: 

This fixes https://github.com/informalsystems/apalache/issues/1235 by using `BigInt#pow` to obtain consistent results without floating point problems, but only after using `Math.pow` to estimate the result size and ensure its not too big and, therefore, too slow to compute.

- [X] Tests added for any new code
- [X] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
