### PR TITLE
Rename adr16 into ReTLA

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -100,4 +100,4 @@
 - [ADR-009: outputs](./adr/009adr-outputs.md)
 - [ADR-011: alternative SMT encoding using arrays](./adr/011adr-smt-arrays.md)
 - [ADR-015: ITF: informal trace format](./adr/015adr-trace.md)
-- [ADR-016: Uninterpreted first-order logic fragment encoding](./adr/016adr-simple.md)
+- [ADR-016: ReTLA: Relational TLA](./adr/016adr-retla.md)

--- a/docs/src/adr/016adr-retla.md
+++ b/docs/src/adr/016adr-retla.md
@@ -1,4 +1,4 @@
-# ADR-16: Uninterpreted first-order logic fragment encoding
+# ADR-16: ReTLA - Relational TLA
 
 | author     | revision |
 | ------------ | --------:|


### PR DESCRIPTION
This is a technical PR, which clarifies the name of ADR016.
