### PR TITLE
Upgrade to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ ThisBuild / versionFile := (ThisBuild / baseDirectory).value / "VERSION"
 ThisBuild / version := scala.io.Source.fromFile(versionFile.value).mkString.trim
 
 ThisBuild / organization := "at.forsyte"
-ThisBuild / scalaVersion := "2.12.15"
+ThisBuild / scalaVersion := "2.13.8"
 
 // https://oss.sonatype.org/content/repositories/snapshots/
 ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")

--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,8 @@ lazy val tla_assignments = (project in file("tla-assignments"))
 lazy val tla_bmcmt = (project in file("tla-bmcmt"))
   .dependsOn(tlair, infra, tla_io, tla_pp, tla_assignments)
   .settings(
-      testSettings
+      testSettings,
+      libraryDependencies += Deps.scalaCollectionContrib,
   )
 
 lazy val tool = (project in file("mod-tool"))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -26,7 +26,7 @@ import org.backuity.clist.Cli
 import util.ExecutionStatisticsCollector
 import util.ExecutionStatisticsCollector.Selection
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 import at.forsyte.apalache.io.ConfigManager
 import at.forsyte.apalache.tla.bmcmt.rules.vmt.TlaExToVMTWriter

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -55,7 +55,7 @@ trait General extends Command with CliConfig {
 
   implicit def featureSeqRead: Read[Seq[Feature]] = {
     Read.reads[Seq[Feature]](expecting = s"a comma-separated list of features: ${featureList}") { str =>
-      str.split(",").map(featureRead.reads)
+      str.split(",").map(featureRead.reads).toIndexedSeq
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
     val logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
     val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.17.1"
     val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1"
+    val scalaCollectionContrib = "org.scala-lang.modules" %% "scala-collection-contrib" % "0.2.2"
     val scalaz = "org.scalaz" %% "scalaz-core" % "7.3.5"
     val slf4j = "org.slf4j" % "slf4j-api" % "1.7.36"
     val tla2tools = "org.lamport" % "tla2tools" % "1.7.0-SNAPSHOT"

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
@@ -421,7 +421,7 @@ class Arena private (
    *   a cell to start from
    */
   def subgraphToString(root: ArenaCell): String = {
-    val builder = StringBuilder.newBuilder
+    val builder = new StringBuilder()
 
     def print(cell: ArenaCell): Unit = {
       builder.append(cell.id)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/CollectCounterexamplesSeqModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/CollectCounterexamplesSeqModelCheckerListener.scala
@@ -39,5 +39,5 @@ class CollectCounterexamplesModelCheckerListener extends ModelCheckerListener wi
   }
 
   private val _counterExamples = ListBuffer.empty[DecodedExecution]
-  def counterExamples: Seq[DecodedExecution] = _counterExamples
+  def counterExamples: Seq[DecodedExecution] = _counterExamples.toSeq
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -107,7 +107,7 @@ class LazyEquality(rewriter: SymbStateRewriter)
    * @return
    *   a new symbolic state that contains the constraints for every pair in the sequence
    */
-  def cacheEqConstraints(state: SymbState, pairs: Traversable[(ArenaCell, ArenaCell)]): SymbState = {
+  def cacheEqConstraints(state: SymbState, pairs: Iterable[(ArenaCell, ArenaCell)]): SymbState = {
     rewriter.solverContext.log("; [START] Caching equality constraints for a sequence: " + pairs)
 
     def makeOne(state: SymbState, pair: (ArenaCell, ArenaCell)): SymbState = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/StackableContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/StackableContext.scala
@@ -33,10 +33,10 @@ trait StackableContext {
    * @param n
    *   pop n times, if n > 0, otherwise, do nothing
    */
-  def pop(n: Int)
+  def pop(n: Int): Unit
 
   /**
    * Clean the context
    */
-  def dispose()
+  def dispose(): Unit
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/EqCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/EqCache.scala
@@ -136,7 +136,7 @@ class EqCache() extends StackableContext with Serializable with Recoverable[EqCa
   override def pop(n: Int): Unit = {
     assert(level >= n)
     level -= n
-    eqCache.retain((_, value) => value._2 <= level)
+    eqCache.filterInPlace((_, value) => value._2 <= level)
   }
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/implicitConversions/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/implicitConversions/package.scala
@@ -5,8 +5,8 @@ package at.forsyte.apalache.tla.bmcmt
  */
 package object implicitConversions {
 
-  implicit class Crossable[X](xs: Traversable[X]) {
+  implicit class Crossable[X](xs: Iterable[X]) {
     // see https://stackoverflow.com/questions/14740199/cross-product-in-scala
-    def cross[Y](ys: Traversable[Y]) = for { x <- xs; y <- ys } yield (x, y)
+    def cross[Y](ys: Iterable[Y]) = for { x <- xs; y <- ys } yield (x, y)
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
@@ -76,7 +76,7 @@ class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
     }
 
     // create the inequality predicate
-    val witnesses = List.fill(threshold)(pick)
+    val witnesses = List.fill(threshold)(pick())
     (witnesses.cross(witnesses)).filter(p => p._1.id < p._2.id).foreach(cacheEq)
     val witnessesNotEq = OperEx(ApalacheInternalOper.distinct, witnesses.map(_.toNameEx): _*)
     nextState = nextState.updateArena(_.appendCell(BoolT()))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
@@ -101,7 +101,7 @@ class FoldSetRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val condEx = tla
           .or(
               tla.not(tla.apalacheSelectInSet(currentCell.toNameEx, setNameEx) ? "bool") ? "bool",
-              tla.or(counted.map(eqToOther(setNameEx, currentCell, _)): _*) ? "bool",
+              tla.or(counted.map(eqToOther(setNameEx, currentCell, _)).toIndexedSeq: _*) ? "bool",
           ) ? "bool"
         solverAssert(tla.eql(condCell.toNameEx, condEx).typed(types, "bool"))
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
@@ -44,7 +44,7 @@ class FoldSetRule(rewriter: SymbStateRewriter) extends RewritingRule {
       val setMembers = setState.arena.getHas(setCell).toArray
 
       // Now, we cache the set element equalities
-      val postCacheState = cacheEqualityConstraints(setState, setMembers)
+      val postCacheState = cacheEqualityConstraints(setState, setMembers.toIndexedSeq)
 
       // Then, we start the folding with the value of baseCell
       val initialState = postCacheState.setRex(baseCell.toNameEx)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/QuantRule.scala
@@ -76,7 +76,7 @@ class QuantRule(rewriter: SymbStateRewriter) extends RewritingRule with LazyLogg
 
   private def findAssignedNames(ex: TlaEx): Map[String, TlaType1] = ex match {
     case OperEx(ApalacheOper.assign, OperEx(TlaActionOper.prime, nex @ NameEx(name)), _) =>
-      Map(name -> nex.typeTag.asTlaType1)
+      Map(name -> nex.typeTag.asTlaType1())
 
     case OperEx(_, args @ _*) =>
       args.flatMap(findAssignedNames).toMap

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MapBase.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import scala.collection.mutable.{HashMap, MultiMap, Set}
+import scala.collection.mutable
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.bmcmt.util.IntTupleIterator
@@ -83,20 +83,23 @@ class MapBase(rewriter: SymbStateRewriter) {
       cellsIter: Iterator[Seq[ArenaCell]]): (SymbState, Iterable[ArenaCell]) = {
     // we could have done it with foldLeft, but that would be even less readable
     var newState = state
-    // Collect target cells and the possible membership expressions in a hash map.
+
+    // Collect target cells and the possible membership expressions in a MultiDict.
+    // (See https://www.javadoc.io/doc/org.scala-lang.modules/scala-collection-contrib_2.13/0.1.0/scala/collection/MultiDict.html)
+    //
     // This is probably a memory-hungry solution.
     // We will replace it with a better one in an array-based SMT encoding:
     // https://github.com/informalsystems/apalache/issues/365
-    val resultsToSource = new HashMap[ArenaCell, Set[TlaEx]] with MultiMap[ArenaCell, TlaEx]
+    val resultsToSource = mutable.MultiDict.empty[ArenaCell, TlaEx]
     for (argCells <- cellsIter) {
       val (ns, resultCell, memEx) =
         mapCellsManyArgsOnce(newState, targetSetCell, mapEx, varNames, setsAsCells, argCells)
       newState = ns
-      resultsToSource.addBinding(resultCell, memEx)
+      resultsToSource.addOne(resultCell -> memEx)
     }
 
     // add the membership constraints: one per target cell
-    for ((targetCell, memExpressions) <- resultsToSource) {
+    for ((targetCell, memExpressions) <- resultsToSource.sets) {
       val inNewSet: TlaEx = tla.apalacheStoreInSet(targetCell.toNameEx, targetSetCell.toNameEx)
       val notInNewSet: TlaEx = tla.apalacheStoreNotInSet(targetCell.toNameEx, targetSetCell.toNameEx)
       val inSourceSet = {
@@ -110,7 +113,7 @@ class MapBase(rewriter: SymbStateRewriter) {
       rewriter.solverContext.assertGroundExpr(tla.ite(inSourceSet, inNewSet, notInNewSet))
     }
 
-    (newState, resultsToSource.keys)
+    (newState, resultsToSource.keySet)
   }
 
   private def mapCellsManyArgsOnce(

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ProtoSeqOps.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ProtoSeqOps.scala
@@ -6,6 +6,8 @@ import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir._
 
+import scala.collection.immutable.ArraySeq
+
 /**
  * <p>Proto sequences that contain the absolute minimum for implementing TLA+ sequences. A proto sequence is a
  * collection of cells, which are ordered by indices 1, ..., `capacity`. Importantly, `capacity` is a static value,
@@ -56,7 +58,7 @@ class ProtoSeqOps(rewriter: SymbStateRewriter) {
     val protoSeq = nextState.arena.topCell
 
     // attach the cells to the proto sequence, do not track this in SMT
-    nextState = nextState.updateArena(_.appendHasNoSmt(protoSeq, cellsAsArray: _*))
+    nextState = nextState.updateArena(_.appendHasNoSmt(protoSeq, ArraySeq.unsafeWrapArray(cellsAsArray): _*))
     nextState.setRex(protoSeq.toNameEx)
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/vmt/EUFRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/vmt/EUFRule.scala
@@ -212,6 +212,9 @@ class EUFRule(rewriter: ToTermRewriter, restrictedSetJudgement: RestrictedSetJud
           // ![a] case
           case OperEx(TlaFunOper.tuple, arg) =>
             List(rewrite(arg))
+
+          case invalidArg =>
+            throw new IllegalArgumentException(s"Invalid arg for TlaFunOper.except in EUFRule: ${invalidArg}")
         }
 
         val exceptTermFn = exceptAsNewFunDef(fnArgTerms, valTerm) _

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/vmt/TermToVMTWriter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/vmt/TermToVMTWriter.scala
@@ -113,7 +113,7 @@ object TermToVMTWriter {
   }
 
   // For uninterpreted literals, we need to specify distinctness
-  def assertDistinct(terms: Traversable[UninterpretedLiteral]): String =
+  def assertDistinct(terms: Iterable[UninterpretedLiteral]): String =
     s"(define-fun .axiom () Bool (! (distinct ${terms.map(tr).mkString(" ")}) :axiom true))"
 
   // Adds the VMT-specific tags, as defined by the VMTExpr wrapper

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverContextMetrics.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/SolverContextMetrics.scala
@@ -19,7 +19,7 @@ class SolverContextMetrics(val nCells: Long, val nConsts: Long, val nSmtExprs: L
    * Compute the weight based on metrics. Currently, the metric equals to nCells + nConsts + sqrt(nSmtExprs). If we find
    * a better metric, we will change it.
    */
-  lazy val weight: Long = nCells + nConsts + Math.sqrt(Math.max(0, nSmtExprs)).toLong
+  lazy val weight: Long = nCells + nConsts + Math.sqrt(Math.max(0, nSmtExprs).toDouble).toLong
 
   def delta(earlier: SolverContextMetrics): SolverContextMetrics = {
     new SolverContextMetrics(nCells - earlier.nCells, nConsts - earlier.nConsts, nSmtExprs - earlier.nSmtExprs)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -418,13 +418,13 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
       maxCellIdPerContext = maxCellIdPerContext.tail
       level -= 1
       // clean the caches
-      cellSorts.retain((_, value) => value._2 <= level)
-      funDecls.retain((_, value) => value._2 <= level)
+      cellSorts.filterInPlace((_, value) => value._2 <= level)
+      funDecls.filterInPlace((_, value) => value._2 <= level)
       cellCache.foreach(entry => cellCache += entry.copy(_2 = entry._2.filter(_._3 <= level)))
-      cellCache.retain((_, value) => value.nonEmpty)
-      inCache.retain((_, value) => value._2 <= level)
-      constantArrayCache.retain((_, value) => value._2 <= level)
-      cellDefaults.retain((_, value) => value._2 <= level)
+      cellCache.filterInPlace((_, value) => value.nonEmpty)
+      inCache.filterInPlace((_, value) => value._2 <= level)
+      constantArrayCache.filterInPlace((_, value) => value._2 <= level)
+      cellDefaults.filterInPlace((_, value) => value._2 <= level)
     }
   }
 
@@ -436,13 +436,13 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
       maxCellIdPerContext = maxCellIdPerContext.drop(n)
       level -= n
       // clean the caches
-      cellSorts.retain((_, value) => value._2 <= level)
-      funDecls.retain((_, value) => value._2 <= level)
+      cellSorts.filterInPlace((_, value) => value._2 <= level)
+      funDecls.filterInPlace((_, value) => value._2 <= level)
       cellCache.foreach(entry => cellCache += entry.copy(_2 = entry._2.filter(_._3 <= level)))
-      cellCache.retain((_, value) => value.nonEmpty)
-      inCache.retain((_, value) => value._2 <= level)
-      constantArrayCache.retain((_, value) => value._2 <= level)
-      cellDefaults.retain((_, value) => value._2 <= level)
+      cellCache.filterInPlace((_, value) => value.nonEmpty)
+      inCache.filterInPlace((_, value) => value._2 <= level)
+      constantArrayCache.filterInPlace((_, value) => value._2 <= level)
+      cellDefaults.filterInPlace((_, value) => value._2 <= level)
     }
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/FilteredTransitionExecutor.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/FilteredTransitionExecutor.scala
@@ -18,8 +18,8 @@ import at.forsyte.apalache.tla.lir.TlaEx
 class FilteredTransitionExecutor[SnapshotT](stepFilter: String, invFilter: String, trex: TransitionExecutor[SnapshotT])
     extends TransitionExecutor[SnapshotT] {
 
-  private val stepRe = stepFilter.r()
-  private val invRe = invFilter.r()
+  private val stepRe = stepFilter.r
+  private val invRe = invFilter.r
 
   /**
    * Translate a transition into SMT and save it under the given number. This method returns false, if the transition

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.{
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler
 
 import scala.collection.immutable.SortedMap
+import scala.math.Ordering.Implicits._
 
 package object types {
   // @Jure 29.10.2017: Change name, too ambiguous, especially with TLA Types in the other package -- Jure, 29.10.17
@@ -27,6 +28,11 @@ package object types {
      */
     def comparableWith(other: CellT): Boolean = {
       this.unify(other).nonEmpty
+    }
+
+    // Prive an odering for CellT so we can build SortedMaps
+    implicit val cellTOrdering = new Ordering[CellT] {
+      def compare(a: CellT, b: CellT) = a.signature.compare(b.signature)
     }
 
     /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
@@ -181,7 +181,7 @@ package object types {
         case SeqT1(elem)       => SeqT(fromType1(elem))
         case FunT1(arg, res)   => FunT(FinSetT(fromType1(arg)), fromType1(res))
         case TupT1(elems @ _*) => TupleT(elems.map(fromType1))
-        case RecT1(fieldTypes) => RecordT(fieldTypes.mapValues(fromType1))
+        case RecT1(fieldTypes) => RecordT(fieldTypes.view.mapValues(fromType1).toMap.to(SortedMap))
 
         case SparseTupT1(_) =>
           // sparse tuple can only appear in operator arguments, which must have been inlined
@@ -436,7 +436,7 @@ package object types {
       s"Record[${fields.map { case (k, v) => "\"" + k + "\" -> " + v }.mkString(", ")}]"
 
     override def toTlaType1: TlaType1 = {
-      RecT1(fields.mapValues(_.toTlaType1))
+      RecT1(fields.view.mapValues(_.toTlaType1).toMap.to(SortedMap))
     }
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
@@ -14,7 +14,7 @@ trait TestSymbStateRewriterBool extends RewriterBase with TestingPredefs {
   private var xyBinding = Binding()
   private val boolTypes = Map("b" -> BoolT1(), "i" -> IntT1(), "I" -> SetT1(IntT1()))
 
-  def prepareArena() {
+  def prepareArena(): Unit = {
     arena = arena.appendCell(BoolT()) // we have to give bindings to the type finder
     x = arena.topCell
     arena = arena.appendCell(BoolT()) // we have to give bindings to the type finder

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -103,7 +103,7 @@ object OutputManager extends LazyLogging {
   }
 
   // Sets the customRunDir, if one is given, otherwise is noop
-  private def setCustomRunDir(fopt: Option[File]) {
+  private def setCustomRunDir(fopt: Option[File]): Unit = {
     fopt.foreach { f =>
       val dir = f.toPath().toAbsolutePath()
       customRunDirOpt = Some(dir)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationArg.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationArg.scala
@@ -30,7 +30,7 @@ object AnnotationArg {
  *   the text of the string argument.
  */
 case class AnnotationStr(text: String) extends AnnotationArg {
-  override def toString: String = '"' + text + '"'
+  override def toString: String = s"\"${text}\""
 }
 
 /**

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
@@ -93,8 +93,8 @@ class AnnotationParser extends Parsers {
 object AnnotationParser {
   def parse(reader: Reader): Either[String, Annotation] = {
     for {
-      tokens <- AnnotationLexer(reader).right
-      ast <- new AnnotationParser()(tokens).right
+      tokens <- AnnotationLexer(reader)
+      ast <- new AnnotationParser()(tokens)
     } yield ast
   }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
@@ -43,9 +43,9 @@ object AnnotationLexer extends RegexParsers {
         leftParen | rightParen | comma | dot | boolean | atIdentifier | identifier | number | string | inline_string | unexpected_char
     ) ///
 
-  def skip: Parser[Unit] = rep(whiteSpace) ^^^ Unit
+  def skip: Parser[Unit] = rep(whiteSpace) ^^^ ()
 
-  def linefeed: Parser[Unit] = "\n" ^^^ Unit
+  def linefeed: Parser[Unit] = "\n" ^^^ ()
 
   private def identifier: Parser[IDENT] = {
     "[a-zA-Z_][a-zA-Z0-9_]*".r ^^ { name => IDENT(name) }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/AnnotationLexer.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.io.annotations.parser
 import java.io.Reader
 import scala.util.matching.Regex
 import scala.util.parsing.combinator.RegexParsers
+import at.forsyte.apalache.io.annotations.AnnotationParserError
 
 /**
  * <p>A lexer for annotations that are hidden in TLA+ comments. Since the annotations are hidden in comments, it is
@@ -34,6 +35,9 @@ object AnnotationLexer extends RegexParsers {
     case NoSuccess(msg, _) =>
       // we ignore the position, as it is the position that is relative to a comment
       Left(msg)
+
+    case Error(msg, _)   => throw new AnnotationParserError(msg)
+    case Failure(msg, _) => throw new AnnotationParserError(msg)
   }
 
   def program: Parser[Seq[AnnotationToken]] = phrase(rep1(token))

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/exceptions.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/exceptions.scala
@@ -8,3 +8,13 @@ package at.forsyte.apalache.io
  *   the error message
  */
 class ConfigurationError(message: String) extends Exception(message)
+
+/**
+ * An exception that should be thrown when something pretty printing fails
+ *
+ * This is considered a bug and should result in a stack trace.
+ *
+ * @param message
+ *   the error message
+ */
+class PrettyPrinterError(message: String) extends Exception(message)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDecoder.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDecoder.scala
@@ -12,5 +12,5 @@ trait JsonDecoder[T <: JsonRepresentation] {
   def asTlaModule(moduleJson: T): TlaModule
   def asTlaDecl(declJson: T): TlaDecl
   def asTlaEx(exJson: T): TlaEx
-  def fromRoot(rootJson: T): Traversable[TlaModule]
+  def fromRoot(rootJson: T): Iterable[TlaModule]
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonEncoder.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonEncoder.scala
@@ -11,5 +11,5 @@ trait JsonEncoder[T <: JsonRepresentation] {
   def apply(ex: TlaEx): T
   def apply(decl: TlaDecl): T
   def apply(module: TlaModule): T
-  def makeRoot(modules: Traversable[TlaModule]): T
+  def makeRoot(modules: Iterable[TlaModule]): T
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonFactory.scala
@@ -10,5 +10,5 @@ trait JsonFactory[T <: JsonRepresentation] {
   def fromInt(int: Int): T
   def fromStr(str: String): T
   def fromBool(bool: Boolean): T
-  def fromTraversable(trv: Traversable[T]): T
+  def fromIterable(trv: Iterable[T]): T
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/ScalaFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/ScalaFactory.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.io.json
 
 /**
  * Generates Scala primitives/collections from JSON primitives/arrays. Inverse to JsonFactory, i.e. as{X}(
- * JsonFactory.from{x}(v: X) ) == v, for X = Int/Str/Bool/Traversable
+ * JsonFactory.from{x}(v: X) ) == v, for X = Int/Str/Bool/Iterable
  * @tparam T
  *   Any class extending JsonRepresentation
  */

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/TlaToJson.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/TlaToJson.scala
@@ -127,7 +127,7 @@ class TlaToJson[T <: JsonRepresentation](
             typeFieldName -> typeTagPrinter(ex.typeTag),
             kindFieldName -> "OperEx",
             "oper" -> oper.name,
-            "args" -> factory.fromTraversable(argJsons),
+            "args" -> factory.fromIterable(argJsons),
         )
       case LetInEx(body, decls @ _*) =>
         val bodyJson = apply(body)
@@ -136,7 +136,7 @@ class TlaToJson[T <: JsonRepresentation](
             typeFieldName -> typeTagPrinter(ex.typeTag),
             kindFieldName -> "LetInEx",
             "body" -> bodyJson,
-            "decls" -> factory.fromTraversable(declJsons),
+            "decls" -> factory.fromIterable(declJsons),
         )
 
       case NullEx =>
@@ -183,7 +183,7 @@ class TlaToJson[T <: JsonRepresentation](
             typeFieldName -> typeTagPrinter(decl.typeTag),
             kindFieldName -> "TlaOperDecl",
             "name" -> name,
-            "formalParams" -> factory.fromTraversable(paramsJsons),
+            "formalParams" -> factory.fromIterable(paramsJsons),
             "isRecursive" -> decl.isRecursive,
             "body" -> bodyJson,
         )
@@ -203,17 +203,17 @@ class TlaToJson[T <: JsonRepresentation](
     factory.mkObj(
         kindFieldName -> "TlaModule",
         "name" -> module.name,
-        "declarations" -> factory.fromTraversable(declJsons),
+        "declarations" -> factory.fromIterable(declJsons),
     )
   }
 
-  override def makeRoot(modules: Traversable[TlaModule]): T = {
+  override def makeRoot(modules: Iterable[TlaModule]): T = {
     val moduleJsons = modules.map(apply)
     factory.mkObj(
         "name" -> "ApalacheIR",
         versionFieldName -> JsonVersion.current,
         "description" -> "https://apalache.informal.systems/docs/adr/005adr-json.html",
-        "modules" -> factory.fromTraversable(moduleJsons),
+        "modules" -> factory.fromIterable(moduleJsons),
     )
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/UJsonFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/UJsonFactory.scala
@@ -27,5 +27,5 @@ object UJsonFactory extends JsonFactory[UJsonRep] {
 
   override def fromBool(bool: Boolean): UJsonRep = Value.JsonableBoolean(bool)
 
-  override def fromTraversable(trv: Traversable[UJsonRep]): UJsonRep = Value.JsonableSeq(trv)
+  override def fromIterable(trv: Iterable[UJsonRep]): UJsonRep = Value.JsonableSeq(trv)
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/UJsonScalaFactory.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/UJsonScalaFactory.scala
@@ -20,7 +20,10 @@ object UJsonScalaFactory extends ScalaFactory[UJsonRep] {
   }
 
   override def asSeq(json: UJsonRep): Seq[UJsonRep] =
-    json.value.arrOpt.map { _.map(UJsonRep) }.getOrElse {
-      throw new JsonDeserializationError("Not an array.")
-    }
+    json.value.arrOpt
+      .map { _.map(UJsonRep) }
+      .getOrElse {
+        throw new JsonDeserializationError("Not an array.")
+      }
+      .toSeq
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -9,6 +9,7 @@ import org.bitbucket.inkytonik.kiama.output.PrettyPrinter
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 import scala.collection.immutable.{HashMap, HashSet}
+import at.forsyte.apalache.io.PrettyPrinterError
 
 /**
  * <p>A pretty printer to a file that formats a TLA+ expression to a given text width (normally, 80 characters). As
@@ -462,6 +463,8 @@ class PrettyWriter(
 
         group(ssep(decls.map(eachDecl).toList, line) <>
           line <> toDoc((0, 0), body))
+
+      case expr => throw new PrettyPrinterError(s"PrettyPrinter failed toDoc conversion on expression ${expr}")
     }
   }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
@@ -46,13 +46,13 @@ object TlcConfigLexer extends RegexParsers {
     ) ///
 
   // it is important that linefeed is not a whiteSpace, as otherwise singleComment consumes the whole input!
-  def skip: Parser[Unit] = rep(whiteSpace | singleComment | multiComment | linefeed) ^^^ Unit
+  def skip: Parser[Unit] = rep(whiteSpace | singleComment | multiComment | linefeed) ^^^ ()
 
-  def linefeed: Parser[Unit] = "\n" ^^^ Unit
+  def linefeed: Parser[Unit] = "\n" ^^^ ()
 
-  def singleComment: Parser[Unit] = "\\*" ~ rep(not("\n") ~ ".".r) ^^^ Unit
+  def singleComment: Parser[Unit] = "\\*" ~ rep(not("\n") ~ ".".r) ^^^ ()
 
-  def multiComment: Parser[Unit] = "(*" ~ rep(not("*)") ~ "(?s).".r) ~ "*)" ^^^ Unit
+  def multiComment: Parser[Unit] = "(*" ~ rep(not("*)") ~ "(?s).".r) ~ "*)" ^^^ ()
 
   private def identifier: Parser[IDENT] = {
     "[a-zA-Z_][a-zA-Z0-9_]*".r ^^ { name => IDENT(name) }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/tlc/config/TlcConfigLexer.scala
@@ -32,6 +32,8 @@ object TlcConfigLexer extends RegexParsers {
   def apply(reader: Reader): List[TlcConfigToken] = parseAll(program, reader) match {
     case Success(result, _)   => result
     case NoSuccess(msg, next) => throw new TlcConfigParseError(msg, next.pos)
+    case Error(msg, next)     => throw new TlcConfigParseError(msg, next.pos)
+    case Failure(msg, next)   => throw new TlcConfigParseError(msg, next.pos)
   }
 
   def program: Parser[List[TlcConfigToken]] = skip ~> rep(token <~ skip) <~ eof

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
@@ -25,6 +25,8 @@ private[parser] object Type1Lexer extends RegexParsers {
   def apply(reader: Reader): List[Type1Token] = parseAll(expr, reader) match {
     case Success(result, _)   => result
     case NoSuccess(msg, next) => throw new Type1ParseError(msg, next.pos)
+    case Error(msg, next)     => throw new Type1ParseError(msg, next.pos)
+    case Failure(msg, next)   => throw new Type1ParseError(msg, next.pos)
   }
 
   def expr: Parser[List[Type1Token]] = skip ~> rep(token <~ skip) <~ eof

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
@@ -40,11 +40,11 @@ private[parser] object Type1Lexer extends RegexParsers {
     ) ///
 
   // it is important that linefeed is not in whiteSpace, as otherwise singleComment consumes the whole input!
-  def skip: Parser[Unit] = rep(whiteSpace | singleComment | linefeed) ^^^ Unit
+  def skip: Parser[Unit] = rep(whiteSpace | singleComment | linefeed) ^^^ ()
 
-  def linefeed: Parser[Unit] = "\n" ^^^ Unit
+  def linefeed: Parser[Unit] = "\n" ^^^ ()
 
-  def singleComment: Parser[Unit] = "//" ~ rep(not("\n") ~ ".".r) ^^^ Unit
+  def singleComment: Parser[Unit] = "//" ~ rep(not("\n") ~ ".".r) ^^^ ()
 
   private def identifier: Parser[IDENT] = {
     "[A-Za-z_][A-Za-z0-9_]*".r ^^ { name => IDENT(name) }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
@@ -168,7 +168,7 @@ private[parser] case class FIELD_NO(no: Int) extends Type1Token {
  *   the string contents
  */
 private[parser] case class STR_LITERAL(text: String) extends Type1Token {
-  override def toString: String = '"' + text + '"'
+  override def toString: String = s"\"${text}\""
 }
 
 /**

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -7,7 +7,8 @@ import at.forsyte.apalache.tla.lir.values.{TlaDecimal, TlaInt, TlaStr}
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
-import tla2sany.semantic._
+// Prevent shadowing our Context trait
+import tla2sany.semantic.{Context => _, _}
 
 import scala.collection.JavaConverters._
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -10,7 +10,7 @@ import com.typesafe.scalalogging.LazyLogging
 // Prevent shadowing our Context trait
 import tla2sany.semantic.{Context => _, _}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Translate a TLA+ expression.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ModuleTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ModuleTranslator.scala
@@ -6,7 +6,7 @@ import at.forsyte.apalache.tla.lir._
 import com.typesafe.scalalogging.LazyLogging
 import tla2sany.semantic.{InstanceNode, ModuleNode, OpDefNode}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import UntypedPredefs._
 
 /**

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/OpApplTranslator.scala
@@ -7,7 +7,8 @@ import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaStrSet}
 import at.forsyte.apalache.tla.lir.values.TlaBool
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
-import tla2sany.semantic._
+// Prevent shadowing our Context trait
+import tla2sany.semantic.{Context => _, _}
 
 /**
  * Translate operator applications. As many TLA+ expressions are defined via operators, this class is quite complex.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
@@ -6,7 +6,8 @@ import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaTempOper}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.typesafe.scalalogging.LazyLogging
-import tla2sany.semantic._
+// Prevent shadowing our Context trait
+import tla2sany.semantic.{Context => _, _}
 
 /**
  * Translate a substitution, that is the part that goes after WITH in INSTANCE Foo WITH x <- e1, y <- e2. The module

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SubstTranslator.scala
@@ -126,7 +126,7 @@ class SubstTranslator(
       s.getOp.getName.toString -> replacement
     }
 
-    Map(substInNode.getSubsts.map(eachSubst): _*)
+    Map(substInNode.getSubsts.map(eachSubst).toIndexedSeq: _*)
   }
 }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1517,6 +1517,7 @@ class TestSanyImporter extends SanyImporterTestBase {
             assert(
                 OperEx(TlaOper.apply, NameEx("f"), NameEx("a")) == zDecl.body
             )
+          case _ => fail(s"invalid result for zDecl: $zDecl")
         }
         assert(sourceStore.contains(zDecl.body.ID)) // and source file information has been saved
         assert(0 == xDecl.formalParams.length)

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -349,9 +349,9 @@ class TestSanyImporter extends SanyImporterTestBase {
         |LOCAL Foo(X) ==
         |  LET A == X IN
         |  A
-        | 
+        |
         |User(X) ==
-        |  LET A == 1 IN  
+        |  LET A == 1 IN
         |  Foo(X)
         |================================
       """.stripMargin

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
@@ -58,7 +58,7 @@ class Inliner(
       operDeclFilter: DeclFilter = negateFilter(nonNullaryFilter),
       scopeFilter: DeclFilter = nonNullaryFilter,
     )(initialScope: Scope,
-      decls: Traversable[TlaDecl]): (Scope, List[TlaDecl]) =
+      decls: Iterable[TlaDecl]): (Scope, List[TlaDecl]) =
     decls.foldLeft((initialScope, List.empty[TlaDecl])) { case ((scope, decls), decl) =>
       decl match {
         case opDecl: TlaOperDecl =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/IntegerQuantificationOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/IntegerQuantificationOptimizer.scala
@@ -69,6 +69,8 @@ class IntegerQuantificationOptimizer(tracker: TransformationTracker) extends Tla
         case ValEx(TlaNatSet) => OperEx(outerPred, ge0(name), pred)(boolTag)
         case OperEx(TlaArithOper.dotdot, lowerBound, upperBound) =>
           OperEx(outerPred, inRange(name, lowerBound, upperBound), pred)(boolTag)
+        case ex =>
+          throw new IllegalArgumentException(s"Invalid expression given to IntegerQuantificationOptimizer ${ex}")
       }
       // nameEx can be copied, and because this is the only place we do so, it will still have a unique ID
       OperEx(unboundedOper, nameEx, newPred)(boolTag)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
@@ -20,7 +20,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
   private var annotationStore: AnnotationStore = _
   private var sanyImporter: SanyImporter = _
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     sourceStore = new SourceStore()
     annotationStore = createAnnotationStore()
     sanyImporter = new SanyImporter(sourceStore, annotationStore)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -32,7 +32,7 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
 
   private def nonemptySetGen(k: Int): Gen[TlaEx] = for {
     n <- Gen.choose(1, k)
-    s <- Gen.pick(n, 0 until k)
+    s <- Gen.pick(n, 0 until k).map(_.toSeq) // Converting generated Seq[Int] to an immutable Seq
     literalNonEmpty = tla.enumSet(s.map { i => tla.int(i).as(IntT1()) }: _*).as(SetT1(IntT1()))
     symbolic = tla.name("S").as(SetT1(IntT1()))
     v <- Gen.oneOf(literalNonEmpty, symbolic)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
@@ -24,7 +24,7 @@ class TestTlcConfigImporter extends AnyFunSuite with BeforeAndAfterEach {
   private var typeChecker: TypeCheckerTool = _
   private val layout80 = TextLayout().copy(textWidth = 80)
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     sourceStore = new SourceStore()
     annotationStore = createAnnotationStore()
     sanyImporter = new SanyImporter(sourceStore, annotationStore)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
@@ -262,7 +262,8 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
         // translate the binders in the lambda expression, so we can quickly propagate the types of the parameters
         val preCtx =
           new TypeContext((ctx.types + (name -> operScheme))
-                .mapValues(p => p.copy(approxSolution.subRec(p.principalType))))
+                .mapValues(p => p.copy(approxSolution.subRec(p.principalType)))
+                .toMap)
         val extCtx = translateBinders(preCtx, letInSolver, binders)
         val annotationParams = operScheme.principalType.asInstanceOf[OperT1].args
         annotationParams.zip(binders.map { case (pname, _) => (pname, extCtx(pname.name).principalType) }).foreach {

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
@@ -261,7 +261,7 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
 
         // translate the binders in the lambda expression, so we can quickly propagate the types of the parameters
         val preCtx =
-          new TypeContext((ctx.types + (name -> operScheme))
+          new TypeContext((ctx.types + (name -> operScheme)).view
                 .mapValues(p => p.copy(approxSolution.subRec(p.principalType)))
                 .toMap)
         val extCtx = translateBinders(preCtx, letInSolver, binders)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/Substitution.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/Substitution.scala
@@ -55,13 +55,13 @@ class Substitution(val mapping: Map[EqClass, TlaType1]) {
 
       case SparseTupT1(fieldTypes) =>
         val ntypesAndChanged = fieldTypes.map(kv => (kv._1, sub(kv._2)))
-        val ntypes = ntypesAndChanged.mapValues(_._1).toMap.to(SortedMap)
+        val ntypes = ntypesAndChanged.view.mapValues(_._1).toMap.to(SortedMap)
         val isChanged = ntypesAndChanged.exists(_._2._2)
         (SparseTupT1(ntypes), isChanged)
 
       case RecT1(fieldTypes) =>
         val ntypesAndChanged = fieldTypes.map(kv => (kv._1, sub(kv._2)))
-        val ntypes = ntypesAndChanged.mapValues(_._1).toMap.to(SortedMap)
+        val ntypes = ntypesAndChanged.view.mapValues(_._1).toMap.to(SortedMap)
         val isChanged = ntypesAndChanged.exists(_._2._2)
         (RecT1(ntypes), isChanged)
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/Substitution.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/Substitution.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.{
   TupT1, VarT1, VariantT1,
 }
 import at.forsyte.apalache.tla.typecheck.etc.Substitution.SUB_LIMIT
+import scala.collection.immutable.SortedMap
 
 /**
  * A substitution from type variables to types.
@@ -54,13 +55,13 @@ class Substitution(val mapping: Map[EqClass, TlaType1]) {
 
       case SparseTupT1(fieldTypes) =>
         val ntypesAndChanged = fieldTypes.map(kv => (kv._1, sub(kv._2)))
-        val ntypes = ntypesAndChanged.mapValues(_._1)
+        val ntypes = ntypesAndChanged.mapValues(_._1).toMap.to(SortedMap)
         val isChanged = ntypesAndChanged.exists(_._2._2)
         (SparseTupT1(ntypes), isChanged)
 
       case RecT1(fieldTypes) =>
         val ntypesAndChanged = fieldTypes.map(kv => (kv._1, sub(kv._2)))
-        val ntypes = ntypesAndChanged.mapValues(_._1)
+        val ntypes = ntypesAndChanged.mapValues(_._1).toMap.to(SortedMap)
         val isChanged = ntypesAndChanged.exists(_._2._2)
         (RecT1(ntypes), isChanged)
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
@@ -239,6 +239,12 @@ class TypeUnifier(varPool: TypeVarPool) {
       rfields: SortedMap[String, TlaType1],
       lvar: Option[VarT1],
       rvar: Option[VarT1]): Option[RowT1] = {
+
+    // Allows ordering on Option types etc.
+    import scala.math.Ordering.Implicits._
+    // Allows ordering on TlaType1, by converting them to strings
+    implicit val tlaType1Ordering = Ordering.by[TlaType1, String](_.toString)
+
     // assuming that a type is either a row, or a variable, make it a row type
     def asRow(rowOpt: Option[TlaType1]): Option[RowT1] = rowOpt.map {
       case r: RowT1 => r

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
@@ -297,8 +297,8 @@ class TypeUnifier(varPool: TypeVarPool) {
         }
       } else {
         // the general case: some fields are shared
-        val lfieldsUniq = lfields.filter(p => !sharedFieldNames.keySet.contains(p._1))
-        val rfieldsUniq = rfields.filter(p => !sharedFieldNames.keySet.contains(p._1))
+        val lfieldsUniq = lfields.filter(p => !sharedFieldNames.contains(p._1))
+        val rfieldsUniq = rfields.filter(p => !sharedFieldNames.contains(p._1))
         // Unify the disjoint fields and tail variables, see the above case
         compute(RowT1(lfieldsUniq, lvar), RowT1(rfieldsUniq, rvar)) match {
           case Some(RowT1(disjointFields, tailVar)) =>

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
@@ -65,7 +65,7 @@ class TypeUnifier(varPool: TypeVarPool) {
       compute(lhs, rhs).flatMap { unifiedType =>
         // use only the representative variables of every equivalence class
         val canonical = mkCanonicalSub
-        val substitution = new Substitution(solution.mapValues(tt => canonical.sub(tt)._1).toMap)
+        val substitution = new Substitution(solution.view.mapValues(tt => canonical.sub(tt)._1).toMap)
         Some((substitution, substitution.sub(unifiedType)._1))
       }
     // help GC to clean up later

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeUnifier.scala
@@ -65,7 +65,7 @@ class TypeUnifier(varPool: TypeVarPool) {
       compute(lhs, rhs).flatMap { unifiedType =>
         // use only the representative variables of every equivalence class
         val canonical = mkCanonicalSub
-        val substitution = new Substitution(solution.mapValues { tt => canonical.sub(tt)._1 })
+        val substitution = new Substitution(solution.mapValues(tt => canonical.sub(tt)._1).toMap)
         Some((substitution, substitution.sub(unifiedType)._1))
       }
     // help GC to clean up later

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/TypeRewriter.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/TypeRewriter.scala
@@ -58,6 +58,9 @@ class TypeRewriter(tracker: TransformationTracker, defaultTag: UID => TypeTag)(t
 
       case ex @ LetInEx(body, defs @ _*) =>
         LetInEx(this(body), defs.map(applyToOperDecl): _*)(getOrDefault(ex.ID))
+
+      case NullEx =>
+        throw new IllegalArgumentException(s"Applied TypeRewriter to NullEx")
     }
 
     transform(e)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
@@ -1,14 +1,11 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
-import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.io.typecheck.parser.{DefaultType1Parser, Type1Parser}
 import at.forsyte.apalache.tla.imp.SanyImporter
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.typecheck.{TypeCheckerListener, TypeCheckerTool}
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.io.json.impl.{DefaultTagReader, TlaToUJson, UJsonToTla}
 import at.forsyte.apalache.io.lir.TlaType1PrinterPredefs
-import at.forsyte.apalache.tla.lir.{TlaType1, Typed, TypingException, UID}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.{TlaType1, Typed, TypingException, UID}
 import at.forsyte.apalache.tla.typecheck.{TypeCheckerListener, TypeCheckerTool}

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
@@ -37,7 +37,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   private val megaSpec = "MegaSpec1"
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     sourceStore = new SourceStore()
     annotationStore = createAnnotationStore()
     sanyImporter = new SanyImporter(sourceStore, annotationStore)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/aux/package.scala
@@ -69,7 +69,7 @@ package object aux {
    * We may need to split an ordered collection of OperDecls (from a LET-IN operator), into segments of 0 arity and >0
    * ariry operators
    */
-  def collectSegments(decls: Traversable[TlaOperDecl]): List[List[TlaOperDecl]] = decls match {
+  def collectSegments(decls: Iterable[TlaOperDecl]): List[List[TlaOperDecl]] = decls match {
     case d if d.isEmpty => List.empty
     case head :: tail =>
       val headPosArity = hasPositiveArity(head)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -17,7 +17,7 @@ object TlaFunOper {
    * <p>Although this constructor could be used for functions in general, it is used only for the records in TLA+. That
    * is why we call it "REC_CTOR".</p>
    */
-  object enum extends TlaFunOper {
+  object `enum` extends TlaFunOper {
     override def arity: OperArity = new OperArity(k => k >= 2 && k % 2 == 0)
 
     override val name: String = "RECORD"

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourcePosition.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourcePosition.scala
@@ -17,9 +17,7 @@ class SourcePosition(val offset: Int) {
   /** Get the column, starting with 1 and up to SourcePosition.MAX_WIDTH */
   def column: Int = 1 + offset % SourcePosition.MAX_WIDTH
 
-  override def toString: String = {
-    line + ":" + column
-  }
+  override def toString: String = s"${line}:${column}"
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[SourcePosition]
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourceRegion.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourceRegion.scala
@@ -27,9 +27,7 @@ class SourceRegion(val start: SourcePosition, val end: SourcePosition) {
     maxStart <= minEnd
   }
 
-  override def toString: String = {
-    start + "-" + end
-  }
+  override def toString: String = s"${start}-${end}"
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[SourceRegion]
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/storage/BodyMapFactory.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/storage/BodyMapFactory.scala
@@ -17,6 +17,6 @@ object BodyMapFactory {
       case _ => initial
     }
 
-  def makeFromDecls(decls: Traversable[TlaDecl], initial: BodyMap = newMap): BodyMap =
+  def makeFromDecls(decls: Iterable[TlaDecl], initial: BodyMap = newMap): BodyMap =
     decls.foldLeft(initial) { case (db, decl) => makeFromDecl(decl, db) }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ContextualLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/ContextualLanguagePred.scala
@@ -18,13 +18,13 @@ abstract class ContextualLanguagePred extends LanguagePred {
     isOkInContext(Set(), expr)
   }
 
-  protected def allArgsOk(letDefs: Set[String], args: Traversable[TlaEx]): PredResult =
+  protected def allArgsOk(letDefs: Set[String], args: Iterable[TlaEx]): PredResult =
     args.foldLeft[PredResult](PredResultOk()) { case (r, arg) =>
       r.and(isOkInContext(letDefs, arg))
     }
 
   // Auxiliary method for checking LET-INs
-  protected def eachDefRec(ctx: Set[String], ds: Traversable[TlaOperDecl]): PredResult =
+  protected def eachDefRec(ctx: Set[String], ds: Iterable[TlaOperDecl]): PredResult =
     ds.foldLeft[(PredResult, Set[String])]((PredResultOk(), ctx)) {
       case ((partialRes, partialCtx), TlaOperDecl(name, _, body)) =>
         (

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/IncrementalRenaming.scala
@@ -102,7 +102,7 @@ object IncrementalRenaming {
   /**
    * Computes then merges maps for all declarations.
    */
-  def nameCounterMapFromDecls(takeMax: Boolean)(decls: Traversable[TlaDecl]): counterMapType =
+  def nameCounterMapFromDecls(takeMax: Boolean)(decls: Iterable[TlaDecl]): counterMapType =
     decls.map(nameCounterMapFromDecl(takeMax)).foldLeft(Map.empty[String, Int]) {
       mergeNameCounters(takeMax)
     }
@@ -298,7 +298,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
   }
 
   // lifted to decls
-  private def shiftCountersDs(offsets: counterMapType): Traversable[TlaDecl] => Traversable[TlaDecl] = {
+  private def shiftCountersDs(offsets: counterMapType): Iterable[TlaDecl] => Iterable[TlaDecl] = {
     _.map(shiftCountersD(offsets))
   }
 
@@ -318,7 +318,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
     shiftCounters(offsetMap)(ex)
   }
 
-  def normalizeExs(exs: Traversable[TlaEx]): Traversable[TlaEx] = {
+  def normalizeExs(exs: Iterable[TlaEx]): Iterable[TlaEx] = {
     val offsetMap = exs
       .map(
           nameCounterMapFromEx(takeMax = false)
@@ -344,7 +344,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
   }
 
   // lifted to decls
-  def normalizeDs(decls: Traversable[TlaDecl]): Traversable[TlaDecl] = {
+  def normalizeDs(decls: Iterable[TlaDecl]): Iterable[TlaDecl] = {
     val offsetMap = nameCounterMapFromDecls(takeMax = false)(decls)
       .withFilter {
         _._2 > 1
@@ -371,7 +371,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
   }
 
   // Lifted to decls
-  private def syncFromDs: Traversable[TlaDecl] => Unit = _.foreach(syncFromD)
+  private def syncFromDs: Iterable[TlaDecl] => Unit = _.foreach(syncFromD)
 
   /**
    * Performs the following steps, in order:
@@ -384,7 +384,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
     normalize(apply(ex))
   }
 
-  def syncAndNormalizeExs(exs: Traversable[TlaEx]): Traversable[TlaEx] = {
+  def syncAndNormalizeExs(exs: Iterable[TlaEx]): Iterable[TlaEx] = {
     exs.foreach(syncFrom)
     normalizeExs(exs.map {
       apply
@@ -398,7 +398,7 @@ class IncrementalRenaming @Inject() (tracker: TransformationTracker) extends Tla
   }
 
   // Lifted to decls
-  def syncAndNormalizeDs(ds: Traversable[TlaDecl]): Traversable[TlaDecl] = {
+  def syncAndNormalizeDs(ds: Iterable[TlaDecl]): Iterable[TlaDecl] = {
     syncFromDs(ds)
     normalizeDs(ds.map(d => tracker.fromExToDeclTransformation(this)(d)))
   }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExpr.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestTlaExpr.scala
@@ -51,6 +51,7 @@ class TestTlaExpr extends AnyFunSuite {
       case OperEx(TlaBoolOper.and, NameEx(i: String), NameEx(j: String)) =>
         assert(i == "x")
         assert(j == "y")
+      case invalid => fail(s"invalid result when constructing conjunction: $invalid")
     }
   }
 


### PR DESCRIPTION
Closes #1509

I thought I'd see how difficult it would be upgrade, and turns out it was
relatively easy to fix the compiler errors.

The remaining compiler issues are warnings.

Opening this PR so we can see how it fairs on the tests.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality