### PR TITLE
Prevent infinite chain of generator calls and re-enable function constructors in PBT

### DIFF
--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -260,10 +260,10 @@ trait IrGenerators extends TlaType1Gen {
    * @return
    *   a generator of operator declarations
    */
-  def genTlaOperDecl(exGen: UserContext => Gen[TlaEx])(ctx: UserContext): Gen[TlaOperDecl] = {
+  def genTlaOperDecl(exGen: UserContext => Gen[TlaEx])(ctx: UserContext): Gen[TlaOperDecl] = sized { size =>
     for {
       name <- identifier.suchThat(n => !ctx.contains(n))
-      body <- exGen(ctx)
+      body <- resize(size - 1, exGen(ctx))
       nparams <- choose(0, maxArgs)
       params <- listOfN(nparams, identifier)
       tt <- genTypeTag

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -82,11 +82,8 @@ trait IrGenerators extends TlaType1Gen {
   /**
    * Function operators (`TlaFunOper._`)
    */
-  val functionOperators =
-    List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.recFunRef, TlaFunOper.except)
-  /* TlaFunOper.{funDef,recFunDef} seem to cause lots of malformed expressions; disable them for now.
-   * cf. https://github.com/informalsystems/apalache/pull/1386#discussion_r811016316
-   */
+  val functionOperators = List(TlaFunOper.enum, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.funDef,
+      TlaFunOper.recFunDef, TlaFunOper.recFunRef, TlaFunOper.except)
 
   /**
    * Action operators (`TlaActionOper._`)


### PR DESCRIPTION
This fixes an infinite (non-`size`-decreasing) chain of generator calls via `genTlaEx` -> `genLetInEx` -> `genTlaOperDecl` -> `genTlaEx`, where in `genTlaEx` a non-resized reference of `genTlaEx` is passed via the `exGen` parameters of `genLetInEx` and `genTlaOperDecl`, where it is (recursively) called.

It seems this infinite chain was only eventually broken by the ScalaCheck RNG.
We fix this by resizing `genTlaEx` in `genTlaOperDecl`.

I checked the call graph for other such cycles, but haven't found any.

This PR also re-enables function constructors in PBT, which where disabled for performance regression in #1401.
Hypothetically, this regression was not introduced directly the additional operators, but by the infinite chain of generator calls fixed in this PR.

Closes #1402