### PR TITLE
Rewrite Cardinality(SUBSET S) into 2^Cardinality(S)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,3 +21,8 @@
 ### Features
 
 * `UNCHANGED x` now rewrites to `x' := x` instead of `x' = x`, when `x` is a variable name
+
+
+### Bug fixes
+
+ * Handle `Cardinality(SUBSET S)` without failing, see #1370

--- a/test/tla/TestSets.tla
+++ b/test/tla/TestSets.tla
@@ -149,8 +149,6 @@ TestForallInPowerset ==
     \A S \in SUBSET Set1357:
         6 \notin S
 
-\* TODO: FIX IT!
-\* https://github.com/informalsystems/apalache/issues/1360
 TestPowersetCardinality ==
     Cardinality(SUBSET Set263) = 8
 
@@ -243,8 +241,8 @@ AllTests ==
     /\ TestChooseEmpty
     /\ TestChooseSet
     /\ TestIsFiniteSet
+    /\ TestPowersetCardinality
     \* IGNORE UNTIL FIXED: /\ TestIsFiniteSetOnInfinite
-    \* IGNORE UNTIL FIXED: /\ TestPowersetCardinality
     \* IGNORE UNTIL FIXED: /\ TestPowersetEmpty
     \* IGNORE UNTIL FIXED: /\ TestPowerset26
     \* IGNORE UNTIL FIXED: /\ TestPowersetSubsetEq

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -80,6 +80,12 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
       val bMinusA = OperEx(TlaArithOper.minus, right, left)(intTag)
       OperEx(TlaArithOper.plus, bMinusA, ValEx(TlaInt(1))(intTag))(intTag)
 
+    case OperEx(TlaFiniteSetOper.cardinality, OperEx(TlaSetOper.powerset, set)) =>
+      // A pattern that emerged in issue #1360
+      // Cardinality(SUBSET S) is equivalent to 2^Cardinality(S).
+      val cardEx = OperEx(TlaFiniteSetOper.cardinality, set)(set.typeTag)
+      OperEx(TlaArithOper.exp, ValEx(TlaInt(2))(intTag), cardEx)(intTag)
+
     case OperEx(TlaOper.eq, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal))) if intVal == BigInt(0) =>
       // Cardinality(Set) = 0, that is, Set = {}.
       // Rewrite it to Set = {}, as its complexity is lower.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -83,7 +83,7 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
     case OperEx(TlaFiniteSetOper.cardinality, OperEx(TlaSetOper.powerset, set)) =>
       // A pattern that emerged in issue #1360
       // Cardinality(SUBSET S) is equivalent to 2^Cardinality(S).
-      val cardEx = OperEx(TlaFiniteSetOper.cardinality, set)(set.typeTag)
+      val cardEx = OperEx(TlaFiniteSetOper.cardinality, set)(intTag)
       OperEx(TlaArithOper.exp, ValEx(TlaInt(2))(intTag), cardEx)(intTag)
 
     case OperEx(TlaOper.eq, OperEx(TlaFiniteSetOper.cardinality, set), ValEx(TlaInt(intVal))) if intVal == BigInt(0) =>

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestExprOptimizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestExprOptimizer.scala
@@ -14,6 +14,7 @@ class TestExprOptimizer extends AnyFunSuite with BeforeAndAfterEach {
   private val intT = IntT1()
   private val boolT = BoolT1()
   private val intSetT = SetT1(IntT1())
+  private val intSetSetT = SetT1(IntT1())
   private val boolSetT = SetT1(BoolT1())
   private var optimizer = new ExprOptimizer(new UniqueNameGenerator(), TrackerWithListeners())
 
@@ -152,6 +153,13 @@ class TestExprOptimizer extends AnyFunSuite with BeforeAndAfterEach {
     val output = optimizer.apply(input)
     val expected =
       plus(minus(name("b").as(intT), name("a").as(intT)).as(intT), int(1).as(intT)).as(intT)
+    assert(expected == output)
+  }
+
+  test("""Cardinality(SUBSET S) becomes 2^(Cardinality(S))""") {
+    val input = card(powSet(name("S").as(intSetT)).as(intSetSetT)).as(intT)
+    val output = optimizer.apply(input)
+    val expected = exp(int(2), card(name("S").as(intSetT)).as(intT)).as(intT)
     assert(expected == output)
   }
 }


### PR DESCRIPTION
Closes #1360. Simply preprocess `Cardinality(SUBSET S)`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
