### PR TITLE
Add scalafix and remove unused imports

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,4 +12,5 @@ maxColumn = 120
 verticalMultiline.atDefnSite = true
 verticalMultiline.arityThreshold = 4
 trailingCommas = multiple
-rewrite.rules = [AvoidInfix, SortModifiers]
+rewrite.rules = [AvoidInfix, SortModifiers, Imports]
+rewrite.imports.sort = original

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,13 @@ common editors.
 
 Our scalafmt configuration is specified in [./.scalafmt.conf](./.scalafmt.conf).
 
+#### Removing unused
+
+We have configured the compiler to warn on unused imports and variables, and we
+have enabled [scalafix](https://scalacenter.github.io/scalafix/) to automate
+removal of unused values. To automate removal of unused stuff run `make
+fmt-fix-unused`.
+
 ### Editors
 
 #### IntelliJ IDEA

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Markdown files used for integration tests
 TEST_MD_FILES := $(wildcard test/tla/*.md)
 
-.PHONY: all apalache apalache-jar compile build-quick test integration clean deps promote docker dist
+.PHONY: all apalache apalache-jar compile build-quick test integration clean deps promote docker dist fmt-fix-unused
 
 all: apalache
 
@@ -56,6 +56,9 @@ fmt-check:
 
 fmt-fix:
 	sbt scalafmtAll scalafmtSbt
+
+fmt-fix-unused:
+	sbt "scalafix RemoveUnused"
 
 clean:
 	sbt clean

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,7 @@ fmt-check:
 		  exit 1 )
 
 fmt-fix:
-	sbt scalafmtAll scalafmtSbt
-
-fmt-fix-unused:
-	sbt "scalafix RemoveUnused"
+	sbt "scalafix RemoveUnused" scalafmtAll scalafmtSbt
 
 clean:
 	sbt clean

--- a/build.sbt
+++ b/build.sbt
@@ -43,10 +43,21 @@ ThisBuild / libraryDependencies ++= Seq(
     TestDeps.scalatestplusScalacheck,
 )
 
+////////////////////////////
+// Linting and formatting //
+////////////////////////////
+
+// scalafmt
 // TODO: Remove if we decide we are happy with allways reformatting all
 // Only check/fix against (tracked) files that have changed relative to the trunk
 // ThisBuild / scalafmtFilter := "diff-ref=origin/unstable"
 ThisBuild / scalafmtPrintDiff := true
+
+// scalafix
+// https://scalacenter.github.io/scalafix/docs/rules/RemoveUnused.html
+ThisBuild / scalacOptions ++= Seq("-Ywarn-unused")
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 ///////////////////////////////
 // Test configuration //

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/Pass.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/Pass.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.infra.passes
 
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 
 /**
  * <p>An analysis or transformation pass. Instead of explicitly setting a pass' input and output, we interconnect passes

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/PassChainExecutor.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/PassChainExecutor.scala
@@ -1,9 +1,7 @@
 package at.forsyte.apalache.infra.passes
 
-import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
-import at.forsyte.apalache.tla.lir.{MissingTransformationError, TlaModule, TlaModuleProperties, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{MissingTransformationError, TlaModule, TlaModuleProperties}
 
 /**
  * This class executes the passes starting with the initial one, until the final pass returns None.

--- a/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestPassChainExecutor.scala
+++ b/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestPassChainExecutor.scala
@@ -4,7 +4,7 @@ import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.easymock.EasyMockSugar
 import org.scalatestplus.junit.JUnitRunner
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 
 @RunWith(classOf[JUnitRunner])
 class TestPassChainExecutor extends AnyFunSuite {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -3,12 +3,11 @@ package at.forsyte.apalache.tla
 // Generated from the build.sbt file by the buildInfo plugin
 import apalache.BuildInfo
 
-import java.io.{File, FileNotFoundException, FileWriter, PrintWriter}
-import java.nio.file.Path
+import java.io.{File, FileNotFoundException}
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import at.forsyte.apalache.infra.log.LogbackConfigurator
-import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor, PassOptions, WriteablePassOptions, ToolModule}
+import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor, WriteablePassOptions, ToolModule}
 import at.forsyte.apalache.tla.lir.{TlaModule}
 import at.forsyte.apalache.infra.{ExceptionAdapter, FailureMessage, NormalErrorMessage, PassOptionException}
 import at.forsyte.apalache.io.{OutputManager, ReportGenerator}
@@ -23,7 +22,7 @@ import com.google.inject.{Guice, Injector}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.configuration2.builder.fluent.Configurations
 import org.apache.commons.configuration2.ex.ConfigurationException
-import org.backuity.clist.{Cli, Command}
+import org.backuity.clist.Cli
 import util.ExecutionStatisticsCollector
 import util.ExecutionStatisticsCollector.Selection
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -7,15 +7,15 @@ import java.io.{File, FileNotFoundException}
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import at.forsyte.apalache.infra.log.LogbackConfigurator
-import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor, WriteablePassOptions, ToolModule}
-import at.forsyte.apalache.tla.lir.{TlaModule}
+import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor, ToolModule, WriteablePassOptions}
+import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.infra.{ExceptionAdapter, FailureMessage, NormalErrorMessage, PassOptionException}
 import at.forsyte.apalache.io.{OutputManager, ReportGenerator}
 import at.forsyte.apalache.tla.bmcmt.config.{CheckerModule, ReTLAToVMTModule}
 import at.forsyte.apalache.tla.imp.passes.ParserModule
 import at.forsyte.apalache.tla.tooling.ExitCodes
 import at.forsyte.apalache.tla.tooling.opt.{
-  CheckCmd, ConfigCmd, TranspileCmd, AbstractCheckerCmd, General, ParseCmd, ServerCmd, TestCmd, TypeCheckCmd,
+  AbstractCheckerCmd, CheckCmd, ConfigCmd, General, ParseCmd, ServerCmd, TestCmd, TranspileCmd, TypeCheckCmd,
 }
 import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
 import com.google.inject.{Guice, Injector}

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-import org.backuity.clist.{Command, arg, opt}
+import org.backuity.clist.{arg, opt, Command}
 
 import java.io.File
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-import at.forsyte.apalache.tla.bmcmt.{SMTEncoding, arraysEncoding, oopsla19Encoding}
+import at.forsyte.apalache.tla.bmcmt.{arraysEncoding, oopsla19Encoding, SMTEncoding}
 import org.backuity.clist.util.Read
 
 import org.backuity.clist._

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -3,8 +3,7 @@ package at.forsyte.apalache.tla.tooling.opt
 import at.forsyte.apalache.tla.bmcmt.{SMTEncoding, arraysEncoding, oopsla19Encoding}
 import org.backuity.clist.util.Read
 
-import java.io.File
-import org.backuity.clist.{Command, _}
+import org.backuity.clist._
 
 /**
  * This command initiates the 'check' command line.

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -4,7 +4,6 @@ import at.forsyte.apalache.io.CliConfig
 
 import java.io.File
 import org.backuity.clist._
-import at.forsyte.apalache.io.OutputManager
 
 /**
  * The general commands.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 // https://github.com/sbt/sbt-native-packager
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.4")
+// https://scalacenter.github.io/scalafix/docs/users/installation.html
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SmtFreeSymbolicTransitionExtractor.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/SmtFreeSymbolicTransitionExtractor.scala
@@ -102,7 +102,7 @@ class SmtFreeSymbolicTransitionExtractor(
       // We sequentially update the partial state
       args.foldLeft(currentState) { getStrategyOptInternal(_, operMap)(_) }
     /** Disjunction */
-    case ex @ OperEx(TlaBoolOper.or, args @ _*) =>
+    case OperEx(TlaBoolOper.or, args @ _*) =>
       handleDisjunctionOrITE(currentState, operMap, args)
 
     /** \E quantifier */

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/PrimingPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/PrimingPassImpl.scala
@@ -1,16 +1,13 @@
 package at.forsyte.apalache.tla.assignments.passes
 
-import java.io.File
-import java.nio.file.Path
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.storage.BodyMapFactory
-import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -20,10 +17,6 @@ class PrimingPassImpl @Inject() (options: PassOptions, tracker: TransformationTr
     extends PrimingPass with LazyLogging {
 
   override def name: String = "PrimingPass"
-
-  private def trSeq(seq: Seq[TlaExTransformation]): TlaExTransformation = { ex =>
-    seq.foldLeft(ex) { case (partial, tr) => tr(partial) }
-  }
 
   override def execute(tlaModule: TlaModule): Option[TlaModule] = {
     val declarations = tlaModule.declarations

--- a/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
+++ b/tla-assignments/src/main/scala/at/forsyte/apalache/tla/assignments/passes/TransitionPassImpl.scala
@@ -11,11 +11,7 @@ import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.pp.NormalizedNames
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
-
-import java.io.File
-import java.nio.file.Path
 
 /**
  * This pass finds symbolic transitions in Init and Next.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -240,7 +240,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
       val elemAsExprs = tupleElems.map(c => decodeCellToTlaEx(arena, c))
       tla.tuple(elemAsExprs: _*).typed(t.toTlaType1)
 
-    case PowSetT(t @ FinSetT(_)) =>
+    case PowSetT(FinSetT(_)) =>
       val baseset = decodeCellToTlaEx(arena, arena.getDom(cell))
       tla.powSet(baseset).typed(SetT1(TlaType1.fromTypeTag(baseset.typeTag)))
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -309,7 +309,7 @@ class SymbStateRewriterImpl(
       case NameEx(name) if ArenaCell.isValidName(name) =>
         Done(state)
 
-      case NameEx(name) =>
+      case NameEx(_) =>
         if (substRule.isApplicable(state)) {
           statListener.enterRule(substRule.getClass.getSimpleName)
           // a variable that can be substituted with a cell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
@@ -51,7 +51,7 @@ class VCGenerator(tracker: TransformationTracker) extends LazyLogging {
               throw new TlaInputError(message, Some(inv.body.ID))
           }
 
-        case Some(traceInv @ TlaOperDecl(name, params @ List(OperParam(_, 0)), body)) =>
+        case Some(traceInv @ TlaOperDecl(_, params @ List(OperParam(_, 0)), body)) =>
           // a trace invariant
           if (TlaLevelConst != levelFinder(traceInv)) {
             throw new TlaInputError(

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
@@ -76,8 +76,7 @@ class ExprGradeAnalysis @Inject() (val store: ExprGradeStoreImpl) {
    */
   def refineOrInExpr(expr: TlaEx): TlaEx = {
     expr match {
-      case OperEx(TlaBoolOper.or, args @ _*) =>
-        args.map(refineOrInExpr)
+      case OperEx(TlaBoolOper.or, _*) =>
         store.get(expr.ID) match {
           case Some(ExprGrade.Constant) | Some(ExprGrade.StateFree) | Some(ExprGrade.StateBound) =>
             expr // keep it

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.analyses
 
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaActionOper, TlaBoolOper, TlaTempOper}
+import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaBoolOper, TlaTempOper}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 
@@ -77,7 +77,7 @@ class ExprGradeAnalysis @Inject() (val store: ExprGradeStoreImpl) {
   def refineOrInExpr(expr: TlaEx): TlaEx = {
     expr match {
       case OperEx(TlaBoolOper.or, args @ _*) =>
-        val newArgs = args.map(refineOrInExpr)
+        args.map(refineOrInExpr)
         store.get(expr.ID) match {
           case Some(ExprGrade.Constant) | Some(ExprGrade.StateFree) | Some(ExprGrade.StateBound) =>
             expr // keep it

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/ModelValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/ModelValueCache.scala
@@ -4,10 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.ConstT
 import at.forsyte.apalache.tla.lir.OperEx
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper
-import at.forsyte.apalache.tla.typecheck.ModelValueHandler
 
 /**
  * A cache for model values that are translated as uninterpreted constants, with a unique sort per uniterpreted type.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerModule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerModule.scala
@@ -12,9 +12,8 @@ import at.forsyte.apalache.io.lir.TlaWriterFactory
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.{TransformationListener, TransformationTracker}
 import at.forsyte.apalache.tla.pp.passes._
-import at.forsyte.apalache.tla.typecheck.passes.{EtcTypeCheckerPass, EtcTypeCheckerPassImpl}
-import com.google.inject.name.Names
-import com.google.inject.{AbstractModule, TypeLiteral}
+import at.forsyte.apalache.tla.typecheck.passes.EtcTypeCheckerPassImpl
+import com.google.inject.TypeLiteral
 
 /**
  * A configuration that binds all the passes from the parser to the checker. If you are not sure how the binding works,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/ReTLAToVMTModule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/ReTLAToVMTModule.scala
@@ -13,9 +13,8 @@ import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard.ReTLALanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguagePred, TransformationListener, TransformationTracker}
 import at.forsyte.apalache.tla.pp.passes._
-import at.forsyte.apalache.tla.typecheck.passes.{EtcTypeCheckerPass, EtcTypeCheckerPassImpl}
-import com.google.inject.name.Names
-import com.google.inject.{AbstractModule, TypeLiteral}
+import at.forsyte.apalache.tla.typecheck.passes.EtcTypeCheckerPassImpl
+import com.google.inject.TypeLiteral
 
 /**
  * Transpiels reTLA inputs to VMT

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/implicitConversions/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/implicitConversions/package.scala
@@ -1,13 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.lir.NameEx
-
 /**
  * Implicit conversions between cells and TLA+ expressions. Use carefully.
  */
 package object implicitConversions {
-
-  import scala.language.implicitConversions
 
   implicit class Crossable[X](xs: Traversable[X]) {
     // see https://stackoverflow.com/questions/14740199/cross-product-in-scala

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/package.scala
@@ -2,8 +2,6 @@ package at.forsyte.apalache.tla
 
 import at.forsyte.apalache.tla.lir.{NameEx, TlaEx}
 
-import scala.collection.immutable.HashMap
-
 package object bmcmt {
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.passes
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
-import at.forsyte.apalache.tla.lir.transformations.{TransformationTracker, fromTouchToExTransformation}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
+import at.forsyte.apalache.tla.lir.transformations.{fromTouchToExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.transformations.standard.ModuleByExTransformer
 import at.forsyte.apalache.tla.lir.{TlaAssumeDecl, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.pp.LetInOptimizer

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/AnalysisPassImpl.scala
@@ -1,16 +1,14 @@
 package at.forsyte.apalache.tla.bmcmt.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.tla.bmcmt.CheckerException
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
 import at.forsyte.apalache.tla.lir.transformations.{TransformationTracker, fromTouchToExTransformation}
 import at.forsyte.apalache.tla.lir.transformations.standard.ModuleByExTransformer
-import at.forsyte.apalache.tla.lir.{NullEx, TlaAssumeDecl, TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{TlaAssumeDecl, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.pp.LetInOptimizer
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -10,17 +10,14 @@ import at.forsyte.apalache.tla.bmcmt.search._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import at.forsyte.apalache.tla.bmcmt.trex._
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.NullEx
 import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.LanguageWatchdog
 import at.forsyte.apalache.tla.lir.transformations.standard.KeraLanguagePred
 import at.forsyte.apalache.tla.pp.NormalizedNames
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
-import java.io.File
 import java.nio.file.Path
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -10,7 +10,7 @@ import at.forsyte.apalache.tla.bmcmt.search._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import at.forsyte.apalache.tla.bmcmt.trex._
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.LanguageWatchdog
 import at.forsyte.apalache.tla.lir.transformations.standard.KeraLanguagePred

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/PostTypeCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/PostTypeCheckerPassImpl.scala
@@ -8,7 +8,6 @@ import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.typecheck.passes.EtcTypeCheckerPassImpl
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/ReTLAToVMTTranspilePassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/ReTLAToVMTTranspilePassImpl.scala
@@ -1,11 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.lir.transformations.{LanguagePred, LanguageWatchdog}
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.bmcmt.VCGenerator
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import com.google.inject.Inject

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/VCGenPassImpl.scala
@@ -1,15 +1,11 @@
 package at.forsyte.apalache.tla.bmcmt.passes
 
-import java.io.File
-import java.nio.file.Path
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.tla.bmcmt.{CheckerException, VCGenerator}
-import at.forsyte.apalache.tla.lir.NullEx
+import at.forsyte.apalache.tla.bmcmt.VCGenerator
 import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.bmcmt.profiler
 
 import at.forsyte.apalache.io.OutputManager
 
-import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
 import scala.collection.immutable.SortedMap
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/MetricProfilerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/MetricProfilerListener.scala
@@ -1,7 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt.rewriter
 
-import java.io.{File, FileWriter, PrintWriter}
-
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContextMetrics
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.{TlaEx, UID}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/AssignmentRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/AssignmentRule.scala
@@ -16,7 +16,7 @@ import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
  *   Igor Konnov
  */
 class AssignmentRule(rewriter: SymbStateRewriter) extends RewritingRule {
-  private val pickRule = new CherryPick(rewriter)
+  new CherryPick(rewriter)
 
   override def isApplicable(state: SymbState): Boolean = {
     def isUnbound(name: String) =

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/AssignmentRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/AssignmentRule.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rules.aux.CherryPick
 import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaActionOper}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
 
@@ -16,7 +15,6 @@ import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
  *   Igor Konnov
  */
 class AssignmentRule(rewriter: SymbStateRewriter) extends RewritingRule {
-  new CherryPick(rewriter)
 
   override def isApplicable(state: SymbState): Boolean = {
     def isUnbound(name: String) =

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, DefaultValueFactory,
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.lir.{BoolT1, OperEx, SetT1, TlaEx, TypingException}
+import at.forsyte.apalache.tla.lir.OperEx
 
 /**
  * <p>Rewriting rule for CHOOSE. Similar to TLC, we implement a non-deterministic choice. It is not hard to add the

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
@@ -2,11 +2,10 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, DefaultValueFactory, OracleHelper}
-import at.forsyte.apalache.tla.bmcmt.types.FinSetT
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.lir.{BoolT1, OperEx, SetT1, TlaEx, TypingException, UID}
+import at.forsyte.apalache.tla.lir.{BoolT1, OperEx, SetT1, TlaEx, TypingException}
 
 /**
  * <p>Rewriting rule for CHOOSE. Similar to TLC, we implement a non-deterministic choice. It is not hard to add the
@@ -36,7 +35,6 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
       case OperEx(TlaOper.chooseBounded, varName, set, pred) =>
         // This is a general encoding, handling both happy and unhappy scenarios,
         // that is, when CHOOSE is defined on its arguments and not, respectively.
-        def solverAssert = rewriter.solverContext.assertGroundExpr _
 
         // compute set comprehension and then pick an element from it
         val filterEx = tla
@@ -49,7 +47,7 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
           defaultValueFactory.makeUpValue(nextState, setCell)
         } else {
           val elems = nextState.arena.getHas(setCell)
-          val nelems = elems.size
+          elems.size
           // add an oracle \in 0..N, where the indices from 0 to N - 1 correspond to the set elements,
           // whereas the index N corresponds to the default choice when the set is empty
           val (oracleState, oracle) = pickRule.oracleFactory.newDefaultOracle(nextState, elems.size + 1)
@@ -75,74 +73,5 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   // This translation is sound only in the happy scenario, that is, when CHOOSE is defined on its argument.
   // It should be used only after resolving the issue #95: https://github.com/informalsystems/apalache/issues/95
-  private def happyChoose(
-      state: SymbState,
-      varName: String,
-      set: TlaEx,
-      pred: TlaEx): SymbState = {
-    // rewrite the bounding set
-    val nextState = rewriter.rewriteUntilDone(state.setRex(set))
-    val setCell = nextState.asCell
-    val isFinSet = PartialFunction.cond(setCell.cellType) { case FinSetT(_) => true }
-    if (isFinSet) {
-      happyChooseFromFinite(nextState, setCell, varName, pred)
-    } else {
-      happyChooseFromOther(nextState, setCell, varName, pred)
-    }
-  }
-
-  private def happyChooseFromFinite(
-      state: SymbState,
-      setCell: ArenaCell,
-      varName: String,
-      pred: TlaEx): SymbState = {
-    def solverAssert = rewriter.solverContext.assertGroundExpr _
-
-    if (state.arena.getHas(setCell).isEmpty) {
-      defaultValueFactory.makeUpValue(state, setCell)
-    } else {
-      val elems = state.arena.getHas(setCell)
-      var (nextState, oracle) = pickRule.oracleFactory.newDefaultOracle(state, elems.size)
-      val trueEx = nextState.arena.cellTrue().toNameEx
-
-      // pick only the elements that belong to the set
-      val elemType = setCell.cellType.toTlaType1 match {
-        case SetT1(tt) => tt
-        case tt        => throw new TypingException("Expected a set, found: " + tt, state.ex.ID)
-      }
-      val elemsIn = elems.map { e =>
-        tla
-          .apalacheSelectInSet(e.toNameEx ? "e", setCell.toNameEx ? "s")
-          .typed(Map("e" -> elemType, "s" -> SetT1(elemType), "b" -> BoolT1()), "b")
-      }
-      solverAssert(oracle.caseAssertions(nextState, elemsIn))
-      nextState = pickRule.pickByOracle(nextState, oracle, elems, trueEx)
-      val witness = nextState.asCell
-      // assert that the predicate holds -- we are in the happy case
-      val tempBinding = Binding(nextState.binding.toMap + (varName -> witness))
-      nextState = rewriter.rewriteUntilDone(nextState.setRex(pred).setBinding(tempBinding))
-      solverAssert(nextState.ex)
-      // return the witness
-      nextState.setRex(witness.toNameEx).setBinding(Binding(nextState.binding.toMap - varName))
-    }
-  }
-
-  private def happyChooseFromOther(
-      state: SymbState,
-      setCell: ArenaCell,
-      varName: String,
-      pred: TlaEx): SymbState = {
-    def solverAssert = rewriter.solverContext.assertGroundExpr _
-
-    // the set is never empty, e.g., a powerset or a function set
-    var nextState = pickRule.pick(setCell, state, state.arena.cellFalse().toNameEx)
-    val witness = nextState.asCell
-    // assert that the witness satisfies the predicate -- we are in the happy case
-    val tempBinding = Binding(nextState.binding.toMap + (varName -> witness))
-    nextState = rewriter.rewriteUntilDone(nextState.setRex(pred).setBinding(tempBinding))
-    solverAssert(nextState.ex)
-    // return the witness
-    nextState.setRex(witness.toNameEx).setBinding(Binding(nextState.binding.toMap - varName))
-  }
 
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
@@ -47,7 +47,6 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
           defaultValueFactory.makeUpValue(nextState, setCell)
         } else {
           val elems = nextState.arena.getHas(setCell)
-          elems.size
           // add an oracle \in 0..N, where the indices from 0 to N - 1 correspond to the set elements,
           // whereas the index N corresponds to the default choice when the set is empty
           val (oracleState, oracle) = pickRule.oracleFactory.newDefaultOracle(nextState, elems.size + 1)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
@@ -61,7 +61,7 @@ class DomainRule(rewriter: SymbStateRewriter, intRangeCache: IntRangeCache) exte
 
   private def mkSeqDomain(state: SymbState, seqCell: ArenaCell): SymbState = {
     // as we do not know the domain precisely, we create the set 1..N and include only its elements between start and end
-    val seqT = seqCell.cellType.asInstanceOf[SeqT]
+    seqCell.cellType.asInstanceOf[SeqT]
     val start :: end +: elems = state.arena.getHas(seqCell)
     val (newArena, staticDom) = intRangeCache.create(state.arena, (1, elems.size))
     // we cannot use staticDom directly, as its in-relation is restricted, create a copy

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
@@ -61,7 +61,6 @@ class DomainRule(rewriter: SymbStateRewriter, intRangeCache: IntRangeCache) exte
 
   private def mkSeqDomain(state: SymbState, seqCell: ArenaCell): SymbState = {
     // as we do not know the domain precisely, we create the set 1..N and include only its elements between start and end
-    seqCell.cellType.asInstanceOf[SeqT]
     val start :: end +: elems = state.arena.getHas(seqCell)
     val (newArena, staticDom) = intRangeCache.create(state.arena, (1, elems.size))
     // we cannot use staticDom directly, as its in-relation is restricted, create a copy

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
@@ -32,7 +32,7 @@ class FoldSetRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = state.ex match {
     // assume isApplicable
-    case ex @ OperEx(ApalacheOper.foldSet, LetInEx(NameEx(_), opDecl), baseEx, setEx) =>
+    case OperEx(ApalacheOper.foldSet, LetInEx(NameEx(_), opDecl), baseEx, setEx) =>
       // rewrite baseEx to its final cell form
       val baseState = rewriter.rewriteUntilDone(state.setRex(baseEx))
       val baseCell = baseState.asCell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -103,7 +103,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
 
     // compute all updated cells in case we are dealing with a function over non-basic indices
-    val updatedCells = relationCells.map(eachRelationPair)
+    relationCells.map(eachRelationPair)
 
     // cache equality constraints between the indices and the indices in the function relation
     def cacheEqForPair(p: ArenaCell): Unit = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -103,7 +103,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
 
     // compute all updated cells in case we are dealing with a function over non-basic indices
-    relationCells.map(eachRelationPair)
+    relationCells.foreach(eachRelationPair)
 
     // cache equality constraints between the indices and the indices in the function relation
     def cacheEqForPair(p: ArenaCell): Unit = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
 import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.TlaType1
-import at.forsyte.apalache.tla.lir.{FunT1, RecT1, TupT1, BoolT1, SetT1}
+import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, RecT1, SetT1, TupT1}
 
 /**
  * Rewriting EXCEPT for functions, tuples, and records.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRuleWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRuleWithArrays.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.lir.TypedPredefs.{BuilderExAsTyped, tlaExToBuilderExAsTyped}
+import at.forsyte.apalache.tla.lir.TypedPredefs.{tlaExToBuilderExAsTyped, BuilderExAsTyped}
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, TlaEx, TupT1}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.types.{FinFunSetT, FinSetT, PowSetT}
+import at.forsyte.apalache.tla.bmcmt.types.FinFunSetT
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IfThenElseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IfThenElseRule.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.TlaControlOper
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, TlaType1}
+import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
 
 /**
  * Rewriting rule for IF A THEN B ELSE C.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
@@ -17,7 +16,6 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
  */
 class IntArithRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val intConstRule: IntConstRule = new IntConstRule(rewriter)
-  new ConstSimplifierForSmt()
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
@@ -17,7 +17,7 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
  */
 class IntArithRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val intConstRule: IntConstRule = new IntConstRule(rewriter)
-  private val simplifier = new ConstSimplifierForSmt()
+  new ConstSimplifierForSmt()
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaBool
@@ -15,8 +14,6 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
  *   Igor Konnov
  */
 class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
-  new ConstSimplifierForSmt()
-
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaArithOper.lt, _, _) | OperEx(TlaArithOper.le, _, _) | OperEx(TlaArithOper.gt, _, _) |

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -15,7 +15,7 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
  *   Igor Konnov
  */
 class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
-  private val simplifier = new ConstSimplifierForSmt()
+  new ConstSimplifierForSmt()
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
@@ -40,7 +40,7 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
   }
 
   private def rewriteGeneral(state: SymbState, ex: TlaEx) = ex match {
-    case ValEx(TlaBool(value)) =>
+    case ValEx(TlaBool(_)) =>
       // keep the simplified expression
       rewriter.rewriteUntilDone(state.setRex(ex))
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IsFiniteSetRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IsFiniteSetRule.scala
@@ -1,11 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.implicitConversions._
-import at.forsyte.apalache.tla.bmcmt.types._
-import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaFiniteSetOper
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
+import at.forsyte.apalache.tla.lir.OperEx
 
 /**
  * Implements the IsFiniteSet operator. It is trivial in our case.
@@ -26,7 +23,7 @@ class IsFiniteSetRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
-      case OperEx(TlaFiniteSetOper.isFiniteSet, setEx) =>
+      case OperEx(TlaFiniteSetOper.isFiniteSet, _) =>
         // All our sets are finite. Non-sets should be rejected by the type checker. So, just return true.
         state.setRex(state.arena.cellTrue().toNameEx)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/NegRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/NegRule.scala
@@ -14,7 +14,7 @@ import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
  *   Igor Konnov
  */
 class NegRule(rewriter: SymbStateRewriter) extends RewritingRule {
-  private val substRule = new SubstRule(rewriter)
+  new SubstRule(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/NegRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/NegRule.scala
@@ -14,7 +14,6 @@ import at.forsyte.apalache.tla.lir.{OperEx, TlaEx}
  *   Igor Konnov
  */
 class NegRule(rewriter: SymbStateRewriter) extends RewritingRule {
-  new SubstRule(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/OrRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/OrRule.scala
@@ -6,7 +6,7 @@ import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
-import at.forsyte.apalache.tla.lir.{BoolT1, OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.{BoolT1, OperEx, TlaEx}
 
 /**
  * For state-level expressions, we express A \/ B as IF A THEN TRUE ELSE B. For action-level expressions, i.e.,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
@@ -67,7 +67,7 @@ class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
         case FunT1(argT, BoolT1()) =>
           (CellT.fromType1(argT), ValEx(TlaBoolSet))
 
-        case FunT1(argT, resultT) =>
+        case FunT1(_, resultT) =>
           val msg = "A result of a recursive function must belong to Int or BOOLEAN. Found: " + resultT
           throw new RewriterException(msg, state.ex)
       }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -40,9 +40,8 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
         // introduce a new set
         val newType = types.unify(leftSetCell.cellType, rightSetCell.cellType)
         if (newType.isEmpty) {
-          s"Failed to unify types ${leftSetCell.cellType} and ${rightSetCell.cellType} when rewriting ${state.ex}"
           throw new TypingException(s"Failed to unify types ${leftSetCell.cellType}"
-                + " and ${rightSetCell.cellType} when rewriting ${state.ex}", state.ex.ID)
+                + f" and ${rightSetCell.cellType} when rewriting ${state.ex}", state.ex.ID)
         }
         nextState = nextState.updateArena(_.appendCell(newType.get))
         val newSetCell = nextState.arena.topCell

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -40,8 +40,7 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
         // introduce a new set
         val newType = types.unify(leftSetCell.cellType, rightSetCell.cellType)
         if (newType.isEmpty) {
-          val msg =
-            s"Failed to unify types ${leftSetCell.cellType} and ${rightSetCell.cellType} when rewriting ${state.ex}"
+          s"Failed to unify types ${leftSetCell.cellType} and ${rightSetCell.cellType} when rewriting ${state.ex}"
           throw new TypingException(s"Failed to unify types ${leftSetCell.cellType}"
                 + " and ${rightSetCell.cellType} when rewriting ${state.ex}", state.ex.ID)
         }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
@@ -26,7 +26,7 @@ class SetExpandRule(rewriter: SymbStateRewriter) extends RewritingRule {
       case ex @ OperEx(ApalacheOper.expand, OperEx(TlaSetOper.funSet, _, _)) =>
         throw new RewriterException("Trying to expand a set of functions. This will blow up the solver.", ex)
 
-      case ex @ OperEx(ApalacheOper.expand, OperEx(TlaSetOper.powerset, basesetEx)) =>
+      case OperEx(ApalacheOper.expand, OperEx(TlaSetOper.powerset, basesetEx)) =>
         var nextState = rewriter.rewriteUntilDone(state.setRex(basesetEx))
         new PowSetCtor(rewriter).confringo(nextState, nextState.asCell)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRuleWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRuleWithArrays.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.bmcmt.rules
 import at.forsyte.apalache.tla.bmcmt.implicitConversions.Crossable
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, CellT, FinFunSetT, FinSetT, FunT, PowSetT}
-import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, SymbState, SymbStateRewriter, types}
+import at.forsyte.apalache.tla.bmcmt.{types, ArenaCell, RewriterException, SymbState, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir.TypedPredefs.BuilderExAsTyped
 import at.forsyte.apalache.tla.lir.{BoolT1, TlaEx}
 import at.forsyte.apalache.tla.lir.convenience.tla

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetUnionRule.scala
@@ -17,8 +17,8 @@ class SetUnionRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
-      case OperEx(TlaSetOper.union, set) => true
-      case _                             => false
+      case OperEx(TlaSetOper.union, _) => true
+      case _                           => false
     }
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/StrConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/StrConstRule.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.lir.{ConstT1, StrT1, ValEx}
+import at.forsyte.apalache.tla.lir.ValEx
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -47,17 +47,17 @@ class CherryPick(rewriter: SymbStateRewriter) {
         // a powerset is never empty, pick an element
         pickFromPowset(t, set, state)
 
-      case FinFunSetT(domt @ FinSetT(_), cdm @ FinSetT(rest)) =>
+      case FinFunSetT(domt @ FinSetT(_), FinSetT(rest)) =>
         // No emptiness check, since we are dealing with a function set [S -> T].
         // If S is empty, we get a function of the empty set.
         pickFunFromFunSet(FunT(domt, rest), set, state)
 
-      case FinFunSetT(domt @ FinSetT(_), cdm @ InfSetT(rest)) =>
+      case FinFunSetT(domt @ FinSetT(_), InfSetT(rest)) =>
         // No emptiness check, since we are dealing with a function set [S -> T].
         // If S is empty, we get a function of the empty set.
         pickFunFromFunSet(FunT(domt, rest), set, state)
 
-      case FinFunSetT(domt @ FinSetT(_), cdm @ PowSetT(resultT @ FinSetT(_))) =>
+      case FinFunSetT(domt @ FinSetT(_), PowSetT(resultT @ FinSetT(_))) =>
         // No emptiness check, since we are dealing with a function set [S -> T].
         // If S is empty, we get a function of the empty set.
         pickFunFromFunSet(FunT(domt, resultT), set, state)
@@ -65,7 +65,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
       case FinFunSetT(dom1T @ FinSetT(_), FinFunSetT(dom2T @ FinSetT(_), FinSetT(result2T))) =>
         pickFunFromFunSet(FunT(dom1T, FunT(dom2T, result2T)), set, state)
 
-      case FinFunSetT(dom1T @ FinSetT(_), cdm @ FinFunSetT(dom2T @ FinSetT(_), PowSetT(result2T @ FinSetT(_)))) =>
+      case FinFunSetT(dom1T @ FinSetT(_), FinFunSetT(dom2T @ FinSetT(_), PowSetT(result2T @ FinSetT(_)))) =>
         pickFunFromFunSet(FunT(dom1T, FunT(dom2T, result2T)), set, state)
 
       case FinFunSetT(FinSetT(_), PowSetT(_)) | FinFunSetT(FinSetT(_), FinFunSetT(_, _)) =>
@@ -603,7 +603,6 @@ class CherryPick(rewriter: SymbStateRewriter) {
       oracle: Oracle,
       memberSeqs: Seq[ArenaCell],
       elseAssert: TlaEx): SymbState = {
-    def solverAssert(e: TlaEx): Unit = rewriter.solverContext.assertGroundExpr(e)
 
     rewriter.solverContext
       .log("; CHERRY-PICK %s FROM [%s] {".format(seqType, memberSeqs.map(_.toString).mkString(", ")))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, SymbState, SymbStateRewriter}
 import at.forsyte.apalache.tla.bmcmt.types._
-import at.forsyte.apalache.tla.lir.{NullEx, TlaEx}
+import at.forsyte.apalache.tla.lir.NullEx
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/Oracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/Oracle.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.bmcmt.{SymbState, SymbStateDecoder, SymbStateRewriter}
+import at.forsyte.apalache.tla.bmcmt.SymbState
 import at.forsyte.apalache.tla.lir.TlaEx
 
 /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.search
 
 import java.io.File
-import at.forsyte.apalache.tla.bmcmt.{CheckerInput, SMTEncoding, oopsla19Encoding}
+import at.forsyte.apalache.tla.bmcmt.{oopsla19Encoding, CheckerInput, SMTEncoding}
 import at.forsyte.apalache.tla.bmcmt.search.ModelCheckerParams.InvariantMode.{AfterJoin, BeforeJoin, InvariantMode}
 
 object ModelCheckerParams {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverConfig.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverConfig.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.smt
 
-import at.forsyte.apalache.tla.bmcmt.{SMTEncoding, oopsla19Encoding}
+import at.forsyte.apalache.tla.bmcmt.{oopsla19Encoding, SMTEncoding}
 
 /**
  * Configuration option to be passed to SolverContext. This class is declared as a case class to enable the concise copy

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -341,7 +341,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
   private def initLog(): PrintWriter =
     OutputManager.runDirPathOpt match {
       case None => new PrintWriter(NullOutputStream.NULL_OUTPUT_STREAM)
-      case Some(runDir) => {
+      case Some(_) => {
         val writer = OutputManager.printWriter(OutputManager.runDir, s"log$id.smt")
         if (!config.debug) {
           writer.println("Logging is disabled (Z3SolverContext.debug = false). Activate with --debug.")
@@ -374,8 +374,8 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
    *   the name of the new function (declared in SMT)
    */
   def declareCellFun(cellName: String, argType: CellT, resultType: CellT): Unit = {
-    val domSig = argType.signature
-    val resSig = resultType.signature
+    argType.signature
+    resultType.signature
     val funName = s"fun$cellName"
     if (funDecls.contains(funName)) {
       val msg = s"SMT $id: Declaring twice the function associated with cell $cellName"
@@ -590,11 +590,11 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
           (n.asInstanceOf[ExprSort], 1)
         }
 
-      case OperEx(oper: TlaArithOper, lex, rex) =>
+      case OperEx(_: TlaArithOper, _, _) =>
         // convert to an arithmetic expression
         toArithExpr(ex)
 
-      case OperEx(oper: TlaArithOper, subex) =>
+      case OperEx(_: TlaArithOper, _) =>
         // convert to an arithmetic expression
         toArithExpr(ex)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -374,8 +374,6 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
    *   the name of the new function (declared in SMT)
    */
   def declareCellFun(cellName: String, argType: CellT, resultType: CellT): Unit = {
-    argType.signature
-    resultType.signature
     val funName = s"fun$cellName"
     if (funDecls.contains(funName)) {
       val msg = s"SMT $id: Declaring twice the function associated with cell $cellName"

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicLong
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.profiler.{IdleSmtListener, SmtListener}
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
-import at.forsyte.apalache.tla.bmcmt.types.{BoolT, CellT, FinSetT, IntT, PowSetT, FunT}
+import at.forsyte.apalache.tla.bmcmt.types.{BoolT, CellT, FinSetT, FunT, IntT, PowSetT}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
 import at.forsyte.apalache.tla.lir.oper._

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/IncrementalExecutionContextSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/IncrementalExecutionContextSnapshot.scala
@@ -1,7 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.types.CellT
-
 /**
  * A snapshot when using an incremental SMT solver. This snapshot is quite simple: It saves the depth of the rewriter
  * stack as well as the types of the type finder.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
@@ -1,9 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt
 
-import at.forsyte.apalache.tla.bmcmt.caches.ModelValueCache
 import at.forsyte.apalache.tla.lir.{
-  BoolT1, ConstT1, FunT1, IntT1, NullEx, OperT1, RealT1, RecT1, SeqT1, SetT1, SparseTupT1, StrT1, TlaType1, TupT1,
-  TypeTag, TypingException, UID, VarT1,
+  BoolT1, ConstT1, FunT1, IntT1, OperT1, RealT1, RecT1, SeqT1, SetT1, SparseTupT1, StrT1, TlaType1, TupT1, TypeTag,
+  TypingException, UID, VarT1,
 }
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/ExecutorBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/ExecutorBase.scala
@@ -1,12 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
 import at.forsyte.apalache.tla.bmcmt.analyses.ExprGradeStoreImpl
-import at.forsyte.apalache.tla.bmcmt.smt.{SolverContext}
-import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl}
+import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
+import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
-import java.io.{PrintStream, File, FileOutputStream}
+import java.io.{File, FileOutputStream, PrintStream}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuite
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndArrays.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl, arraysEncoding}
+import at.forsyte.apalache.tla.bmcmt.{arraysEncoding, SymbStateRewriterImpl}
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import org.junit.runner.RunWith

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndArrays.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
-import at.forsyte.apalache.tla.bmcmt.{SymbStateRewriterImpl, arraysEncoding}
+import at.forsyte.apalache.tla.bmcmt.{arraysEncoding, SymbStateRewriterImpl}
 import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import org.junit.runner.RunWith

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.io
 
 import pureconfig._
 import pureconfig.generic.auto._
-import java.io.{File}
-import java.nio.file.{Path, Files, Paths}
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
 
 // Provides implicit conversions used when deserializing into configurable values.
 private object Converters {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -4,8 +4,6 @@ import pureconfig._
 import pureconfig.generic.auto._
 import java.io.{File}
 import java.nio.file.{Path, Files, Paths}
-import com.typesafe.config.ConfigValueFactory
-import com.typesafe.config.ConfigObject
 
 // Provides implicit conversions used when deserializing into configurable values.
 private object Converters {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.io
 
 import com.typesafe.scalalogging.LazyLogging
 
-import java.io.{File, FileInputStream, FileWriter, PrintWriter}
+import java.io.{File, FileWriter, PrintWriter}
 import java.nio.file.{Files, Path, Paths}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.io
 
 import java.io.File
 import java.util.regex.Matcher
-import scala.io.Source
 
 object ReportGenerator {
   private val reportFile = "BugReport.md"

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
@@ -91,7 +91,7 @@ class AnnotationParser extends Parsers {
 }
 
 object AnnotationParser {
-  private val parser: AnnotationParser = new AnnotationParser
+  new AnnotationParser
 
   def parse(reader: Reader): Either[String, Annotation] = {
     for {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
@@ -91,8 +91,6 @@ class AnnotationParser extends Parsers {
 }
 
 object AnnotationParser {
-  new AnnotationParser
-
   def parse(reader: Reader): Either[String, Annotation] = {
     for {
       tokens <- AnnotationLexer(reader).right

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
@@ -1,7 +1,5 @@
 package at.forsyte.apalache.io.annotations.parser
 
-import at.forsyte.apalache.io.annotations.AnnotationParserError
-
 import java.io.Reader
 import scala.util.matching.Regex
 import scala.util.parsing.combinator.RegexParsers

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/DefaultTagReader.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/DefaultTagReader.scala
@@ -13,7 +13,7 @@ object DefaultTagReader extends TypeTagReader {
         try {
           Typed(DefaultType1Parser(tagStr))
         } catch {
-          case e: Type1ParseError =>
+          case _: Type1ParseError =>
             throw new JsonDeserializationError(
                 s"Error in type annotation: Expected Type1 expression or 'Untyped', found: $s"
             )

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/CounterexampleWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/CounterexampleWriter.scala
@@ -7,9 +7,8 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.values.TlaBool
 
-import java.io.{File, FileWriter, PrintWriter}
+import java.io.PrintWriter
 import java.util.Calendar
-import org.apache.commons.io.FilenameUtils
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriterFactory.scala
@@ -2,9 +2,8 @@ package at.forsyte.apalache.io.lir
 
 import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.tla.lir.TlaModule
-import OutputManager.Names._
 
-import java.io.{File, FileWriter, PrintWriter}
+import java.io.{File, PrintWriter}
 
 /**
  * An interface for constructing instances of TlaWriter.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.io.typecheck.parser
 
 import java.io.Reader
-import at.forsyte.apalache.io.tlc.config.TlcConfigParseError
 
 import scala.util.matching.Regex
 import scala.util.parsing.combinator.RegexParsers

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.imp
 
-import at.forsyte.apalache.io.annotations.{Annotation, AnnotationParser, AnnotationParserError, AnnotationStr}
+import at.forsyte.apalache.io.annotations.{Annotation, AnnotationParser, AnnotationStr}
 import at.forsyte.apalache.io.annotations.parser.CommentPreprocessor
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.imp.AnnotationExtractor.FREE_TEXT

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/NullOpDefTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/NullOpDefTranslator.scala
@@ -2,8 +2,7 @@ package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.TlaOper
-import tla2sany.semantic.{OpApplNode, OpDefNode}
+import tla2sany.semantic.OpDefNode
 
 /**
  * DummyOpDefTranslator creates a proper operator declaration but produces NullEx instead of the body.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -6,7 +6,6 @@ import at.forsyte.apalache.io.annotations.store._
 import org.apache.commons.io.output.WriterOutputStream
 import tla2sany.drivers.SANY
 import tla2sany.modanalyzer.SpecObj
-import util.SimpleFilenameToStream
 
 import java.io._
 import java.nio.file.Files

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/ParserModule.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/ParserModule.scala
@@ -6,8 +6,7 @@ import at.forsyte.apalache.io.annotations.{AnnotationStoreProvider, PrettyWriter
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.imp.ParserExceptionAdapter
 import at.forsyte.apalache.io.lir.TlaWriterFactory
-import com.google.inject.name.Names
-import com.google.inject.{AbstractModule, TypeLiteral}
+import com.google.inject.TypeLiteral
 
 /**
  * A module that consists only of the parsing pass.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/ParserModule.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/ParserModule.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.imp.passes
 
 import at.forsyte.apalache.infra.ExceptionAdapter
-import at.forsyte.apalache.infra.passes.{Pass, PassOptions, WriteablePassOptions, ToolModule}
+import at.forsyte.apalache.infra.passes.{Pass, PassOptions, ToolModule, WriteablePassOptions}
 import at.forsyte.apalache.io.annotations.{AnnotationStoreProvider, PrettyWriterWithAnnotationsFactory}
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.imp.ParserExceptionAdapter

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -1,22 +1,17 @@
 package at.forsyte.apalache.tla.imp.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.io.json.impl.{DefaultTagReader, UJsonRep, UJsonToTla}
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.{CyclicDependencyError, TlaModule}
-import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.standard.DeclarationSorter
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.imp.{SanyImporter, SanyImporterException, utils}
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 import java.io.File
-import java.nio.file.Path
-import org.apache.commons.io.FilenameUtils
 
 /**
  * Parsing TLA+ code with SANY.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.{CyclicDependencyError, TlaModule}
 import at.forsyte.apalache.tla.lir.transformations.standard.DeclarationSorter
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
-import at.forsyte.apalache.tla.imp.{SanyImporter, SanyImporterException, utils}
+import at.forsyte.apalache.tla.imp.{utils, SanyImporter, SanyImporterException}
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/src/SourceStore.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/src/SourceStore.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.imp.src
 
 import at.forsyte.apalache.tla.lir.src.{
   RegionTree,
-  // Prevent name clash with the SourceLocation object defined in this dir
+// Prevent name clash with the SourceLocation object defined in this dir
   SourceLocation => SourceLocationClass,
 }
 import at.forsyte.apalache.tla.lir.storage.SourceMap

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestAnnotationParser.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestAnnotationParser.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.io.annotations
 import org.junit.runner.RunWith
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.{alphaNumStr, alphaStr, identifier, listOf, oneOf}
-import org.scalacheck.Prop.{AnyOperators, falsified, forAll, passed}
+import org.scalacheck.Prop.{falsified, forAll, passed, AnyOperators}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaNatSet, TlaStrSet}
 import org.junit.runner.RunWith
-import org.scalacheck.Prop.{AnyOperators, forAll}
+import org.scalacheck.Prop.{forAll, AnyOperators}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/SanyImporterTestBase.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/SanyImporterTestBase.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.imp
 
-import at.forsyte.apalache.io.annotations.store.{AnnotationStore, createAnnotationStore}
+import at.forsyte.apalache.io.annotations.store.{createAnnotationStore, AnnotationStore}
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, OperParam, TlaDecl, TlaEx, TlaModule, TlaOperDecl}
 import org.scalatest.BeforeAndAfter

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/CallByNameOperatorEmbedder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/CallByNameOperatorEmbedder.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.pp
 
 import at.forsyte.apalache.tla.lir.TypedPredefs.TypeTagAsTlaType1
-import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, OperT1, TlaEx, TlaOperDecl, Typed, TypingException}
+import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx, TlaEx, TlaOperDecl, Typed}
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper
 import at.forsyte.apalache.tla.lir.storage.{BodyMap, BodyMapFactory}
 import at.forsyte.apalache.tla.lir.transformations.standard.DeepCopy

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstAndDefRewriter.scala
@@ -65,7 +65,7 @@ class ConstAndDefRewriter(tracker: TransformationTracker) extends TlaModuleTrans
           overridingDef.copy(name = name)
         }
 
-      case df @ TlaVarDecl(name) if overrides.contains(name) =>
+      case TlaVarDecl(name) if overrides.contains(name) =>
         val msg = s"  > Trying to replace variable $name with an operator OVERRIDE_$name. Use INSTANCE ... WITH"
         throw new OverridingError(msg, NullEx)
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifier.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.pp
 
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.FlatLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -4,8 +4,6 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
 
-import scala.math.BigInt
-
 /**
  * <p>A base class for constant simplification that is shared by more specialized simplifiers.</p>
  *
@@ -69,38 +67,38 @@ abstract class ConstSimplifierBase {
     // Evaluate constant multiplication
     case OperEx(TlaArithOper.mult, ValEx(TlaInt(left)), ValEx(TlaInt(right))) => ValEx(TlaInt(left * right))(intTag)
     // 0 * x = 0
-    case OperEx(TlaArithOper.mult, ValEx(TlaInt(left)), rightEx) if (left == 0) => ValEx(TlaInt(0))(intTag)
+    case OperEx(TlaArithOper.mult, ValEx(TlaInt(left)), _) if (left == 0) => ValEx(TlaInt(0))(intTag)
     // 1 * x = x
     case OperEx(TlaArithOper.mult, ValEx(TlaInt(left)), rightEx) if (left == 1) => rightEx
     // x * 0 = 0
-    case OperEx(TlaArithOper.mult, leftEx, ValEx(TlaInt(right))) if (right == 0) => ValEx(TlaInt(0))(intTag)
+    case OperEx(TlaArithOper.mult, _, ValEx(TlaInt(right))) if (right == 0) => ValEx(TlaInt(0))(intTag)
     // x * 1 = x
     case OperEx(TlaArithOper.mult, leftEx, ValEx(TlaInt(right))) if (right == 1) => leftEx
 
     // x / 0 = undefined
-    case ex @ OperEx(TlaArithOper.div, leftEx, ValEx(TlaInt(right))) if (right == 0) =>
+    case ex @ OperEx(TlaArithOper.div, _, ValEx(TlaInt(right))) if (right == 0) =>
       throw new TlaInputError(s"Division by zero at ${ex.toString}")
     // Evaluate constant division
     case OperEx(TlaArithOper.div, ValEx(TlaInt(left)), ValEx(TlaInt(right))) => ValEx(TlaInt(left / right))(intTag)
     // 0 / x = 0
-    case OperEx(TlaArithOper.div, ValEx(TlaInt(left)), rightEx) if (left == 0) => ValEx(TlaInt(0))(intTag)
+    case OperEx(TlaArithOper.div, ValEx(TlaInt(left)), _) if (left == 0) => ValEx(TlaInt(0))(intTag)
     // x / 1 = x
     case OperEx(TlaArithOper.div, leftEx, ValEx(TlaInt(right))) if (right == 1) => leftEx
     // x / x = 1
     case OperEx(TlaArithOper.div, leftEx, rightEx) if (leftEx == rightEx) => ValEx(TlaInt(1))(intTag)
 
     // x % 0 = undefined
-    case ex @ OperEx(TlaArithOper.mod, leftEx, ValEx(TlaInt(right))) if (right == 0) =>
+    case ex @ OperEx(TlaArithOper.mod, _, ValEx(TlaInt(right))) if (right == 0) =>
       throw new TlaInputError(s"Mod by zero at ${ex.toString}")
     // Evaluate constant mod
     case OperEx(TlaArithOper.mod, ValEx(TlaInt(left)), ValEx(TlaInt(right))) => ValEx(TlaInt(left % right))(intTag)
     // x % 1 = 0
-    case OperEx(TlaArithOper.mod, leftEx, ValEx(TlaInt(right))) if (right == 1) => ValEx(TlaInt(0))(intTag)
+    case OperEx(TlaArithOper.mod, _, ValEx(TlaInt(right))) if (right == 1) => ValEx(TlaInt(0))(intTag)
     // x % x = 0
     case OperEx(TlaArithOper.mod, leftEx, rightEx) if (leftEx == rightEx) => ValEx(TlaInt(0))(intTag)
 
     // 0 ^ 0 = undefined
-    case ex @ OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) if (base == 0 && power == 0) =>
+    case OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) if (base == 0 && power == 0) =>
       throw new TlaInputError(s"0 ^ 0 is undefined")
     // Try to evaluante constant exponentiation
     case ex @ OperEx(TlaArithOper.exp, ValEx(TlaInt(base)), ValEx(TlaInt(power))) =>
@@ -120,13 +118,13 @@ abstract class ConstSimplifierBase {
       }
 
     // x ^ 0 = 1
-    case OperEx(TlaArithOper.exp, leftEx, ValEx(TlaInt(right))) if (right == 0) => ValEx(TlaInt(1))(intTag)
+    case OperEx(TlaArithOper.exp, _, ValEx(TlaInt(right))) if (right == 0) => ValEx(TlaInt(1))(intTag)
     // x ^ 1 = x
     case OperEx(TlaArithOper.exp, leftEx, ValEx(TlaInt(right))) if (right == 1) => leftEx
     // 0 ^ x = 0
-    case OperEx(TlaArithOper.exp, ValEx(TlaInt(left)), rightEx) if (left == 0) => ValEx(TlaInt(0))(intTag)
+    case OperEx(TlaArithOper.exp, ValEx(TlaInt(left)), _) if (left == 0) => ValEx(TlaInt(0))(intTag)
     // 1 ^ x = 1
-    case OperEx(TlaArithOper.exp, ValEx(TlaInt(left)), rightEx) if (left == 1) => ValEx(TlaInt(1))(intTag)
+    case OperEx(TlaArithOper.exp, ValEx(TlaInt(left)), _) if (left == 1) => ValEx(TlaInt(1))(intTag)
 
     // -0 = 0
     case OperEx(TlaArithOper.uminus, ValEx(TlaInt(value))) if (value == 0) => ValEx(TlaInt(0))(intTag)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -156,7 +156,7 @@ class ExprOptimizer(nameGen: UniqueNameGenerator, tracker: TransformationTracker
    *   a transformed \exists expression
    */
   private def transformExistsOverSets: PartialFunction[TlaEx, TlaEx] = {
-    case OperEx(TlaBoolOper.exists, xe @ NameEx(x), OperEx(TlaSetOper.filter, ye @ NameEx(y), s, e), g) =>
+    case OperEx(TlaBoolOper.exists, xe @ NameEx(_), OperEx(TlaSetOper.filter, ye @ NameEx(y), s, e), g) =>
       // \E x \in {y \in S: e}: g becomes \E y \in S: e /\ g [x replaced with y]
       val eAndG = tla.and(e, g).typed(BoolT1())
       val newPred =

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Keramelizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Keramelizer.scala
@@ -46,14 +46,14 @@ class Keramelizer(gen: UniqueNameGenerator, tracker: TransformationTracker)
    *   a transformed set expression
    */
   private def transformSets: PartialFunction[TlaEx, TlaEx] = {
-    case ex @ OperEx(TlaSetOper.cap, setX, setY) =>
+    case OperEx(TlaSetOper.cap, setX, setY) =>
       val elemType = getElemType(setX)
       val tempName = gen.newName()
       tla
         .filter(tla.name(tempName) ? "e", setX, tla.in(tla.name(tempName) ? "e", setY) ? "b")
         .typed(Map("b" -> BoolT1(), "e" -> elemType, "s" -> SetT1(elemType)), "s")
 
-    case ex @ OperEx(TlaSetOper.setminus, setX, setY) =>
+    case OperEx(TlaSetOper.setminus, setX, setY) =>
       val elemType = getElemType(setX)
       val tempName = gen.newName()
       tla
@@ -133,7 +133,7 @@ class Keramelizer(gen: UniqueNameGenerator, tracker: TransformationTracker)
    *   a transformed expression
    */
   private def transformAssignments: PartialFunction[TlaEx, TlaEx] = {
-    case OperEx(TlaSetOper.in, prime @ OperEx(TlaActionOper.prime, NameEx(x)), set) =>
+    case OperEx(TlaSetOper.in, prime @ OperEx(TlaActionOper.prime, NameEx(_)), set) =>
       // rewrite x' \in S
       // into \E y \in S: x' = y
       val elemType = getElemType(set)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Normalizer.scala
@@ -242,7 +242,7 @@ class Normalizer(tracker: TransformationTracker) extends TlaExTransformation {
       case OperEx(TlaBoolOper.not, OperEx(TlaOper.apply, NameEx(name))) if tlaEx.typeTag == Typed(toBoolT) =>
         Set(name)
 
-      case OperEx(op, args @ _*) =>
+      case OperEx(_, args @ _*) =>
         args.map(negAppearingOpers).foldLeft(Set.empty[String]) {
           _ ++ _
         }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/OperAppToLetInDef.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/OperAppToLetInDef.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.pp
 
-import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaOper}
+import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Unroller.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Unroller.scala
@@ -68,7 +68,7 @@ class Unroller(nameGenerator: UniqueNameGenerator, tracker: TransformationTracke
    */
   private def replaceWithDefaults(defaultsMap: Map[String, TlaEx]): TlaExTransformation = tracker.trackEx {
     // We need to check the base name, because the names of recursive operators defined with LET get changed
-    case ex @ OperEx(TlaOper.apply, NameEx(name), _*) if defaultsMap.contains(IncrementalRenaming.getBase(name)) =>
+    case OperEx(TlaOper.apply, NameEx(name), _*) if defaultsMap.contains(IncrementalRenaming.getBase(name)) =>
       // Get the default body, ignore the args
       defaultsMap(IncrementalRenaming.getBase(name))
     // recursive processing of composite operators and let-in definitions

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -6,18 +6,16 @@ import at.forsyte.apalache.io.tlc.TlcConfigParserApalache
 import at.forsyte.apalache.io.tlc.config._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.io.lir.{PrettyWriter, TlaWriter, TlaWriterFactory}
+import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaBoolOper, TlaOper, TlaTempOper}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.pp._
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FilenameUtils
 
-import java.io.{File, FileNotFoundException, FileReader}
-import java.nio.file.Path
+import java.io.{FileNotFoundException, FileReader}
 
 /**
  * The pass that collects the configuration parameters and overrides constants and definitions. This pass also overrides

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
@@ -7,11 +7,7 @@ import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.pp.{Desugarer, SelectSeqAsFold, UniqueNameGenerator}
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
-
-import java.io.File
-import java.nio.file.Path
 
 /**
  * Desugarer pass.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/DesugarerPassImpl.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.imp.findBodyOf
 import at.forsyte.apalache.tla.lir.storage.{BodyMap, BodyMapFactory}
 import at.forsyte.apalache.tla.lir.transformations._
 import at.forsyte.apalache.tla.lir.transformations.standard.ModuleByExTransformer
-import at.forsyte.apalache.tla.lir.{TlaModule, TlaOperDecl, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule, TlaOperDecl}
 import at.forsyte.apalache.tla.pp._
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -10,7 +10,6 @@ import at.forsyte.apalache.tla.lir.transformations.standard.ModuleByExTransforme
 import at.forsyte.apalache.tla.lir.{TlaModule, TlaOperDecl, ModuleProperty}
 import at.forsyte.apalache.tla.pp._
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
@@ -1,7 +1,5 @@
 package at.forsyte.apalache.tla.pp.passes
 
-import java.io.File
-import java.nio.file.Path
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
@@ -9,7 +7,6 @@ import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.pp.{ConstSimplifier, ExprOptimizer, UniqueNameGenerator}
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/OptPassImpl.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard._

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
@@ -2,17 +2,13 @@ package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
-import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
+import at.forsyte.apalache.io.lir.TlaWriterFactory
+import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.transformations.{
-  PredResultFail, PredResultOk, TlaModuleTransformation, TransformationTracker,
-}
-import at.forsyte.apalache.tla.lir.{TlaDecl, TlaModule, TlaOperDecl, UID, ModuleProperty}
+import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
 import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
 import com.google.inject.Inject
-import com.google.inject.name.Named
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * A preprocessing pass that simplifies TLA+ expression by running multiple transformation.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassImpl.scala
@@ -6,7 +6,7 @@ import at.forsyte.apalache.io.lir.TlaWriterFactory
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
 import com.google.inject.Inject
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAPreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAPreproPassImpl.scala
@@ -6,7 +6,7 @@ import at.forsyte.apalache.io.lir.TlaWriterFactory
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.tla.pp.{Normalizer, UniqueNameGenerator}
 import com.google.inject.Inject
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAPreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAPreproPassImpl.scala
@@ -2,17 +2,13 @@ package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
-import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
+import at.forsyte.apalache.io.lir.TlaWriterFactory
+import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard._
-import at.forsyte.apalache.tla.lir.transformations.{
-  PredResultFail, PredResultOk, TlaModuleTransformation, TransformationTracker,
-}
-import at.forsyte.apalache.tla.lir.{TlaDecl, TlaModule, TlaOperDecl, UID, ModuleProperty}
-import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.pp.{Normalizer, UniqueNameGenerator}
 import com.google.inject.Inject
-import com.google.inject.name.Named
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * A preprocessing pass that simplifies TLA+ expressions by running multiple transformations.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.pp.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
-import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
+import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/UnrollPassImpl.scala
@@ -1,7 +1,5 @@
 package at.forsyte.apalache.tla.pp.passes
 
-import java.io.File
-import java.nio.file.Path
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.lir.{TlaModule, ModuleProperty}
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
@@ -9,7 +7,6 @@ import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.pp.{UniqueNameGenerator, Unroller}
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/WatchdogPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/WatchdogPassImpl.scala
@@ -4,7 +4,6 @@ import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.lir.transformations.{LanguagePred, LanguageWatchdog}
 import at.forsyte.apalache.tla.lir.TlaModule
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
 
 class WatchdogPassImpl @Inject() (val options: PassOptions, val pred: LanguagePred)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.{
-  BoolT1, FunT1, IntT1, OperT1, RecT1, SeqT1, SetT1, OperParam, StrT1, TlaEx, TlaType1, TupT1,
+  BoolT1, FunT1, IntT1, OperParam, OperT1, RecT1, SeqT1, SetT1, StrT1, TlaEx, TlaType1, TupT1,
 }
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ConstSubstitution.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ConstSubstitution.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
 import at.forsyte.apalache.tla.lir.{
-  BoolT1, ConstT1, FunT1, IntT1, NullEx, OperT1, RealT1, RecT1, SeqT1, SetT1, SparseTupT1, StrT1, TlaType1, TupT1,
+  BoolT1, ConstT1, FunT1, IntT1, OperT1, RealT1, RecT1, SeqT1, SetT1, SparseTupT1, StrT1, TlaType1, TupT1,
   TypingException, UID, VarT1,
 }
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ConstraintSolver.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ConstraintSolver.scala
@@ -104,7 +104,7 @@ class ConstraintSolver(approximateSolution: Substitution = Substitution.empty) {
         // try to solve a disjunctive clause
         eqs.flatMap(solveOne(solution, _)) match {
           case Seq(uniqueSolution) => Some(uniqueSolution)
-          case _noneOrAmbiguous    => None
+          case _                   => None
         }
     }
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcBuilder.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
 import at.forsyte.apalache.tla.lir.{TlaType1, UID}
-import at.forsyte.apalache.tla.typecheck._
 
 /**
  * A builder trait to conveniently construct instances of EtcExpr. Mix this trait to your class to construct Etc

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
@@ -120,7 +120,7 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
             // report the result of operator application, not the operator type itself
             onTypeFound(ex.sourceRef, res)
 
-          case tt =>
+          case _ =>
             throw new TypingException("Expected an operator type, found: ", appEx.sourceRef.tlaId)
         }
 
@@ -242,10 +242,10 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
         val letInSolver = new ConstraintSolver()
         val operScheme =
           ctx.types.get(name) match {
-            case Some(scheme @ TlaType1Scheme(declaredType @ OperT1(_, _), allVars)) =>
+            case Some(scheme @ TlaType1Scheme(OperT1(_, _), _)) =>
               scheme
 
-            case Some(scheme @ TlaType1Scheme(someType: TlaType1, allVars)) =>
+            case Some(TlaType1Scheme(someType: TlaType1, allVars)) =>
               // The definition has a type annotation which is not an operator. Assume it is a nullary operator.
               // Strictly speaking, this is a hack. However, it is quite common to declare a constant with LET.
               TlaType1Scheme(OperT1(Seq(), someType), allVars)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -220,7 +220,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         val opsig = OperT1(Seq(a, a), BoolT1())
         val etcExpr = mkExRefApp(opsig, args)
         val operation = if (op == TlaOper.eq) "equality" else "inequality"
-        etcExpr.typeErrorExplanation = (expectedTypes: List[TlaType1], actualTypes: List[TlaType1]) => {
+        etcExpr.typeErrorExplanation = (_: List[TlaType1], actualTypes: List[TlaType1]) => {
           Some(s"Arguments of $operation should have the same type. For arguments ${args.mkString(", ")} with types ${actualTypes
               .mkString(", ")}, in expression $ex")
         }
@@ -240,7 +240,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         }
         etcExpr
 
-      case ex @ OperEx(TlaOper.apply, opName, args @ _*) =>
+      case ex @ OperEx(TlaOper.apply, opName, _*) =>
         throw new TypingException(s"Bug in ToEtcExpr. Expected an operator name, found: ${opName}", ex.ID)
 
       case OperEx(
@@ -457,7 +457,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
           OperT1(Seq(funType, argType), resType)
         }
         val etcExpr = mkApp(ref, signatures, this(fun), this(arg))
-        etcExpr.typeErrorExplanation = (expectedTypes: List[TlaType1], actualTypes: List[TlaType1]) =>
+        etcExpr.typeErrorExplanation = (_: List[TlaType1], _: List[TlaType1]) =>
           Some(s"Cannot apply $fun to the argument $arg in $ex.")
         etcExpr
 
@@ -465,7 +465,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         // DOMAIN f
         val a = varPool.fresh
         val b = varPool.fresh
-        val c = varPool.fresh
+        varPool.fresh
         val funType = OperT1(Seq(FunT1(a, b)), SetT1(a)) // (a -> b) => Set(a)
         val seqType =
           OperT1(Seq(SeqT1(a)), SetT1(IntT1())) // Seq(c) => Set(Int)
@@ -805,7 +805,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         val typeVar = varPool.fresh
         mkExRefApp(OperT1(nameAndArgs.map(_ => StrT1()) :+ typeVar, typeVar), nameAndArgs :+ labelledEx)
 
-      case OperEx(ApalacheOper.withType, lhs, annotation) =>
+      case OperEx(ApalacheOper.withType, _, annotation) =>
         // Met an old type annotation. Warn the user and ignore the annotation.
         logger.error("Met an old type annotation: " + annotation)
         logger.error("See: https://apalache.informal.systems/docs/apalache/typechecker-snowcat.html")

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
 import at.forsyte.apalache.io.annotations.{Annotation, AnnotationStr, StandardAnnotations}
-import at.forsyte.apalache.io.annotations.store.{AnnotationStore, findAnnotation}
+import at.forsyte.apalache.io.annotations.store.{findAnnotation, AnnotationStore}
 import at.forsyte.apalache.io.typecheck.parser.Type1ParseError
 import at.forsyte.apalache.tla.lir.{SparseTupT1, ValEx, _}
 import at.forsyte.apalache.tla.lir.oper._

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -465,10 +465,12 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         // DOMAIN f
         val a = varPool.fresh
         val b = varPool.fresh
-        varPool.fresh
+        val c = varPool.fresh
+        // The possible types to which which DOMAIN can be be applied,
+        // and the corresponding type of the domain when so applied:
         val funType = OperT1(Seq(FunT1(a, b)), SetT1(a)) // (a -> b) => Set(a)
         val seqType =
-          OperT1(Seq(SeqT1(a)), SetT1(IntT1())) // Seq(c) => Set(Int)
+          OperT1(Seq(SeqT1(c)), SetT1(IntT1())) // Seq(c) => Set(Int)
         val recType = OperT1(Seq(RecT1()), SetT1(StrT1())) // [] => Set(Str)
         val tupType =
           OperT1(Seq(SparseTupT1()), SetT1(IntT1())) // {} => Set(Int)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/TypeRewriter.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/TypeRewriter.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.typecheck.integration
 
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaFunOper, TlaOper}
+import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaStr
 import TypedPredefs._
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.typecheck.passes
 
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.io.OutputManager
-import at.forsyte.apalache.io.OutputManager.Names.IntermediateFoldername
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
 import at.forsyte.apalache.io.json.impl.TlaToUJson
 import at.forsyte.apalache.tla.imp.src.SourceStore
@@ -14,11 +13,7 @@ import at.forsyte.apalache.tla.typecheck.TypeCheckerTool
 import at.forsyte.apalache.io.lir.TlaType1PrinterPredefs.printer
 import at.forsyte.apalache.tla.imp.utils
 import com.google.inject.Inject
-import com.google.inject.name.Named
 import com.typesafe.scalalogging.LazyLogging
-
-import java.io.{File, FileWriter, PrintWriter}
-import java.nio.file.Path
 
 class EtcTypeCheckerPassImpl @Inject() (
     val options: PassOptions,

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/TypeCheckerModule.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/TypeCheckerModule.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.typecheck.passes
 
 import at.forsyte.apalache.infra.ExceptionAdapter
-import at.forsyte.apalache.infra.passes.{Pass, PassOptions, WriteablePassOptions, ToolModule}
+import at.forsyte.apalache.infra.passes.{Pass, PassOptions, ToolModule, WriteablePassOptions}
 import at.forsyte.apalache.io.annotations.{AnnotationStoreProvider, PrettyWriterWithAnnotationsFactory}
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
 import at.forsyte.apalache.tla.imp.passes.{SanyParserPass, SanyParserPassImpl}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/TypeCheckerModule.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/TypeCheckerModule.scala
@@ -9,8 +9,7 @@ import at.forsyte.apalache.io.lir.TlaWriterFactory
 import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.{TransformationListener, TransformationTracker}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
-import com.google.inject.{AbstractModule, TypeLiteral}
-import com.google.inject.name.Names
+import com.google.inject.TypeLiteral
 
 class TypeCheckerModule extends ToolModule {
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/types/SmtVarGenerator.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/types/SmtVarGenerator.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.types
 
 class SmtVarGenerator {
   private var idx_t: Long = 0
-  private var idx_i: Long = 0
 
   def getFresh: SmtTypeVariable = {
     val ret = SmtTypeVariable(idx_t)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/types/TypeReduction.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/types/TypeReduction.scala
@@ -34,7 +34,6 @@ class TypeReduction(private val gen: SmtVarGenerator) {
       val phi = sizeOfEql(tupIdx, l) +: constraints
       ReductionResult(tup(tupIdx), phi)
     case RecT(ts @ _*) =>
-      ts.length
       val recIdx = gen.getFreshInt
       val constraints = ts.flatMap { case KvPair(k, v) =>
         val ReductionResult(t, phi) = apply(v, m)
@@ -42,7 +41,6 @@ class TypeReduction(private val gen: SmtVarGenerator) {
       }
       ReductionResult(rec(recIdx), constraints)
     case SparseTupT(ts @ _*) =>
-      ts.length
       val tupIdx = gen.getFreshInt
       val constraints = ts.flatMap { case KvPair(k, v) =>
         val ReductionResult(t, phi) = apply(v, m)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/types/TypeReduction.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/types/TypeReduction.scala
@@ -34,7 +34,7 @@ class TypeReduction(private val gen: SmtVarGenerator) {
       val phi = sizeOfEql(tupIdx, l) +: constraints
       ReductionResult(tup(tupIdx), phi)
     case RecT(ts @ _*) =>
-      val l = ts.length
+      ts.length
       val recIdx = gen.getFreshInt
       val constraints = ts.flatMap { case KvPair(k, v) =>
         val ReductionResult(t, phi) = apply(v, m)
@@ -42,7 +42,7 @@ class TypeReduction(private val gen: SmtVarGenerator) {
       }
       ReductionResult(rec(recIdx), constraints)
     case SparseTupT(ts @ _*) =>
-      val l = ts.length
+      ts.length
       val tupIdx = gen.getFreshInt
       val constraints = ts.flatMap { case KvPair(k, v) =>
         val ReductionResult(t, phi) = apply(v, m)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
@@ -8,7 +8,7 @@ import at.forsyte.apalache.io.typecheck.parser.DefaultType1Parser
 import org.junit.runner.RunWith
 import org.scalacheck.Gen.alphaStr
 import org.scalacheck.Prop
-import org.scalacheck.Prop.{AnyOperators, falsified, forAll, passed}
+import org.scalacheck.Prop.{falsified, forAll, passed, AnyOperators}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
 import at.forsyte.apalache.io.annotations.StandardAnnotations
-import at.forsyte.apalache.io.annotations.store.{AnnotationStore, createAnnotationStore}
+import at.forsyte.apalache.io.annotations.store.{createAnnotationStore, AnnotationStore}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaFunOper}

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -436,7 +436,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
 
   test("DOMAIN f") {
     // DOMAIN is applied to one of the four objects: a function, a sequence, a record, or a sparse tuple
-    val types = Seq(parser("(a -> b) => Set(a)"), parser("Seq(a) => Set(Int)"), parser("[] => Set(Str)"),
+    val types = Seq(parser("(a -> b) => Set(a)"), parser("Seq(c) => Set(Int)"), parser("[] => Set(Str)"),
         parser("{} => Set(Int)"))
 
     val expected = mkAppByName(types, "f")

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprDecls.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprDecls.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
 import at.forsyte.apalache.io.annotations.StandardAnnotations
-import at.forsyte.apalache.io.annotations.store.{AnnotationStore, createAnnotationStore}
+import at.forsyte.apalache.io.annotations.store.{createAnnotationStore, AnnotationStore}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TestingPredefs.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TestingPredefs.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.lir
 
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt}
+import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 // Igor@02.11.2019: why are TestingPredefs located in src/main?

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaEx.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaEx.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
-import at.forsyte.apalache.tla.lir.oper.{FixedArity, TlaOper}
+import at.forsyte.apalache.tla.lir.oper.TlaOper
 
 /**
  * An abstract TLA+ expression. Note that the class is sealed, so we allow only a limited set of values. Importantly,

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
@@ -114,7 +114,7 @@ package object aux {
   }
 
   def allDiffs(ex: TlaEx): Seq[TlaEx] = ex match {
-    case OperEx(TlaOper.apply, NameEx("Diff"), ex1, ex2) =>
+    case OperEx(TlaOper.apply, NameEx("Diff"), _, _) =>
       Seq(ex)
     case OperEx(_, args @ _*) =>
       args.flatMap {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -66,13 +66,6 @@ object UTFPrinter extends Printer {
         fn: TlaEx => String) =
       seq.grouped(n).toSeq.map(s => pattern.format(s.map(fn): _*)).mkString(sep)
 
-    def strPattern(
-        seq: Seq[TlaEx],
-        n: Int,
-        pattern: String,
-        sep: String): String =
-      groupMapMk(seq, n, pattern, sep, apply)
-
     def opAppPattern(
         seq: Seq[TlaEx],
         n: Int,

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaControlOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaControlOper.scala
@@ -1,7 +1,5 @@
 package at.forsyte.apalache.tla.lir.oper
 
-import at.forsyte.apalache.tla.lir.TlaOperDecl
-
 /**
  * A control-flow operator.
  */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/predef/standardSets.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/predef/standardSets.scala
@@ -1,3 +1,1 @@
 package at.forsyte.apalache.tla.lir.predef
-
-import at.forsyte.apalache.tla.lir.values.TlaPredefSet

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/LanguageWatchdog.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/LanguageWatchdog.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.lir.transformations
 
-import at.forsyte.apalache.tla.lir.{TlaEx, TlaModule, LanguagePredError}
+import at.forsyte.apalache.tla.lir.{LanguagePredError, TlaEx, TlaModule}
 
 /**
  * Given a language predicate, the watchdog checks, whether an expression or a module satisfies the predicate. If not,

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/FlatLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/FlatLanguagePred.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.transformations.{LanguagePred, PredResult, PredResultFail, PredResultOk}
+import at.forsyte.apalache.tla.lir.transformations.{PredResult, PredResultFail, PredResultOk}
 
 /**
  * <p>Test whether the expressions fit into the flat fragment: all calls to user operators are inlined, except the calls
@@ -43,7 +43,7 @@ class FlatLanguagePred extends ContextualLanguagePred {
           r.and(isOkInContext(letDefs, arg))
         }
 
-      case e =>
+      case _ =>
         PredResultOk()
     }
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Flatten.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TlaOperDecl, TypeTag}
+import at.forsyte.apalache.tla.lir.{LetInEx, OperEx, TlaEx, TypeTag}
 import at.forsyte.apalache.tla.lir.oper.{TlaBoolOper, TlaOper}
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 
@@ -48,12 +48,6 @@ object Flatten {
     ex match {
       case LetInEx(body, defs @ _*) =>
         // Transform bodies of all op.defs
-        def xform: TlaOperDecl => TlaOperDecl =
-          tracker.trackOperDecl { d: TlaOperDecl =>
-            d.copy(
-                body = self(d.body)
-            )
-          }
 
         val newDefs = defs.map(tracker.trackOperDecl { d => d.copy(body = self(d.body)) })
         val newBody = self(body)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
@@ -38,7 +38,7 @@ object IncrementalRenaming {
           } =>
         Some((n, i.toInt))
       // Never renamed before
-      case Array(n) => None
+      case Array(_) => None
       // Error
       case _ => throw new IllegalArgumentException("Variable names should never contain more than one separator")
     }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaSeqOper, _}
-import at.forsyte.apalache.tla.lir.transformations.{LanguagePred, PredResult, PredResultFail, PredResultOk}
+import at.forsyte.apalache.tla.lir.transformations.{PredResult, PredResultFail, PredResultOk}
 import at.forsyte.apalache.tla.lir.values._
 
 import scala.collection.immutable.HashSet

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeramelizerInputLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeramelizerInputLanguagePred.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.ApalacheOper.gen
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{PredResult, PredResultFail, PredResultOk}
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/Prime.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.lir.transformations.standard
 
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaActionOper
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.{LetInEx, NameEx, OperEx}

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ReTLALanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ReTLALanguagePred.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.lir.transformations.standard
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.transformations.{LanguagePred, PredResult, PredResultFail, PredResultOk}
+import at.forsyte.apalache.tla.lir.transformations.{PredResult, PredResultFail, PredResultOk}
 import at.forsyte.apalache.tla.lir.values._
 
 import scala.collection.immutable.HashSet

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaDeclLevelFinder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaDeclLevelFinder.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import org.junit.runner.RunWith
 import org.scalacheck.Prop
-import org.scalacheck.Prop.{AnyOperators, all, forAll, passed}
+import org.scalacheck.Prop.{all, forAll, passed, AnyOperators}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExLevelFinder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExLevelFinder.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.lir
 
 import org.junit.runner.RunWith
-import org.scalacheck.Prop.{AnyOperators, forAll, passed}
+import org.scalacheck.Prop.{forAll, passed, AnyOperators}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTransformations.scala
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.Outcome
-import java.io.{PrintStream, File, FileOutputStream}
+import java.io.{File, FileOutputStream, PrintStream}
 
 @RunWith(classOf[JUnitRunner])
 class TestTransformations extends AnyFunSuite with TestingPredefs {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/impl/TestStableTopologicalSort.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/impl/TestStableTopologicalSort.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.lir.transformations.impl
 
 import org.junit.runner.RunWith
-import org.scalacheck.Prop.{AnyOperators, falsified, forAll, passed, propBoolean}
+import org.scalacheck.Prop.{falsified, forAll, passed, propBoolean, AnyOperators}
 import org.scalacheck.{Arbitrary, Gen, Prop}
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestReplaceFixed.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestReplaceFixed.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
 import at.forsyte.apalache.tla.lir.transformations.TlaExTransformation
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
-import at.forsyte.apalache.tla.lir.{OperParam, NameEx, OperEx, TestingPredefs, TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.{NameEx, OperEx, OperParam, TestingPredefs, TlaEx, TlaOperDecl}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite


### PR DESCRIPTION
Closes #1389

Please individual commits for details on the changes. The only "substantive"
changes are:

- b0dc5d91b03790f2a5de99409cb19e301184323a just adds the scalafix plugin
- 240d414c46323b9573c2665c0568e63b6889a907 configures the plugin for our builds
- 7ab898880c51669eee19f6867f89c74899aa497e adds a scalafmt rule to sort imports

The other changes are just automated application of these configurations (or
documentation).

With this changes in place, our IDEs should now warn us on unused variables and
imports, and we'll get warnings during compilation too.

Running `sbt "scalafix RemoveUnused"` should remove the unused terms.

(Note that on my first run I had to make 3 manual fixes, in places with nested
`@` bindings resulted in syntactically incorrect rewriting by scalafix. So, be
on guard.)

to @gabrielamafra and @thpani for motivating and directing this
improvement.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality