### PR TITLE
support for BagsExt

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@
 ### Features
 
  * Look up modules in the same directory, see #1491
+ * Support for the community module BagsExt, see #1555
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,7 +17,7 @@
 ### Features
 
  * Look up modules in the same directory, see #1491
- * Support for the community module BagsExt, see #1555
+ * Support for the community module `BagsExt`, see #1555
 
 ### Bug fixes
 

--- a/build.sbt
+++ b/build.sbt
@@ -257,6 +257,8 @@ lazy val root = (project in file("."))
                   "tla2sany/StandardModules/__rewire_sequences_in_apalache.tla",
                 (src_dir / "__rewire_bags_in_apalache.tla") ->
                   "tla2sany/StandardModules/__rewire_bags_in_apalache.tla",
+                (src_dir / "__rewire_bags_ext_in_apalache.tla") ->
+                  "tla2sany/StandardModules/__rewire_bags_ext_in_apalache.tla",
                 (src_dir / "__apalache_folds.tla") ->
                   "tla2sany/StandardModules/__apalache_folds.tla",
                 (src_dir / "__apalache_internal.tla") ->

--- a/src/tla/__rewire_bags_ext_in_apalache.tla
+++ b/src/tla/__rewire_bags_ext_in_apalache.tla
@@ -1,0 +1,49 @@
+--------------------------- MODULE BagsExt -----------------------------------
+\*------ MODULE __rewire_bags_ext_in_apalache -----------------------
+(**
+ * ^^^^^^^^^^^^^^^^^^^^^^ We have to call this module BagsExt in any
+ * case, otherwise, SANY complains.
+ *
+ * This file contains alternative definitions for the operators defined in
+ * BagsExt. Most importantly, we are adding type annotations. We also
+ * define the Apalache-compatible behavior.
+ *
+ * These definitions are automatically rewired by the Apalache importer.
+ *
+ * Compare with the original definitions in BagsExt.tla:
+ *
+ * https://github.com/tlaplus/CommunityModules/blob/master/modules/BagsExt.tla
+ *)
+
+EXTENDS Integers, Bags, __apalache_internal, __apalache_folds
+
+(**
+ * Add an element x to bag B. Same as B (+) SetToBag({x}).
+ *
+ * @type: (a -> Int, a) => (a -> Int);
+ *)
+BagAdd(B, x) ==
+   IF x \in DOMAIN B
+   THEN [e \in DOMAIN B |-> IF e = x THEN B[e] + 1 ELSE B[e]]
+   ELSE [e \in DOMAIN B \union { x } |-> IF e = x THEN 1 ELSE B[e]]
+
+(**
+ * Remove an element x from bag B. Same as B (-) SetToBag({x}).
+ *
+ * @type: (a -> Int, a) => (a -> Int);
+ *)
+BagRemove(B, x) ==
+   IF x \in DOMAIN B
+   THEN IF B[x] = 1
+        THEN [e \in DOMAIN B \ {x} |-> B[e]]
+        ELSE [e \in DOMAIN B |-> IF e = x THEN B[e] - 1 ELSE B[e]]
+   ELSE B
+
+(**
+ * Remove all copies of an element x from bag B.
+ *
+ * @type: (a -> Int, a) => (a -> Int);
+ *)
+BagRemoveAll(B, x) ==
+   [e \in DOMAIN B \ {x} |-> B[e]]
+=============================================================================

--- a/src/tla/__rewire_bags_ext_in_apalache.tla
+++ b/src/tla/__rewire_bags_ext_in_apalache.tla
@@ -46,4 +46,46 @@ BagRemove(B, x) ==
  *)
 BagRemoveAll(B, x) ==
    [e \in DOMAIN B \ {x} |-> B[e]]
+
+(**
+ * Fold operation op over the images through f of all elements of bag
+ * B, starting from base. The parameter choose indicates the order in
+ * which elements of the bag are processed; all replicas of an element
+ * are processed consecutively.
+ *
+ * Apalache does not support this operator. Use FoldFunction.
+ *
+ * @type: ((a, b) => b, b, a => b, Set(a) => a, a -> Int) => b;
+ *)
+MapThenFoldBag(op(_, _), base, f(_), choose(_), B) ==
+    __NotSupportedByModelChecker("MapThenFoldBag. Use FoldFunction.")
+
+(**
+ * Fold op over all elements of bag B, starting with value base.
+ *
+ * Apalache does not support this operator. Use FoldFunction.
+ *
+ * @type: ((a, b) => b, b, a -> Int) => (a -> Int);
+ *)
+FoldBag(op(_, _), base, B) ==
+    __NotSupportedByModelChecker("FoldBag. Use FoldFunction.")
+
+(**
+ * Compute the sum of the elements of B.
+ *
+ * @type: (Int -> Int) => Int;
+ *)
+SumBag(B) ==
+  LET __map(x, y) == x + y * B[y] IN
+  __ApalacheFoldSet(__map, 0, DOMAIN B)
+
+(**
+ * Compute the product of the elements of B.
+ *
+ * @type: (Int -> Int) => Int;
+ *)
+ProductBag(B) ==
+  LET __map(x, y) == x * (y^B[y]) IN
+  __ApalacheFoldSet(__map, 1, DOMAIN B)
+
 =============================================================================

