### PR TITLE
Fix the equality of sequences once again

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,4 +22,4 @@
 
  * Fix uncaught `FileNotFoundException` in commands called on nonexistent files,
    see #1503
- * Fix equality on sequences, see #1548  
+ * Fix equality on sequences, see #1548, #1554

--- a/test/tla/TestSequences.tla
+++ b/test/tla/TestSequences.tla
@@ -201,6 +201,9 @@ TestExceptDomain ==
 TestSubSeqEq ==
     SubSeq(<<"a", "b", "c">>, 1, 2) = SubSeq(<<"a", "b", "d">>, 1, 2)
 
+TestSubSeqNeq ==
+    SubSeq(<<"a", "b", "c">>, 1, 3) /= SubSeq(<<"a", "b", "d">>, 1, 3)
+
 \* this test is a disjunction of all smaller tests
 AllTests ==
     /\ TestHeadEmpty
@@ -247,4 +250,6 @@ AllTests ==
     /\ TestExceptLen
     /\ TestExceptDomain
     /\ TestSubSeqEq
+    /\ TestSubSeqNeq
+
 ===============================================================================

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -583,7 +583,7 @@ class LazyEquality(rewriter: SymbStateRewriter)
       tla.or(outside1, outside2, safeEq(cells._1, cells._2))
     }
 
-    val elemsEq = tla.and(1.until(sharedCapacity).zip(elems1.zip(elems2)).map((eqPairwise _).tupled): _*)
+    val elemsEq = tla.and(1.to(sharedCapacity).zip(elems1.zip(elems2)).map((eqPairwise _).tupled): _*)
     val sizesEq = tla.eql(len1Ex, len2Ex).as(BoolT1())
 
     // seq1 and seq2 are equal if and only if: (1) their lengths are equal, and (2) their shared prefixes are equal.

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -244,7 +244,6 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SubSeq(<<1, 2, 3>>, 1, 2) = SubSeq(<<1, 2, 4>>, 1, 2)""") { rewriterType: SMTEncoding =>
-    // TLC throws an error in this case. We cannot produce side effects, so we are doing the best we can do here.
     val seq123 = tuple(int(1), int(2), int(3)).as(SeqT1(IntT1()))
     val subseqEx1 = subseq(seq123, int(1), int(2)).as(intSeqT)
     val seq124 = tuple(int(1), int(2), int(4)).as(SeqT1(IntT1()))
@@ -256,7 +255,6 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
   }
 
   test("""SubSeq(<<1, 2, 3>>, 1, 3) /= SubSeq(<<1, 2, 4>>, 1, 3)""") { rewriterType: SMTEncoding =>
-    // TLC throws an error in this case. We cannot produce side effects, so we are doing the best we can do here.
     val seq123 = tuple(int(1), int(2), int(3)).as(SeqT1(IntT1()))
     val seq124 = tuple(int(1), int(2), int(4)).as(SeqT1(IntT1()))
     val subseqEx1 = subseq(seq123, int(1), int(3)).as(intSeqT)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSequence.scala
@@ -255,6 +255,19 @@ trait TestSymbStateRewriterSequence extends RewriterBase {
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
+  test("""SubSeq(<<1, 2, 3>>, 1, 3) /= SubSeq(<<1, 2, 4>>, 1, 3)""") { rewriterType: SMTEncoding =>
+    // TLC throws an error in this case. We cannot produce side effects, so we are doing the best we can do here.
+    val seq123 = tuple(int(1), int(2), int(3)).as(SeqT1(IntT1()))
+    val seq124 = tuple(int(1), int(2), int(4)).as(SeqT1(IntT1()))
+    val subseqEx1 = subseq(seq123, int(1), int(3)).as(intSeqT)
+    val subseqEx2 = subseq(seq124, int(1), int(3)).as(intSeqT)
+    val eq = eql(subseqEx1, subseqEx2).as(boolT)
+    val neq = not(eq).as(BoolT1())
+
+    val state = new SymbState(neq, arena, Binding())
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
   test("""Append(<<4, 5>>, 10)""") { rewriterType: SMTEncoding =>
     val tup = tuple(4.to(5).map(int): _*).as(intSeqT)
     val seqAppend = append(tup, int(10)).as(intSeqT)


### PR DESCRIPTION
My previous fix in #1548 was partially correct. This one hopefully fixes #1547.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
