### PR TITLE
Remove unused `SymbStateRewriter` arg to IntOracle.create

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/IntOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/IntOracle.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.IntT
-import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
+import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState}
 import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
@@ -85,7 +85,7 @@ class IntOracle(val intCell: ArenaCell, nvalues: Int) extends Oracle {
 }
 
 object IntOracle {
-  def create(rewriter: SymbStateRewriter, state: SymbState, nvalues: Int): (SymbState, IntOracle) = {
+  def create(state: SymbState, nvalues: Int): (SymbState, IntOracle) = {
     val nextState = state.setArena(state.arena.appendCell(IntT()))
     val oracleCell = nextState.arena.topCell
     val oracle = new IntOracle(oracleCell, nvalues)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/OracleFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/OracleFactory.scala
@@ -60,6 +60,6 @@ class OracleFactory(rewriter: SymbStateRewriter) {
    *   a new symbolic state and the oracle, the state.rex equals to state.rex
    */
   def newIntOracle(state: SymbState, nvalues: Int): (SymbState, IntOracle) = {
-    IntOracle.create(rewriter, state, nvalues)
+    IntOracle.create(state, nvalues)
   }
 }


### PR DESCRIPTION
Towards #1064

Identified by compiler warnings, this parameter is not used in the
method, or required by an interface.

-------

<!-- Please ensure that your PR includes the following, as needed -->