### PR TITLE
Fix compiler warnings for unused mutable variables

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -37,7 +37,7 @@ trait General extends Command with CliConfig {
   private var _env = ""
 
   private def getOptionEnvVar(option: CliOption[_]): Option[String] = {
-    var envVar = option.name.replace("-", "_").toUpperCase()
+    val envVar = option.name.replace("-", "_").toUpperCase()
     sys.env.get(envVar).map(value => s"${envVar}=${value}")
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -119,7 +119,7 @@ class SymbStateRewriterImpl(
   /**
    * A storage for the messages associated with assertion failures, see MessageStorage.
    */
-  private var messages: mutable.Map[Int, String] = new mutable.HashMap()
+  private val messages: mutable.Map[Int, String] = new mutable.HashMap()
 
   /**
    * Get the current context level, that is the difference between the number of pushes and pops made so far.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
@@ -35,7 +35,7 @@ class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
       case OperEx(ApalacheOper.constCard,
               OperEx(TlaArithOper.ge, OperEx(TlaFiniteSetOper.cardinality, setEx), ValEx(TlaInt(thresholdBigInt)))) =>
         val threshold = thresholdBigInt.toInt
-        var nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
+        val nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
         val setCell = nextState.asCell
         val elems = nextState.arena.getHas(setCell)
         if (threshold <= 0) {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityRule.scala
@@ -29,7 +29,7 @@ class CardinalityRule(rewriter: SymbStateRewriter) extends RewritingRule {
   override def apply(state: SymbState): SymbState = {
     state.ex match {
       case OperEx(TlaFiniteSetOper.cardinality, setEx) =>
-        var nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
+        val nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
         val setCell = nextState.asCell
         setCell.cellType match {
           case FinSetT(_) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -45,7 +45,7 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
       val leftState = rewriter.rewriteUntilDone(state.setRex(left))
       val rightState = rewriter.rewriteUntilDone(leftState.setRex(right))
       // compare integers directly in SMT
-      var arena = rightState.arena.appendCell(BoolT())
+      val arena = rightState.arena.appendCell(BoolT())
       val eqPred = arena.topCell
       val cons =
         OperEx(TlaOper.eq, eqPred.toNameEx, OperEx(oper, leftState.ex, rightState.ex))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
@@ -141,7 +141,7 @@ class QuantRule(rewriter: SymbStateRewriter) extends RewritingRule with LazyLogg
         tla.or(tla.not(tla.apalacheSelectInSet(elemAndPred._1.toNameEx, set.toNameEx)), elemAndPred._2)
       }
 
-      var finalState = predState.updateArena(_.appendCell(BoolT()))
+      val finalState = predState.updateArena(_.appendCell(BoolT()))
       val pred = finalState.arena.topCell
       val iff =
         if (isExists) {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SeqOpsRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SeqOpsRule.scala
@@ -171,7 +171,7 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
   }
 
   private def translateLen(state: SymbState, seq: TlaEx) = {
-    var nextState = rewriter.rewriteUntilDone(state.setRex(seq))
+    val nextState = rewriter.rewriteUntilDone(state.setRex(seq))
     val cells = nextState.arena.getHas(nextState.asCell)
     val start = cells.head
     val end = cells.tail.head

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
@@ -27,7 +27,7 @@ class SetExpandRule(rewriter: SymbStateRewriter) extends RewritingRule {
         throw new RewriterException("Trying to expand a set of functions. This will blow up the solver.", ex)
 
       case OperEx(ApalacheOper.expand, OperEx(TlaSetOper.powerset, basesetEx)) =>
-        var nextState = rewriter.rewriteUntilDone(state.setRex(basesetEx))
+        val nextState = rewriter.rewriteUntilDone(state.setRex(basesetEx))
         new PowSetCtor(rewriter).confringo(nextState, nextState.asCell)
 
       case e @ _ =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRule.scala
@@ -138,7 +138,7 @@ class SetInRule(rewriter: SymbStateRewriter) extends RewritingRule {
       // i \in Nat <=> i >= 0
       assert(setCell == state.arena.cellNatSet())
       assert(elemType == IntT())
-      var nextState = state.updateArena(_.appendCell(BoolT()))
+      val nextState = state.updateArena(_.appendCell(BoolT()))
       val pred = nextState.arena.topCell
       rewriter.solverContext.assertGroundExpr(tla.equiv(pred.toNameEx, tla.ge(elemCell.toNameEx, tla.int(0))))
       nextState.setRex(pred.toNameEx)
@@ -158,7 +158,7 @@ class SetInRule(rewriter: SymbStateRewriter) extends RewritingRule {
       // the set cell points to no other cell => return false
       state.setRex(state.arena.cellFalse().toNameEx)
     } else {
-      var nextState = state.updateArena(_.appendCell(BoolT()))
+      val nextState = state.updateArena(_.appendCell(BoolT()))
       val pred = nextState.arena.topCell.toNameEx
 
       // cache equality constraints first

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -173,7 +173,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
       elems: Seq[ArenaCell],
       elseAssert: TlaEx): SymbState = {
     rewriter.solverContext.log("; CHERRY-PICK %s FROM [%s] {".format(cellType, elems.map(_.toString).mkString(", ")))
-    var arena = state.arena.appendCell(cellType)
+    val arena = state.arena.appendCell(cellType)
     val resultCell = arena.topCell
     // compare the set contents with the result
     val eqState = rewriter.lazyEq.cacheEqConstraints(state, elems.map(e => (e, resultCell)))
@@ -859,7 +859,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
   // just declare an integer, and in case of Nat make it non-negative
   def pickFromIntOrNatSet(set: ArenaCell, state: SymbState): SymbState = {
     assert(set == state.arena.cellNatSet() || set == state.arena.cellIntSet())
-    var nextState = state.updateArena(_.appendCell(IntT()))
+    val nextState = state.updateArena(_.appendCell(IntT()))
     val intCell = nextState.arena.topCell
     if (set == state.arena.cellNatSet()) {
       rewriter.solverContext.assertGroundExpr(tla.ge(intCell.toNameEx, tla.int(0)))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
@@ -46,7 +46,7 @@ class MapBase(rewriter: SymbStateRewriter) {
       }
     }
 
-    val (setsAsCells, elemTypes) = (sets.map(nextState.arena.findCellByNameEx).map(findSetCellAndElemType)).unzip
+    val (setsAsCells, _) = (sets.map(nextState.arena.findCellByNameEx).map(findSetCellAndElemType)).unzip
     val elemsOfSets = setsAsCells.map(nextState.arena.getHas)
     val setLimits = elemsOfSets.map(_.size - 1)
     // find the types of the target expression and of the target set
@@ -67,7 +67,7 @@ class MapBase(rewriter: SymbStateRewriter) {
     val tupleIter = new IntTupleIterator(setLimits).map(byIndex)
 
     // the SMT constraints are added right in the method
-    val (newState, resultElemCells) =
+    val (newState, _) =
       mapCellsManyArgs(nextState, resultSetCell, mapEx, varNames, setsAsCells, tupleIter)
 
     // that's it
@@ -87,7 +87,7 @@ class MapBase(rewriter: SymbStateRewriter) {
     // This is probably a memory-hungry solution.
     // We will replace it with a better one in an array-based SMT encoding:
     // https://github.com/informalsystems/apalache/issues/365
-    var resultsToSource = new HashMap[ArenaCell, Set[TlaEx]] with MultiMap[ArenaCell, TlaEx]
+    val resultsToSource = new HashMap[ArenaCell, Set[TlaEx]] with MultiMap[ArenaCell, TlaEx]
     for (argCells <- cellsIter) {
       val (ns, resultCell, memEx) =
         mapCellsManyArgsOnce(newState, targetSetCell, mapEx, varNames, setsAsCells, argCells)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/PropositionalOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/PropositionalOracle.scala
@@ -120,7 +120,7 @@ object PropositionalOracle {
     // create nbits cells to hold the propositional variables
     val (newArena, newCells) = state.arena.appendCellSeq((0 until nbits).map(_ => BoolT()): _*)
     val oracle = new PropositionalOracle(newCells, nvalues)
-    var nextState = state.setArena(newArena)
+    val nextState = state.setArena(newArena)
 
     // exclude the values that are above nvalues
     def pow(n: Int): Int = if (n <= 0) 1 else 2 * pow(n - 1)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -895,7 +895,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
 }
 
 object Z3SolverContext {
-  private var nextId: AtomicLong = new AtomicLong(0)
+  private val nextId: AtomicLong = new AtomicLong(0)
 
   private def createId(): Long = {
     nextId.getAndIncrement()

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/util/IntTupleIterator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/util/IntTupleIterator.scala
@@ -11,7 +11,7 @@ import at.forsyte.apalache.tla.lir.NullEx
  *   Igor Konnov
  */
 class IntTupleIterator(limits: Seq[Int]) extends Iterator[Seq[Int]] {
-  private var vec: Array[Int] = (-1) +: Array.fill(limits.size - 1)(0)
+  private val vec: Array[Int] = (-1) +: Array.fill(limits.size - 1)(0)
   // we have to enumerate that many elements
   private var toEnumerate: BigInt = limits.map(BigInt(_) + 1).product // bugfix: use BigInt to avoid overflow
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/src/SourceStore.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/src/SourceStore.scala
@@ -31,12 +31,12 @@ class SourceStore extends TransformationListener with LazyLogging {
   /**
    * A mapping from a filenames to an index in trees. This map is typically quite small.
    */
-  private var filenameToIndex: mutable.Map[String, Int] = mutable.HashMap()
+  private val filenameToIndex: mutable.Map[String, Int] = mutable.HashMap()
 
   /**
    * An inverse mapping of filenameToIndex.
    */
-  private var indexToFilename: mutable.Map[Int, String] = mutable.HashMap()
+  private val indexToFilename: mutable.Map[Int, String] = mutable.HashMap()
 
   /**
    * A sequence of region trees, one per filename. The following invariant is maintained: filenames.size == trees.size.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/UniqueNameGenerator.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/UniqueNameGenerator.scala
@@ -15,7 +15,7 @@ import com.google.inject.Singleton
  */
 @Singleton
 class UniqueNameGenerator {
-  private var nextId: AtomicLong = new AtomicLong(1)
+  private val nextId: AtomicLong = new AtomicLong(1)
 
   /**
    * Produce a new unique name for a variable

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/identifiers.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/identifiers.scala
@@ -30,7 +30,7 @@ object UID {
    * The value of the id that will be assigned by the next call to unique(). We start with 1, to omit the default value
    * 0. By using AtomicLong, we make sure that unique() is assigning unique identifiers in the concurrent setting.
    */
-  private var nextId: AtomicLong = new AtomicLong(1)
+  private val nextId: AtomicLong = new AtomicLong(1)
 
   // TODO: remove this method in the future, as it allows one to work around uniqueness
   def apply(id: Long) = new UID(id)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -11,8 +11,11 @@ import at.forsyte.apalache.tla.lir.values._
 abstract class Printer {
   def apply(p_ex: TlaEx): String
 
-  def apply(p_decl: TlaDecl): String = ""
-
+  def apply(p_decl: TlaDecl): String = {
+    // Telling the compiler we know we're not using p_decl here
+    locally(p_decl);
+    ""
+  }
 }
 
 object UTFPrinter extends Printer {
@@ -52,11 +55,11 @@ object UTFPrinter extends Printer {
   override def apply(p_ex: TlaEx): String = apply(p_ex, false)
 
   def apply(p_ex: TlaEx, p_rmSpace: Boolean): String = {
-    def mapMk(seq: Seq[TlaEx], sep: String = ", ", fn: TlaEx => String) = seq.map(fn).mkString(sep)
+    def mapMk(seq: Seq[TlaEx], sep: String, fn: TlaEx => String) = seq.map(fn).mkString(sep)
 
     def str(seq: Seq[TlaEx], sep: String = ", ") = mapMk(seq, sep, apply)
 
-    def opAppStr(seq: Seq[TlaEx], sep: String = ", ") = mapMk(seq, sep, opApp)
+    def opAppStr(seq: Seq[TlaEx], sep: String) = mapMk(seq, sep, opApp)
 
     def groupMapMk(
         seq: Seq[TlaEx],

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/TransformationTracker.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/TransformationTracker.scala
@@ -68,8 +68,7 @@ trait TransformationTracker {
    *   the new expression
    */
   def hold(from: TlaEx, to: TlaEx): TlaEx = {
-    def tr(f: TlaEx): TlaEx = to
-    trackEx(tr)(from)
+    trackEx(Function.const(to))(from)
   }
 
   /**


### PR DESCRIPTION
Towards #1064

The main thrust of this changeset is to fix compiler warnings of the form

``` sh
local var foo in method bar is never updated: consider using immutable val
```


This PR addresses the warnings by replacing the identified cases of unneeded
`var` with `val`.

I also made two unrelated fixes in

- 67ec68849cdb08a5b0cf4cdba44bc41ebffa52ab
- 6ff163b3fda56a9c06d69877f93b9bc77f977a98

These are special cases of unused values, too complicated for scalafix to
address automatically. See the individual commits for details.

<!-- Please ensure that your PR includes the following, as needed -->