### PR TITLE
Fix tutorials index on docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 # Tutorials
 
+- [Overview](./tutorials/index.md)
 - [Entry-level Model Checker Tutorial](./tutorials/entry-tutorial.md)
 - [Type Checker Tutorial](./tutorials/snowcat-tutorial.md)
 - [Checking Pluscal specifications](./tutorials/pluscal-tutorial.md)

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -2,4 +2,6 @@
 
 1. [Entry-level Tutorial on the Model Checker](./entry-tutorial.md)
 1. [Tutorial on the Type Checker Snowcat](./snowcat-tutorial.md)
+1. [Checking Pluscal specifications](./pluscal-tutorial.md)
+1. [Symbolic Model Checking](./symbmc.md)
 


### PR DESCRIPTION
Hello :octocat: 

This link currently does not work: [https://apalache.informal.systems/docs/tutorials/index.html](https://www.google.com/url?q=https://apalache.informal.systems/docs/tutorials/index.html&sa=D&source=docs&ust=1647614328718738&usg=AOvVaw3LIEqwpST0_p703Xk0NjPn). This fixes the problem and update the index context to list our newest tutorials.