### PR TITLE
Add a short Twitter widget for narrow screens

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,13 +38,19 @@
         </ul>
         {% endif %}
 
-        <a class="twitter-timeline" href="https://twitter.com/ApalacheTLA?ref_src=twsrc%5Etfw">Tweets by ApalacheTLA</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <!-- Tall Twitter widget for wide screens. See `style.scss` for details. -->
+        <a class="twitter-timeline" id="twitter-timeline-0" href="https://twitter.com/ApalacheTLA?ref_src=twsrc%5Etfw">Tweets by ApalacheTLA</a>
       </header>
       <section>
 
       {{ content }}
 
       </section>
+
+      <!-- Short Twitter widget for narrow screens. See `style.scss` for details. -->
+      <a class="twitter-timeline" id="twitter-timeline-1" data-height="400" href="https://twitter.com/ApalacheTLA?ref_src=twsrc%5Etfw">Tweets by ApalacheTLA</a>
+      <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
     {% if site.google_analytics %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -6,15 +6,15 @@
 // Custom styles go here
 
 /* 
- * Workaround for showing a smaller Twitter widget on narrow screens.
+ * Show a smaller Twitter widget on narrow screens.
  *
  * We use two widgets, #twitter-widget-0 (unbounded height for wide screens),
  * and #twitter-widget-1 (bounded height for narrow screens).
  *
- * This workaround is necessary because the widget location is marked in HTML
- * using an <a> element. An iframe of correct bounding height is injected via
- * Twitter's JS. The iframe height is pre-set via `data-height` attribute on
- * the corresponding <a>.
+ * This CSS hack is necessary because the widget location is marked in HTML
+ * using an <a> element. An iframe of correct bounding height is injected at
+ * its location via Twitter's JS. The iframe height is pre-set via
+ * `data-height` attribute on the corresponding <a>.
  *
  * Custom resizing of the widget iframe via CSS is not an option, because
  *   - Twitter's injected JS resets the iframe height on resize events, and
@@ -22,7 +22,7 @@
  *     within the viewport.
  *
  * We use !important to override the element-level `display` property set by
- * Twitter JS.
+ * Twitter's JS.
  */
 
 // Default: hide the short twitter widget and its injection <a>.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,3 +4,43 @@
 @import "{{ site.theme }}";
 
 // Custom styles go here
+
+/* 
+ * Workaround for showing a smaller Twitter widget on narrow screens.
+ *
+ * We use two widgets, #twitter-widget-0 (unbounded height for wide screens),
+ * and #twitter-widget-1 (bounded height for narrow screens).
+ *
+ * This workaround is necessary because the widget location is marked in HTML
+ * using an <a> element. An iframe of correct bounding height is injected via
+ * Twitter's JS. The iframe height is pre-set via `data-height` attribute on
+ * the corresponding <a>.
+ *
+ * Custom resizing of the widget iframe via CSS is not an option, because
+ *   - Twitter's injected JS resets the iframe height on resize events, and
+ *   - contained HTML is rendered wrt/ to iframe height to keep user controls
+ *     within the viewport.
+ *
+ * We use !important to override the element-level `display` property set by
+ * Twitter JS.
+ */
+
+// Default: hide the short twitter widget and its injection <a>.
+#twitter-timeline-1,
+#twitter-widget-1 {
+  display: none !important;
+}
+
+// On narrow screens: Show short twitter widget, hide tall one.
+@media print, screen and (max-width: 960px) {
+  #twitter-timeline-1 {
+    display: inline !important;
+  }
+  #twitter-widget-1 {
+    display: inline-block !important;
+  }
+  #twitter-timeline-0,
+  #twitter-widget-0 {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
The current Twitter widget has unbounded height. On narrow screens
(e.g., phones) one needs to scroll past the Twitter feed to get to the
main page contents.

This adds a second (shorter) Twitter widget below the main content, that
is only displayed on narrow screens. The other widget is then hidden.