### PR TITLE
Revert CHANGES.md for tag v0.21.0 and fix release script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,25 +2,6 @@
      This file is generated. Do not write release notes here.
      Notes for unreleased changes go in ./UNRELEASED.md -->
 
-## 0.21.0
-
-### Breaking changes
-
- * The `profiling.csv` file output by the `--smtprof` flag moved into the
-   configurable `run-dir`, see #1321
- * The distribution package structure has changed. This shouldn't cause any
-   breakage in operation, but may impact some automated deployment pipelines,
-   see #1357
-
-### Features
-
-* `UNCHANGED x` now rewrites to `x' := x` instead of `x' = x`, when `x` is a variable name
-
-
-### Bug fixes
-
- * Handle `Cardinality(SUBSET S)` without failing, see #1370
-
 ## 0.20.3
 
 ### Features

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,19 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Breaking changes
+
+ * The `profiling.csv` file output by the `--smtprof` flag moved into the
+   configurable `run-dir`, see #1321
+ * The distribution package structure has changed. This shouldn't cause any
+   breakage in operation, but may impact some automated deployment pipelines,
+   see #1357
+
+### Features
+
+* `UNCHANGED x` now rewrites to `x' := x` instead of `x' = x`, when `x` is a variable name
+
+
+### Bug fixes
+
+ * Handle `Cardinality(SUBSET S)` without failing, see #1370

--- a/script/release-publish.sh
+++ b/script/release-publish.sh
@@ -36,8 +36,6 @@ then
     exit 5
 fi
 
-cd "$PROJ_ROOT"
-
 make dist
 
 # Package the artifacts
@@ -51,6 +49,7 @@ TGZF_NO_VER="target/universal/apalache.tgz"
 
 # We put a `v` in front of our versions for tags
 TAG_NAME="v${VERSION}"
+
 # Tag the commit and push the tag
 git tag -a "$TAG_NAME" -m "$msg"
 git push --tags

--- a/script/release-publish.sh
+++ b/script/release-publish.sh
@@ -40,17 +40,17 @@ cd "$PROJ_ROOT"
 
 make dist
 
-TAG_NAME="v${VERSION}"
-
 # Package the artifacts
 # The archives without version suffix support stable links to the latest version.
 # See https://github.com/informalsystems/apalache/issues/716
-ZIPF="target/universal/apalache-${TAG_NAME}.zip"
+ZIPF="target/universal/apalache-${VERSION}.zip"
 ZIPF_NO_VER="target/universal/apalache.zip"
 
-TGZF="target/universal/apalache-${TAG_NAME}.tgz"
+TGZF="target/universal/apalache-${VERSION}.tgz"
 TGZF_NO_VER="target/universal/apalache.tgz"
 
+# We put a `v` in front of our versions for tags
+TAG_NAME="v${VERSION}"
 # Tag the commit and push the tag
 git tag -a "$TAG_NAME" -m "$msg"
 git push --tags


### PR DESCRIPTION
Followup to #1357

We are now using the archives that are generated automatically by
sbt-native-packager. These don't include a `v` before the version in the
archive name. I missed this discrepancy when adjusting the release
script to the new packaging process.

This PR fixes the release script and reverts the changelog. Once this is merged
into master, we'll cut a new release, that will increment the tag and use the
same release notes for the next patch version.

<!-- Please ensure that your PR includes the following, as needed -->