### PR TITLE
Fix release 0.21.0 again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,25 +2,6 @@
      This file is generated. Do not write release notes here.
      Notes for unreleased changes go in ./UNRELEASED.md -->
 
-## 0.21.0
-
-### Breaking changes
-
- * The `profiling.csv` file output by the `--smtprof` flag moved into the
-   configurable `run-dir`, see #1321
- * The distribution package structure has changed. This shouldn't cause any
-   breakage in operation, but may impact some automated deployment pipelines,
-   see #1357
-
-### Features
-
-* `UNCHANGED x` now rewrites to `x' := x` instead of `x' = x`, when `x` is a variable name
-
-
-### Bug fixes
-
- * Handle `Cardinality(SUBSET S)` without failing, see #1370
-
 ## 0.20.3
 
 ### Features

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,14 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Breaking changes
+
+ * The `profiling.csv` file output by the `--smtprof` flag moved into the
+   configurable `run-dir`, see #1321
+ * The distribution package structure has changed. This shouldn't cause any
+   breakage in operation, but may impact some automated deployment pipelines,
+   see #1357
+
 ### Features
 
 * `UNCHANGED x` now rewrites to `x' := x` instead of `x' = x`, when `x` is a variable name


### PR DESCRIPTION
I forgot to increment the patch version for the next release, and so I hit a
tag collision when trying to cut the next release.

This just reverts the change log.