### PR TITLE
Extend `IrGenerators` with function operators

### DIFF
--- a/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
@@ -118,7 +118,7 @@ class TestUJsonToTla extends AnyFunSuite with Checkers {
     val gens: IrGenerators = new IrGenerators {
       override val maxArgs: Int = 3
     }
-    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators
+    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators ++ gens.functionOperators
     val genDecl = gens.genTlaDeclButNotVar(gens.genTlaEx(operators)) _
     val prop = forAll(gens.genTlaModuleWith(genDecl)) { module =>
       val moduleJson = enc(module)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
@@ -118,7 +118,8 @@ class TestUJsonToTla extends AnyFunSuite with Checkers {
     val gens: IrGenerators = new IrGenerators {
       override val maxArgs: Int = 3
     }
-    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators ++ gens.functionOperators
+    val operators =
+      gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators ++ gens.functionOperators
     val genDecl = gens.genTlaDeclButNotVar(gens.genTlaEx(operators)) _
     val prop = forAll(gens.genTlaModuleWith(genDecl)) { module =>
       val moduleJson = enc(module)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -26,7 +26,7 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
   private val gens = new IrGenerators {
     override val maxArgs: Int = 3
   }
-  private val ops = gens.simpleOperators ++ gens.arithOperators ++ gens.setOperators
+  private val ops = gens.simpleOperators ++ gens.arithOperators ++ gens.setOperators ++ gens.functionOperators
   private val twoExpressions = for {
     e1 <- gens.genTlaEx(ops)(gens.emptyContext)
     e2 <- gens.genTlaEx(ops)(gens.emptyContext)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestKeramelizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestKeramelizer.scala
@@ -301,8 +301,11 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
   test("simplifies TLA+ expressions to KerA+") {
     // Generator for PBT
     val gens = new IrGenerators { override val maxArgs: Int = 3 }
+
     // Generated operators
-    val ops = gens.simpleOperators ++ gens.logicOperators ++ gens.arithOperators ++ gens.setOperators
+    val ops =
+      gens.simpleOperators ++ gens.logicOperators ++ gens.arithOperators ++ gens.setOperators ++ gens.functionOperators
+
     // Predicates for Keramelizer input and Keramelizer output (= KerA+)
     val inputPred = KeramelizerInputLanguagePred()
     val outputPred = KeraLanguagePred()

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -81,6 +81,12 @@ trait IrGenerators extends TlaType1Gen {
       TlaSetOper.setminus, TlaSetOper.subseteq, TlaSetOper.times, TlaSetOper.union)
 
   /**
+   * Function operators (`TlaFunOper._`)
+   */
+  val functionOperators = List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.funDef,
+      TlaFunOper.recFunDef, TlaFunOper.recFunRef, TlaFunOper.except)
+
+  /**
    * The list of action operators.
    */
   val actionOperators = List(TlaActionOper.prime, TlaActionOper.enabled, TlaActionOper.stutter, TlaActionOper.nostutter,

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaDeclLevelFinder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaDeclLevelFinder.scala
@@ -19,7 +19,8 @@ class TestTlaDeclLevelFinder extends AnyFunSuite with Checkers {
       override val maxArgs: Int = 3
     }
     // all names are considered constants
-    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators
+    val operators =
+      gens.simpleOperators ++ gens.setOperators ++ gens.functionOperators ++ gens.logicOperators ++ gens.arithOperators
     val genDecl = gens.genTlaDeclButNotVar(gens.genTlaEx(operators))(_)
     val prop = forAll(gens.genTlaModuleWith(genDecl)) { module =>
       val finder = new TlaDeclLevelFinder(module)
@@ -39,7 +40,8 @@ class TestTlaDeclLevelFinder extends AnyFunSuite with Checkers {
       override val maxArgs: Int = 3
     }
     // all names are considered constants
-    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators
+    val operators =
+      gens.simpleOperators ++ gens.setOperators ++ gens.functionOperators ++ gens.logicOperators ++ gens.arithOperators
 
     val prop = forAll(gens.genTlaModule(gens.genTlaEx(operators))) { module =>
       val finder = new TlaDeclLevelFinder(module)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExLevelFinder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExLevelFinder.scala
@@ -18,7 +18,8 @@ class TestTlaExLevelFinder extends AnyFunSuite with Checkers {
     }
     // all names are considered constants
     val finder = new TlaExLevelFinder({ _ => TlaLevelConst })
-    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators
+    val operators =
+      gens.simpleOperators ++ gens.setOperators ++ gens.functionOperators ++ gens.logicOperators ++ gens.arithOperators
     val prop = forAll(gens.genTlaEx(operators)(gens.emptyContext)) { ex =>
       finder(ex) =? TlaLevelConst
     }
@@ -30,7 +31,8 @@ class TestTlaExLevelFinder extends AnyFunSuite with Checkers {
       override val maxArgs: Int = 3
     }
     // all names are considered constants
-    val operators = gens.simpleOperators ++ gens.setOperators ++ gens.logicOperators ++ gens.arithOperators
+    val operators =
+      gens.simpleOperators ++ gens.setOperators ++ gens.functionOperators ++ gens.logicOperators ++ gens.arithOperators
     val prop = forAll(gens.genTlaEx(operators)(gens.emptyContext)) { ex =>
       val finder = new TlaExLevelFinder(_ => TlaLevelState)
       val level = finder(ex)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestIncrementalRenamingScalacheck.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestIncrementalRenamingScalacheck.scala
@@ -22,7 +22,7 @@ class TestIncrementalRenamingScalacheck extends AnyFunSuite with BeforeAndAfter 
     }
 
     val prop = {
-      val ops = gens.simpleOperators ++ gens.arithOperators ++ gens.setOperators
+      val ops = gens.simpleOperators ++ gens.arithOperators ++ gens.setOperators ++ gens.functionOperators
       val exGen = gens.genTlaEx(ops)(_)
       forAll(gens.genTlaModule(exGen)) { input =>
         try {


### PR DESCRIPTION
Closes #1355

* Extends `IrGenerators` with function operators.
* Adds them to PBT specs where applicable.