### PR TITLE
Make warnings fatal in CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,7 @@
 # Some useful variables include
 #
 # - RELEASEME_TOKEN: a github token used in ./script/release
+# - APALACHE_FATAL_WARNINGS: Set to "true" to fail builds on compiler warnings
 [[ -f "./.local-envrc" ]] && source "./.local-envrc"
 
 # This function is to protect local variables from polluting downstream scripts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
         run: make fmt-check
 
   unit-tests:
+    env:
+      APALACHE_FATAL_WARNINGS: true
     runs-on: ${{ matrix.operating-system }}
     strategy:
       # Allows other OS tests to proceed even if one fails
@@ -72,6 +74,8 @@ jobs:
           find $HOME/.sbt                              -name "*.lock"               -delete || true
 
   integration-tests:
+    env:
+      APALACHE_FATAL_WARNINGS: true
     runs-on: ${{ matrix.operating-system }}
     strategy:
       # Allows other OS tests to proceed even if one fails
@@ -124,6 +128,8 @@ jobs:
           TEST_FILTER: ${{ matrix.smt-encoding == 'arrays' && 'array-encoding' || '' }}
 
   docker-tests:
+    env:
+      APALACHE_FATAL_WARNINGS: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,19 @@ The necessary shell environment is specified in [.envrc](./.envrc). You can:
 
 [direnv]: https://direnv.net/
 
+#### Compiler warnings
+
+We fail CI builds on compiler warnings.
+
+To have compiler warnings also fail on local builds, set
+
+```sh
+export APALACHE_FATAL_WARNINGS=true
+```
+
+You may add this to your `.local-envrc` file at the root of this repo to have
+`denvenv` load this into your development environment.
+
 ## Development Environment
 
 If you use a different development environment or editor set up, please document

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ export APALACHE_FATAL_WARNINGS=true
 ```
 
 You may add this to your `.local-envrc` file at the root of this repo to have
-`denvenv` load this into your development environment.
+`direnv` load this into your development environment.
 
 ## Development Environment
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,17 +48,23 @@ ThisBuild / libraryDependencies ++= Seq(
 // Compiler options //
 //////////////////////
 
-ThisBuild / scalacOptions ++= Seq(
-    // Enable deprecation and feature warnings
-    "-deprecation",
-    "-feature",
-    // Enable `unused` compiler warnings; required by scalafix
-    // https://scalacenter.github.io/scalafix/docs/rules/RemoveUnused.html
-    "-Ywarn-unused",
-    // Fixes warning: "Exhaustivity analysis reached max recursion depth, not all missing cases are reported."
-    "-Ypatmat-exhaust-depth",
-    "22",
-)
+fatalWarnings := sys.env.get("APALACHE_FATAL_WARNINGS").getOrElse("false").toBoolean
+ThisBuild / scalacOptions ++= {
+  val commonOptions = Seq(
+      // Enable deprecation and feature warnings
+      "-deprecation",
+      "-feature",
+      // Enable `unused` compiler warnings; required by scalafix
+      // https://scalacenter.github.io/scalafix/docs/rules/RemoveUnused.html
+      "-Ywarn-unused",
+      // Fixes warning: "Exhaustivity analysis reached max recursion depth, not all missing cases are reported."
+      "-Ypatmat-exhaust-depth",
+      "22",
+  )
+  val conditionalOptions = if (fatalWarnings.value) Seq("-Xfatal-warnings") else Nil
+
+  commonOptions ++ conditionalOptions
+}
 
 ////////////////////////////
 // Linting and formatting //
@@ -384,3 +390,5 @@ incrVersion := {
   IO.writeLines((ThisBuild / versionFile).value, Seq(nextVersion))
   nextVersion
 }
+
+lazy val fatalWarnings = settingKey[Boolean]("Whether or not to compile with fatal warnings")


### PR DESCRIPTION
Closes #1064

This setting is controlled via the environment variable
`APALACHE_FATAL_WARNINGS`, making it possible for developers to opt in
or out of having compiler warnings fail their builds locally.

Instructions on configuration have been added to CONTRIBUTING.md

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality