### PR TITLE
Cache default values

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@
  * Implement the sequence constructor `Apalache!MkSeq`, see #1439
  * Add support for `Apalache!FunAsSeq`, see #1442
  * Implement `EXCEPT` on sequences, see #1444
+ * Cache default values, see #1465
 
 ### Bug fixes
  * Fixed bug where TLA+ `LAMBDA`s wouldn't inline outside `Fold` and `MkSeq`, see #1446

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriter.scala
@@ -2,7 +2,9 @@ package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.RewritingResult
 import at.forsyte.apalache.tla.bmcmt.analyses.ExprGradeStore
-import at.forsyte.apalache.tla.bmcmt.caches.{ExprCache, IntValueCache, ModelValueCache, RecordDomainCache}
+import at.forsyte.apalache.tla.bmcmt.caches.{
+  DefaultValueCache, ExprCache, IntValueCache, ModelValueCache, RecordDomainCache,
+}
 import at.forsyte.apalache.tla.bmcmt.rewriter.{Recoverable, RewriterConfig, SymbStateRewriterSnapshot}
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.TlaEx
@@ -67,6 +69,11 @@ trait SymbStateRewriter extends StackableContext with MessageStorage with Recove
    * A cache for strings and model values.
    */
   def modelValueCache: ModelValueCache
+
+  /**
+   * A cache for default values.
+   */
+  def defaultValueCache: DefaultValueCache
 
   /**
    * A cache of record domains.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAuto.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAuto.scala
@@ -1,7 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.analyses._
-import at.forsyte.apalache.tla.bmcmt.caches.{ExprCache, IntValueCache, ModelValueCache, RecordDomainCache}
+import at.forsyte.apalache.tla.bmcmt.caches.{
+  DefaultValueCache, ExprCache, IntValueCache, ModelValueCache, RecordDomainCache,
+}
 import at.forsyte.apalache.tla.bmcmt.rewriter.{RewriterConfig, SymbStateRewriterSnapshot}
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.TlaEx
@@ -56,6 +58,8 @@ class SymbStateRewriterAuto(private var _solverContext: SolverContext) extends S
   override def intValueCache: IntValueCache = impl.intValueCache
 
   override def modelValueCache: ModelValueCache = impl.modelValueCache
+
+  override def defaultValueCache: DefaultValueCache = impl.defaultValueCache
 
   override def recordDomainCache: RecordDomainCache = impl.recordDomainCache
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -103,6 +103,11 @@ class SymbStateRewriterImpl(
   val modelValueCache = new ModelValueCache(solverContext)
 
   /**
+   * A cache for default values.
+   */
+  val defaultValueCache = new DefaultValueCache(this)
+
+  /**
    * A cache of record domains.
    */
   val recordDomainCache = new RecordDomainCache(solverContext, modelValueCache)
@@ -471,7 +476,7 @@ class SymbStateRewriterImpl(
    */
   override def snapshot(): SymbStateRewriterSnapshot = {
     new SymbStateRewriterSnapshot(intValueCache.snapshot(), intRangeCache.snapshot(), modelValueCache.snapshot(),
-        recordDomainCache.snapshot(), exprCache.snapshot())
+        defaultValueCache.snapshot(), recordDomainCache.snapshot(), exprCache.snapshot())
   }
 
   /**
@@ -485,6 +490,7 @@ class SymbStateRewriterImpl(
     intValueCache.recover(shot.intValueCacheSnapshot)
     intRangeCache.recover(shot.intRangeCacheSnapshot)
     modelValueCache.recover(shot.modelValueCacheSnapshot)
+    defaultValueCache.recover(shot.defaultValueCacheSnapshot)
     recordDomainCache.recover(shot.recordDomainCache)
     exprCache.recover(shot.exprCacheSnapshot)
   }
@@ -497,6 +503,7 @@ class SymbStateRewriterImpl(
     intValueCache.push()
     intRangeCache.push()
     modelValueCache.push()
+    defaultValueCache.push()
     recordDomainCache.push()
     lazyEq.push()
     exprCache.push()
@@ -512,6 +519,7 @@ class SymbStateRewriterImpl(
     intValueCache.pop()
     intRangeCache.pop()
     modelValueCache.pop()
+    defaultValueCache.pop()
     recordDomainCache.pop()
     lazyEq.pop()
     exprCache.pop()
@@ -530,6 +538,7 @@ class SymbStateRewriterImpl(
     intValueCache.pop(n)
     intRangeCache.pop(n)
     modelValueCache.pop(n)
+    defaultValueCache.pop(n)
     recordDomainCache.pop(n)
     lazyEq.pop(n)
     exprCache.pop(n)
@@ -550,6 +559,7 @@ class SymbStateRewriterImpl(
     intValueCache.dispose()
     intRangeCache.dispose()
     modelValueCache.dispose()
+    defaultValueCache.dispose()
     recordDomainCache.dispose()
     lazyEq.dispose()
     solverContext.dispose()

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/DefaultValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/DefaultValueCache.scala
@@ -1,8 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.caches
 
 import at.forsyte.apalache.tla.bmcmt.rules.aux.DefaultValueFactory
-import at.forsyte.apalache.tla.bmcmt.types.CellT
-import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
+import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir.TlaType1
 
 /**
@@ -12,11 +11,10 @@ import at.forsyte.apalache.tla.lir.TlaType1
  *   Igor Konnov
  */
 class DefaultValueCache(rewriter: SymbStateRewriter)
