### PR TITLE
downgrade the exception to a log message

### DIFF
--- a/test/tla/Test1275.tla
+++ b/test/tla/Test1275.tla
@@ -1,0 +1,6 @@
+------------- MODULE Test1275 ----------------------
+\* TLA+ Toolbox generates comments like the one below:
+
+\* CONSTANT definitions @modelParameterConstants:0Foo
+Foo == "Foo"
+====================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -169,6 +169,20 @@ EXITCODE: OK
 ...
 ```
 
+### parse Test1275 succeeds
+
+We have decided to display a warning instead of exiting with an error,
+because TLA+ Toolbox generates comments that look like malformed annotations.
+
+```sh
+$ apalache-mc parse Test1275.tla | sed 's/W@.*//'
+...
+[Test1275:5:1-5:12]: Syntax error in annotation -- Unexpected character. Missing ')' or ';'?
+...
+EXITCODE: OK
+...
+```
+
 ### parse --output=annotations.tla Annotations succeeds
 
 And also check that it actually parses into TLA (see #1079)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -2,13 +2,14 @@ package at.forsyte.apalache.tla.bmcmt.config
 
 import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, FailureMessage, NormalErrorMessage}
 import at.forsyte.apalache.io.ConfigurationError
+import at.forsyte.apalache.io.annotations.AnnotationParserError
 import at.forsyte.apalache.tla.assignments.AssignmentException
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.imp.SanyException
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.{
-  LanguagePredError, MalformedSepecificationError, MalformedTlaError, OutdatedAnnotationsError, TypingException, UID
+  LanguagePredError, MalformedSepecificationError, MalformedTlaError, OutdatedAnnotationsError, TypingException, UID,
 }
 import at.forsyte.apalache.tla.pp.{IrrecoverablePreprocessingError, NotInKeraError, OverridingError, TlaInputError}
 import at.forsyte.apalache.tla.typecheck.TypingInputException
@@ -30,6 +31,9 @@ class CheckerExceptionAdapter @Inject() (sourceStore: SourceStore, changeListene
     // normal errors
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
+
+    case err: AnnotationParserError =>
+      NormalErrorMessage("Syntax error in annotation: " + err.getMessage)
 
     case err: ConfigurationError =>
       NormalErrorMessage("Configuration error (see the manual): " + err.getMessage)

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
@@ -25,8 +25,13 @@ class AnnotationExtractor(annotationStore: AnnotationStore) extends LazyLogging 
 
       case Left(message) =>
         // Warn the user and continue. It may be a piece of text that looks like an annotation, but it is not an annotation.
-        val msg = node.getLocation.toString + ": " + message
-        throw new AnnotationParserError(msg)
+        // It would be better to throw an exception here. However, TLA+ Toolbox is automatically generating comments
+        // that look like malformed annotations, e.g., CONSTANT definitions @modelParameterConstants:0Foo
+        val loc = node.getLocation
+        val msg = "[%s:%d:%d-%d:%d]: Syntax error in annotation -- %s"
+          .format(loc.source(), loc.beginLine(), loc.beginColumn(), loc.endLine(), loc.endColumn(), message)
+        logger.warn(msg)
+        None
     }
 
     val freeTextTrimmed = freeText.trim()

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
@@ -1,6 +1,8 @@
 package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, NormalErrorMessage}
+import at.forsyte.apalache.io.annotations.AnnotationParserError
+
 import javax.inject.{Inject, Singleton}
 
 /**
@@ -10,7 +12,11 @@ import javax.inject.{Inject, Singleton}
  */
 @Singleton
 class ParserExceptionAdapter @Inject() () extends ExceptionAdapter {
-  override def toMessage: PartialFunction[Exception, ErrorMessage] = { case err: SanyException =>
-    NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
+  override def toMessage: PartialFunction[Exception, ErrorMessage] = {
+    case err: SanyException =>
+      NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
+
+    case err: AnnotationParserError =>
+      NormalErrorMessage("Syntax error in annotation: " + err.getMessage)
   }
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
@@ -279,11 +279,14 @@ class TestSanyImporterAnnotations extends FunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val caught = intercept[AnnotationParserError] {
-      loadModule(text, "missing")
-    }
-    assert(
-        "line 4, col 1 to line 4, col 14 of module missing: Unexpected character. Missing ')' or ';'?" == caught.getMessage)
+    // as explained in #1292, we are not throwing an exception anymore
+    val module = loadModule(text, "missing")
+
+    val action = module.declarations
+      .find(_.name == "action")
+      .getOrElse(fail("Expected an operator"))
+    val annotations = annotationStore(action.ID)
+    assert(annotations.length == 1)
   }
 
   test("corner cases") {

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.typecheck.passes
 
 import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, FailureMessage, NormalErrorMessage}
+import at.forsyte.apalache.io.annotations.AnnotationParserError
 import at.forsyte.apalache.tla.imp.SanyException
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
@@ -20,6 +21,9 @@ class EtcTypeCheckerAdapter @Inject() (sourceStore: SourceStore, changeListener:
   override def toMessage: PartialFunction[Exception, ErrorMessage] = {
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
+
+    case err: AnnotationParserError =>
+      NormalErrorMessage("Syntax error in annotation: " + err.getMessage)
 
     case err: TypingInputException =>
       NormalErrorMessage("Typing input error: " + err.getMessage)


### PR DESCRIPTION
Since TLA+ Toolbox is producing comments that look very much like ill-formed annotations, this PR downgrades the exception in `AnnotationExtractor` to a `log.error` message. Just in case, `AnnotationParseError` is still processed in all adapters.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~
