### PR TITLE
Implement EXCEPT applied to sequences

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Features
 
  * Implement the sequence constructor `Apalache!MkSeq`, see #1439
+ * Implement `EXCEPT` on sequences, see #1444

--- a/docs/src/apalache/features.md
+++ b/docs/src/apalache/features.md
@@ -154,10 +154,11 @@ Operator  | Supported? | Milestone | Comment
 
 Operator  | Supported? | Milestone | Comment
 ------------------------|:------------------:|:---------------:|--------------
-``<<...>>``, ``Head``, ``Tail``, ``Len``, ``SubSeq``, `Append`, `\o`, `f[e]` | ✔ | - | The sequence constructor ``<<...>>`` needs a [type annotation](https://apalache.informal.systems/docs/tutorials/snowcat-tutorial.html).
-`EXCEPT` | ✖ |   | If you need it, let us know, issue #324
+`<<...>>` | ✔ |   | Often needs a [type annotation](https://apalache.informal.systems/docs/tutorials/snowcat-tutorial.html).
+`Head`, `Tail`, `Len``, `SubSeq`, `Append`, `\o`, `f[e]` | ✔ | - |
+`EXCEPT` | ✔ |   |
+`SelectSeq` | ✔ | - | Not as efficient, as it could be, see [#1350](https://github.com/informalsystems/apalache/issues/1350).
 `Seq(S)` | ✖ | - | Use `Gen` of Apalache to produce bounded sequences
-`SelectSeq` | ✖ | - | Planned in [#873](https://github.com/informalsystems/apalache/issues/873). Till then, use `FoldSeq`.
 
 ### FiniteSets
 

--- a/test/tla/TestSequences.tla
+++ b/test/tla/TestSequences.tla
@@ -176,6 +176,12 @@ TestSelectSeqEmpty ==
 TestFoldSeqOverSelectSeq ==
     FoldSeq(Add, 0, SelectSeq(seq345, IsOdd)) = 3 + 5
 
+TestExceptLen ==
+    Len([seq345 EXCEPT ![2] = 10]) = 3
+
+TestExceptDomain ==
+    DOMAIN [seq345 EXCEPT ![2] = 10] = DOMAIN seq345
+
 \* this test is a disjunction of all smaller tests
 AllTests ==
     /\ TestHeadEmpty
@@ -216,4 +222,6 @@ AllTests ==
     /\ TestMkSeqSubSeq
     /\ TestMkSeqLen
     /\ TestMkSeqFold
+    /\ TestExceptLen
+    /\ TestExceptDomain
 ===============================================================================

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunExceptRule.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
+import at.forsyte.apalache.tla.bmcmt.rules.aux.ProtoSeqOps
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, OperEx, RecT1, SeqT1, SetT1, TlaEx, TlaType1, TupT1, ValEx}
 import at.forsyte.apalache.tla.lir.TypedPredefs._
-import at.forsyte.apalache.tla.lir.TlaType1
-import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, RecT1, SetT1, TupT1}
 
 /**
  * Rewriting EXCEPT for functions, tuples, and records.
@@ -16,6 +15,8 @@ import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, RecT1, SetT1, TupT1}
  *   Igor Konnov
  */
 class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
+  private val proto = new ProtoSeqOps(rewriter)
+
   private def cacheEq(s: SymbState, l: ArenaCell, r: ArenaCell) = rewriter.lazyEq.cacheOneEqConstraint(s, l, r)
 
   private def solverAssert = rewriter.solverContext.assertGroundExpr _
@@ -45,6 +46,7 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
           case ft @ FunT1(_, _)  => rewriteFun(nextState, funCell, ft, indexCell, valueCell)
           case rt @ RecT1(_)     => rewriteRec(nextState, funCell, rt, indexEx, valueCell)
           case tt @ TupT1(_ @_*) => rewriteTuple(nextState, funCell, tt, indexEx, valueCell)
+          case SeqT1(et)         => rewriteSeq(nextState, funCell, et, indexCell, valueCell)
           case _ =>
             throw new NotImplementedError(s"EXCEPT is not implemented for $funT. Write a feature request.")
         }
@@ -188,5 +190,30 @@ class FunExceptRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
 
     rewriter.rewriteUntilDone(nextState.setRex(newTuple.toNameEx))
+  }
+
+  // rewrite a sequence with EXCEPT semantics
+  def rewriteSeq(
+      state: SymbState,
+      oldSeq: ArenaCell,
+      elemT: TlaType1,
+      indexCell: ArenaCell,
+      newValue: ArenaCell): SymbState = {
+    val (oldProtoSeq, len, capacity) = proto.unpackSeq(state.arena, oldSeq)
+
+    // make an element for the new proto sequence
+    def mkElem(state: SymbState, index: Int): (SymbState, ArenaCell) = {
+      val oldValue = proto.at(state.arena, oldProtoSeq, index)
+      val cond = tla.eql(indexCell.toNameEx, tla.int(index)).as(BoolT1())
+      // IF indexCell = index THEN newValue ELSE oldValue
+      val iteEx = tla.ite(cond, newValue.toNameEx, oldValue.toNameEx).as(elemT)
+      val newState = rewriter.rewriteUntilDone(state.setRex(iteEx))
+      (newState, newState.asCell)
+    }
+
+    // make a new proto sequence of the same capacity and the same length
+    val nextState = proto.make(state, capacity, mkElem)
+    val newProtoSeq = nextState.asCell
+    proto.mkSeq(nextState, SeqT1(elemT), newProtoSeq, len)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -328,5 +328,35 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assert(solverContext.sat())
   }
 
+  test("""(<<3, 4, 5, 6>> EXCEPT ![2] = 7) = <<3, 7, 5, 6>>""") { rewriterType: SMTEncoding =>
+    val tup3to6 = tuple(3.to(6).map(int): _*).as(intSeqT)
+    val tup3756 = tuple(Seq(3, 7, 5, 6).map(int): _*).as(intSeqT)
+    val exceptEx = except(tup3to6, tuple(int(2)).as(TupT1(IntT1())), int(7)).as(intSeqT)
+    val eq = eql(exceptEx, tup3756).as(boolT)
+
+    val state = new SymbState(eq, arena, Binding())
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
+  test("""(<<3, 4, 5, 6>> EXCEPT ![10] = 7) = <<3, 4, 5, 6>>""") { rewriterType: SMTEncoding =>
+    val tup3to6 = tuple(3.to(6).map(int): _*).as(intSeqT)
+    val exceptEx = except(tup3to6, tuple(int(10)).as(TupT1(IntT1())), int(7)).as(intSeqT)
+    // since 10 does not belong to the domain, the sequence does not change
+    val eq = eql(exceptEx, tup3to6).as(boolT)
+
+    val state = new SymbState(eq, arena, Binding())
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
+  test("""(<< >> EXCEPT ![10] = 7) = << >>""") { rewriterType: SMTEncoding =>
+    val emptyTuple = tuple().as(intSeqT)
+    val exceptEx = except(emptyTuple, tuple(int(10)).as(TupT1(IntT1())), int(7)).as(intSeqT)
+    // since 10 does not belong to the domain, the sequence does not change
+    val eq = eql(exceptEx, emptyTuple).as(boolT)
+
+    val state = new SymbState(eq, arena, Binding())
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
   // for PICK see TestCherryPick
 }


### PR DESCRIPTION
Close #324. This PR implement the missing feature that allows one to write `[seq EXCEPT ![e1] = e2]`, where `seq` is a sequence.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
