### PR TITLE
Exclude operators causing malformed expressions from PBT

### DIFF
--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -82,8 +82,11 @@ trait IrGenerators extends TlaType1Gen {
   /**
    * Function operators (`TlaFunOper._`)
    */
-  val functionOperators = List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.funDef,
-      TlaFunOper.recFunDef, TlaFunOper.recFunRef, TlaFunOper.except)
+  val functionOperators =
+    List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.recFunRef, TlaFunOper.except)
+  /* TlaFunOper.{funDef,recFunDef} seem to cause lots of malformed expressions; disable them for now.
+   * cf. https://github.com/informalsystems/apalache/pull/1386#discussion_r811016316
+   */
 
   /**
    * Action operators (`TlaActionOper._`)


### PR DESCRIPTION
`TlaFunOper.{funDef,recFunDef}` introduced in #1386 seem to cause lots of malformed expressions in PBT that slow down unit tests. Jure suggested this may happen in [#1386 (comment)](https://github.com/informalsystems/apalache/pull/1386#discussion_r811016316).
Therefore, disable them for now.