### PR TITLE
Fix unused parameter compiler warnings

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
@@ -399,7 +399,7 @@ class Arena private (
    *   true, if src has an edge to dst labelled with 'has'
    */
   def isLinkedViaHas(src: ArenaCell, dst: ArenaCell): Boolean = {
-    def default(c: ArenaCell): List[ArenaCell] = List()
+    def default: ArenaCell => List[ArenaCell] = _ => List()
 
     hasEdges.applyOrElse(src, default).contains(dst)
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.implicitConversions._
 import at.forsyte.apalache.tla.bmcmt.rewriter.{ConstSimplifierForSmt, Recoverable}
 import at.forsyte.apalache.tla.bmcmt.rules.aux.ProtoSeqOps
 import at.forsyte.apalache.tla.bmcmt.types._
-import at.forsyte.apalache.tla.lir.TypedPredefs.{BuilderExAsTyped, tlaExToBuilderExAsTyped}
+import at.forsyte.apalache.tla.lir.TypedPredefs.{tlaExToBuilderExAsTyped, BuilderExAsTyped}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, MalformedTlaError, NullEx, TlaEx}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -5,11 +5,12 @@ import at.forsyte.apalache.tla.bmcmt.implicitConversions._
 import at.forsyte.apalache.tla.bmcmt.rewriter.{ConstSimplifierForSmt, Recoverable}
 import at.forsyte.apalache.tla.bmcmt.rules.aux.ProtoSeqOps
 import at.forsyte.apalache.tla.bmcmt.types._
-import at.forsyte.apalache.tla.lir.TypedPredefs.{tlaExToBuilderExAsTyped, BuilderExAsTyped}
+import at.forsyte.apalache.tla.lir.TypedPredefs.{BuilderExAsTyped, tlaExToBuilderExAsTyped}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, MalformedTlaError, NullEx, TlaEx}
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler
+import scalaz.unused
 
 /**
  * Generate equality constraints between cells and cache them to avoid redundant constraints.
@@ -224,7 +225,7 @@ class LazyEquality(rewriter: SymbStateRewriter)
       }
     }
 
-    def isNonStatic(pair: (ArenaCell, ArenaCell), entryAndLevel: (EqCache.CacheEntry, Int)): Int = {
+    def isNonStatic(@unused pair: (ArenaCell, ArenaCell), entryAndLevel: (EqCache.CacheEntry, Int)): Int = {
       entryAndLevel._1 match {
         case EqCache.FalseEntry() => 0
         case EqCache.TrueEntry()  => 0
@@ -233,8 +234,8 @@ class LazyEquality(rewriter: SymbStateRewriter)
     }
 
     val eqMap = eqCache.getMap
-    val nConst = (eqMap.map((onEntry _).tupled)).sum
-    val nNonStatic = (eqMap.map((isNonStatic _).tupled)).sum
+    val nConst = eqMap.map((onEntry _).tupled).sum
+    val nNonStatic = eqMap.map((isNonStatic _).tupled).sum
     (nConst, nNonStatic)
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -45,7 +45,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
       } else {
         // if not in the cache, it might be the case that another cell, which has asserted equivalence
         // with the original cell can be found
-        findCellInSet(arena, rewriter.modelValueCache.values().toSeq, cell.toNameEx) match {
+        findCellInSet(rewriter.modelValueCache.values().toSeq, cell.toNameEx) match {
           // found among the cached keys
           case Some(c) =>
             decodeCellToTlaEx(arena, c)
@@ -221,7 +221,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
     }
   }
 
-  private def findCellInSet(arena: Arena, cells: Seq[ArenaCell], ex: TlaEx): Option[ArenaCell] = {
+  private def findCellInSet(cells: Seq[ArenaCell], ex: TlaEx): Option[ArenaCell] = {
     def isEq(c: ArenaCell): Boolean = {
       val query = tla.and(tla.eql(c.toNameEx, ex))
       tla.bool(true).typed() == solverContext.evalGroundExpr(query.untyped())

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAuto.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAuto.scala
@@ -63,28 +63,23 @@ class SymbStateRewriterAuto(private var _solverContext: SolverContext) extends S
 
   override def exprGradeStore: ExprGradeStore = exprGradeStoreImpl
 
-  private def reset(arena: Arena, binding: Binding): Unit = {}
-
   private def preprocess(ex: TlaEx): Unit = {
     exprGradeAnalysis.labelExpr(consts, vars, ex)
   }
 
   override def rewriteOnce(state: SymbState): SymbStateRewriter.RewritingResult = {
-    reset(state.arena, state.binding)
     preprocess(state.ex)
     impl.rewriteOnce(state)
   }
 
   // TODO: rename to rewrite
   override def rewriteUntilDone(state: SymbState): SymbState = {
-    reset(state.arena, state.binding)
     preprocess(state.ex)
     impl.rewriteUntilDone(state)
   }
 
   // TODO: rename to rewriteSeq
   override def rewriteSeqUntilDone(state: SymbState, es: Seq[TlaEx]): (SymbState, Seq[TlaEx]) = {
-    reset(state.arena, state.binding)
     preprocess(state.ex)
     es.foreach(preprocess)
     impl.rewriteSeqUntilDone(state, es)
@@ -92,7 +87,6 @@ class SymbStateRewriterAuto(private var _solverContext: SolverContext) extends S
 
   // TODO: rename to rewriteSeqWithBindings
   override def rewriteBoundSeqUntilDone(state: SymbState, es: Seq[(Binding, TlaEx)]): (SymbState, Seq[TlaEx]) = {
-    reset(state.arena, state.binding)
     preprocess(state.ex)
     es.map(_._2).foreach(preprocess)
     impl.rewriteBoundSeqUntilDone(state, es)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/SymbStateRewriterListener.scala
@@ -10,7 +10,7 @@ import at.forsyte.apalache.tla.lir.TlaEx
  *   Igor Konnov
  */
 trait SymbStateRewriterListener {
-  def onRewrite(translatedEx: TlaEx, metricsDelta: SolverContextMetrics): Unit = {}
+  def onRewrite(translatedEx: TlaEx, metricsDelta: SolverContextMetrics): Unit
 
-  def dispose(): Unit = {}
+  def dispose(): Unit
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -52,7 +52,7 @@ object OutputManager extends LazyLogging {
   }
 
   /* This should only ever be set if the IntermediateFlag is true */
-  private def setIntermediateDir(namespace: String): Unit = {
+  private def setIntermediateDir: Unit = {
     intermediateDirOpt = Some(runDir.resolve(IntermediateFoldername))
   }
 
@@ -128,7 +128,7 @@ object OutputManager extends LazyLogging {
     setCustomRunDir(config.runDir)
 
     if (cfg.writeIntermediate) {
-      setIntermediateDir(fileName)
+      setIntermediateDir
       intermediateDirOpt.foreach(ensureDirExists)
       customIntermediateRunDir.foreach(ensureDirExists)
     }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -52,7 +52,7 @@ object OutputManager extends LazyLogging {
   }
 
   /* This should only ever be set if the IntermediateFlag is true */
-  private def setIntermediateDir: Unit = {
+  private def setIntermediateDir(): Unit = {
     intermediateDirOpt = Some(runDir.resolve(IntermediateFoldername))
   }
 
@@ -128,7 +128,7 @@ object OutputManager extends LazyLogging {
     setCustomRunDir(config.runDir)
 
     if (cfg.writeIntermediate) {
-      setIntermediateDir
+      setIntermediateDir()
       intermediateDirOpt.foreach(ensureDirExists)
       customIntermediateRunDir.foreach(ensureDirExists)
     }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaDeclAnnotator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaDeclAnnotator.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.io.lir
 
 import at.forsyte.apalache.tla.lir.TlaDecl
+import scalaz.unused
 
 /**
  * An interface for additional decorators of declarations that can be used in PrettyWriter. The default behavior is to
@@ -22,5 +23,5 @@ class TlaDeclAnnotator {
    * @return
    *   a string annotation
    */
-  def apply(layout: TextLayout)(decl: TlaDecl): Option[List[String]] = None
+  def apply(@unused layout: TextLayout)(@unused decl: TlaDecl): Option[List[String]] = None
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ModuleTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ModuleTranslator.scala
@@ -51,7 +51,7 @@ class ModuleTranslator(
 
         case NoneUnit() =>
           // translate only the user-defined operators, skip the aliases
-          val decl = NullOpDefTranslator(sourceStore, ctx).translate(opDef)
+          val decl = NullOpDefTranslator().translate(opDef)
           ctx.push(DeclUnit(decl))
 
         case _ => ctx // skip the aliases

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/NullOpDefTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/NullOpDefTranslator.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.imp
 
-import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir._
 import tla2sany.semantic.OpDefNode
 
@@ -10,7 +9,7 @@ import tla2sany.semantic.OpDefNode
  * @author
  *   konnov
  */
-class NullOpDefTranslator(sourceStore: SourceStore, context: Context) {
+class NullOpDefTranslator {
   def translate(node: OpDefNode): TlaOperDecl = {
     val params = node.getParams.toList.map(FormalParamTranslator().translate)
     val nodeName = node.getName.toString.intern()
@@ -19,7 +18,7 @@ class NullOpDefTranslator(sourceStore: SourceStore, context: Context) {
 }
 
 object NullOpDefTranslator {
-  def apply(sourceStore: SourceStore, context: Context): NullOpDefTranslator = {
-    new NullOpDefTranslator(sourceStore, context)
+  def apply(): NullOpDefTranslator = {
+    new NullOpDefTranslator
   }
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1570,7 +1570,7 @@ class TestSanyImporter extends SanyImporterTestBase {
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
 
-    def assertRec(name: String, nparams: Int, expectedBody: TlaEx) = {
+    def assertRec(name: String, expectedBody: TlaEx) = {
       root.declarations.find {
         _.name == name
       } match {
@@ -1588,13 +1588,13 @@ class TestSanyImporter extends SanyImporterTestBase {
     }
 
     // in the recursive sections, the calls to recursive operators should be replaced with (apply ...)
-    assertRec("R", 1, OperEx(TlaOper.apply, NameEx("R"), NameEx("n")))
+    assertRec("R", OperEx(TlaOper.apply, NameEx("R"), NameEx("n")))
 
-    assertRec("A", 1, OperEx(TlaOper.apply, NameEx("B"), NameEx("n")))
-    assertRec("B", 1, OperEx(TlaOper.apply, NameEx("C"), NameEx("n")))
-    assertRec("C", 1, OperEx(TlaOper.apply, NameEx("A"), NameEx("n")))
+    assertRec("A", OperEx(TlaOper.apply, NameEx("B"), NameEx("n")))
+    assertRec("B", OperEx(TlaOper.apply, NameEx("C"), NameEx("n")))
+    assertRec("C", OperEx(TlaOper.apply, NameEx("A"), NameEx("n")))
 
-    assertRec("X", 0, OperEx(TlaOper.apply, NameEx("X")))
+    assertRec("X", OperEx(TlaOper.apply, NameEx("X")))
 
     // however, in non-recursive sections, the calls to recursive operators are just normal OperEx(operator, ...)
     root.declarations.find {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.io.tlc.config._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
-import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
+import at.forsyte.apalache.tla.lir.transformations.TlaModuleTransformation
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -16,7 +16,7 @@ import com.typesafe.scalalogging.LazyLogging
  * @author
  *   Andrey Kuprianov
  */
-class TlcConfigImporter(config: TlcConfig, tracker: TransformationTracker)
+class TlcConfigImporter(config: TlcConfig)
     extends TlaModuleTransformation with LazyLogging {
   private val boolOperT = OperT1(Seq(), BoolT1())
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlcConfigImporter.scala
@@ -16,8 +16,7 @@ import com.typesafe.scalalogging.LazyLogging
  * @author
  *   Andrey Kuprianov
  */
-class TlcConfigImporter(config: TlcConfig)
-    extends TlaModuleTransformation with LazyLogging {
+class TlcConfigImporter(config: TlcConfig) extends TlaModuleTransformation with LazyLogging {
   private val boolOperT = OperT1(Seq(), BoolT1())
 
   private def mkBoolName(name: String): TlaEx = {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -9,7 +9,6 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.io.lir.{TlaWriter, TlaWriterFactory}
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaBoolOper, TlaOper, TlaTempOper}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
-import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.pp._
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
@@ -144,9 +143,7 @@ class ConfigurationPassImpl @Inject() (
 
     try {
       val config = TlcConfigParserApalache.apply(new FileReader(filename))
-      configuredModule = new TlcConfigImporter(config, new IdleTracker())(
-          module
-      )
+      configuredModule = new TlcConfigImporter(config)(module)
       config.behaviorSpec match {
         case InitNextSpec(init, next) =>
           setInit(init)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAInlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAInlinePassImpl.scala
@@ -10,19 +10,9 @@ import com.google.inject.Inject
 
 /**
  * A pass that expands operators and let-in definitions.
- *
- * @param options
- *   pass options
- * @param gen
- *   name generator
- * @param tracker
- *   transformation tracker
- * @param nextPass
- *   next pass to call
  */
 class ReTLAInlinePassImpl @Inject() (
     options: PassOptions,
-    gen: UniqueNameGenerator,
     tracker: TransformationTracker,
     writerFactory: TlaWriterFactory)
     extends PartialInlinePassImpl(options, tracker, writerFactory) {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAPreproPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ReTLAPreproPassImpl.scala
@@ -7,24 +7,14 @@ import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
-import at.forsyte.apalache.tla.pp.{Normalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.pp.Normalizer
 import com.google.inject.Inject
 
 /**
  * A preprocessing pass that simplifies TLA+ expressions by running multiple transformations.
- *
- * @param options
- *   pass options
- * @param gen
- *   name generator
- * @param tracker
- *   transformation tracker
- * @param nextPass
- *   next pass to call
  */
 class ReTLAPreproPassImpl @Inject() (
     options: PassOptions,
-    gen: UniqueNameGenerator,
     renaming: IncrementalRenaming,
     tracker: TransformationTracker,
     sourceStore: SourceStore,

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
@@ -43,7 +43,7 @@ class TestTlcConfigImporter extends AnyFunSuite with BeforeAndAfterEach {
         .checkAndTag(new IdleTracker(), new MultiTypeCheckerListener(), defaultTag = { _ => Untyped() }, mod)
         .get
 
-    val mod2 = new TlcConfigImporter(config, new IdleTracker())(typedModule)
+    val mod2 = new TlcConfigImporter(config)(typedModule)
     val stringWriter = new StringWriter()
     val printWriter = new PrintWriter(stringWriter)
     val writer = new PrettyWriter(printWriter, layout80)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUniqueNameGenerator.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestUniqueNameGenerator.scala
@@ -1,9 +1,9 @@
 package at.forsyte.apalache.tla.pp
 
 import org.junit.runner.RunWith
-import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestUniqueNameGenerator extends AnyFunSuite with BeforeAndAfterEach {
@@ -16,7 +16,7 @@ class TestUniqueNameGenerator extends AnyFunSuite with BeforeAndAfterEach {
 
   test("after 10000") {
     val gen = new UniqueNameGenerator
-    for (i <- 1.to(10000)) {
+    1.to(10000).foreach { _ =>
       gen.newName()
     }
     assert("t_7pt" == gen.newName())

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir.{OperT1, SetT1, TlaType1, TlaType1Scheme, TypingException, VarT1}
 import at.forsyte.apalache.tla.typecheck._
 import at.forsyte.apalache.tla.typecheck.etc.EtcTypeChecker.UnwindException
+import scalaz.unused
 
 /**
  * ETC: Embarrassingly simple Type Checker.
@@ -142,7 +143,7 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
           }
         }
 
-        def onArgsMatchError(sub: Substitution, types: Seq[TlaType1]): Unit = {
+        def onArgsMatchError(sub: Substitution, @unused types: Seq[TlaType1]): Unit = {
           // no solution for: operVar = (arg_1, ..., arg_k) => resVar
           val evalArgTypes = argTypes.map(sub.subRec)
           val argOrArgs = pluralArgs(argTypes.length)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/formulas/Base.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/formulas/Base.scala
@@ -1,5 +1,7 @@
 package at.forsyte.apalache.tla.lir.formulas
 
+import scalaz.unused
+
 /**
  * A representation of an SMT/VMT sort. We only support non-parametric sorts at the moment.
  *
@@ -18,7 +20,7 @@ trait Term {
   val sort: Sort
 }
 
-abstract class Variable(name: String) extends Term
+abstract class Variable(@unused name: String) extends Term
 
 sealed case class BoolSort() extends Sort("Boolean")
 sealed case class IntSort() extends Sort("Integer")

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.lir.oper
 
 import at.forsyte.apalache.tla.lir.{TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.values.TlaStr
+import scalaz.unused
 
 import scala.annotation.tailrec
 
@@ -39,7 +40,7 @@ trait TlaOper extends Serializable {
    * @return
    *   true, if the invariant is satisfied
    */
-  def permitsArgs(args: Seq[TlaEx]): Boolean = { true }
+  def permitsArgs(@unused args: Seq[TlaEx]): Boolean = true
 }
 
 object TlaOper {


### PR DESCRIPTION
Towards #1064. First chunk of fixes for compiler warnings of the shape

    parameter value arg in {class, method} MySymbol is never used

Rationale for the fix in the commit message.