### PR TITLE
Fix docker continuous deployment

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - unstable
+      - shon/fix-docker-cd
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,10 +45,16 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      # Our Dockerfile is specified in the build.sbt file, so we need to
+      # generate the file along with the artifacts it requires for inclusion
+      # in the image.
+      - name: Build Dockerfile
+        run: make docker
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          context: .
+          context: target/docker
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,6 @@ on:
   push:
     branches:
       - unstable
-      - shon/fix-docker-cd
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This is a followup to #1234, which accidentally broke the continuous
deployment of docker containers to the github container registry.

This happened because we are now generating our docker files based 
on the sbt build configuration, but the current github workflow expects
a Dockerfile in the root of the project. The proposed fix here (to be
tested once the PR is merged into unstable) is to generate the docker
file using our make target, and then point the github action to the 
"context" (directory) where the build file and its related artifacts are stored
in our artifact dir.

This patch fixes that buy first building the docker image, before
invoking the github action to upload the image to the registry

-------

<!-- Please ensure that your PR includes the following, as needed -->