### PR TITLE
Fix docs for `transitionFilter`

### DIFF
--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -40,7 +40,7 @@ mode may drastically reduce memory consumption, but it may take longer than the
   The regular expression should recognize words over of the form 's->t', where `s`
   is a regular expression over step numbers and `t` is a regular expression over
   transition numbers. For instance,
-  `search.transitionFilter=(0->0|1->5|2->2|3->3|[4-9]->.*|[1-9][0-9]+->.*)`
+  `search.transitionFilter=(0->0|1->5|2->2|2->3|[3-9]->.*|[1-9][0-9]+->.*)`
   requires to start with the 0th transition, continue with the 5th transition,
   then execute either the 2nd or the 3rd transition and after that execute
   arbitrary transitions until the `length.` Note that there is no direct correspondence

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -44,8 +44,8 @@ mode may drastically reduce memory consumption, but it may take longer than the
   requires to start with the 0th transition, continue with the 5th transition,
   then execute either the 2nd or the 3rd transition and after that execute
   arbitrary transitions until the `length.` Note that there is no direct correspondence
-  between the transition numbers and the actions in the TLA+ spec. Check the
-  transition numbers in `./x/**/out-transition.tla`: 0th transition is called `Next$0`, 1st transition is called `Next$1`, etc.
+  between the transition numbers and the actions in the TLA+ spec. To find the numbers, run Apalache with `--write-intermediate=true` and check the
+  transition numbers in `_apalache-out/<MySpec>.tla/*/intermediate/09_OutTransition.tla`: the 0th transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`, etc.
 
 1. __Invariant checking at certain steps__: `search.invariantFilter=regex`.
   Check the invariant only at the steps that satisfy the regular expression.

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -35,17 +35,21 @@ mode may drastically reduce memory consumption, but it may take longer than the
 `after` mode, provided that Apalache has enough memory. The default mode is
 `before`.
 
-1. __Guided search__: `search.transitionFilter=<regex>`.
-  Restrict the choice of symbolic transitions at every step with a regular expression.
-  The regular expression should recognize words over of the form 's->t', where `s`
-  is a regular expression over step numbers and `t` is a regular expression over
-  transition numbers. For instance,
-  `search.transitionFilter=(0->0|1->5|2->2|2->3|[3-9]->.*|[1-9][0-9]+->.*)`
-  requires to start with the 0th transition, continue with the 5th transition,
-  then execute either the 2nd or the 3rd transition and after that execute
-  arbitrary transitions until the `length.` Note that there is no direct correspondence
-  between the transition numbers and the actions in the TLA+ spec. To find the numbers, run Apalache with `--write-intermediate=true` and check the
-  transition numbers in `_apalache-out/<MySpec>.tla/*/intermediate/09_OutTransition.tla`: the 0th transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`, etc.
+1. __Guided search__: `search.transitionFilter=<regex>`. Restrict the choice of
+   symbolic transitions at every step with a regular expression. The regular
+expression should recognize words over of the form 's->t', where `s` is a
+regular expression over step numbers and `t` is a regular expression over
+transition numbers. For instance,
+`search.transitionFilter=(0->0|1->5|2->2|2->3|[3-9]->.*|[1-9][0-9]+->.*)`
+requires to start with the 0th transition, continue with the 5th transition,
+then execute either the 2nd or the 3rd transition and after that execute
+arbitrary transitions until the `length.` Note that there is no direct
+correspondence between the transition numbers and the actions in the TLA+ spec.
+To find the numbers, run Apalache with `--write-intermediate=true` and check the
+transition numbers in
+`_apalache-out/<MySpec>.tla/*/intermediate/09_OutTransition.tla`: the 0th
+transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`,
+etc.
 
 1. __Invariant checking at certain steps__: `search.invariantFilter=regex`.
   Check the invariant only at the steps that satisfy the regular expression.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -579,8 +579,8 @@ class PrettyWriter(
   }
 
   private def parseableName(name: String): String = {
-    // An operator name may contain '!', if it comes from an instance. Replace it '!' with "_I_".
-    // Additionally, the name may contain '$', which is produced during preprocessing. Replace it with "_SI_".
+    // An operator name may contain '!', if it comes from an instance. Replace it '!' with "_i_".
+    // Additionally, the name may contain '$', which is produced during preprocessing. Replace it with "_si_".
     name.replaceAll("!", "_i_").replaceAll("\\$", "_si_")
   }
 


### PR DESCRIPTION
Fixes a few issues with the docs on `transitionFilter`:
- Sync the regex to specify what's given as prose description (c8e1ace9a08abe65ac1f991007470934df338824)
- Fix intermediate output paths (45f4dd444036c07480ec31fe173e9165ce1757af)

💡 The last commit formats the `.md`; viewing only the earlier commits should give you a nicer diff.