### PR TITLE
Fix flipped test_file and corrected_file

### DIFF
--- a/test/mdx-test.py
+++ b/test/mdx-test.py
@@ -113,8 +113,8 @@ if __name__ == "__main__":
     corrected_file = test_target_dir / (test_file.name + ".corrected")
 
     working_dir_str = str(working_dir)
-    test_file_str = str(corrected_file)
-    corrected_file_str = str(test_file)
+    corrected_file_str = str(corrected_file)
+    test_file_str = str(test_file)
 
     # Must come after the `test_target_dir` is created
     configure_logger(args.debug)
@@ -128,8 +128,8 @@ if __name__ == "__main__":
         "--root",
         working_dir_str,
         "--output",
-        test_file_str,
         corrected_file_str,
+        test_file_str,
     ]
     if args.test is not None:
         if test_is_in_file(args.test, test_file):


### PR DESCRIPTION
Small fix for `mdx-test.py`: `corrected_file` and `test_file` were flipped when converting from Path to string.

I think the call to `diff` below is still fine, because it now reports `test.md` as `---` and `test.md.corrected` as `+++`, as I would expect:

    $ test/mdx-test.py --test test/tla/test.md
    --- /Users/.../test.md
    +++ /Users/.../test.md.corrected
    @@ -1,5 +1,6 @@
     # asdf
     
     ```sh
     $ pwd
    +/Users/.../tla
     ```