### PR TITLE
Fix the comment preprocessor

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,3 +18,4 @@
 
 ### Bug fixes
  * Fixed bug where TLA+ `LAMBDA`s wouldn't inline outside `Fold` and `MkSeq`, see #1446
+ * Fix the comment preprocessor to extract annotations after a linefeed, see #1456

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/CommentPreprocessor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/CommentPreprocessor.scala
@@ -190,6 +190,7 @@ class CommentPreprocessor {
       true
     } else {
       val char = text(index - 1)
+      // @foo is written either after a whitespace (to exclude emails), or after the comment token, e.g., (* or \*
       char.isWhitespace || char == '*'
     }
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/CommentPreprocessor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/CommentPreprocessor.scala
@@ -11,8 +11,9 @@ package at.forsyte.apalache.io.annotations.parser
  * respect the structure of the comments, but it may return ill-formed annotations, if they are ill-formed in the
  * original text. This preprocessor prunes the comment tokens, even in arguably valid cases (e.g., inside a string).
  * Although it is usually not a good idea to write an ad-hoc lexer, it is not obvious to me, how to use a lexer
- * generator here. However, if someone knows how to write this preprocessor with a lexer generator, it would be great!
- * </p>
+ * generator here. However, if someone knows how to write this preprocessor with a lexer generator, let me know.
+ * Perhaps, the first step would be to write a precise grammar for this lexer, instead of write the spaghetti of
+ * if-then-else expressions, as we have in this preprocessor.</p>
  *
  * <p>See the annotations HOWTO: https://apalache.informal.systems/docs/HOWTOs/howto-write-type-annotations.html</p>
  *
