### PR TITLE
Fix compiler deprecation warnings

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArena.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArena.scala
@@ -2,14 +2,16 @@ package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.smt.Z3SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.{BoolT, FinSetT, UnknownT}
-import org.scalatest.funsuite.FixtureAnyFunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-trait TestArena extends FixtureAnyFunSuite {
-  protected type FixtureParam = Any
-
+/**
+ * [[Arena]] tests. Override [[AnyFunSuite.withFixture()]] to set up specific solver contexts (e.g., for different
+ * encodings).
+ */
+trait TestArena extends AnyFunSuite {
   protected var solver: Z3SolverContext = _
 
-  test("create cells") { _ =>
+  test("create cells") {
     val emptyArena = Arena.create(solver)
     val arena = emptyArena.appendCell(UnknownT())
     assert(emptyArena.cellCount + 1 == arena.cellCount)
@@ -19,7 +21,7 @@ trait TestArena extends FixtureAnyFunSuite {
     assert(BoolT() == arena2.topCell.cellType)
   }
 
-  test("add 'has' edges") { _ =>
+  test("add 'has' edges") {
     val arena = Arena.create(solver).appendCell(FinSetT(UnknownT()))
     val set = arena.topCell
     val arena2 = arena.appendCell(BoolT())
@@ -28,7 +30,7 @@ trait TestArena extends FixtureAnyFunSuite {
     assert(List(elem) == arena3.getHas(set))
   }
 
-  test("BOOLEAN has FALSE and TRUE") { _ =>
+  test("BOOLEAN has FALSE and TRUE") {
     val arena = Arena.create(solver)
     assert(List(arena.cellFalse(), arena.cellTrue()) == arena.getHas(arena.cellBooleanSet()))
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithArrays.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestArenaWithArrays extends TestArena {
-  override protected def withFixture(test: OneArgTest): Outcome = {
+  override protected def withFixture(test: NoArgTest): Outcome = {
     solver = new Z3SolverContext(SolverConfig.default.copy(debug = true, smtEncoding = arraysEncoding))
     val result = test()
     solver.dispose()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestArenaWithOOPSLA19.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestArenaWithOOPSLA19 extends TestArena {
-  override protected def withFixture(test: OneArgTest): Outcome = {
+  override protected def withFixture(test: NoArgTest): Outcome = {
     solver = new Z3SolverContext(SolverConfig.default.copy(debug = true, smtEncoding = oopsla19Encoding))
     val result = test()
     solver.dispose()

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContext.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContext.scala
@@ -3,18 +3,20 @@ package at.forsyte.apalache.tla.bmcmt.smt
 import at.forsyte.apalache.tla.bmcmt.Arena
 import at.forsyte.apalache.tla.bmcmt.types.IntT
 import at.forsyte.apalache.tla.lir.TlaEx
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
-import org.scalatest.funsuite.FixtureAnyFunSuite
+import at.forsyte.apalache.tla.lir.convenience.tla
+import org.scalatest.funsuite.AnyFunSuite
 
-trait TestRecordingSolverContext extends FixtureAnyFunSuite {
-  protected type FixtureParam = Any
-
+/**
+ * [[RecordingSolverContext]] tests. Override [[AnyFunSuite.withFixture()]] to set up specific solver contexts (e.g.,
+ * for different encodings).
+ */
+trait TestRecordingSolverContext extends AnyFunSuite {
   protected var solverConfig: SolverConfig = _
 
   private val int42: TlaEx = tla.int(42)
 
-  test("operations proxied") { _ =>
+  test("operations proxied") {
     val solver = RecordingSolverContext.createZ3(None, solverConfig)
     val arena = Arena.create(solver).appendCell(IntT())
     val x = arena.topCell
@@ -23,7 +25,7 @@ trait TestRecordingSolverContext extends FixtureAnyFunSuite {
     assert(solver.evalGroundExpr(x.toNameEx) == int42)
   }
 
-  test("write and read") { _ =>
+  test("write and read") {
     val solver = RecordingSolverContext.createZ3(None, solverConfig)
     val arena = Arena.create(solver).appendCell(IntT())
     val x = arena.topCell
@@ -42,7 +44,7 @@ trait TestRecordingSolverContext extends FixtureAnyFunSuite {
     assert(restoredSolver.evalGroundExpr(x.toNameEx) == int42)
   }
 
-  test("pop on empty") { _ =>
+  test("pop on empty") {
     val solver = RecordingSolverContext.createZ3(None, solverConfig)
     assertThrows[IllegalArgumentException](solver.pop(2))
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithArrays.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestRecordingSolverContextWithArrays extends TestRecordingSolverContext {
-  override protected def withFixture(test: OneArgTest): Outcome = {
+  override protected def withFixture(test: NoArgTest): Outcome = {
     solverConfig = SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = arraysEncoding)
     test()
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContextWithOOPSLA19.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TestRecordingSolverContextWithOOPSLA19 extends TestRecordingSolverContext {
-  override protected def withFixture(test: OneArgTest): Outcome = {
+  override protected def withFixture(test: NoArgTest): Outcome = {
     solverConfig = SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = oopsla19Encoding)
     test()
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -2,8 +2,9 @@ package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.tla.lir.TlaValue
 import at.forsyte.apalache.tla.lir.oper._
-import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet, TlaRealSet}
-import at.forsyte.apalache.tla.lir.values.TlaRealInfinity
+import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet, TlaRealInfinity, TlaRealSet}
+
+import scala.annotation.nowarn
 
 /**
  * Values and operators that are defined in the standard TLA+ library.
@@ -84,6 +85,7 @@ object StandardLibrary {
    * Global operators are translated to IR operators. However, we advise against this practice: TLA+ does not allow one
    * to override the same operator in different modules.
    */
+  @nowarn("cat=deprecation&msg=object withType in object ApalacheOper is deprecated")
   val globalOperators: Map[String, TlaOper] =
     Map[String, TlaOper](
         // This operator is deprecated and should not be used.

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -1,14 +1,15 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
-import at.forsyte.apalache.io.annotations.{Annotation, AnnotationStr, StandardAnnotations}
 import at.forsyte.apalache.io.annotations.store.{findAnnotation, AnnotationStore}
-import at.forsyte.apalache.io.typecheck.parser.Type1ParseError
-import at.forsyte.apalache.tla.lir.{SparseTupT1, ValEx, _}
+import at.forsyte.apalache.io.annotations.{Annotation, AnnotationStr, StandardAnnotations}
+import at.forsyte.apalache.io.typecheck.parser.{DefaultType1Parser, Type1ParseError}
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.typecheck._
-import at.forsyte.apalache.io.typecheck.parser.DefaultType1Parser
 import com.typesafe.scalalogging.LazyLogging
+
+import scala.annotation.nowarn
 
 /**
  * <p>ToEtcExpr takes a TLA+ expression and produces an EtcExpr. The most interesting part of this translation is
@@ -188,6 +189,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
     }
   }
 
+  @nowarn("cat=deprecation&msg=object withType in object ApalacheOper is deprecated")
   private def transform(ex: TlaEx): EtcExpr = {
 
     val ref = ExactRef(ex.ID)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -13,6 +13,8 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 
+import scala.annotation.nowarn
+
 /**
  * Unit tests for translating TLA+ expressions to EtcExpr.
  *
@@ -822,8 +824,11 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
 
   test("old annotations: e <: tp") {
     val oldTypeAnnotation = tla.enumSet(tla.intSet())
+
     // we explicitly use OperEx here, as we have removed Builder.withType
+    @nowarn("cat=deprecation&msg=object withType in object ApalacheOper is deprecated")
     val input = OperEx(ApalacheOper.withType, tla.name("e"), oldTypeAnnotation)(Untyped())
+
     assertThrows[OutdatedAnnotationsError](gen(input))
   }
 }


### PR DESCRIPTION
Towards #1473, #1064

Fixes all current compiler deprecation warnings.
This addresses two kinds of warnings; rationale for each fix in the commit message.