### PR TITLE
Fix unexpected polymorphism

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,4 +22,5 @@
 ### Bug fixes
 
  * Fix the semantics of @@ by using the TLC definition, see #1182, #951, #1234
+ * Fix unexpected polymorphism, see #1262
   

--- a/test/tla/Test1259.tla
+++ b/test/tla/Test1259.tla
@@ -1,0 +1,23 @@
+------------------ MODULE Test1259 ---------------------
+
+VARIABLES
+    \* @type: Str -> Int;
+    fun
+
+\* @type: (a -> b) => (a -> b);
+Foo(f) ==
+    LET \* @type: a -> b;
+        f2 == f
+    IN
+    LET
+        d == DOMAIN f2
+    IN
+    [ x \in d |-> f[x] ]
+
+Init ==
+    fun = Foo([ x \in { "a" } |-> 1 ])
+
+Next ==
+    UNCHANGED fun
+
+====================================================

--- a/test/tla/Test1259.tla
+++ b/test/tla/Test1259.tla
@@ -1,14 +1,14 @@
 ------------------ MODULE Test1259 ---------------------
 
 VARIABLES
-    \* @type: Str -> Int;
+    \* @type: Bool;
     fun
 
-\* @type: (a -> b) => (a -> b);
+\* @type: (a -> b) => Bool;
 Foo(f) ==
     LET f2 == f IN
     LET d == DOMAIN f2 IN
-    [ x \in d |-> f[x] ]
+    d = DOMAIN f
 
 Init ==
     fun = Foo([ x \in { "a" } |-> 1 ])

--- a/test/tla/Test1259.tla
+++ b/test/tla/Test1259.tla
@@ -6,12 +6,8 @@ VARIABLES
 
 \* @type: (a -> b) => (a -> b);
 Foo(f) ==
-    LET \* @type: a -> b;
-        f2 == f
-    IN
-    LET
-        d == DOMAIN f2
-    IN
+    LET f2 == f IN
+    LET d == DOMAIN f2 IN
     [ x \in d |-> f[x] ]
 
 Init ==

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1674,12 +1674,10 @@ EXITCODE: OK
 
 ### check Test951.tla reports no error on Inv: regression for #951
 
-But currently, it does. Bad luck. It should be fixed.
-
 ```sh
 $ apalache-mc check --inv=Inv Test951.tla | sed 's/[IEW]@.*//'
 ...
-EXITCODE: ERROR (12)
+EXITCODE: OK
 ```
 
 ### check Test1259.tla reports no error: regression for #1259

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1682,6 +1682,14 @@ $ apalache-mc check --inv=Inv Test951.tla | sed 's/[IEW]@.*//'
 EXITCODE: ERROR (12)
 ```
 
+### check Test1259.tla reports no error: regression for #1259
+
+```sh
+$ apalache-mc check Test1259.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ## running the typecheck command
 
 ### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ConstraintSolver.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ConstraintSolver.scala
@@ -84,7 +84,11 @@ class ConstraintSolver(approximateSolution: Substitution = Substitution.empty) {
    * @return true if the variable occurs in the partial solution of the solver
    */
   def isFreeVar(varNo: Int): Boolean = {
-    approximateSolution.mapping.keySet.forall(cls => !cls.typeVars.contains(varNo))
+    def outsideClass(cls: EqClass): Boolean = !cls.typeVars.contains(varNo)
+    // Check both the approximate solution, which the solver was initialized with, and the solution, if it exists.
+    // This is probably a computationally expensive check:
+    // https://github.com/informalsystems/apalache/issues/973
+    approximateSolution.mapping.keySet.forall(outsideClass) && solution.mapping.keySet.forall(outsideClass)
   }
 
   private def solveOne(solution: Substitution, constraint: Clause): Option[(Substitution, TlaType1)] = {


### PR DESCRIPTION
Closes #1259 and #951. After all, it is a one-line fix. But given how hard it was to find, we should consider making quantified type variables explicit in the annotations and types.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
