### PR TITLE
Mount user's ~/.tlaplus dir in docker container

### DIFF
--- a/bin/run-in-docker-container
+++ b/bin/run-in-docker-container
@@ -13,6 +13,13 @@ GROUP_ID=${GROUP_ID:-1000}
 groupadd --gid "$GROUP_ID" --non-unique apalache
 useradd --create-home --shell /bin/bash --uid "$USER_ID" --non-unique --gid "$GROUP_ID" apalache
 
+# Since we bound mount the users ~/.tlaplus into the home dir, useradd won't
+# populate the existing home with the usual skeleton, so we do that as a followup.
+cp -r /etc/skel/. /home/apalache
+
+# Ensure the apalache user owns their home
+chown -R apalache:apalache /home/apalache
+
 echo 'Assuming you bind-mounted your local directory into /var/apalache...'
 cd /var/apalache
 if [ "$(ls -A *.tla 2>/dev/null)" == "" ]; then

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -28,7 +28,7 @@ cmd="docker run \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
     --rm \
     -v $(pwd):/var/apalache \
-    -v "$HOME/.tlaplus":/root/.tlaplus \
+    -v "$HOME/.tlaplus":/home/apalache/.tlaplus \
     ${img} ${*}"
 >&2 echo "# running command: ${cmd}"
 $cmd

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -26,6 +26,9 @@ cmd="docker run \
     -e OUT_DIR -e WRITE_INTERMEDIATE -e SMT_ENCODING \
     -e TLA_PATH -e JVM_ARGS \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
-    --rm -v $(pwd):/var/apalache ${img} ${*}"
+    --rm \
+    -v $(pwd):/var/apalache \
+    -v "$HOME/.tlaplus":/root/.tlaplus \
+    ${img} ${*}"
 >&2 echo "# running command: ${cmd}"
 $cmd


### PR DESCRIPTION
Aims to fix the docker integration issues hit in #1317, and this PR is into
that feature branch.

This is probably the desired behavior for the docker container in any case,
since it allows it to function even more accurately as a mimic of the
uncontained executable.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality