### PR TITLE
Exclude operators causing malformed expressions from PBT

### DIFF
--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -82,8 +82,8 @@ trait IrGenerators extends TlaType1Gen {
   /**
    * Function operators (`TlaFunOper._`)
    */
-  val functionOperators = List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.funDef,
-      TlaFunOper.recFunDef, TlaFunOper.recFunRef, TlaFunOper.except)
+  val functionOperators = List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, /*TlaFunOper.funDef,
+      TlaFunOper.recFunDef,*/ TlaFunOper.recFunRef, TlaFunOper.except)
 
   /**
    * Action operators (`TlaActionOper._`)


### PR DESCRIPTION
`IncrementalRenaming` checks argument arity of `map`, `funDef`, `recFunDef`.
Including these causes lots of `MalformedTlaError`s. I'm not sure about the cause, but this seems to slow down PBT significantly.
For now, exclude these operators in `TestIncrementalRenamingScalacheck`.