### PR TITLE
Fix funAppWithArrays static check

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix function application static check in arrays encoding, see #1490


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

This PR fixes the handling of function applications when the function's arguments can be computed statically in`FunAppRuleWithArrays`. Instead of creating a new `res` cell and propagating the `dom` and `cdm`, we now return `elemRes` directly.

The addition of an SMT constraint to the application of the function to `elemArg` is still needed, since functions derived from function sets are initially unconstrained. This is relevant not only for explicit function sets, but also for recursive functions, which rely on function sets.

Closes #1490.