### PR TITLE
Cleaned up `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,26 +6,14 @@ target/
 .bsp
 .bloop
 
+# Generated if running integration tests locally
+_apalache-out/
+
 # Auto generated file for metals
-
 metals.sbt
-log*.smt
-test/tla/testSpec\.smt2
-test/tla/counterexample*
-
-tla-assignments/src/test/resources/assignmentTest1.smt2
-tla-bmcmt/counterexample*
-tla-bmcmt/profile-rules.txt
-
-*.err
-*.out
-*.log
 
 # Local envars for direnv
 /.local-envrc
-
-# Ignore directories where test artifacts are stored
-x/
 
 # Ignore artifacts created when previewing the gh-pages site
 /Gemfile.lock

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -279,6 +279,7 @@ Check that a file produced with `--output` is valid input (see #1281)
 $ apalache-mc typecheck --output=output.json Annotations.tla ; apalache-mc typecheck output.json | sed 's/I@.*//'
 ...
 EXITCODE: OK
+$ rm output.json
 ```
 
 ### parse FormulaRefs fails


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

I took the liberty of reviewing the `.gitignore` file, and pruned file formats that shouldn't be appearing in the directories at all anymore. Removing them from `.gitignore` also lets us see if these files still get produced, which would be a bug at this point (e.g. the missing `rm` in the tests file).