### PR TITLE
Simplify records in TypeOK

### DIFF
--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -64,7 +64,7 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
     // 3. [s1 -> s2] for type-defining sets `s1` and `s2`
     case OperEx(TlaSetOper.funSet, set1, set2) => isTypeDefining(set1) && isTypeDefining(set2)
     // 4. s1 \X ... \X sn for type-defining sets `s1` to `sn`
-    case OperEx(TlaSetOper.times, args @ _*) => args.forall(set => isTypeDefining(set))
+    case OperEx(TlaSetOper.times, args @ _*) => args.forall(isTypeDefining)
     // 5. [name_1: s1, ..., name_n: sn] for type-defining sets `s1` to `sn`
     case OperEx(TlaSetOper.recSet, namesAndSets @ _*) =>
       val (_, sets) = TlaOper.deinterleave(namesAndSets)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -20,6 +20,7 @@ import at.forsyte.apalache.tla.lir.values._
  *   - `fun \in [TDS1 -> TDS2]` ~> `TRUE`
  *   - `fun \in [Dom -> TDS]` ~> `DOMAIN fun = Dom`
  *   - `tup \in TDS1 \X ... \X TDSn` ~> `TRUE`
+ *   - `rec \in [name_1: TDS1, ..., name_n: TDSn]` ~> `TRUE`
  *
  * @author
  *   Thomas Pani
@@ -45,7 +46,8 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
    *   - sets of sequences over type-defining sets, e.g., Seq(BOOLEAN), Seq(Int), Seq(Seq(Int)), Seq(SUBSET Int), ...
    *   - power sets of type-defining sets, e.g., SUBSET BOOLEAN, SUBSET Int, SUBSET Seq(Int), ...
    *   - sets of functions over type-defining sets, e.g., [Int -> BOOLEAN], ...
-   *   - the cartesian product TDS1 \X ...\X TDSn of type-defining sets
+   *   - the cartesian product TDS1 \X ...\X TDSn of type-defining sets, e.g., BOOLEAN \X Int, ...
+   *   - sets of records over type-defining field types, e.g., [type: STRING, val: Int], ...
    *
    * In particular, `Nat` is not type-defining, nor are sequence sets / power sets thereof, since `i \in Nat` does not
    * hold for all `IntT1`-typed `i`.
@@ -63,6 +65,10 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
     case OperEx(TlaSetOper.funSet, set1, set2) => isTypeDefining(set1) && isTypeDefining(set2)
     // 4. s1 \X ... \X sn for type-defining sets `s1` to `sn`
     case OperEx(TlaSetOper.times, args @ _*) => args.forall(set => isTypeDefining(set))
+    // 5. [name_1: s1, ..., name_n: sn] for type-defining sets `s1` to `sn`
+    case OperEx(TlaSetOper.recSet, namesAndSets @ _*) =>
+      val (_, sets) = TlaOper.deinterleave(namesAndSets)
+      sets.forall(isTypeDefining)
 
     // otherwise
     case _ => false

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -68,8 +68,8 @@ class TestSetMembershipSimplifier
   private val intPowerset = tla.seqSet(tla.intSet()).as(SetT1(intSeqT))
   private val natPowerset = tla.seqSet(tla.natSet()).as(SetT1(intSeqT))
 
