### PR TITLE
Simplify records in TypeOK

### DIFF
--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -64,7 +64,7 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
     // 3. [s1 -> s2] for type-defining sets `s1` and `s2`
     case OperEx(TlaSetOper.funSet, set1, set2) => isTypeDefining(set1) && isTypeDefining(set2)
     // 4. s1 \X ... \X sn for type-defining sets `s1` to `sn`
-    case OperEx(TlaSetOper.times, args @ _*) => args.forall(set => isTypeDefining(set))
+    case OperEx(TlaSetOper.times, args @ _*) => args.forall(isTypeDefining)
     // 5. [name_1: s1, ..., name_n: sn] for type-defining sets `s1` to `sn`
     case OperEx(TlaSetOper.recSet, namesAndSets @ _*) =>
       val (_, sets) = TlaOper.deinterleave(namesAndSets)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -20,6 +20,7 @@ import at.forsyte.apalache.tla.lir.values._
  *   - `fun \in [TDS1 -> TDS2]` ~> `TRUE`
  *   - `fun \in [Dom -> TDS]` ~> `DOMAIN fun = Dom`
  *   - `tup \in TDS1 \X ... \X TDSn` ~> `TRUE`
+ *   - `rec \in [name_1: TDS1, ..., name_n: TDSn]` ~> `TRUE`
  *
  * @author
  *   Thomas Pani
@@ -45,7 +46,8 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
    *   - sets of sequences over type-defining sets, e.g., Seq(BOOLEAN), Seq(Int), Seq(Seq(Int)), Seq(SUBSET Int), ...
    *   - power sets of type-defining sets, e.g., SUBSET BOOLEAN, SUBSET Int, SUBSET Seq(Int), ...
    *   - sets of functions over type-defining sets, e.g., [Int -> BOOLEAN], ...
-   *   - the cartesian product TDS1 \X ...\X TDSn of type-defining sets
+   *   - the cartesian product TDS1 \X ...\X TDSn of type-defining sets, e.g., BOOLEAN \X Int, ...
+   *   - sets of records over type-defining field types, e.g., [type: STRING, val: Int], ...
    *
    * In particular, `Nat` is not type-defining, nor are sequence sets / power sets thereof, since `i \in Nat` does not
    * hold for all `IntT1`-typed `i`.
@@ -63,6 +65,10 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
     case OperEx(TlaSetOper.funSet, set1, set2) => isTypeDefining(set1) && isTypeDefining(set2)
     // 4. s1 \X ... \X sn for type-defining sets `s1` to `sn`
     case OperEx(TlaSetOper.times, args @ _*) => args.forall(set => isTypeDefining(set))
+    // 5. [name_1: s1, ..., name_n: sn] for type-defining sets `s1` to `sn`
+    case OperEx(TlaSetOper.recSet, namesAndSets @ _*) =>
+      val (_, sets) = TlaOper.deinterleave(namesAndSets)
+      sets.forall(isTypeDefining)
 
     // otherwise
     case _ => false

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -76,6 +76,12 @@ class TestSetMembershipSimplifier
   private val cartesianSet =
     tla.times(tla.intSet().as(intSetT), tla.intSet().as(intSetT)).as(SetT1(TupT1(IntT1(), IntT1())))
 
+  private val recType = RecT1("a" -> IntT1(), "b" -> BoolT1())
+  private val recVal = tla.enumFun(tla.str("a").as(StrT1()), intVal, tla.str("b").as(StrT1()), boolVal).as(recType)
+  private val recName = tla.name("rec").as(recType)
+  private val recordSet =
+    tla.recSet(tla.str("a").as(StrT1()), intSet, tla.str("b").as(StrT1()), boolSet).as(SetT1(recType))
+
   override def beforeEach(): Unit = {
     simplifier = SetMembershipSimplifier(new IdleTracker)
   }
@@ -94,6 +100,7 @@ class TestSetMembershipSimplifier
         (strSetName, strSetVal, strPowerset),
         (intSetName, intSetVal, intPowerset),
         (tupleVal, tupleName, cartesianSet),
+        (recVal, recName, recordSet),
     )
 
     expressions.foreach { case (name, value, set) =>
@@ -157,6 +164,20 @@ class TestSetMembershipSimplifier
             .as(nestedFunSetType))
       .as(BoolT1())
     simplifier(nestedInput) shouldBe tlaTrue
+  }
+
+  test("rewrites function over records over Seq/SUBSET to TRUE") {
+    import at.forsyte.apalache.tla.lir.convenience.tla._
+    // fun \in [["a": Seq(SUBSET Int)] -> ["b": SUBSET Seq(BOOLEAN)]], ...  ~>  TRUE
+    val funRecType = SetT1(FunT1(RecT1("a" -> intPowersetSeqType), RecT1("b" -> boolSeqPowersetType)))
+    val funRecInput = in(funName,
+        funSet(recSet(str("a").as(StrT1()), seqSet(intSeqSet).as(intPowersetSeqType))
+              .as(RecT1("a" -> intPowersetSeqType)),
+            recSet(str("b").as(StrT1()), powSet(boolSeqSet).as(boolSeqPowersetType))
+              .as(RecT1("b" -> boolSeqPowersetType)))
+          .as(funRecType))
+      .as(BoolT1())
+    simplifier(funRecInput) shouldBe tlaTrue
   }
 
   test("rewrites non-typedefining function set domain to DOMAIN") {


### PR DESCRIPTION
Blocked by [#401 Precise type checking for records](https://github.com/informalsystems/apalache/issues/401)
Closes #723

Add record sets to the type-defining sets and simplify membership tests against them.