### PR TITLE
Split TestSetMembershipSimplifier

### DIFF
--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -68,8 +68,8 @@ class TestSetMembershipSimplifier
   private val intPowerset = tla.seqSet(tla.intSet()).as(SetT1(intSeqT))
   private val natPowerset = tla.seqSet(tla.natSet()).as(SetT1(intSeqT))
 
-  private val tupleVal = tla.tuple(tla.int(1).as(IntT1()), tla.int(42).as(IntT1())).as(intSeqT)
-  private val tupleName = tla.name("tup").as(intSeqT)
+  private val tupleVal = tla.tuple(tla.int(1).as(IntT1()), tla.int(42).as(IntT1())).as(TupT1(IntT1(), IntT1()))
+  private val tupleName = tla.name("tup").as(TupT1(IntT1(), IntT1()))
   private val cartesianSet =
     tla.times(tla.intSet().as(intSetT), tla.intSet().as(intSetT)).as(SetT1(TupT1(IntT1(), IntT1())))
 

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -94,12 +94,6 @@ class TestSetMembershipSimplifier
   }
 
   test("simplifies appropriately-typed set membership") {
-    // i \in Nat  ~>  i >= 0
-    val intNameInNat = tla.in(intName, tla.natSet()).as(BoolT1())
-    val intValInNat = tla.in(intVal, tla.natSet()).as(BoolT1())
-    simplifier(intNameInNat) shouldBe tla.ge(intName, tla.int(0)).as(BoolT1())
-    simplifier(intValInNat) shouldBe tla.ge(intVal, tla.int(0)).as(BoolT1())
-
     /* *** tests for all supported types of applicable sets *** */
 
     expressions.foreach { case (name, value, set) =>
@@ -165,6 +159,16 @@ class TestSetMembershipSimplifier
     val funSetType = SetT1(FunT1(BoolT1(), IntT1()))
     val funConstToBoolean = tla.in(funName, tla.funSet(domain, boolSet).as(funSetType)).as(BoolT1())
     simplifier(funConstToBoolean) shouldBe tla.eql(tla.dom(funName).as(intSetT), domain).as(BoolT1())
+  }
+
+  /* *** rewriting of `Nat` *** */
+
+  test("rewrites i \\in Nat to \\ge") {
+    // i \in Nat  ~>  i >= 0
+    val intNameInNat = tla.in(intName, tla.natSet()).as(BoolT1())
+    val intValInNat = tla.in(intVal, tla.natSet()).as(BoolT1())
+    simplifier(intNameInNat) shouldBe tla.ge(intName, tla.int(0)).as(BoolT1())
+    simplifier(intValInNat) shouldBe tla.ge(intVal, tla.int(0)).as(BoolT1())
   }
 
   test("returns myInt \\in Nat unchanged") {

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -12,7 +12,7 @@ import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 
 /**
- * Tests for SetMembershipSimplifier.
+ * Tests for [[SetMembershipSimplifier]].
  */
 @RunWith(classOf[JUnitRunner])
 class TestSetMembershipSimplifier

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -29,6 +29,9 @@ class TestSetMembershipSimplifier
   private val strSetT: SetT1 = SetT1(StrT1())
   private val intSetT: SetT1 = SetT1(IntT1())
 
+  private val intPowersetSeqType = SeqT1(intSetT)
+  private val boolSeqPowersetType = SetT1(boolSeqT)
+
   private val boolVal = tla.bool(true).as(BoolT1())
   private val strVal = tla.str("abc").as(StrT1())
   private val intVal = tla.int(42).as(IntT1())
@@ -148,8 +151,6 @@ class TestSetMembershipSimplifier
     simplifier(nestedSubsetSeqTest) shouldBe tlaTrue
 
     // fun \in [Seq(SUBSET Int) -> SUBSET Seq(BOOLEAN)], ...  ~>  TRUE
-    val intPowersetSeqType = SeqT1(intSetT)
-    val boolSeqPowersetType = SetT1(boolSeqT)
     val nestedFunSetType = SetT1(FunT1(intPowersetSeqType, boolSeqPowersetType))
     val nestedInput = tla
       .in(funName,


### PR DESCRIPTION
Simple refactoring that splits `TestSetMembershipSimplifier` into multiple, smaller unit tests.

This is in prep for supporting records in #723