### PR TITLE
Add all CLI args and env config to checker options

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -177,10 +177,10 @@ object Tool extends LazyLogging {
   }
 
   private def setCoreOptions(executor: PassChainExecutor, cmd: AbstractCheckerCmd): Unit = {
-    logger.info(
-        "Checker options: filename=%s, init=%s, next=%s, inv=%s"
-          .format(cmd.file, cmd.init, cmd.next, cmd.inv)
-    )
+    logger.info {
+      val environment = if (cmd.env != "") s"(${cmd.env})" else ""
+      s"Checker options: ${environment} ${cmd.name} ${cmd.invocation}"
+    }
     executor.options.set("parser.filename", cmd.file.getAbsolutePath)
     if (cmd.config != "")
       executor.options.set("checker.config", cmd.config)

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -178,8 +178,8 @@ object Tool extends LazyLogging {
 
   private def setCoreOptions(executor: PassChainExecutor, cmd: AbstractCheckerCmd): Unit = {
     logger.info {
-      val environment = if (cmd.env != "") s"(${cmd.env})" else ""
-      s"Checker options: ${environment} ${cmd.name} ${cmd.invocation}"
+      val environment = if (cmd.env != "") s"(${cmd.env}) " else ""
+      s"Checker options: ${environment}${cmd.name} ${cmd.invocation}"
     }
     executor.options.set("parser.filename", cmd.file.getAbsolutePath)
     if (cmd.config != "")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -5,7 +5,8 @@ import org.backuity.clist.{arg, opt, Command}
 import java.io.File
 
 // Holds the minimal necessary info about a specification.
-abstract class AbstractCheckerCmd(name: String, description: String) extends Command(name, description) with General {
+abstract class AbstractCheckerCmd(val name: String, description: String)
+    extends Command(name, description) with General {
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var config: String = opt[String](name = "config", default = "",
       description = "configuration file in TLC format,\n" +


### PR DESCRIPTION
Closes #1507

May provide clearer diagnostics for bug reports too.

With this change, the output now looks like this:

```sh
$  SMT_ENCODING=arrays apalache-mc check --next=Next --init=Init Foo.tla | rg "Checker options"
Checker options: (SMT_ENCODING=arrays) check --next=Next --init=Init Foo.tla I@16:45:25.503
```

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)