### PR TITLE
Add make target to build and run apalache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,6 +242,14 @@ https://scalameta.org/metals/docs/editors/emacs.html
 
 ## Testing
 
+### Build and run Apalache from source
+
+Execute apalache from the unpackaged source, ensuring any updates are built, run
+
+```sh
+make run <arguments>
+```
+
 ### Unit tests
 
 Run the units

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,16 @@ fmt-fix:
 clean:
 	sbt clean
 	rm -rf target/
+
+# Adapted from https://github.com/ocaml/dune/blob/d60cfbc0c78bb8733115d9100a8f7f6cb3dcf85b/Makefile#L121-L127
+# If the first argument is "run"...
+ifeq (run,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "run"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+
+# Run apalache with the given `RUN_ARGS`, ensuring it has been built first
+run:
+	sbt "tool / run $(RUN_ARGS)"


### PR DESCRIPTION
Using this target can help ensure we don't forget to, e.g, build a fresh
executable after pulling fresh changes in (which I did today) :)

You can run it like

  make run check --length=1 Foo.tla

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality