### PR TITLE
Fix compiler warnings on non-exhaustive matches

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -154,6 +154,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
           } else {
             n.toInt
           }
+        case ex => throw new RewriterException("Expected an int, found " + ex, ex)
       }
       val decodedElems = protoSeqOps.elems(arena, protoSeq).map(decodeCellToTlaEx(arena, _)).toList.slice(0, len)
       tla.tuple(decodedElems: _*).typed(SeqT1(elemT1))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/vmt/EUFRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/vmt/EUFRule.scala
@@ -4,8 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.RewriterException
 import at.forsyte.apalache.tla.lir.formulas.Booleans._
 import at.forsyte.apalache.tla.lir.formulas.EUF._
 import at.forsyte.apalache.tla.lir.formulas._
-import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
 import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaControlOper, TlaFunOper, TlaOper}
+import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
 import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 
 /**
@@ -169,8 +169,9 @@ class EUFRule(rewriter: ToTermRewriter, restrictedSetJudgement: RestrictedSetJud
         val (vars, sets) = TlaOper.deinterleave(varsAndSets)
         val setSorts = sets.map(restrictedSetJudgement.getSort)
         // Construct pairs of formal parameter names and sorts
-        val argList = vars.zip(setSorts).toList.map { case (NameEx(name), sort) =>
-          (name, sort)
+        val argList = vars.zip(setSorts).toList.map {
+          case (NameEx(name), sort) => (name, sort)
+          case (ex, _)              => throw new RewriterException(s"$ex must be a name.", ex)
         }
         FunDef(gen.newName(), argList, rewrite(e))
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -33,7 +33,7 @@ class Desugarer(gen: UniqueNameGenerator, stateVariables: Set[String], tracker: 
       val (accessors, newValues) = TlaOper.deinterleave(trArgs)
       val isMultidimensional = accessors.exists {
         case OperEx(TlaFunOper.tuple, lst @ _*) => lst.size > 1
-        case _                                  => assert(false); false // all accessors are tuples
+        case accessor => throw new LirError("Expected a tuple of keys as an accessor in EXCEPT. Found: " + accessor)
       }
       if (accessors.length < 2 && !isMultidimensional) {
         // the simplest update [ f EXCEPT ![i] = e ]

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -1,11 +1,11 @@
 package at.forsyte.apalache.tla.pp
 
+import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
-import TypedPredefs._
 
 import javax.inject.Singleton
 
@@ -31,7 +31,10 @@ class Desugarer(gen: UniqueNameGenerator, stateVariables: Set[String], tracker: 
     case ex @ OperEx(TlaFunOper.except, fun, args @ _*) =>
       val trArgs = args.map(transform)
       val (accessors, newValues) = TlaOper.deinterleave(trArgs)
-      val isMultidimensional = accessors.exists { case OperEx(TlaFunOper.tuple, lst @ _*) => lst.size > 1 }
+      val isMultidimensional = accessors.exists {
+        case OperEx(TlaFunOper.tuple, lst @ _*) => lst.size > 1
+        case _                                  => assert(false); false // all accessors are tuples
+      }
       if (accessors.length < 2 && !isMultidimensional) {
         // the simplest update [ f EXCEPT ![i] = e ]
         OperEx(TlaFunOper.except, transform(fun) +: trArgs: _*)(ex.typeTag)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -361,6 +361,7 @@ class ConfigurationPassImpl @Inject() (
             }
 
             (init, next)
+          case _ => throwError(decl)
         }
 
       case Some(d) =>

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
@@ -101,6 +101,9 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
           } else {
             throw new IllegalArgumentException(s"No index $key in $tt")
           }
+
+        case type_ =>
+          throw new IllegalArgumentException(s"Unexpected type $type_")
       }
     }
 

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUnroller.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUnroller.scala
@@ -72,10 +72,10 @@ class TestUnroller extends AnyFunSuite with BeforeAndAfterEach with TestingPrede
 
     val unrolled = unroller(module)
 
-    val newAOpt = unrolled.operDeclarations.find(_.name == name)
+    val newAOpt = unrolled.operDeclarations.find(_.name == name).get
 
     newAOpt match {
-      case Some(d @ TlaOperDecl(_, _, body)) =>
+      case d @ TlaOperDecl(_, _, body) =>
         assert(!d.isRecursive)
         body match {
           case LetInEx(letBody, TlaOperDecl(_, Nil, declBody)) =>


### PR DESCRIPTION
Towards #1064 

Fix compiler warnings on non-exhaustive matches.
Rationale for each fix in the commit message.