### PR TITLE
Fix the bug in equality of sequences

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,3 +22,4 @@
 
  * Fix uncaught `FileNotFoundException` in commands called on nonexistent files,
    see #1503
+ * Fix equality on sequences, see #1548  

--- a/test/tla/TestSequences.tla
+++ b/test/tla/TestSequences.tla
@@ -198,6 +198,9 @@ TestExceptLen ==
 TestExceptDomain ==
     DOMAIN [seq345 EXCEPT ![2] = 10] = DOMAIN seq345
 
+TestSubSeqEq ==
+    SubSeq(<<"a", "b", "c">>, 1, 2) = SubSeq(<<"a", "b", "d">>, 1, 2)
+
 \* this test is a disjunction of all smaller tests
 AllTests ==
     /\ TestHeadEmpty
@@ -243,4 +246,5 @@ AllTests ==
     /\ TestFunAsSeqLargerCapacity
     /\ TestExceptLen
     /\ TestExceptDomain
+    /\ TestSubSeqEq
 ===============================================================================

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -571,14 +571,20 @@ class LazyEquality(rewriter: SymbStateRewriter)
 
     // compare the shared prefix
     var nextState = state
+    val len1Ex = len1.toNameEx.as(IntT1())
+    val len2Ex = len2.toNameEx.as(IntT1())
 
-    def eqPairwise(leftCell: ArenaCell, rightCell: ArenaCell): TlaEx = {
-      nextState = cacheOneEqConstraint(nextState, leftCell, rightCell)
-      safeEq(leftCell, rightCell)
+    def eqPairwise(indexBase1: Int, cells: (ArenaCell, ArenaCell)): TlaEx = {
+      nextState = cacheOneEqConstraint(nextState, cells._1, cells._2)
+      // Either (1) one of the lengths is below the index, or (2) the elements are equal.
+      // The case (1) is compensated with the constraint sizesEq below.
+      val outside1 = tla.lt(len1Ex, tla.int(indexBase1)).as(BoolT1())
+      val outside2 = tla.lt(len2Ex, tla.int(indexBase1)).as(BoolT1())
+      tla.or(outside1, outside2, safeEq(cells._1, cells._2))
     }
 
-    val elemsEq = tla.and(elems1.zip(elems2).map((eqPairwise _).tupled): _*)
-    val sizesEq = tla.eql(len1.toNameEx.as(IntT1()), len2.toNameEx.as(IntT1())).as(BoolT1())
+    val elemsEq = tla.and(1.until(sharedCapacity).zip(elems1.zip(elems2)).map((eqPairwise _).tupled): _*)
+    val sizesEq = tla.eql(len1Ex, len2Ex).as(BoolT1())
 
     // seq1 and seq2 are equal if and only if: (1) their lengths are equal, and (2) their shared prefixes are equal.
     rewriter.solverContext

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -243,6 +243,18 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
+  test("""SubSeq(<<1, 2, 3>>, 1, 2) = SubSeq(<<1, 2, 4>>, 1, 2)""") { rewriterType: SMTEncoding =>
+    // TLC throws an error in this case. We cannot produce side effects, so we are doing the best we can do here.
+    val seq123 = tuple(int(1), int(2), int(3)).as(SeqT1(IntT1()))
+    val subseqEx1 = subseq(seq123, int(1), int(2)).as(intSeqT)
+    val seq124 = tuple(int(1), int(2), int(4)).as(SeqT1(IntT1()))
+    val subseqEx2 = subseq(seq124, int(1), int(2)).as(intSeqT)
+    val eq = eql(subseqEx1, subseqEx2).as(boolT)
+
+    val state = new SymbState(eq, arena, Binding())
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
   test("""Append(<<4, 5>>, 10)""") { rewriterType: SMTEncoding =>
     val tup = tuple(4.to(5).map(int): _*).as(intSeqT)
     val seqAppend = append(tup, int(10)).as(intSeqT)


### PR DESCRIPTION
Closes #1547. This bug was happening when two sequences had the capacity larger than their actual lengths.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
