### PR TITLE
Fix infallible ToEtcExpr tests

### DIFF
--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -107,7 +107,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
     assert(mkExpected(parser("(b, b) => Bool")) == gen(tla.neql(tla.int(1), tla.int(2))))
 
     // Has custom type error message
-    assert(gen(tla.eql(tla.int(1), tla.int(2))).explain(List(), List()) != "")
+    assert(gen(tla.eql(tla.int(1), tla.int(2))).explain(List(), List()).isDefined)
   }
 
   test("operator application") {
@@ -119,7 +119,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
     assert(expected2 == gen(expr))
 
     // Has custom type error message
-    assert(gen(expr).explain(List(OperT1(Seq(), BoolT1())), List()) != "")
+    assert(gen(expr).explain(List(OperT1(Seq(), BoolT1())), List()).isDefined)
   }
 
   test("LET-IN simple") {


### PR DESCRIPTION
These two asserts were comparing a value of type `Optional[String]` with
a value of type `String` for inequality, so they were guaranteed to
always succeed.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)