### PR TITLE
Fix compiler warnings for unused pattern vars

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
@@ -63,7 +63,7 @@ class DomainRule(rewriter: SymbStateRewriter, intRangeCache: IntRangeCache) exte
   }
 
   protected def mkSeqDomain(state: SymbState, seqCell: ArenaCell): SymbState = {
-    val (protoSeq, len, capacity) = proto.unpackSeq(state.arena, seqCell)
+    val (protoSeq @ _, len, capacity) = proto.unpackSeq(state.arena, seqCell)
     // We do not know the domain precisely, as it depends on the length of the sequence.
     // Hence, we create the set `1..capacity` and include only those elements that are not greater than `len`.
     val (newArena, staticDom) = intRangeCache.create(state.arena, (1, capacity))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
@@ -4,11 +4,11 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.caches.IntRangeCache
 import at.forsyte.apalache.tla.bmcmt.rules.aux.ProtoSeqOps
 import at.forsyte.apalache.tla.bmcmt.types._
-import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, OperEx}
 import at.forsyte.apalache.tla.lir.TypedPredefs.{tlaExToBuilderExAsTyped, BuilderExAsTyped}
-import at.forsyte.apalache.tla.lir.oper.TlaFunOper
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.oper.TlaFunOper
+import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, OperEx}
 
 /**
  * Rewriting DOMAIN f, that is, translating the domain of a function, record, tuple, or sequence.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecFunDefAndRefRule.scala
@@ -4,10 +4,10 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.CherryPick
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet}
-import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, IntT1, NameEx, OperEx, TlaEx, TlaType1, ValEx}
 
 /**
  * This rule translates the definition of a recursive function. It is similar to CHOOSE. Unlike CHOOSE, it does not have
@@ -59,18 +59,13 @@ class RecFunDefAndRefRule(rewriter: SymbStateRewriter) extends RewritingRule {
     var nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
 
     val funT = CellT.fromType1(funT1)
-    val (elemT, codomain) =
-      funT1 match {
-        case FunT1(argT, IntT1()) =>
-          (CellT.fromType1(argT), ValEx(TlaIntSet))
-
-        case FunT1(argT, BoolT1()) =>
-          (CellT.fromType1(argT), ValEx(TlaBoolSet))
-
-        case FunT1(_, resultT) =>
-          val msg = "A result of a recursive function must belong to Int or BOOLEAN. Found: " + resultT
-          throw new RewriterException(msg, state.ex)
-      }
+    val codomain = funT1 match {
+      case FunT1(_, IntT1())  => ValEx(TlaIntSet)
+      case FunT1(_, BoolT1()) => ValEx(TlaBoolSet)
+      case FunT1(_, resultT) =>
+        val msg = "A result of a recursive function must belong to Int or BOOLEAN. Found: " + resultT
+        throw new RewriterException(msg, state.ex)
+    }
 
     // one more safety check, as the domain cell can happen to be a powerset or a function set
     val domainCell = nextState.asCell

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
@@ -126,9 +126,8 @@ class TestVCGenerator extends AnyFunSuite {
 
   private def loadFromText(moduleName: String, text: String): TlaModule = {
     val locationStore = new SourceStore
-    val (rootName, modules) =
-      new SanyImporter(locationStore, createAnnotationStore())
-        .loadFromSource(moduleName, Source.fromString(text))
+    val (_, modules) =
+      new SanyImporter(locationStore, createAnnotationStore()).loadFromSource(moduleName, Source.fromString(text))
     modules(moduleName)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
@@ -4,9 +4,9 @@ import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.imp.SanyImporter
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.TypedPredefs.BuilderDeclAsTyped
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
-import at.forsyte.apalache.tla.lir._
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
@@ -11,7 +11,7 @@ trait TestPropositionalOracle extends RewriterBase with TestingPredefs {
     val rewriter = create(rewriterType)
     val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
-    val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 6)
+    PropositionalOracle.create(rewriter, state, 6)
     assert(solverContext.sat())
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
@@ -11,7 +11,7 @@ trait TestSparseOracle extends RewriterBase with TestingPredefs {
     val rewriter = create(rewriterType)
     val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
-    val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 2)
+    val (_, oracle) = PropositionalOracle.create(rewriter, state, 2)
     new SparseOracle(oracle, Set(1, 10))
     assert(solverContext.sat())
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
@@ -11,7 +11,7 @@ trait TestUninterpretedConstOracle extends RewriterBase with TestingPredefs {
     val rewriter = create(rewriterType)
     val state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle
-    val (nextState, oracle) = UninterpretedConstOracle.create(rewriter, state, 6)
+    UninterpretedConstOracle.create(rewriter, state, 6)
     assert(solverContext.sat())
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1,16 +1,16 @@
 package at.forsyte.apalache.tla.imp
 
-import java.io.{File, PrintWriter}
-import java.nio.file.Files
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.src.{SourcePosition, SourceRegion}
 import at.forsyte.apalache.tla.lir.values._
-import at.forsyte.apalache.tla.lir.{NameEx, OperEx, ValEx, _}
-import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
+import java.io.{File, PrintWriter}
+import java.nio.file.Files
 import scala.collection.immutable.HashSet
 import scala.io.Source
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -29,8 +29,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |================================
       """.stripMargin
 
-    val (rootName, modules) = sanyImporter
-      .loadFromSource("justASimpleTest", Source.fromString(text))
+    val (rootName, _) = sanyImporter.loadFromSource("justASimpleTest", Source.fromString(text))
     assert("justASimpleTest" == rootName)
   }
 
@@ -51,8 +50,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       pw.close()
     }
 
-    val (rootName, modules) = sanyImporter
-      .loadFromFile(temp)
+    val (rootName, _) = sanyImporter.loadFromFile(temp)
     assert("justASimpleTest" == rootName)
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
@@ -475,8 +475,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |================================
       """.stripMargin
 
-    val (rootName, modules) = sanyImporter
-      .loadFromSource("localSum", Source.fromString(text))
+    val (_, modules) = sanyImporter.loadFromSource("localSum", Source.fromString(text))
     assert(4 == modules.size) // Naturals, Sequences, TLC, FiniteSets, Bags, and our module
 
     val root = modules("localSum")
@@ -510,8 +509,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         "TLA-Library = %s".format(System.getProperty("TLA-Library"))
     )
 
-    val (rootName, modules) = sanyImporter
-      .loadFromSource("root", Source.fromString(text))
+    val (_, modules) = sanyImporter.loadFromSource("root", Source.fromString(text))
     assert(6 == modules.size) // root, Apalache, Integers, FiniteSets, and whatever they import
 
     val root = modules("root")


### PR DESCRIPTION
Towards #1064. Fixes/silences compiler warnings of the shape

    pattern var v in value V is never used: use a wildcard `_` or suppress this warning with `v@_`

Similar modifications are grouped into the same commit.