### PR TITLE
Fix #1425

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+ * Fix a corner case in `\E x \in S: P`, see #1426

--- a/test/tla/Test1425.tla
+++ b/test/tla/Test1425.tla
@@ -1,0 +1,25 @@
+------------------------ MODULE Test1425 -----------------------------
+\* This test demonstrates an issue that appears in the original Bakery.
+\* https://github.com/informalsystems/apalache/issues/1425
+EXTENDS Integers
+
+VARIABLES
+    \* @type: Int -> Set(Int);
+    unchecked,
+    \* @type: Int -> Int;
+    nxt
+
+Procs == 1..4    
+
+Init ==
+    /\ unchecked = [ p \in Procs |-> {} ]
+    /\ nxt = [ p \in Procs |-> 1 ]
+
+Next ==
+    \/ \E self \in Procs:
+        /\ \E i \in unchecked[self]:
+            nxt' = [nxt EXCEPT ![self] = i]
+        /\ nxt'[self] \in unchecked[self]
+        /\ UNCHANGED unchecked
+    \/ UNCHANGED <<unchecked, nxt>>
+=====================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1865,6 +1865,16 @@ $ apalache-mc check --inv=Inv --cinit=ConstInit TestHash2.tla | sed 's/[IEW]@.*/
 EXITCODE: OK
 ```
 
+### check Test1425.tla reports no error
+
+A regression test for assignments under quantification over empty sets.
+
+```sh
+$ apalache-mc check --length=1 Test1425.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ## running the typecheck command
 
 ### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -85,7 +85,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     nextState.ex match {
       case NameEx(name) =>
         assert(arena.cellFalse().toString == name)
-        assert(nextState.binding.toMap.isEmpty)
+        assert(nextState.binding.toMap.contains("x'"))
 
       case _ =>
         fail("Unexpected rewriting result")


### PR DESCRIPTION
Closes #1425. This PR fixes the corner case in `\E x \in S: P`, when `P` contains assignments and `S` is non-empty.

I have accidentally created this branch from the branch ik/pluscal1412, where this issue appeared, so rebasing against this branch.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
