### PR TITLE
add __ApalacheSeqCapacity and __NotSupportedByModelChecker

### DIFF
--- a/src/tla/__apalache_folds.tla
+++ b/src/tla/__apalache_folds.tla
@@ -5,7 +5,11 @@
  *)
 
 (**
- * A copy of Apalache!FoldSet.
+ * A copy of Apalache!FoldSet, which should be used only in Apalache rewirings.
+ *
+ * The folding operator, used to implement computation over a set.
+ * Apalache implements a more efficient encoding than the one below.
+ * (from the community modules).
  *
  * @type: ((a, b) => a, a, Set(b)) => a;
  *)
@@ -14,7 +18,11 @@ __ApalacheFoldSet(Op(_, _), v, S) ==
     v
 
 (**
- * A copy of Apalache!FoldSeq.
+ * A copy of Apalache!FoldSeq, which should be used only in Apalache rewirings.
+ *
+ * The folding operator, used to implement computation over a sequence.
+ * Apalache implements a more efficient encoding than the one below.
+ * (from the community modules).
  *
  * @type: ((a, b) => a, a, Seq(b)) => a;
  *)

--- a/src/tla/__apalache_internal.tla
+++ b/src/tla/__apalache_internal.tla
@@ -11,9 +11,6 @@
 (**
  * Return the capacity of a sequence (a static upper bound on its length).
  *
- * The folding operator, used to implement computation over a set.
- * Apalache implements a more efficient encoding than the one below.
- * (from the community modules).
  *
  * @type: Seq(a) => Int;
  *)