@@ -20,7 +21,7 @@ package at.forsyte.apalache.io.annotations.parser
  *   Igor Konnov
  */
 class CommentPreprocessor {
-  private val tokenRegex = """(\n|\\\*|\(\*|\*\)|[ \t\n\r]@[a-zA-Z_][a-zA-Z0-9_]*|\)|;|")""".r
+  private val tokenRegex = """(\n|\\\*|\(\*|\*\)|@[a-zA-Z_][a-zA-Z0-9_]*|\)|;|")""".r
 
   // internal state of the preprocessor
   private case class State(
@@ -64,7 +65,7 @@ class CommentPreprocessor {
       if (!inOneLineComment) {
         this.copy(multiCommentLevel = multiCommentLevel + 1)
       } else {
-        // a multi-level comment is ignored inside a multi-level comment
+        // a multi-level comment is ignored inside a single-line comment
         // \* ... (* ....
         this
       }
@@ -106,6 +107,7 @@ class CommentPreprocessor {
     val matchIterator = tokenRegex.findAllIn(text)
     while (matchIterator.hasNext) {
       val group = matchIterator.next()
+      val hasWhitespaceBefore = (matchIterator.start == 0) || text(matchIterator.start - 1).isWhitespace
       if (matchIterator.start > lastIndexOfUnmatchedText && !state.isExcludingText) {
         // add the text between the last match and this match
         val fragment = text.substring(lastIndexOfUnmatchedText, matchIterator.start)
@@ -124,21 +126,26 @@ class CommentPreprocessor {
       // look one character ahead to figure out the annotation type
       val lookaheadChar = if (lastIndexOfUnmatchedText < text.length) Some(text(lastIndexOfUnmatchedText)) else None
       // figure out whether we have met an annotation or not
-      if (!state.inAnnotation && !state.inString && group.startsWith(" @")) {
-        if (lookaheadChar.contains(':') || lookaheadChar.contains('(')) {
-          // Advance the last unmatched index beyond "@annotation:" or "@annotation(".
-          lastIndexOfUnmatchedText += 1
-        } else if (isEndOfParameterlessAnnotation(lookaheadChar)) {
-          // Add this annotation immediately.
-          // Do not advance the index in case of "@annotation " or similar.
-          annotations = annotations :+ group.trim
-        } else {
+      if (!state.inAnnotation && !state.inString && group.startsWith("@")) {
+        if (!hasWhitespaceBefore) {
           // this is not an annotation, push it back to the free text
           textBuilder.append(group)
+        } else {
+          if (lookaheadChar.contains(':') || lookaheadChar.contains('(')) {
+            // Advance the last unmatched index beyond "@annotation:" or "@annotation(".
+            lastIndexOfUnmatchedText += 1
+          } else if (isEndOfParameterlessAnnotation(lookaheadChar)) {
+            // Add this annotation immediately.
+            // Do not advance the index in case of "@annotation " or similar.
+            annotations = annotations :+ group.trim
+          } else {
+            // this is not an annotation, push it back to the free text
+            textBuilder.append(group)
+          }
         }
       }
 
-      val nextState = getNextState(state, group, lookaheadChar)
+      val nextState = getNextState(state, group, lookaheadChar, hasWhitespaceBefore)
 
       (state.inAnnotation, nextState.inAnnotation) match {
         case (false, false) => ()
@@ -178,7 +185,11 @@ class CommentPreprocessor {
     (textBuilder.toString(), annotations)
   }
 
-  private def getNextState(state: State, group: String, lookaheadChar: Option[Char]): State = {
+  private def getNextState(
+      state: State,
+      group: String,
+      lookaheadChar: Option[Char],
+      isWhitespaceBefore: Boolean): State = {
     group match {
       case "\\*" =>
         state.enterOneLineComment()
@@ -225,7 +236,7 @@ class CommentPreprocessor {
         }
 
       case _ =>
-        if (!group.startsWith(" @")) {
+        if (!group.startsWith("@") || !isWhitespaceBefore) {
           state
         } else {
           if (lookaheadChar.contains('(') && !state.inAnnotation) {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
@@ -78,14 +78,14 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers {
         |""".stripMargin
     val (output, potentialAnnotations) = CommentPreprocessor()(input)
     val expected =
-      """ (aaa)
+      """  (aaa)
         | not an annotation: john@example.org
-        | xxx
-        |ddd
+        |  xxx
+        | ddd
         | zzz@bbb(1)
         |""".stripMargin
-    assert(output == expected)
     assert(potentialAnnotations == List("@annotation(\"a\", 1)", "@semi: foo ;", "@multi: aaa bbb ccc;"))
+    assert(output == expected)
   }
 
   test("unclosed annotations") {
@@ -95,7 +95,7 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers {
         |""".stripMargin
     val (output, potentialAnnotations) = CommentPreprocessor()(input)
     val expected =
-      """ xx: bar 
+      """ xx : bar 
         |""".stripMargin
     assert(output == expected)
     // The extracted annotation is ill-formed. This will be detected by the annotation parser.
@@ -113,10 +113,10 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers {
         |""".stripMargin
     val (output, potentialAnnotations) = CommentPreprocessor()(input)
     val expected =
-      """ (aaa)
-        |
-        | type annotation
-        |
+      """  (aaa)
+        | 
+        | type annotation 
+        | 
         |""".stripMargin
     assert(output == expected)
     assert(potentialAnnotations.size == 4)
@@ -124,6 +124,18 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers {
     assert(potentialAnnotations(1) == "@beware: of :) ;")
     assert(potentialAnnotations(2) == "@type: Set(Set(a)) ;")
     assert(potentialAnnotations(3) == "@type: a          => Int ;")
+  }
+
+  test("annotation starting with @") {
+    // Regression: https://github.com/informalsystems/apalache/issues/1304
+    val input =
+      """(*
+        |@type: Int;
+        |""".stripMargin
+    val (output, potentialAnnotations) = CommentPreprocessor()(input)
+    assert(output.trim.isEmpty)
+    assert(potentialAnnotations.size == 1)
+    assert(potentialAnnotations.head == "@type: Int;")
   }
 
   test("no failure on random inputs") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
@@ -147,7 +147,7 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers {
     assert(potentialAnnotations.size == 1)
     assert(potentialAnnotations.head == "@type: Int;")
   }
-  
+
   test("Single-line comment only") {
     hasAnnotationsWhenNonEmpty("""\*""")
   }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
@@ -138,6 +138,16 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers {
     assert(potentialAnnotations.head == "@type: Int;")
   }
 
+  test("annotation in the very beginning") {
+    // Regression: https://github.com/informalsystems/apalache/issues/1304
+    val input =
+      """\*@type: Int;"""
+    val (output, potentialAnnotations) = CommentPreprocessor()(input)
+    assert(output.trim.isEmpty)
+    assert(potentialAnnotations.size == 1)
+    assert(potentialAnnotations.head == "@type: Int;")
+  }
+
   test("no failure on random inputs") {
     check(
         {


### PR DESCRIPTION
Closes #1304. This PR handles the cases when an annotation is starting either right after a linefeed, or right after the comment token. The logic of this preprocessor is getting harder to understand.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
