### PR TITLE
Bugfix for #1285

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix a bug where some simplified `Or` expressions were not expected by the rewriting rules, see #1285

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/OrRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/OrRule.scala
@@ -71,12 +71,9 @@ class OrRule(rewriter: SymbStateRewriter) extends RewritingRule {
           rewriter.rewriteUntilDone(newState)
         }
 
-      case e @ ValEx(_) =>
-        // the simplifier has rewritten the disjunction to TRUE or FALSE
-        rewriter.rewriteUntilDone(state.setRex(e))
-
       case e @ _ =>
-        throw new RewriterException("%s is not applicable to %s".format(getClass.getSimpleName, e), state.ex)
+        // the simplifier has rewritten the conjunction to some other expression
+        rewriter.rewriteUntilDone(state.setRex(e))
     }
   }
 }


### PR DESCRIPTION
Hello :octocat: 

The newly implemented simplifications for `Or` expressions allow a generic expression to arise from simplification
since expressions like `\/ x` and `x \/ true` are now simplified to `x`. However, `OrRule` calls a simplification over an `Or` expression and expects the result to be either a value (`TRUE` or `FALSE`) or another `Or` expression. This expectation breaks with the newly introduced simplification.

 Fixes https://github.com/informalsystems/apalache/issues/1285

- [ ] Tests added for any new code
- [X] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
