### PR TITLE
Fix a typo in packaging `Apalache.tla` in jar

### DIFF
--- a/bin/apalache-mc
+++ b/bin/apalache-mc
@@ -32,18 +32,6 @@ case `cat $DISTS | wc -l | sed 's/[[:space:]]*//g'` in
 esac
 rm -f "$DISTS"
 
-# an additional lookup list for the TLA+ modules
-TLA_LIB="$DIR/src/tla"
-
-# This is a temporary solution for handling TLA_PATH via a Java variable.
-# See apalache/#187.
-# Once tlaplus/#490,#493 are released, remove this workaround.
-if [ -z "$TLA_PATH" ]; then
-    TLA_PATH="$TLA_LIB"
-else
-    TLA_PATH="$TLA_LIB:$TLA_PATH"
-fi
-
 JVM_ARGS=${JVM_ARGS:-""}
 
 # Check of the heap size is already set

--- a/build.sbt
+++ b/build.sbt
@@ -210,9 +210,6 @@ docker / dockerfile := {
   val runners = rootDir / "bin"
   val runnersTarget = s"${dwd}/bin"
 
-  // val modules = rootDir / "src" / "tla"
-  // val modulesTarget = s"${dwd}/src/tla"
-
   val license = rootDir / "LICENSE"
   val readme = rootDir / "README.md"
 
@@ -225,7 +222,6 @@ docker / dockerfile := {
     add(runners, runnersTarget)
     add(license, s"${dwd}/${license.name}")
     add(readme, s"${dwd}/${readme.name}")
-    // add(modules, modulesTarget)
 
     // TLA parser requires all specification files to be in the same directory
     // We assume the user bind-mounted the spec dir into /var/apalache

--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,7 @@ lazy val root = (project in file("."))
         sbtassembly.MappingSet(
             None,
             Vector(
-                (src_dir / "Apalache.tla") -> "tla2sany/StandardModules/Apalacha.tla",
+                (src_dir / "Apalache.tla") -> "tla2sany/StandardModules/Apalache.tla",
                 (src_dir / "Variants.tla") -> "tla2sany/StandardModules/Variants.tla",
             ),
         )
@@ -210,8 +210,8 @@ docker / dockerfile := {
   val runners = rootDir / "bin"
   val runnersTarget = s"${dwd}/bin"
 
-  val modules = rootDir / "src" / "tla"
-  val modulesTarget = s"${dwd}/src/tla"
+  // val modules = rootDir / "src" / "tla"
+  // val modulesTarget = s"${dwd}/src/tla"
 
   val license = rootDir / "LICENSE"
   val readme = rootDir / "README.md"
@@ -225,7 +225,7 @@ docker / dockerfile := {
     add(runners, runnersTarget)
     add(license, s"${dwd}/${license.name}")
     add(readme, s"${dwd}/${readme.name}")
-    add(modules, modulesTarget)
+    // add(modules, modulesTarget)
 
     // TLA parser requires all specification files to be in the same directory
     // We assume the user bind-mounted the spec dir into /var/apalache


### PR DESCRIPTION
I was including the file in the fat jar as `Apalacha.tla` :facepalm: 

This PR also removes the part of the runner script that appends the location of the Apalache.tla modules into the path, since we don't need that and it adds more complexity to the end user artifact.