-  private val tupleVal = tla.tuple(tla.int(1).as(IntT1()), tla.int(42).as(IntT1())).as(intSeqT)
-  private val tupleName = tla.name("tup").as(intSeqT)
+  private val tupleVal = tla.tuple(tla.int(1).as(IntT1()), tla.int(42).as(IntT1())).as(TupT1(IntT1(), IntT1()))
+  private val tupleName = tla.name("tup").as(TupT1(IntT1(), IntT1()))
   private val cartesianSet =
     tla.times(tla.intSet().as(intSetT), tla.intSet().as(intSetT)).as(SetT1(TupT1(IntT1(), IntT1())))
 

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -94,12 +94,6 @@ class TestSetMembershipSimplifier
   }
 
   test("simplifies appropriately-typed set membership") {
-    // i \in Nat  ~>  i >= 0
-    val intNameInNat = tla.in(intName, tla.natSet()).as(BoolT1())
-    val intValInNat = tla.in(intVal, tla.natSet()).as(BoolT1())
-    simplifier(intNameInNat) shouldBe tla.ge(intName, tla.int(0)).as(BoolT1())
-    simplifier(intValInNat) shouldBe tla.ge(intVal, tla.int(0)).as(BoolT1())
-
     /* *** tests for all supported types of applicable sets *** */
 
     expressions.foreach { case (name, value, set) =>
@@ -165,6 +159,16 @@ class TestSetMembershipSimplifier
     val funSetType = SetT1(FunT1(BoolT1(), IntT1()))
     val funConstToBoolean = tla.in(funName, tla.funSet(domain, boolSet).as(funSetType)).as(BoolT1())
     simplifier(funConstToBoolean) shouldBe tla.eql(tla.dom(funName).as(intSetT), domain).as(BoolT1())
+  }
+
+  /* *** rewriting of `Nat` *** */
+
+  test("rewrites i \\in Nat to \\ge") {
+    // i \in Nat  ~>  i >= 0
+    val intNameInNat = tla.in(intName, tla.natSet()).as(BoolT1())
+    val intValInNat = tla.in(intVal, tla.natSet()).as(BoolT1())
+    simplifier(intNameInNat) shouldBe tla.ge(intName, tla.int(0)).as(BoolT1())
+    simplifier(intValInNat) shouldBe tla.ge(intVal, tla.int(0)).as(BoolT1())
   }
 
   test("returns myInt \\in Nat unchanged") {

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -12,7 +12,7 @@ import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 
 /**
- * Tests for SetMembershipSimplifier.
+ * Tests for [[SetMembershipSimplifier]].
  */
 @RunWith(classOf[JUnitRunner])
 class TestSetMembershipSimplifier

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -29,6 +29,9 @@ class TestSetMembershipSimplifier
   private val strSetT: SetT1 = SetT1(StrT1())
   private val intSetT: SetT1 = SetT1(IntT1())
 
+  private val intPowersetSeqType = SeqT1(intSetT)
+  private val boolSeqPowersetType = SetT1(boolSeqT)
+
   private val boolVal = tla.bool(true).as(BoolT1())
   private val strVal = tla.str("abc").as(StrT1())
   private val intVal = tla.int(42).as(IntT1())
@@ -148,8 +151,6 @@ class TestSetMembershipSimplifier
     simplifier(nestedSubsetSeqTest) shouldBe tlaTrue
 
     // fun \in [Seq(SUBSET Int) -> SUBSET Seq(BOOLEAN)], ...  ~>  TRUE
-    val intPowersetSeqType = SeqT1(intSetT)
-    val boolSeqPowersetType = SetT1(boolSeqT)
     val nestedFunSetType = SetT1(FunT1(intPowersetSeqType, boolSeqPowersetType))
     val nestedInput = tla
       .in(funName,

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -76,6 +76,12 @@ class TestSetMembershipSimplifier
   private val cartesianSet =
     tla.times(tla.intSet().as(intSetT), tla.intSet().as(intSetT)).as(SetT1(TupT1(IntT1(), IntT1())))
 
+  private val recType = RecT1("a" -> IntT1(), "b" -> BoolT1())
+  private val recVal = tla.enumFun(tla.str("a").as(StrT1()), intVal, tla.str("b").as(StrT1()), boolVal).as(recType)
+  private val recName = tla.name("rec").as(recType)
+  private val recordSet =
+    tla.recSet(tla.str("a").as(StrT1()), intSet, tla.str("b").as(StrT1()), boolSet).as(SetT1(recType))
+
   override def beforeEach(): Unit = {
     simplifier = SetMembershipSimplifier(new IdleTracker)
   }
@@ -94,6 +100,7 @@ class TestSetMembershipSimplifier
         (strSetName, strSetVal, strPowerset),
         (intSetName, intSetVal, intPowerset),
         (tupleVal, tupleName, cartesianSet),
+        (recVal, recName, recordSet),
     )
 
     expressions.foreach { case (name, value, set) =>
@@ -157,6 +164,20 @@ class TestSetMembershipSimplifier
             .as(nestedFunSetType))
       .as(BoolT1())
     simplifier(nestedInput) shouldBe tlaTrue
+  }
+
+  test("rewrites function over records over Seq/SUBSET to TRUE") {
+    import at.forsyte.apalache.tla.lir.convenience.tla._
+    // fun \in [["a": Seq(SUBSET Int)] -> ["b": SUBSET Seq(BOOLEAN)]], ...  ~>  TRUE
+    val funRecType = SetT1(FunT1(RecT1("a" -> intPowersetSeqType), RecT1("b" -> boolSeqPowersetType)))
+    val funRecInput = in(funName,
+        funSet(recSet(str("a").as(StrT1()), seqSet(intSeqSet).as(intPowersetSeqType))
+              .as(RecT1("a" -> intPowersetSeqType)),
+            recSet(str("b").as(StrT1()), powSet(boolSeqSet).as(boolSeqPowersetType))
+              .as(RecT1("b" -> boolSeqPowersetType)))
+          .as(funRecType))
+      .as(BoolT1())
+    simplifier(funRecInput) shouldBe tlaTrue
   }
 
   test("rewrites non-typedefining function set domain to DOMAIN") {


### PR DESCRIPTION
Closes #723

Add record sets to the type-defining sets and simplify membership tests against them.