### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
         run: make test-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
+        with:
+          # See https://app.codecov.io/gh/informalsystems/apalache/
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
       - name: Cleanup before cache
         # See https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html#Caching
         shell: bash


### PR DESCRIPTION
We're seeing some rate limiting from codecov. This might just be a hard limit of
the service, but thought adding in a codecov token might help.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality