### PR TITLE
Pack integer arithmetic comparisons in IntCmpRule

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,11 @@
 
  * Look up modules in the same directory, see #1491
 
+### Improvements
+
+ * Pack arithmetic expressions and comparisons into a single SMT constraint,
+   see #1540 and #1545
+
 ### Bug fixes
 
  * Fix uncaught `FileNotFoundException` in commands called on nonexistent files,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/EqRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/EqRule.scala
@@ -2,18 +2,19 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
-import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.lir.{NameEx, OperEx}
+import at.forsyte.apalache.tla.lir.{IntT1, NameEx, OperEx, Typed}
 
 /**
- * Implement equality test by delegating the actual test to LazyEquality.
+ * Implement equality test by delegating the actual test to LazyEquality. Integer equality is packed into a single SMT
+ * constraint.
  *
  * @author
- *   Igor Konnov
+ *   Igor Konnov, Thomas Pani
  */
-class EqRule(rewriter: SymbStateRewriter) extends RewritingRule {
+class EqRule(rewriter: SymbStateRewriter) extends RewritingRule with IntArithPacker {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaOper.eq, _, _) => true
@@ -26,6 +27,22 @@ class EqRule(rewriter: SymbStateRewriter) extends RewritingRule {
     case OperEx(TlaOper.eq, NameEx(left), NameEx(right)) if left == right =>
       // identical constants are obviously equal
       state.setRex(state.arena.cellTrue().toNameEx)
+
+    // Pack integer equality into a single SMT constraint
+    case OperEx(TlaOper.eq, lhs, rhs) if lhs.typeTag == rhs.typeTag && rhs.typeTag == Typed(IntT1()) =>
+      // pack the arithmetic expression `state.ex` into `packedState.ex`
+      val leftState = packArithExpr(state.setRex(lhs), rewriter)
+      val rightState = packArithExpr(leftState.setRex(rhs), rewriter)
+
+      // add new arena cell
+      val newArena = rightState.arena.appendCell(BoolT())
+      val newCell = newArena.topCell
+
+      // assert the new cell is equal to the packed comparison
+      val packedComparison = OperEx(TlaOper.eq, leftState.ex, rightState.ex)
+      rewriter.solverContext.assertGroundExpr(tla.eql(newCell.toNameEx, packedComparison))
+      // return rewritten state; the input arithmetic expression has been rewritten into the new arena cell
+      rightState.setArena(newArena).setRex(newCell.toNameEx)
 
     case OperEx(TlaOper.eq, lhs, rhs) =>
       var newState = rewriter.rewriteUntilDone(state.setRex(lhs))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/EqRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/EqRule.scala
@@ -29,10 +29,10 @@ class EqRule(rewriter: SymbStateRewriter) extends RewritingRule with IntArithPac
       state.setRex(state.arena.cellTrue().toNameEx)
 
     // Pack integer equality into a single SMT constraint
-    case OperEx(TlaOper.eq, lhs, rhs) if lhs.typeTag == rhs.typeTag && rhs.typeTag == Typed(IntT1()) =>
+    case OperEx(TlaOper.eq, lhs, rhs) if lhs.typeTag == Typed(IntT1()) && rhs.typeTag == Typed(IntT1()) =>
       // pack the arithmetic expression `state.ex` into `packedState.ex`
-      val leftState = packArithExpr(state.setRex(lhs), rewriter)
-      val rightState = packArithExpr(leftState.setRex(rhs), rewriter)
+      val leftState = packArithExpr(rewriter, state.setRex(lhs))
+      val rightState = packArithExpr(rewriter, leftState.setRex(rhs))
 
       // add new arena cell
       val newArena = rightState.arena.appendCell(BoolT())

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithPacker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithPacker.scala
@@ -19,14 +19,14 @@ trait IntArithPacker {
    * Rewrite [[state]]'s expression into an expression that is purely arithmetic, referring to arena cells for
    * non-arithmetic subexpressions.
    *
-   * @param state
-   *   current rewriter state, `state.ex` is the arithmetic expression to rewrite
    * @param rewriter
    *   rewriter to use for non-arithmetic subexpressions
+   * @param state
+   *   current rewriter state, `state.ex` is the arithmetic expression to rewrite
    * @return
    *   the rewritten state
    */
-  protected def packArithExpr(state: SymbState, rewriter: SymbStateRewriter): SymbState = state.ex match {
+  protected def packArithExpr(rewriter: SymbStateRewriter, state: SymbState): SymbState = state.ex match {
     /* *** base case: integer literals + names *** */
 
     // keep integer literals as-is
@@ -41,12 +41,12 @@ trait IntArithPacker {
     /* *** recursion: recursively rewrite arithmetic expressions *** */
 
     case OperEx(TlaArithOper.uminus, subex) =>
-      val subState = packArithExpr(state.setRex(subex), rewriter)
+      val subState = packArithExpr(rewriter, state.setRex(subex))
       subState.setRex(OperEx(TlaArithOper.uminus, subState.ex))
 
     case OperEx(oper: TlaArithOper, left, right) =>
-      val leftState = packArithExpr(state.setRex(left), rewriter)
-      val rightState = packArithExpr(leftState.setRex(right), rewriter)
+      val leftState = packArithExpr(rewriter, state.setRex(left))
+      val rightState = packArithExpr(rewriter, leftState.setRex(right))
       rightState.setRex(OperEx(oper, leftState.ex, rightState.ex))
 
     case ex =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithPacker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithPacker.scala
@@ -1,0 +1,56 @@
+package at.forsyte.apalache.tla.bmcmt.rules
+
+import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.oper.TlaArithOper
+import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.{NameEx, OperEx, ValEx}
+
+/**
+ * Rewrite integer arithmetic expressions, referring to arena cells for non-arithmetic subexpressions as necessary.
+ *
+ * @author
+ *   Thomas Pani
+ */
+trait IntArithPacker {
+  private lazy val substRule = new SubstRule
+
+  /**
+   * Rewrite [[state]]'s expression into an expression that is purely arithmetic, referring to arena cells for
+   * non-arithmetic subexpressions.
+   *
+   * @param state
+   *   current rewriter state, `state.ex` is the arithmetic expression to rewrite
+   * @param rewriter
+   *   rewriter to use for non-arithmetic subexpressions
+   * @return
+   *   the rewritten state
+   */
+  protected def packArithExpr(state: SymbState, rewriter: SymbStateRewriter): SymbState = state.ex match {
+    /* *** base case: integer literals + names *** */
+
+    // keep integer literals as-is
+    case ValEx(TlaInt(_)) => state
+
+    // keep cell names as-is
+    case NameEx(name) if ArenaCell.isValidName(name) => state
+
+    // substitute variable names
+    case NameEx(_) => substRule(state)
+
+    /* *** recursion: recursively rewrite arithmetic expressions *** */
+
+    case OperEx(TlaArithOper.uminus, subex) =>
+      val subState = packArithExpr(state.setRex(subex), rewriter)
+      subState.setRex(OperEx(TlaArithOper.uminus, subState.ex))
+
+    case OperEx(oper: TlaArithOper, left, right) =>
+      val leftState = packArithExpr(state.setRex(left), rewriter)
+      val rightState = packArithExpr(leftState.setRex(right), rewriter)
+      rightState.setRex(OperEx(oper, leftState.ex, rightState.ex))
+
+    case ex =>
+      // Cannot pack arbitrary expression, delegate to SymbStateRewriter
+      rewriter.rewriteUntilDone(state.setRex(ex))
+  }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithRule.scala
@@ -54,7 +54,7 @@ class IntArithRule(rewriter: SymbStateRewriter) extends RewritingRule with IntAr
    */
   private def rewritePacked(state: SymbState): SymbState = {
     // pack the arithmetic expression `state.ex` into `packedState.ex`
-    val packedState = packArithExpr(state, rewriter)
+    val packedState = packArithExpr(rewriter, state)
 
     // add new arena cell
     val newArena = packedState.arena.appendCell(IntT())

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -39,8 +39,8 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule with IntArit
   private def rewritePacked(state: SymbState) = state.ex match {
     case OperEx(oper, left, right) =>
       // pack the arithmetic expression `state.ex` into `packedState.ex`
-      val leftState = packArithExpr(state.setRex(left), rewriter)
-      val rightState = packArithExpr(leftState.setRex(right), rewriter)
+      val leftState = packArithExpr(rewriter, state.setRex(left))
+      val rightState = packArithExpr(rewriter, leftState.setRex(right))
 
       // add new arena cell
       val newArena = rightState.arena.appendCell(BoolT())

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntCmpRule.scala
@@ -2,18 +2,18 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
-import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaOper}
-import at.forsyte.apalache.tla.lir.values.TlaBool
-import at.forsyte.apalache.tla.lir.{OperEx, TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.oper.TlaArithOper
+import at.forsyte.apalache.tla.lir.OperEx
 
 /**
  * Integer comparisons: <, <=, >, >=. For equality and inequality, check EqRule.
  *
  * @author
- *   Igor Konnov
+ *   Igor Konnov, Thomas Pani
  */
-class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
+class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule with IntArithPacker {
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaArithOper.lt, _, _) | OperEx(TlaArithOper.le, _, _) | OperEx(TlaArithOper.gt, _, _) |
@@ -30,29 +30,30 @@ class IntCmpRule(rewriter: SymbStateRewriter) extends RewritingRule {
     case OperEx(oper: TlaArithOper, _, _)
         if (oper == TlaArithOper.lt || oper == TlaArithOper.le
           || oper == TlaArithOper.gt || oper == TlaArithOper.ge) =>
-      rewriteGeneral(state, state.ex)
+      rewritePacked(state)
 
     case _ =>
       throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)
   }
 
-  private def rewriteGeneral(state: SymbState, ex: TlaEx) = ex match {
-    case ValEx(TlaBool(_)) =>
-      // keep the simplified expression
-      rewriter.rewriteUntilDone(state.setRex(ex))
-
+  private def rewritePacked(state: SymbState) = state.ex match {
     case OperEx(oper, left, right) =>
-      val leftState = rewriter.rewriteUntilDone(state.setRex(left))
-      val rightState = rewriter.rewriteUntilDone(leftState.setRex(right))
-      // compare integers directly in SMT
-      val arena = rightState.arena.appendCell(BoolT())
-      val eqPred = arena.topCell
-      val cons =
-        OperEx(TlaOper.eq, eqPred.toNameEx, OperEx(oper, leftState.ex, rightState.ex))
-      rewriter.solverContext.assertGroundExpr(cons)
-      rightState.setArena(arena).setRex(eqPred.toNameEx)
+      // pack the arithmetic expression `state.ex` into `packedState.ex`
+      val leftState = packArithExpr(state.setRex(left), rewriter)
+      val rightState = packArithExpr(leftState.setRex(right), rewriter)
+
+      // add new arena cell
+      val newArena = rightState.arena.appendCell(BoolT())
+      val newCell = newArena.topCell
+
+      // assert the new cell is equal to the packed comparison
+      val packedComparison = OperEx(oper, leftState.ex, rightState.ex)
+      rewriter.solverContext.assertGroundExpr(tla.eql(newCell.toNameEx, packedComparison))
+      // return rewritten state; the input arithmetic expression has been rewritten into the new arena cell
+      rightState.setArena(newArena).setRex(newCell.toNameEx)
 
     case _ =>
-      throw new RewriterException("It should not happen. Report a bug", ex)
+      throw new RewriterException("It should not happen. Report a bug", state.ex)
   }
+
 }


### PR DESCRIPTION
Closes #1342 

Pack arithmetic expressions in `IntCmpRule` and `EqRule`. Translate TLA+ arithmetic comparisons into a single SMT constraint, without introducing intermediate cells.

Uses the same logic for packing arithmetic expressions as #1541, which is refactored into a trait in 835e717.