### PR TITLE
`UNCHANGED` now introduces Apalache assignments, if possible

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,3 +14,7 @@
 
  * The `profiling.csv` file output by the `--smtprof` flag moved into the
    configurable `run-dir`, see #1321
+
+### Features
+
+* `UNCHANGED x` now rewrites to `x' := x` instead of `x' = x`, when `x` is a variable name

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -12,7 +12,8 @@ import javax.inject.Singleton
 /**
  * <p>Remove all annoying syntactic sugar.</p>
  *
- * @author Igor Konnov
+ * @author
+ *   Igor Konnov
  */
 @Singleton
 class Desugarer(gen: UniqueNameGenerator, tracker: TransformationTracker) extends TlaExTransformation {
@@ -51,10 +52,13 @@ class Desugarer(gen: UniqueNameGenerator, tracker: TransformationTracker) extend
       // map every x to x' = x
       val eqs = flatArgs map { x: TlaEx =>
         val tt = x.typeTag.asTlaType1()
-        val xb = tla.fromTlaEx(x)
-        tla
-          .eql(tla.prime(xb) ? "x", xb)
-          .typed(Map("b" -> BoolT1(), "x" -> tt), "b")
+        def xb = tla.fromTlaEx(x) as tt
+        // We translate UNCHANGED x' to x' := x and UNCHANGED F[x] to the generic F[x]' = F[x]
+        val asgnOrEq: (TlaEx, TlaEx) => BuilderEx = x match {
+          case _: NameEx => tla.assign(_, _)
+          case _         => tla.eql(_, _)
+        }
+        asgnOrEq(tla.prime(xb) as tt, xb) as BoolT1()
       }
       // x' = x /\ y' = y /\ z' = z
       eqs match {
@@ -230,10 +234,14 @@ class Desugarer(gen: UniqueNameGenerator, tracker: TransformationTracker) extend
   /**
    * Transform filter expressions like {<< x, y >> \in S: x = 1} to { x_y \in S: x_y[1] = 1 }
    *
-   * @param boundEx a bound expression, e.g., x or << x, y >>
-   * @param setEx   a set expression, e.g., S
-   * @param predEx  a predicate expression, e.g., x == 1
-   * @return transformed arguments
+   * @param boundEx
+   *   a bound expression, e.g., x or << x, y >>
+   * @param setEx
+   *   a set expression, e.g., S
+   * @param predEx
+   *   a predicate expression, e.g., x == 1
+   * @return
+   *   transformed arguments
    */
   def collapseTuplesInFilter(boundEx: TlaEx, setEx: TlaEx, predEx: TlaEx): Seq[TlaEx] = {
     val boundName = mkTupleName(boundEx) // rename a tuple into a name, if needed
@@ -247,9 +255,12 @@ class Desugarer(gen: UniqueNameGenerator, tracker: TransformationTracker) extend
   /**
    * Transform filter expressions like {x : << x, y >> \in S} to { x_y[1] : x_y \in S }
    *
-   * @param mapEx the mapping, e.g., x
-   * @param args  bindings and sets
-   * @return transformed arguments
+   * @param mapEx
+   *   the mapping, e.g., x
+   * @param args
+   *   bindings and sets
+   * @return
+   *   transformed arguments
    */
   def collapseTuplesInMap(mapEx: TlaEx, args: Seq[TlaEx]): Seq[TlaEx] = {
     val (boundEs, setEs) = TlaOper.deinterleave(args)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -13,7 +13,7 @@ import javax.inject.Singleton
  * <p>Remove all annoying syntactic sugar.</p>
  *
  * @author
- *   Igor Konnov
+ *   Igor Konnov, Jure Kukovec
  */
 @Singleton
 class Desugarer(gen: UniqueNameGenerator, varNames: Set[String], tracker: TransformationTracker)
@@ -54,7 +54,7 @@ class Desugarer(gen: UniqueNameGenerator, varNames: Set[String], tracker: Transf
       val eqs = flatArgs map { x: TlaEx =>
         val tt = x.typeTag.asTlaType1()
         def xb = tla.fromTlaEx(x) as tt
-        // We translate UNCHANGED x' to x' := x and UNCHANGED F[x] to the generic F[x]' = F[x]
+        // We translate UNCHANGED x' to x' := x and the generic UNCHANGED e to (e)' = e
         val asgnOrEq: (TlaEx, TlaEx) => BuilderEx = x match {
           case NameEx(n) if varNames.contains(n) => tla.assign(_, _)
           case _                                 => tla.eql(_, _)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -16,7 +16,7 @@ import javax.inject.Singleton
  *   Igor Konnov, Jure Kukovec
  */
 @Singleton
-class Desugarer(gen: UniqueNameGenerator, varNames: Set[String], tracker: TransformationTracker)
+class Desugarer(gen: UniqueNameGenerator, stateVariables: Set[String], tracker: TransformationTracker)
     extends TlaExTransformation {
 
   override def apply(expr: TlaEx): TlaEx = {
@@ -56,8 +56,8 @@ class Desugarer(gen: UniqueNameGenerator, varNames: Set[String], tracker: Transf
         def xb = tla.fromTlaEx(x) as tt
         // We translate UNCHANGED x' to x' := x and the generic UNCHANGED e to (e)' = e
         val asgnOrEq: (TlaEx, TlaEx) => BuilderEx = x match {
-          case NameEx(n) if varNames.contains(n) => tla.assign(_, _)
-          case _                                 => tla.eql(_, _)
+          case NameEx(n) if stateVariables.contains(n) => tla.assign(_, _)
+          case _                                       => tla.eql(_, _)
         }
         asgnOrEq(tla.prime(xb) as tt, xb) as BoolT1()
       }
@@ -393,7 +393,7 @@ class Desugarer(gen: UniqueNameGenerator, varNames: Set[String], tracker: Transf
 }
 
 object Desugarer {
-  def apply(gen: UniqueNameGenerator, varNames: Set[String], tracker: TransformationTracker): Desugarer = {
-    new Desugarer(gen, varNames, tracker)
+  def apply(gen: UniqueNameGenerator, stateVariables: Set[String], tracker: TransformationTracker): Desugarer = {
+    new Desugarer(gen, stateVariables, tracker)
   }
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
@@ -32,7 +32,8 @@ class DesugarerPassImpl @Inject() (
   override def execute(tlaModule: TlaModule): Option[TlaModule] = {
     logger.info("  > Desugaring...")
     val input = tlaModule
-    val afterDesug = ModuleByExTransformer(Desugarer(gen, tracker))(input)
+    val varNames = input.varDeclarations.map { _.name }.toSet
+    val afterDesug = ModuleByExTransformer(Desugarer(gen, varNames, tracker))(input)
     val output = ModuleByExTransformer(SelectSeqAsFold(gen, tracker))(afterDesug)
 
     // dump the result of preprocessing

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
@@ -45,7 +45,7 @@ class PreproPassImpl @Inject() (
     val transformationSequence: List[(String, TlaModuleTransformation)] =
       List(
           ("PrimePropagation", createModuleTransformerForPrimePropagation(varSet)),
-          ("Desugarer", ModuleByExTransformer(Desugarer(gen, tracker))),
+          ("Desugarer", ModuleByExTransformer(Desugarer(gen, varSet, tracker))),
           ("UniqueRenamer", renaming.renameInModule),
           ("Normalizer", ModuleByExTransformer(Normalizer(tracker))),
           ("Keramelizer", ModuleByExTransformer(Keramelizer(gen, tracker))),


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

As per our discussions, `UNCHANGED x` now produces `x' := x`, instead of `x' = x`, when `x` is a `NameEx`. The behavior in the case of `UNCHANGED F[x]` remains unchanged; `(F[x]') = F[x]`