### PR TITLE
Fix stats collection debug output

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -40,7 +40,6 @@ import at.forsyte.apalache.tla.bmcmt.rules.vmt.TlaExToVMTWriter
  */
 object Tool extends LazyLogging {
   lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
-  lazy val ERROR_EXIT_CODE = 99
   lazy val OK_EXIT_CODE = 0
 
   /**
@@ -439,15 +438,15 @@ object Tool extends LazyLogging {
                        |# build  : ${BuildInfo.build}
                        |#""".stripMargin)
 
-    if (ExecutionStatisticsCollector.promptUser()) {
+    if (new ExecutionStatisticsCollector().isEnabled) {
+      // Statistic collection is enabled. Thank the user
+      Console.println("# Usage statistics is ON. Thank you!")
+      Console.println("# If you have changed your mind, disable the statistics with config --enable-stats=false.")
+    } else {
       // Statistics collection is not enabled. Cry for help.
       Console.println("# Usage statistics is OFF. We care about your privacy.")
       Console.println(
           "# If you want to help our project, consider enabling statistics with config --enable-stats=true.")
-    } else {
-      // Statistic collection is enabled. Thank the user
-      Console.println("# Usage statistics is ON. Thank you!")
-      Console.println("# If you have changed your mind, disable the statistics with config --enable-stats=false.")
     }
     Console.println("")
   }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -129,7 +129,9 @@ Statistics collection is ON.
 ...
 EXITCODE: OK
 $ apalache-mc parse Empty.tla | grep '# Usage statistics'
+...
 # Usage statistics is ON. Thank you!
+...
 $ grep -q -v NO_STATISTICS $HOME/.tlaplus/esc.txt
 $ echo NO_STATISTICS >$HOME/.tlaplus/esc.txt
 ```
@@ -149,7 +151,9 @@ Statistics collection is OFF.
 ...
 EXITCODE: OK
 $ apalache-mc parse Empty.tla | grep '# Usage statistics'
+...
 # Usage statistics is OFF. We care about your privacy.
+...
 $ head -n 1 $HOME/.tlaplus/esc.txt
 NO_STATISTICS
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -128,6 +128,8 @@ $ apalache-mc config --enable-stats=true | sed 's/[IEW]@.*//'
 Statistics collection is ON.
 ...
 EXITCODE: OK
+$ apalache-mc parse Empty.tla | grep '# Usage statistics'
+# Usage statistics is ON. Thank you!
 $ grep -q -v NO_STATISTICS $HOME/.tlaplus/esc.txt
 $ echo NO_STATISTICS >$HOME/.tlaplus/esc.txt
 ```
@@ -146,6 +148,8 @@ $ apalache-mc config --enable-stats=false | sed 's/[IEW]@.*//'
 Statistics collection is OFF.
 ...
 EXITCODE: OK
+$ apalache-mc parse Empty.tla | grep '# Usage statistics'
+# Usage statistics is OFF. We care about your privacy.
 $ head -n 1 $HOME/.tlaplus/esc.txt
 NO_STATISTICS
 ```


### PR DESCRIPTION
Fixes #1504 – statistics collection was reported as `ON` even when disabled.

We previously only checked for existence of `~/.tlaplus/esc.txt` to report `ON`.
This fixes it to also check the file for a valid identifier (not `NO_STATISTICS`).