-    extends AbstractCache[SymbState, TlaType1, ArenaCell] with Serializable {
+    extends AbstractCache[Arena, TlaType1, ArenaCell] with Serializable {
   private val factory = new DefaultValueFactory(rewriter)
 
-  override protected def create(state: SymbState, typ: TlaType1): (SymbState, ArenaCell) = {
-    val nextState = factory.makeUpValue(state, CellT.fromType1(typ))
-    (nextState, nextState.asCell)
+  override protected def create(arena: Arena, typ: TlaType1): (Arena, ArenaCell) = {
+    factory.makeUpValue(arena, typ)
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/DefaultValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/DefaultValueCache.scala
@@ -1,0 +1,22 @@
+package at.forsyte.apalache.tla.bmcmt.caches
+
+import at.forsyte.apalache.tla.bmcmt.rules.aux.DefaultValueFactory
+import at.forsyte.apalache.tla.bmcmt.types.CellT
+import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
+import at.forsyte.apalache.tla.lir.TlaType1
+
+/**
+ * A cache for default values that are created via DefaultValueFactory.
+ *
+ * @author
+ *   Igor Konnov
+ */
+class DefaultValueCache(rewriter: SymbStateRewriter)
+    extends AbstractCache[SymbState, TlaType1, ArenaCell] with Serializable {
+  private val factory = new DefaultValueFactory(rewriter)
+
+  override protected def create(state: SymbState, typ: TlaType1): (SymbState, ArenaCell) = {
+    val nextState = factory.makeUpValue(state, CellT.fromType1(typ))
+    (nextState, nextState.asCell)
+  }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.tla.bmcmt.rewriter
 
 import at.forsyte.apalache.tla.bmcmt.analyses.ExprGrade
 import at.forsyte.apalache.tla.bmcmt.caches.{AbstractCacheSnapshot, SimpleCacheSnapshot}
-import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
-import at.forsyte.apalache.tla.lir.TlaEx
+import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell, SymbState}
+import at.forsyte.apalache.tla.lir.{TlaEx, TlaType1}
 
 import scala.collection.immutable.SortedSet
 
@@ -11,5 +11,6 @@ class SymbStateRewriterSnapshot(
     val intValueCacheSnapshot: AbstractCacheSnapshot[Arena, BigInt, ArenaCell],
     val intRangeCacheSnapshot: AbstractCacheSnapshot[Arena, (Int, Int), ArenaCell],
     val modelValueCacheSnapshot: AbstractCacheSnapshot[Arena, (String, String), ArenaCell],
+    val defaultValueCacheSnapshot: AbstractCacheSnapshot[SymbState, TlaType1, ArenaCell],
     val recordDomainCache: AbstractCacheSnapshot[Arena, (SortedSet[String], SortedSet[String]), ArenaCell],
     val exprCacheSnapshot: SimpleCacheSnapshot[TlaEx, (TlaEx, ExprGrade.Value)]) {}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rewriter
 
 import at.forsyte.apalache.tla.bmcmt.analyses.ExprGrade
 import at.forsyte.apalache.tla.bmcmt.caches.{AbstractCacheSnapshot, SimpleCacheSnapshot}
-import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell, SymbState}
+import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell}
 import at.forsyte.apalache.tla.lir.{TlaEx, TlaType1}
 
 import scala.collection.immutable.SortedSet

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterSnapshot.scala
@@ -11,6 +11,6 @@ class SymbStateRewriterSnapshot(
     val intValueCacheSnapshot: AbstractCacheSnapshot[Arena, BigInt, ArenaCell],
     val intRangeCacheSnapshot: AbstractCacheSnapshot[Arena, (Int, Int), ArenaCell],
     val modelValueCacheSnapshot: AbstractCacheSnapshot[Arena, (String, String), ArenaCell],
-    val defaultValueCacheSnapshot: AbstractCacheSnapshot[SymbState, TlaType1, ArenaCell],
+    val defaultValueCacheSnapshot: AbstractCacheSnapshot[Arena, TlaType1, ArenaCell],
     val recordDomainCache: AbstractCacheSnapshot[Arena, (SortedSet[String], SortedSet[String]), ArenaCell],
     val exprCacheSnapshot: SimpleCacheSnapshot[TlaEx, (TlaEx, ExprGrade.Value)]) {}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
@@ -46,8 +46,8 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
         if (nextState.arena.getHas(setCell).isEmpty) {
           setT match {
             case SetT1(elemT) =>
-              val (stateAfter, _) = rewriter.defaultValueCache.getOrCreate(nextState, elemT)
-              stateAfter
+              val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState.arena, elemT)
+              nextState.setArena(newArena).setRex(defaultValue.toNameEx)
 
             case _ =>
               throw new IllegalStateException(s"Expected a set, found: $setT")

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/ChooseRule.scala
@@ -1,11 +1,11 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, DefaultValueFactory, OracleHelper}
-import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, OracleHelper}
+import at.forsyte.apalache.tla.lir.{OperEx, SetT1}
 import at.forsyte.apalache.tla.lir.TypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.lir.OperEx
 
 /**
  * <p>Rewriting rule for CHOOSE. Similar to TLC, we implement a non-deterministic choice. It is not hard to add the
@@ -18,7 +18,6 @@ import at.forsyte.apalache.tla.lir.OperEx
  */
 class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val pickRule = new CherryPick(rewriter)
-  private val defaultValueFactory = new DefaultValueFactory(rewriter)
 
   override def isApplicable(state: SymbState): Boolean = {
     state.ex match {
@@ -37,14 +36,22 @@ class ChooseRule(rewriter: SymbStateRewriter) extends RewritingRule {
         // that is, when CHOOSE is defined on its arguments and not, respectively.
 
         // compute set comprehension and then pick an element from it
+        val setT = set.typeTag.asTlaType1()
         val filterEx = tla
           .filter(varName, set, pred)
-          .typed(set.typeTag.asTlaType1())
+          .typed(setT)
         var nextState = rewriter.rewriteUntilDone(state.setRex(filterEx))
         // pick an arbitrary witness
         val setCell = nextState.asCell
         if (nextState.arena.getHas(setCell).isEmpty) {
-          defaultValueFactory.makeUpValue(nextState, setCell)
+          setT match {
+            case SetT1(elemT) =>
+              val (stateAfter, _) = rewriter.defaultValueCache.getOrCreate(nextState, elemT)
+              stateAfter
+
+            case _ =>
+              throw new IllegalStateException(s"Expected a set, found: $setT")
+          }
         } else {
           val elems = nextState.arena.getHas(setCell)
           // add an oracle \in 0..N, where the indices from 0 to N - 1 correspond to the set elements,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunAppRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunAppRule.scala
@@ -1,13 +1,13 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, DefaultValueFactory, ProtoSeqOps}
+import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, ProtoSeqOps}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
+import at.forsyte.apalache.tla.lir.{FunT1, OperEx, TlaEx, ValEx}
 
 /**
  * Implements f[x] for: functions, records, and tuples.
@@ -17,7 +17,6 @@ import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
  */
 class FunAppRule(rewriter: SymbStateRewriter) extends RewritingRule {
   protected val picker = new CherryPick(rewriter)
-  protected val defaultValueFactory = new DefaultValueFactory(rewriter)
   private val proto = new ProtoSeqOps(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = {
@@ -65,8 +64,7 @@ class FunAppRule(rewriter: SymbStateRewriter) extends RewritingRule {
       argEx: TlaEx,
       elemT: CellT): SymbState = {
     val (protoSeq, _, capacity) = proto.unpackSeq(state.arena, seqCell)
-    val nextState = defaultValueFactory.makeUpValue(state, elemT)
-    val defaultValue = nextState.asCell
+    val (nextState, defaultValue) = rewriter.defaultValueCache.getOrCreate(state, elemT.toTlaType1)
     argEx match {
       case ValEx(TlaInt(indexBase1)) =>
         if (indexBase1 < 1 || indexBase1 > capacity) {
@@ -106,7 +104,8 @@ class FunAppRule(rewriter: SymbStateRewriter) extends RewritingRule {
       state.setRex(elems(index).toNameEx)
     } else {
       // The key does not belong to the record. This can happen as records of different domains can be unified
-      defaultValueFactory.makeUpValue(state, resultT)
+      val (nextState, _) = rewriter.defaultValueCache.getOrCreate(state, resultT.toTlaType1)
+      nextState
     }
   }
 
@@ -142,7 +141,15 @@ class FunAppRule(rewriter: SymbStateRewriter) extends RewritingRule {
     val nelems = relationElems.size
     if (nelems == 0) {
       // Just return a default value. Most likely, this expression will never propagate.
-      defaultValueFactory.makeUpValue(nextState, funCell.cellType.asInstanceOf[FunT].resultType)
+      val funT = funCell.cellType.toTlaType1
+      funT match {
+        case FunT1(_, resultT) =>
+          val (stateAfter, _) = rewriter.defaultValueCache.getOrCreate(nextState, resultT)
+          stateAfter
+
+        case _ =>
+          throw new IllegalStateException(s"Expected a function, found: $funT")
+      }
     } else {
       val (oracleState, oracle) = picker.oracleFactory.newDefaultOracle(nextState, relationElems.size + 1)
       nextState = oracleState

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IfThenElseRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IfThenElseRule.scala
@@ -47,10 +47,12 @@ class IfThenElseRule(rewriter: SymbStateRewriter) extends RewritingRule {
           val resultType = CellT.fromTypeTag(ex.typeTag)
           resultType match {
             // basic types, we can use SMT equality
-            case BoolT() | IntT() | ConstT(_) => iteBasic(nextState, resultType, predCell.toNameEx, thenCell, elseCell)
+            case BoolT() | IntT() | ConstT(_) =>
+              iteBasic(nextState, resultType, predCell.toNameEx, thenCell, elseCell)
 
             // sets, functions, records, tuples, sequence: use pick
-            case _ => iteGeneral(nextState, resultType, predCell.toNameEx, thenCell, elseCell)
+            case _ =>
+              iteGeneral(nextState, resultType, predCell.toNameEx, thenCell, elseCell)
           }
         }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
@@ -229,9 +229,9 @@ class QuantRule(rewriter: SymbStateRewriter) extends RewritingRule with LazyLogg
       val assignedNames = findAssignedNames(predEx)
       var nextState = setState
       for ((name, tp) <- assignedNames) {
-        val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, tp)
+        val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState.arena, tp)
         val newBinding = nextState.binding ++ Binding(name + "'" -> defaultValue)
-        nextState = stateAfter.setBinding(newBinding)
+        nextState = nextState.setArena(newArena).setBinding(newBinding)
       }
       nextState.setRex(setState.arena.cellFalse().toNameEx)
     } else {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
@@ -1,14 +1,14 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, DefaultValueFactory, OracleHelper}
+import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, OracleHelper}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs.TypeTagAsTlaType1
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
-import at.forsyte.apalache.tla.lir._
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -19,7 +19,6 @@ import com.typesafe.scalalogging.LazyLogging
  */
 class QuantRule(rewriter: SymbStateRewriter) extends RewritingRule with LazyLogging {
   private val pickRule = new CherryPick(rewriter)
-  private val defaultValueFactory = new DefaultValueFactory(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
@@ -230,9 +229,9 @@ class QuantRule(rewriter: SymbStateRewriter) extends RewritingRule with LazyLogg
       val assignedNames = findAssignedNames(predEx)
       var nextState = setState
       for ((name, tp) <- assignedNames) {
-        nextState = defaultValueFactory.makeUpValue(nextState, CellT.fromType1(tp))
-        val newBinding = nextState.binding ++ Binding(name + "'" -> nextState.asCell)
-        nextState = nextState.setBinding(newBinding)
+        val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, tp)
+        val newBinding = nextState.binding ++ Binding(name + "'" -> defaultValue)
+        nextState = stateAfter.setBinding(newBinding)
       }
       nextState.setRex(setState.arena.cellFalse().toNameEx)
     } else {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/RecCtorRule.scala
@@ -68,8 +68,8 @@ class RecCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
               valueCells(ctorKeys.indexOf(key)) // get the cell associated with the value
             } else {
               // produce a default value
-              val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, tp.toTlaType1)
-              nextState = stateAfter
+              val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState.arena, tp.toTlaType1)
+              nextState = nextState.setArena(newArena)
               defaultValue
             }
           // link this cell to the record

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SeqOpsRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SeqOpsRule.scala
@@ -83,8 +83,8 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
       // This is the rare case when the spec author has made a typo, e.g., Head(<<>>).
       // We cannot throw an exception here, as it would report an error in a correct specification, e.g.,
       // Len(s) = 0 \/ Head(s) = 2
-      val (stateAfter, _) = rewriter.defaultValueCache.getOrCreate(nextState, elemType)
-      stateAfter
+      val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState.arena, elemType)
+      nextState.setArena(newArena).setRex(defaultValue.toNameEx)
     }
   }
 
@@ -127,7 +127,7 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
    * @param state
    *   a symbolic state to start with
    * @param seqEx
-   *   a sequence `S``
+   *   a sequence `S`
    * @param newStartEx
    *   the starting index `m` (inclusive)
    * @param newEndEx
@@ -172,8 +172,8 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
               tla.ite(tla.le(newEndBase1asInt, asInt(len)).as(BoolT1()), newEndBase1asInt, asInt(len)).as(IntT1()))
           .as(BoolT1()))
 
-    val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, seqT.elem)
-    nextState = stateAfter
+    val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState.arena, seqT.elem)
+    nextState = nextState.setArena(newArena)
 
     def copy(state: SymbState, dstIndexBase1: Int): (SymbState, ArenaCell) = {
       // Blindly copy the element adjustedStart + (dstIndex - 1) into the position at dstIndex.
@@ -260,8 +260,8 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
     val (protoSeq2, len2, capacity2) = proto.unpackSeq(nextState.arena, seq2)
 
     // we need the default value, when the sequences are empty
-    val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, seqT.elem)
-    nextState = stateAfter
+    val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState.arena, seqT.elem)
+    nextState = nextState.setArena(newArena)
 
     def pick(state: SymbState, dstIndexBase1: Int): (SymbState, ArenaCell) = {
       if (dstIndexBase1 > capacity1) {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SeqOpsRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SeqOpsRule.scala
@@ -1,12 +1,12 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, DefaultValueFactory, ProtoSeqOps}
-import at.forsyte.apalache.tla.bmcmt.types.{CellT, IntT}
+import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, ProtoSeqOps}
+import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.TypedPredefs._
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaSeqOper
-import at.forsyte.apalache.tla.lir._
 
 /**
  * Sequence operations: Head, Tail, Len, SubSeq, Append, Concat.
@@ -17,7 +17,6 @@ import at.forsyte.apalache.tla.lir._
 class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val picker = new CherryPick(rewriter)
   private val proto = new ProtoSeqOps(rewriter)
-  private val defaultValueFactory = new DefaultValueFactory(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
@@ -84,7 +83,8 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
       // This is the rare case when the spec author has made a typo, e.g., Head(<<>>).
       // We cannot throw an exception here, as it would report an error in a correct specification, e.g.,
       // Len(s) = 0 \/ Head(s) = 2
-      defaultValueFactory.makeUpValue(nextState, CellT.fromType1(elemType))
+      val (stateAfter, _) = rewriter.defaultValueCache.getOrCreate(nextState, elemType)
+      stateAfter
     }
   }
 
@@ -172,8 +172,8 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
               tla.ite(tla.le(newEndBase1asInt, asInt(len)).as(BoolT1()), newEndBase1asInt, asInt(len)).as(IntT1()))
           .as(BoolT1()))
 
-    nextState = defaultValueFactory.makeUpValue(nextState, CellT.fromType1(seqT.elem))
-    val defaultValue = nextState.asCell
+    val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, seqT.elem)
+    nextState = stateAfter
 
     def copy(state: SymbState, dstIndexBase1: Int): (SymbState, ArenaCell) = {
       // Blindly copy the element adjustedStart + (dstIndex - 1) into the position at dstIndex.
@@ -260,8 +260,8 @@ class SeqOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
     val (protoSeq2, len2, capacity2) = proto.unpackSeq(nextState.arena, seq2)
 
     // we need the default value, when the sequences are empty
-    nextState = defaultValueFactory.makeUpValue(nextState, CellT.fromType1(seqT.elem))
-    val defaultValue = nextState.asCell
+    val (stateAfter, defaultValue) = rewriter.defaultValueCache.getOrCreate(nextState, seqT.elem)
+    nextState = stateAfter
 
     def pick(state: SymbState, dstIndexBase1: Int): (SymbState, ArenaCell) = {
       if (dstIndexBase1 > capacity1) {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -291,8 +291,8 @@ class CherryPick(rewriter: SymbStateRewriter) {
         // This record does not have the key, but it was mixed with other records and produced a more general type.
         // Return a default value. As we are iterating over fields of commonRecordT, we will always find a value.
         val valueT = commonRecordT.fields(key)
-        val (nextState, defaultValue) = rewriter.defaultValueCache.getOrCreate(newState, valueT.toTlaType1)
-        newState = nextState
+        val (newArena, defaultValue) = rewriter.defaultValueCache.getOrCreate(newState.arena, valueT.toTlaType1)
+        newState = newState.setArena(newArena)
         defaultValue
       }
     }
@@ -616,9 +616,9 @@ class CherryPick(rewriter: SymbStateRewriter) {
     }
 
     // we need the default value to pad the shorter sequences
-    val (stateAfter, defaultValue) =
-      rewriter.defaultValueCache.getOrCreate(state, seqType.toTlaType1.asInstanceOf[SeqT1].elem)
-    var nextState = stateAfter
+    val (newArena, defaultValue) =
+      rewriter.defaultValueCache.getOrCreate(state.arena, seqType.toTlaType1.asInstanceOf[SeqT1].elem)
+    var nextState = state.setArena(newArena)
 
     // Here we are using the awesome linear encoding that uses interleaving.
     // We give an explanation for two statically non-empty sequences, the static case should be handled differently.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
@@ -43,18 +43,18 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
       case tupT @ TupT1(argTypes @ _*) =>
         var newArena = arena.appendCell(CellT.fromType1(tupT))
         val tuple = newArena.topCell
-        for (argt <- argTypes) {
-          val (nextArena, valueCell) = makeUpValue(newArena, argt)
-          newArena = nextArena.appendHasNoSmt(tuple, valueCell)
+        newArena = argTypes.foldLeft(newArena) { (arena, argT) =>
+          val (nextArena, valueCell) = makeUpValue(arena, argT)
+          nextArena.appendHasNoSmt(tuple, valueCell)
         }
         (newArena, tuple)
 
       case recT @ RecT1(_) =>
         var newArena = arena.appendCell(CellT.fromType1(recT))
         val recCell = newArena.topCell
-        for (v <- recT.fieldTypes.values) {
-          val (nextArena, valueCell) = makeUpValue(newArena, v)
-          newArena = nextArena.appendHasNoSmt(recCell, valueCell)
+        newArena = recT.fieldTypes.values.foldLeft(newArena) { (arena, v) =>
+          val (nextArena, valueCell) = makeUpValue(arena, v)
+          nextArena.appendHasNoSmt(recCell, valueCell)
         }
         // create the domain and attach it to the record
         val pairOfSets = (recT.fieldTypes.keySet, SortedSet[String]())

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
@@ -17,10 +17,6 @@ import scala.collection.immutable.SortedSet
 class DefaultValueFactory(rewriter: SymbStateRewriter) {
   private val protoSeqOps = new ProtoSeqOps(rewriter)
 
-  def makeUpValue(state: SymbState, set: ArenaCell): SymbState = {
-    makeUpValue(state, findElemType(set))
-  }
-
   /**
    * Produce a default value that, for instance, can be used as a value when picking from an empty set.
    * @param state
@@ -94,16 +90,6 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
 
       case tp @ _ =>
         throw new RewriterException(s"I do not know how to generate a default value for the type $tp", state.ex)
-    }
-  }
-
-  private def findElemType(setCell: ArenaCell): CellT = {
-    setCell.cellType match {
-      case FinSetT(et) =>
-        et
-
-      case tp @ _ =>
-        throw new RewriterException(s"Expected a set, found: $tp", NullEx)
     }
   }
 }


### PR DESCRIPTION
Closes #1348. This PR introduces `DefaultValueCache` that caches calls to `DefaultValueFactory`. Since caches operate over arenas, not states, this PR required some refactoring of `DefaultValueFactory`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
