### PR TITLE
Fix some classes of compiler warnings

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -148,7 +148,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
     cellCache += (cell.id -> List((const, cell.cellType, level)))
 
     // If arrays are used, they are initialized here.
-    if (cellSort.isInstanceOf[ArraySort[Sort, Sort]] && !cell.isUnconstrained) {
+    if (cellSort.isInstanceOf[ArraySort[_, _]] && !cell.isUnconstrained) {
       val arrayInitializer = constantArrayCache.get(cellSort) match {
         case Some(emptySet) =>
           z3context.mkEq(const, emptySet._1)
@@ -553,7 +553,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
           z3context.mkFalse()
         case _: IntSort =>
           z3context.mkInt(0)
-        case arraySort: ArraySort[Sort, Sort] =>
+        case arraySort: ArraySort[_, _] =>
           z3context.mkConstArray(arraySort.getDomain, getOrMkCellDefaultValue(arraySort.getRange))
         case _ =>
           z3context.mkConst(sig, cellSort)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecFun.scala
@@ -27,7 +27,7 @@ trait TestSymbStateRewriterRecFun extends RewriterBase with TestingPredefs {
       .typed(types, "i_to_i")
 
     val rewriter = create(rewriterType)
-    var state = rewriter.rewriteUntilDone(new SymbState(fun, arena, Binding()))
+    val state = rewriter.rewriteUntilDone(new SymbState(fun, arena, Binding()))
     val funCell = state.ex
 
     def resEq(i: Int, j: Int) = {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
@@ -9,7 +9,7 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
 trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
   test("""Propositional Oracle.create""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 6)
     assert(solverContext.sat())
@@ -17,7 +17,7 @@ trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
 
   test("""Propositional Oracle.whenEqualTo""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 6)
     assert(solverContext.sat())
@@ -29,7 +29,7 @@ trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
 
   test("""Propositional Oracle.evalPosition""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 6)
     assert(solverContext.sat())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
@@ -9,7 +9,7 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
 trait TestSparseOracle extends RewriterBase with TestingPredefs {
   test("""Sparse Oracle.create""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 2)
     new SparseOracle(oracle, Set(1, 10))
@@ -18,7 +18,7 @@ trait TestSparseOracle extends RewriterBase with TestingPredefs {
 
   test("""Sparse Oracle.whenEqualTo""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 3)
     val sparseOracle = new SparseOracle(oracle, Set(1, 5, 10))
@@ -29,7 +29,7 @@ trait TestSparseOracle extends RewriterBase with TestingPredefs {
 
   test("""Sparse Oracle.evalPosition""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 3)
     val sparseOracle = new SparseOracle(oracle, Set(1, 5, 10))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
@@ -9,7 +9,7 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
 trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
   test("""UninterpretedConst Oracle.create""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = UninterpretedConstOracle.create(rewriter, state, 6)
     assert(solverContext.sat())
@@ -17,7 +17,7 @@ trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
 
   test("""UninterpretedConst Oracle.whenEqualTo""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = UninterpretedConstOracle.create(rewriter, state, 6)
     assert(solverContext.sat())
@@ -29,7 +29,7 @@ trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
 
   test("""UninterpretedConst Oracle.evalPosition""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(tla.bool(true), arena, Binding())
+    val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
     val (nextState, oracle) = UninterpretedConstOracle.create(rewriter, state, 6)
     assert(solverContext.sat())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContext.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContext.scala
@@ -16,7 +16,7 @@ trait TestRecordingSolverContext extends FixtureAnyFunSuite {
 
   test("operations proxied") { _ =>
     val solver = RecordingSolverContext.createZ3(None, solverConfig)
-    var arena = Arena.create(solver).appendCell(IntT())
+    val arena = Arena.create(solver).appendCell(IntT())
     val x = arena.topCell
     solver.assertGroundExpr(tla.eql(x.toNameEx, int42))
     assert(solver.sat())
@@ -25,7 +25,7 @@ trait TestRecordingSolverContext extends FixtureAnyFunSuite {
 
   test("write and read") { _ =>
     val solver = RecordingSolverContext.createZ3(None, solverConfig)
-    var arena = Arena.create(solver).appendCell(IntT())
+    val arena = Arena.create(solver).appendCell(IntT())
     val x = arena.topCell
     solver.assertGroundExpr(tla.eql(x.toNameEx, int42))
     assert(solver.sat())

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -462,7 +462,7 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
   }
 
   test("evaluates logical expressions over constants") {
-    var trueExpressions: Seq[TlaEx] = Seq(
+    val trueExpressions: Seq[TlaEx] = Seq(
         tla.not(tla.bool(false)).as(BoolT1()),
         tla.impl(tla.bool(false), tla.bool(true)).as(BoolT1()),
         tla.impl(tla.bool(false), tla.bool(false)).as(BoolT1()),
@@ -471,7 +471,7 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
         tla.and().as(BoolT1()),
     )
 
-    var falseExpressions: Seq[TlaEx] = Seq(
+    val falseExpressions: Seq[TlaEx] = Seq(
         tla.not(tla.bool(true)).as(BoolT1()),
         tla.impl(tla.bool(true), tla.bool(false)).as(BoolT1()),
         tla.or(tla.bool(false)).as(BoolT1()),

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
@@ -202,7 +202,7 @@ class TestDefaultType1Parser extends AnyFunSuite with Checkers with TlaType1Gen 
               case _: Type1ParseError =>
                 passed
 
-              case _ =>
+              case _: Throwable =>
                 falsified
             }
           // no exceptions

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/predef/standardSets.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/predef/standardSets.scala
@@ -1,1 +1,0 @@
-package at.forsyte.apalache.tla.lir.predef


### PR DESCRIPTION
Towards #1064. Fixes all compiler warnings related to

- empty files (00f4926)
- catching all `Throwables` (ece65b5)
- Using `val` instead of `var` for immutable values (542d6e7)
- Type arguments eliminated by erasure (cb0742498ec5543423e814738b24fdc44fefbb06)

Further info in the commit comments.