### PR TITLE
Add auto-update github action

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,18 @@
+# Help automate PR updates
+# See https://github.com/tibdex/auto-update/blob/main/.github/workflows/auto-update.yml
+name: Auto-update
+# Auto-update only listens to `push` events.
+# If a pull request is already outdated when enabling auto-merge, manually click on the "Update branch" button a first time to avoid having to wait for another commit to land on the base branch for the pull request to be updated.
+on:
+  push:
+    branches:
+      - unstable
+
+jobs:
+  Auto:
+    name: Auto-update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/auto-update@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should help alleviate the tedium resulting from the PR
updating/merging race condition.

When changes are pushed to our default branch, this action is meant to
check any PRs that have 'auto-merge' enabled, and trigger their update.

If everything works as intended, then once a PR is ready for merge and
we've enabled `auto-merge`, this action will do the work of ensuring the
PR is kept up to date in case a different PR is merged in before the CI
can complete.

-------

<!-- Please ensure that your PR includes the following, as needed -->