### PR TITLE
Improve clarity of test output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,10 @@ lazy val tlaModuleTestSettings = Seq(
 )
 
 lazy val testSettings = Seq(
-    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDT"),
+    // Configure the test reporters for concise but informative output.
+    // See https://www.scalatest.org/user_guide/using_scalatest_with_sbt
+    // for the meaning of the flags.
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oCDEHT"),
 )
 
 /////////////////////////////

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -51,7 +51,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     val and1 =
       and(
           assign(x_prime, int(1)) ? "b",
-          assign(y_prime, int(2)) ? "b",
+          assign(y_prime, int(2)) ? "b"
       ).typed(types, "b")
 
     val state = new SymbState(and1, arena, Binding())
@@ -71,7 +71,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assertUnsatOrExplain(rewriter, nextState) // should not be possible
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(neql(y_cell, int(5)).typed(types, "b"))
+    solverContext.assertGroundExpr(neql(y_cell, int(2)).typed(types, "b"))
     assertUnsatOrExplain(rewriter, nextState) // should not be possible
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -51,7 +51,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     val and1 =
       and(
           assign(x_prime, int(1)) ? "b",
-          assign(y_prime, int(2)) ? "b"
+          assign(y_prime, int(2)) ? "b",
       ).typed(types, "b")
 
     val state = new SymbState(and1, arena, Binding())
@@ -71,7 +71,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assertUnsatOrExplain(rewriter, nextState) // should not be possible
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(neql(y_cell, int(2)).typed(types, "b"))
+    solverContext.assertGroundExpr(neql(y_cell, int(5)).typed(types, "b"))
     assertUnsatOrExplain(rewriter, nextState) // should not be possible
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndOOPSLA19.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl, oopsla19Encoding}
-import at.forsyte.apalache.tla.bmcmt.analyses._
+import at.forsyte.apalache.tla.bmcmt.oopsla19Encoding
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
@@ -10,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 /**
  * The tests for TransitionExecutorImpl that are using IncrementalSnapshot.
  *
- * @author Igor Konnov
+ * @author Igor Konnov, Shon Feder
  */
 @RunWith(classOf[JUnitRunner])
 class TestTransitionExecutorWithIncrementalAndOOPSLA19
@@ -19,12 +18,6 @@ class TestTransitionExecutorWithIncrementalAndOOPSLA19
   override protected def withFixture(test: OneArgTest): Outcome = {
     val solver =
       new Z3SolverContext(SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding))
-    val rewriter = new SymbStateRewriterImpl(solver, new ExprGradeStoreImpl())
-    val exeCtx = new IncrementalExecutionContext(rewriter)
-    try {
-      test(exeCtx)
-    } finally {
-      rewriter.dispose()
-    }
+    withFixtureInContext(solver, new IncrementalExecutionContext(_), test)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndOOPSLA19.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl, oopsla19Encoding}
-import at.forsyte.apalache.tla.bmcmt.analyses._
+import at.forsyte.apalache.tla.bmcmt.oopsla19Encoding
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
@@ -10,19 +9,13 @@ import org.scalatest.junit.JUnitRunner
 /**
  * The tests for TransitionExecutorImpl that are using IncrementalSnapshot.
  *
- * @author Igor Konnov
+ * @author Igor Konnov, Shon Feder
  */
 @RunWith(classOf[JUnitRunner])
 class TestTransitionExecutorWithOfflineAndOOPSLA19 extends TestTransitionExecutorImpl[OfflineExecutionContextSnapshot] {
-  override protected def withFixture(test: OneArgTest): Outcome = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val solver = RecordingSolverContext.createZ3(None,
         SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding))
-    val rewriter = new SymbStateRewriterImpl(solver, new ExprGradeStoreImpl())
-    val exeCtx = new OfflineExecutionContext(rewriter)
-    try {
-      test(exeCtx)
-    } finally {
-      rewriter.dispose()
-    }
+    withFixtureInContext(solver, (new OfflineExecutionContext(_)), test)
   }
 }


### PR DESCRIPTION
Igor hit a case earlier where the build of a test was failing but there was so
much noise in the output that it wasn't clear what was causing the failure. 

This pr adds some setup/teardown to tests that write noisly to stdout, and some
config flags to make the test output more concise and easier to read.

There are still some tests in `tla-io` dumping stuff to stdout, but afaict those tests seem to be written in such a way that I can't redirect stdout without breaking the tests...

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
