### PR TITLE
Cleanup Makefile targets & supporting docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,18 +180,16 @@ We use [scalafmt](https://scalameta.org/scalafmt/) to standardize formatting
 across the codebase. It is integrated into our sbt build configuration, and
 formatting fixes will be applied on build, or via the make target `make fmt-fix`.
 
+In addition, we have configured the compiler to warn on unused imports and
+variables, and we have enabled [scalafix](https://scalacenter.github.io/scalafix/)
+to automate removal of unused values. To automate removal of unused stuff run
+`make fmt-fix`.
+
 However, for a smoother development experience you should ensure your editor
 automatically runs formatting. The scalafmt site documents installation for all
 common editors.
 
 Our scalafmt configuration is specified in [./.scalafmt.conf](./.scalafmt.conf).
-
-#### Removing unused
-
-We have configured the compiler to warn on unused imports and variables, and we
-have enabled [scalafix](https://scalacenter.github.io/scalafix/) to automate
-removal of unused values. To automate removal of unused stuff run `make
-fmt-fix-unused`.
 
 ### Editors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,8 +182,7 @@ formatting fixes will be applied on build, or via the make target `make fmt-fix`
 
 In addition, we have configured the compiler to warn on unused imports and
 variables, and we have enabled [scalafix](https://scalacenter.github.io/scalafix/)
-to automate removal of unused values. To automate removal of unused stuff run
-`make fmt-fix`.
+to automate removal of unused values. This is also run by `fmt-fix` target.
 
 However, for a smoother development experience you should ensure your editor
 automatically runs formatting. The scalafmt site documents installation for all

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Markdown files used for integration tests
 TEST_MD_FILES := $(wildcard test/tla/*.md)
 
-.PHONY: all apalache apalache-jar compile build-quick test integration clean deps promote docker dist fmt-fix-unused
+.PHONY: all apalache package compile test test-coverage integration docker dist fmt-check fmt-fix clean run
 
 all: apalache
 


### PR DESCRIPTION
- Updates the `.PHONY` Makefile targets to reflect the status quo
- Updates `CONTRIBUTING.md` to reflect that we're running scalafix as part of the `fmt-fix` target