### PR TITLE
Use the apalache bot token for auto update

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: tibdex/auto-update@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.APALACHE_BOT_TOKEN }}


### PR DESCRIPTION
Without this, the updates triggered by this action won't allow the
subsequent CI to kick off. This is a limitation on what reactions
GitHub's API will trigger in response to the GITHUB_TOKEN.