--- a/test/tla/TestBagsExt.tla
+++ b/test/tla/TestBagsExt.tla
@@ -23,6 +23,18 @@ TestBagRemoveAll1 ==
     LET B == SetAsFun({<<1, 2>>, <<2, 1>>}) IN
     BagRemoveAll(B, 1) = SetToBag({2})
 
+TestSumBag1 ==
+    LET B == SetAsFun({<<1, 2>>, <<2, 1>>, <<3, 2>>}) IN
+    SumBag(B) = 10
+
+TestSumBag2 ==
+    LET B == SetAsFun({<<1, 2>>, <<-2, 1>>}) IN
+    SumBag(B) = 0
+
+TestProductBag1 ==
+    LET B == SetAsFun({<<1, 2>>, <<-2, 1>>}) IN
+    ProductBag(B) = -2
+
 Init == TRUE
 
 Next == TRUE
@@ -33,5 +45,8 @@ AllTests ==
   /\ TestBagRemove1
   /\ TestBagRemove2
   /\ TestBagRemoveAll1
+  /\ TestSumBag1
+  /\ TestSumBag2
+  /\ TestProductBag1
 
 ====================

--- a/test/tla/TestBagsExt.tla
+++ b/test/tla/TestBagsExt.tla
@@ -1,0 +1,37 @@
+---------- MODULE TestBagsExt ----------
+
+EXTENDS Integers, Apalache, Bags, BagsExt
+
+TestBagAdd1 ==
+    LET B == SetToBag({1, 2}) IN
+    BagAdd(B, 2) = B (+) SetToBag({2})
+
+TestBagAdd2 ==
+    LET B == SetToBag({1, 2}) IN
+    BagAdd(B, 3) = B (+) SetToBag({3})
+
+TestBagRemove1 ==
+    LET B == SetToBag({1, 2}) IN
+    BagRemove(B, 2) = B (-) SetToBag({2})
+
+TestBagRemove2 ==
+    LET B == SetToBag({1, 2}) IN 
+           /\ BagRemove(B, 3) = B (-) SetToBag({3})
+           /\ BagRemove(B, 3) = B
+
+TestBagRemoveAll1 ==
+    LET B == SetAsFun({<<1, 2>>, <<2, 1>>}) IN
+    BagRemoveAll(B, 1) = SetToBag({2})
+
+Init == TRUE
+
+Next == TRUE
+
+AllTests ==
+  /\ TestBagAdd1
+  /\ TestBagAdd2
+  /\ TestBagRemove1
+  /\ TestBagRemove2
+  /\ TestBagRemoveAll1
+
+====================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1880,6 +1880,14 @@ $ apalache-mc check --length=0 --inv=Inv TestBags.tla | sed 's/[IEW]@.*//'
 EXITCODE: OK
 ```
 
+### check TestBagsExt.tla reports no error
+
+```sh
+$ apalache-mc check --length=0 --inv=AllTests TestBagsExt.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check Test1343.tla reports no error
 
 Regression test for #1343

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -82,6 +82,7 @@ object StandardLibrary {
         "TLC.tla" -> "__rewire_tlc_in_apalache.tla",
         "Sequences.tla" -> "__rewire_sequences_in_apalache.tla",
         "Bags.tla" -> "__rewire_bags_in_apalache.tla",
+        "BagsExt.tla" -> "__rewire_bags_ext_in_apalache.tla",
         "Functions.tla" -> "__rewire_functions_in_apalache.tla",
         "FiniteSetsExt.tla" -> "__rewire_finite_sets_ext_in_apalache.tla",
         // will be enabled later


### PR DESCRIPTION
Closes #1524. This PR rewires the few operators of `BagsExt`. The following two operators are not supported as they require unbounded loops:

 - `MapThenFoldBag`
 - `FoldBag`

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
