### PR TITLE
Fix capitalization of changelog entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,10 +337,10 @@ Every non-trivial PR must update the [unreleased changes log](./UNRELEASED.md).
 
 Changes for a given release should be split between the five sections:
 
-1. Breaking Changes
+1. Breaking changes
 2. Features
 3. Improvements
-4. Bug Fixes
+4. Bug fixes
 5. Documentation
 
 ## Releases


### PR DESCRIPTION
We're always using sentence case in [CHANGES.md](https://github.com/informalsystems/apalache/blob/unstable/CHANGES.md); update [CONTRIBUTING.md](CONTRIBUTING.md) accordingly.