--- a/src/tla/__apalache_internal.tla
+++ b/src/tla/__apalache_internal.tla
@@ -1,0 +1,37 @@
+------------------- MODULE __apalache_internal --------------------------------
+(*
+ * This is an internal module that exposes Apalache operators that are
+ * needed for rewiring the standard modules and the community modules.
+ *
+ * DO NOT USE THIS MODULE IN YOUR SPECIFICATIONS.
+ *
+ * We may change this module as much as we need and as often as we like.
+ *)
+
+(**
+ * Return the capacity of a sequence (a static upper bound on its length).
+ *
+ * The folding operator, used to implement computation over a set.
+ * Apalache implements a more efficient encoding than the one below.
+ * (from the community modules).
+ *
+ * @type: Seq(a) => Int;
+ *)
+__ApalacheSeqCapacity(seq) ==
+    \* A dummy implementation.
+    \* Apalache binds it to ApalacheInternalOper.apalacheSeqCapacity.
+    0
+
+(**
+ * This operator is well-typed, but as soon as it reaches the model checker,
+ * the model checker should print the message and stop. The type checker should
+ * be able to process this operator.
+ *
+ * @type: Str => a;
+ *)
+__NotSupportedByModelChecker(msg) ==
+    \* A dummy implementation.
+    \* Apalache binds it to ApalacheInternalOper.notSupportedByModelChecker.
+    CHOOSE x \in {}: TRUE
+
+===============================================================================

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -275,6 +275,8 @@ class SymbStateRewriterImpl(
           -> List(new SeqOpsRule(this)),
         key(tla.len(tla.tuple(tla.name("x"))))
           -> List(new SeqOpsRule(this)),
+        key(OperEx(ApalacheInternalOper.apalacheSeqCapacity, tla.name("seq")))
+          -> List(new SeqOpsRule(this)),
         key(tla.append(tla.tuple(tla.name("x")), tla.int(10)))
           -> List(new SeqOpsRule(this)),
         key(tla.concat(tla.name("Seq1"), tla.name("Seq2")))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -362,7 +362,6 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
   test("""(ApalacheSeqCapacity(<<3, 4, 5, 6>>) = 4""") { rewriterType: SMTEncoding =>
     val seq3to6 = tuple(3.to(6).map(int): _*).as(intSeqT)
     val ex = OperEx(ApalacheInternalOper.apalacheSeqCapacity, seq3to6)(Typed(IntT1()))
-    // since 10 does not belong to the domain, the sequence does not change
     val eq = eql(ex, int(4)).as(boolT)
 
     val state = new SymbState(eq, arena, Binding())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.oper.ApalacheInternalOper
 
 trait TestSymbStateRewriterSequence extends RewriterBase {
   private val intT = IntT1()
@@ -353,6 +354,16 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     val exceptEx = except(emptyTuple, tuple(int(10)).as(TupT1(IntT1())), int(7)).as(intSeqT)
     // since 10 does not belong to the domain, the sequence does not change
     val eq = eql(exceptEx, emptyTuple).as(boolT)
+
+    val state = new SymbState(eq, arena, Binding())
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
+  test("""(ApalacheSeqCapacity(<<3, 4, 5, 6>>) = 4""") { rewriterType: SMTEncoding =>
+    val seq3to6 = tuple(3.to(6).map(int): _*).as(intSeqT)
+    val ex = OperEx(ApalacheInternalOper.apalacheSeqCapacity, seq3to6)(Typed(IntT1()))
+    // since 10 does not belong to the domain, the sequence does not change
+    val eq = eql(ex, int(4)).as(boolT)
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -67,6 +67,8 @@ object StandardLibrary {
         ("__apalache_folds", "__ApalacheFoldSet") -> ApalacheOper.foldSet,
         ("Apalache", "FoldSeq") -> ApalacheOper.foldSeq,
         ("__apalache_folds", "__ApalacheFoldSeq") -> ApalacheOper.foldSeq,
+        ("ApalacheInternal", "__NotSupportedByModelChecker") -> ApalacheInternalOper.notSupportedByModelChecker,
+        ("ApalacheInternal", "__ApalacheSeqCapacity") -> ApalacheInternalOper.apalacheSeqCapacity,
     ) ////
 
   /**
@@ -79,6 +81,8 @@ object StandardLibrary {
     Map(
         "TLC.tla" -> "__rewire_tlc_in_apalache.tla",
         "Sequences.tla" -> "__rewire_sequences_in_apalache.tla",
+        // will be enabled later
+        //        "SequencesExt.tla" -> "__rewire_sequences_ext_in_apalache.tla",
     ) ////
 
   /**

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -794,6 +794,19 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         val opsig = OperT1(Seq(OperT1(Seq(a, b), a), a, SeqT1(b)), a)
         mkExRefApp(opsig, Seq(oper, base, seq))
 
+      // ******************************* Apalache internals **************************************************
+      case OperEx(ApalacheInternalOper.apalacheSeqCapacity, seq) =>
+        val a = varPool.fresh
+        // Seq(a) => Int
+        val opsig = OperT1(Seq(SeqT1(a)), IntT1())
+        mkExRefApp(opsig, Seq(seq))
+
+      case OperEx(ApalacheInternalOper.notSupportedByModelChecker, msg) =>
+        val a = varPool.fresh
+        // Str => a
+        val opsig = OperT1(Seq(StrT1()), a)
+        mkExRefApp(opsig, Seq(msg))
+
       // ******************************************** MISC **************************************************
       case OperEx(TlaOper.label, labelledEx, nameAndArgs @ _*) =>
         val typeVar = varPool.fresh

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -808,7 +808,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
     assert(expected == gen(ex))
   }
 
-  test("ApalacheInternal!____NotSupportedByModelChecker") {
+  test("ApalacheInternal!__NotSupportedByModelChecker") {
     val typ = parser("Str => a")
     val expected = mkAppByName(Seq(typ), "x")
     val ex = OperEx(ApalacheInternalOper.notSupportedByModelChecker, tla.name("x"))

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -6,7 +6,7 @@ import at.forsyte.apalache.io.typecheck.parser.{DefaultType1Parser, Type1Parser}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
-import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaFunOper}
+import at.forsyte.apalache.tla.lir.oper.{ApalacheInternalOper, ApalacheOper, TlaFunOper}
 import at.forsyte.apalache.tla.lir.values.TlaReal
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
@@ -798,6 +798,20 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
     val typ = parser("(a, a) => Bool")
     val expected = mkAppByName(Seq(typ), "x", "y")
     val ex = OperEx(ApalacheOper.distinct, tla.name("x"), tla.name("y"))
+    assert(expected == gen(ex))
+  }
+
+  test("ApalacheInternal!__ApalacheSeqCapacity") {
+    val typ = parser("Seq(a) => Int")
+    val expected = mkAppByName(Seq(typ), "x")
+    val ex = OperEx(ApalacheInternalOper.apalacheSeqCapacity, tla.name("x"))
+    assert(expected == gen(ex))
+  }
+
+  test("ApalacheInternal!____NotSupportedByModelChecker") {
+    val typ = parser("Str => a")
+    val expected = mkAppByName(Seq(typ), "x")
+    val ex = OperEx(ApalacheInternalOper.notSupportedByModelChecker, tla.name("x"))
     assert(expected == gen(ex))
   }
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
@@ -1,0 +1,39 @@
+package at.forsyte.apalache.tla.lir.oper
+
+/**
+ * The operators defined in the module `__apalache_internals.tla`. The operators in this module are designed for the
+ * Apalache code and its internal TLA+ definitions. The users should not use these operators.
+ *
+ * @author
+ *   Igor Konnov
+ */
+abstract class ApalacheInternalOper extends TlaOper {
+  override def interpretation: Interpretation.Value = Interpretation.StandardLib
+}
+
+object ApalacheInternalOper {
+
+  /**
+   * This operator receives an error message (a string literal), which should be printed if this operator reaches the
+   * model checker.
+   */
+  object notSupportedByModelChecker extends ApalacheOper {
+    override def name: String = "ApalacheInternal!__NotSupportedByModelChecker"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override val precedence: (Int, Int) = (100, 100)
+  }
+
+  /**
+   * This operator returns the capacity of a given sequence, that is, a static upper bound on its length.
+   */
+  object apalacheSeqCapacity extends ApalacheOper {
+    override def name: String = "ApalacheInternal!__ApalacheSeqCapacity"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override val precedence: (Int, Int) = (100, 100)
+  }
+
+}

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
@@ -7,9 +7,7 @@ package at.forsyte.apalache.tla.lir.oper
  * @author
  *   Igor Konnov
  */
-abstract class ApalacheInternalOper extends TlaOper {
-  override def interpretation: Interpretation.Value = Interpretation.StandardLib
-}
+abstract class ApalacheInternalOper extends ApalacheOper
 
 object ApalacheInternalOper {
 
@@ -17,7 +15,7 @@ object ApalacheInternalOper {
    * This operator receives an error message (a string literal), which should be printed if this operator reaches the
    * model checker.
    */
-  object notSupportedByModelChecker extends ApalacheOper {
+  object notSupportedByModelChecker extends ApalacheInternalOper {
     override def name: String = "ApalacheInternal!__NotSupportedByModelChecker"
 
     override def arity: OperArity = FixedArity(1)
@@ -28,7 +26,7 @@ object ApalacheInternalOper {
   /**
    * This operator returns the capacity of a given sequence, that is, a static upper bound on its length.
    */
-  object apalacheSeqCapacity extends ApalacheOper {
+  object apalacheSeqCapacity extends ApalacheInternalOper {
     override def name: String = "ApalacheInternal!__ApalacheSeqCapacity"
 
     override def arity: OperArity = FixedArity(1)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
@@ -93,6 +93,10 @@ class KeraLanguagePred extends ContextualLanguagePred {
           PredResultOk()
         }
 
+      case e @ OperEx(ApalacheInternalOper.notSupportedByModelChecker, ValEx(TlaStr(msg))) =>
+        // unconditionally report an error
+        PredResultFail(List((e.ID, "Not supported: " + msg)))
+
       case e =>
         PredResultFail(List((e.ID, e.toString)))
     }
@@ -122,6 +126,7 @@ object KeraLanguagePred {
         ApalacheOper.expand,
         ApalacheOper.constCard,
         ApalacheOper.setAsFun,
+        ApalacheInternalOper.apalacheSeqCapacity,
         // for the future
         //    TlaActionOper.enabled,
         //    TlaActionOper.unchanged,

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
@@ -4,6 +4,8 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.oper.ApalacheInternalOper
+import at.forsyte.apalache.tla.lir.transformations.PredResultFail
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -111,6 +113,13 @@ class TestKeraLanguagePred extends LanguagePredTestSuite {
   test("not a KerA control expression") {
     expectFail(pred.isExprOk(caseOther(int(1), bool(false), int(2))))
     expectFail(pred.isExprOk(caseSplit(bool(false), int(2))))
+  }
+
+  test("not supported by the model checker") {
+    pred.isExprOk(OperEx(ApalacheInternalOper.notSupportedByModelChecker, str("foo"))) match {
+      case PredResultFail(Seq((_, "Not supported: foo"))) => () // OK
+      case _                                              => fail("expected a failure")
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds two internals operators that are required by #1486 and #1527.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
