### PR TITLE
Remove --overwrite in apalacheCurrentPackage task to fix failing builds on MacOS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,8 +231,8 @@ lazy val root = (project in file("."))
         val (unzipped, _) = IO.split(pkg.toString)
         val target_dir = (Universal / target).value
         val current_pkg = (Universal / target).value / "current-pkg"
-        log.info(s"Unpacking package ${pkg}")
-        s"tar zxvf ${pkg} --overwrite -C ${target_dir}" ! log
+        log.info(s"Unpacking package ${pkg} to ${target_dir}")
+        s"tar zxvf ${pkg} -U -C ${target_dir}" ! log
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
         s"ln -sfn ${unzipped} ${current_pkg}" ! log
         file(unzipped)

--- a/build.sbt
+++ b/build.sbt
@@ -232,7 +232,7 @@ lazy val root = (project in file("."))
         val target_dir = (Universal / target).value
         val current_pkg = (Universal / target).value / "current-pkg"
         log.info(s"Unpacking package ${pkg} to ${target_dir}")
-        s"tar zxvf ${pkg} -U -C ${target_dir}" ! log
+        s"tar zxvf ${pkg} -C ${target_dir}" ! log
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
         s"ln -sfn ${unzipped} ${current_pkg}" ! log
         file(unzipped)


### PR DESCRIPTION
This is a temporary fix for #1368, which lets `make package` go through on my computer. This needs a more thorough analysis though.

It is still producing error messages while unpacking:

```
[info] Unpacking package /Users/.../apalache/target/universal/apalache-0.20.4-SNAPSHOT.tgz to /Users/.../apalache/target/universal
[error] x apalache-0.20.4-SNAPSHOT/
[error] x apalache-0.20.4-SNAPSHOT/LICENSE
[error] x apalache-0.20.4-SNAPSHOT/bin/
[error] x apalache-0.20.4-SNAPSHOT/lib/
[error] x apalache-0.20.4-SNAPSHOT/lib/apalache.jar
[error] x apalache-0.20.4-SNAPSHOT/bin/apalache-mc
[info] Symlinking /Users/.../apalache/target/universal/current-pkg -> /Users/.../apalache/target/universal/apalache-0.20.4-SNAPSHOT
[success] Total time: 8 s, completed Feb 18, 2022 9:42:51 AM

```
