### PR TITLE
Move internal operators to ApalacheInternalOper

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
@@ -33,7 +33,7 @@ class SymbStateRewriterImplWithArrays(
     Map(
         // sets
         key(tla.in(tla.name("x"), tla.name("S")))
-          -> List(new SetInRuleWithArrays(this)), // TODO: add support for funSet later
+          -> List(new SetInRuleWithArrays(this)),
         key(tla.apalacheSelectInSet(tla.name("x"), tla.name("S")))
           -> List(new SetInRuleWithArrays(this)),
         key(tla.apalacheSelectInFun(tla.name("x"), tla.name("F")))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -71,7 +71,8 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       OperEx(op, name, transform(true)(set), transform(false)(pred))(tag)
 
     case ex @ OperEx(op, elem, set)
-        if op == TlaSetOper.in || op == ApalacheOper.selectInSet || op == ApalacheOper.storeInSet || op == TlaSetOper.notin || op == ApalacheOper.storeNotInSet =>
+        if op == TlaSetOper.in || op == ApalacheInternalOper.selectInSet || op == ApalacheInternalOper.storeInSet ||
+          op == TlaSetOper.notin || op == ApalacheInternalOper.storeNotInSet =>
       // when checking e \in S or e \notin S, we can keep S unexpanded, but e should be expanded
       val tag = ex.typeTag
       OperEx(op, transform(true)(elem), transform(false)(set))(tag)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/ModelValueCache.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/caches/ModelValueCache.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.ConstT
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
-import at.forsyte.apalache.tla.lir.oper.ApalacheOper
+import at.forsyte.apalache.tla.lir.oper.ApalacheInternalOper
 
 /**
  * A cache for model values that are translated as uninterpreted constants, with a unique sort per uniterpreted type.
@@ -25,7 +25,7 @@ class ModelValueCache(solverContext: SolverContext)
     // The fresh cell should differ from the previously created cells.
     // We use the SMT constraint (distinct ...).
     val others = values().filter(_.cellType == ConstT(utype)).map(_.toNameEx).toSeq
-    solverContext.assertGroundExpr(OperEx(ApalacheOper.distinct, newCell.toNameEx +: others: _*))
+    solverContext.assertGroundExpr(OperEx(ApalacheInternalOper.distinct, newCell.toNameEx +: others: _*))
     solverContext.log("; cached \"%s\" to %s".format(typeAndIndex, newCell))
     (newArena, newCell)
   }
@@ -59,7 +59,7 @@ class ModelValueCache(solverContext: SolverContext)
     val newCells = foundOrNewCells.collect { case Right(c) => c }
     // require that all new cells and old cells are distinct
     if (newCells.nonEmpty) {
-      solverContext.assertGroundExpr(OperEx(ApalacheOper.distinct, oldCells ++ newCells.map(_.toNameEx): _*))
+      solverContext.assertGroundExpr(OperEx(ApalacheInternalOper.distinct, oldCells ++ newCells.map(_.toNameEx): _*))
     }
     (nextArena, foundOrNewCells.map(_.fold(c => c, c => c)).toSeq)
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rewriter/ConstSimplifierForSmt.scala
@@ -50,8 +50,9 @@ class ConstSimplifierForSmt extends ConstSimplifierBase {
       }
 
     // do not go in tla.in and tla.notin, as it breaks down our SMT encoding
-    case ex @ (OperEx(TlaSetOper.in, _*) | OperEx(TlaSetOper.notin, _*) | OperEx(ApalacheOper.selectInSet, _*) |
-        OperEx(ApalacheOper.storeInSet, _*) | OperEx(ApalacheOper.storeNotInSet, _*)) =>
+    case ex @ OperEx(op, _*)
+        if op == TlaSetOper.in || op == ApalacheInternalOper.selectInSet || op == ApalacheInternalOper.storeInSet ||
+          op == TlaSetOper.notin || op == ApalacheInternalOper.storeNotInSet =>
       ex
 
     // using isTrueConst and isFalseConst that are more precise than those of ConstSimplifierBase

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/CardinalityConstRule.scala
@@ -6,7 +6,7 @@ import at.forsyte.apalache.tla.bmcmt.rules.aux.CherryPick
 import at.forsyte.apalache.tla.bmcmt.types.BoolT
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
-import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaArithOper, TlaFiniteSetOper}
+import at.forsyte.apalache.tla.lir.oper.{ApalacheInternalOper, ApalacheOper, TlaArithOper, TlaFiniteSetOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.{OperEx, ValEx}
 
@@ -78,7 +78,7 @@ class CardinalityConstRule(rewriter: SymbStateRewriter) extends RewritingRule {
     // create the inequality predicate
     val witnesses = List.fill(threshold)(pick)
     (witnesses.cross(witnesses)).filter(p => p._1.id < p._2.id).foreach(cacheEq)
-    val witnessesNotEq = OperEx(ApalacheOper.distinct, witnesses.map(_.toNameEx): _*)
+    val witnessesNotEq = OperEx(ApalacheInternalOper.distinct, witnesses.map(_.toNameEx): _*)
     nextState = nextState.updateArena(_.appendCell(BoolT()))
     val pred = nextState.arena.topCell
     // either the set is empty and threshold <= 0, or all witnesses are not equal to each other

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetAsFunRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetAsFunRule.scala
@@ -49,7 +49,7 @@ class SetAsFunRule(rewriter: SymbStateRewriter) extends RewritingRule {
                   val resElem = nextState.arena.getHas(pair)(1)
 
                   nextState = nextState.updateArena(_.appendHas(domainCell, domElem))
-                  val inExpr = OperEx(ApalacheOper.storeInSet, domElem.toNameEx, domainCell.toNameEx)
+                  val inExpr = tla.apalacheStoreInSet(domElem.toNameEx, domainCell.toNameEx)
                   rewriter.solverContext.assertGroundExpr(inExpr)
 
                   nextState = nextState.updateArena(_.appendHasNoSmt(relationCell, pair))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/UninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/UninterpretedConstOracle.scala
@@ -36,7 +36,7 @@ class UninterpretedConstOracle(valueCells: Seq[ArenaCell], oracleCell: ArenaCell
    *   an expression ite(oracle = 0, ite(oracle = 1, ...))
    */
   override def caseAssertions(state: SymbState, assertions: Seq[TlaEx], elseAssertions: Seq[TlaEx] = Seq()): TlaEx = {
-    if (elseAssertions.nonEmpty & assertions.size != elseAssertions.size) {
+    if (elseAssertions.nonEmpty && assertions.size != elseAssertions.size) {
       throw new IllegalStateException(s"Invalid call to Oracle, malformed elseAssertions")
     }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
@@ -110,10 +110,10 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
       for (elem <- elems) {
         nextState = nextState.updateArena(_.appendCell(BoolT()))
         val pred = nextState.arena.topCell.toNameEx
-        val storeElem = tla.apalacheStoreInSet(elem.toNameEx, setCell.toNameEx)
-        val notStoreElem = tla.apalacheStoreNotInSet(elem.toNameEx, setCell.toNameEx)
+        val storeElem = tla.apalacheStoreInSet(elem.toNameEx, setCell.toNameEx).typed(SetT1(elemType))
+        val notStoreElem = tla.apalacheStoreNotInSet(elem.toNameEx, setCell.toNameEx).typed(SetT1(elemType))
         // elem is added to setCell based on the unconstrained predicate pred
-        val ite = tla.ite(pred, storeElem, notStoreElem).typed(BoolT1())
+        val ite = tla.ite(pred, storeElem, notStoreElem).typed(SetT1(elemType))
         rewriter.solverContext.assertGroundExpr(ite)
       }
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -621,7 +621,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         val (eq, n) = toExpr(OperEx(TlaOper.eq, lhs, rhs))
         (z3context.mkNot(eq.asInstanceOf[BoolExpr]).asInstanceOf[ExprSort], 1 + n)
 
-      case OperEx(ApalacheOper.distinct, args @ _*) =>
+      case OperEx(ApalacheInternalOper.distinct, args @ _*) =>
         val (es, ns) = (args.map(toExpr)).unzip
         val distinct = z3context.mkDistinct(es: _*)
         (distinct.asInstanceOf[ExprSort],
@@ -679,7 +679,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         val elemId = ArenaCell.idFromName(elemName)
         (getInPred(setId, elemId), 1)
 
-      case OperEx(ApalacheOper.selectInSet, NameEx(elemName), NameEx(setName)) =>
+      case OperEx(ApalacheInternalOper.selectInSet, NameEx(elemName), NameEx(setName)) =>
         encoding match {
           case `arraysEncoding` =>
             val setId = ArenaCell.idFromName(setName)
@@ -691,8 +691,8 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
             throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
         }
 
-      case OperEx(ApalacheOper.selectInSet, OperEx(ApalacheOper.selectInSet, NameEx(elemName), NameEx(funName)),
-              NameEx(setName)) =>
+      case OperEx(ApalacheInternalOper.selectInSet,
+              OperEx(ApalacheInternalOper.selectInSet, NameEx(elemName), NameEx(funName)), NameEx(setName)) =>
         encoding match {
           case `arraysEncoding` =>
             // Nested selects are used to check if the result of a function application is in a given set
@@ -705,7 +705,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
             throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
         }
 
-      case OperEx(ApalacheOper.storeInSet, NameEx(elemName), NameEx(setName)) =>
+      case OperEx(ApalacheInternalOper.storeInSet, NameEx(elemName), NameEx(setName)) =>
         encoding match {
           case `arraysEncoding` =>
             val setId = ArenaCell.idFromName(setName)
@@ -717,7 +717,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
             throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
         }
 
-      case OperEx(ApalacheOper.storeInSet, NameEx(elemName), NameEx(funName), NameEx(argName)) =>
+      case OperEx(ApalacheInternalOper.storeInSet, NameEx(elemName), NameEx(funName), NameEx(argName)) =>
         encoding match {
           case `arraysEncoding` =>
             // Updates a function for a given argument
@@ -730,7 +730,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
             throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
         }
 
-      case OperEx(ApalacheOper.storeNotInSet, NameEx(elemName), NameEx(setName)) =>
+      case OperEx(ApalacheInternalOper.storeNotInSet, NameEx(elemName), NameEx(setName)) =>
         encoding match {
           case `arraysEncoding` =>
             // In the arrays encoding the sets are initially empty, so elem is not a member of set implicitly
@@ -743,7 +743,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
             throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
         }
 
-      case OperEx(ApalacheOper.smtMap, NameEx(inputSetName), NameEx(resultSetName)) =>
+      case OperEx(ApalacheInternalOper.smtMap, NameEx(inputSetName), NameEx(resultSetName)) =>
         val inputSetId = ArenaCell.idFromName(inputSetName)
         val resultSetId = ArenaCell.idFromName(resultSetName)
         // The latest SSA array for resultSet contains the constraints. An updated SSA array is made to store the result
@@ -755,7 +755,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         val eq = toEqExpr(updatedResultSet, map)
         (eq.asInstanceOf[ExprSort], 2)
 
-      case OperEx(ApalacheOper.unconstrainArray, NameEx(arrayElemName)) =>
+      case OperEx(ApalacheInternalOper.unconstrainArray, NameEx(arrayElemName)) =>
         val arrayElemId = ArenaCell.idFromName(arrayElemName)
         updateArrayConst(arrayElemId) // A new array is declared and left unconstrained
         toExpr(ValEx(TlaBool(true))) // Nothing to assert

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -774,7 +774,7 @@ class ToEtcExpr(annotationStore: AnnotationStore, aliasSubstitution: ConstSubsti
         val opsig = OperT1(Seq(BoolT1()), BoolT1())
         mkExRefApp(opsig, Seq(predicate))
 
-      case OperEx(ApalacheOper.distinct, args @ _*) =>
+      case OperEx(ApalacheInternalOper.distinct, args @ _*) =>
         val a = varPool.fresh
         // (a, ..., a) => Bool
         val opsig = OperT1(args.map(_ => a), BoolT1())

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -797,7 +797,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
   test("Apalache!Distinct") {
     val typ = parser("(a, a) => Bool")
     val expected = mkAppByName(Seq(typ), "x", "y")
-    val ex = OperEx(ApalacheOper.distinct, tla.name("x"), tla.name("y"))
+    val ex = OperEx(ApalacheInternalOper.distinct, tla.name("x"), tla.name("y"))
     assert(expected == gen(ex))
   }
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -631,35 +631,35 @@ class Builder {
   }
 
   def apalacheSelectInSet(elem: BuilderEx, set: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.selectInSet, elem, set)
+    BuilderOper(ApalacheInternalOper.selectInSet, elem, set)
   }
 
   def apalacheSelectInFun(elem: BuilderEx, fun: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.selectInSet, elem, fun)
+    BuilderOper(ApalacheInternalOper.selectInSet, elem, fun)
   }
 
   def apalacheStoreInSet(elem: BuilderEx, set: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.storeInSet, elem, set)
+    BuilderOper(ApalacheInternalOper.storeInSet, elem, set)
   }
 
   def apalacheStoreInFun(elem: BuilderEx, fun: BuilderEx, arg: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.storeInSet, elem, fun, arg)
+    BuilderOper(ApalacheInternalOper.storeInSet, elem, fun, arg)
   }
 
   def apalacheStoreNotInSet(elem: BuilderEx, set: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.storeNotInSet, elem, set)
+    BuilderOper(ApalacheInternalOper.storeNotInSet, elem, set)
   }
 
   def apalacheStoreNotInFun(elem: BuilderEx, fun: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.storeNotInSet, elem, fun)
+    BuilderOper(ApalacheInternalOper.storeNotInSet, elem, fun)
   }
 
   def apalacheSmtMap(inputSet: BuilderEx, resultSet: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.smtMap, inputSet, resultSet)
+    BuilderOper(ApalacheInternalOper.smtMap, inputSet, resultSet)
   }
 
   def apalacheUnconstrainArray(arrayElemName: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheOper.unconstrainArray, arrayElemName)
+    BuilderOper(ApalacheInternalOper.unconstrainArray, arrayElemName)
   }
 
   private val m_nameMap: Map[String, TlaOper] =
@@ -744,15 +744,15 @@ class Builder {
         ApalacheOper.skolem.name -> ApalacheOper.skolem,
         ApalacheOper.expand.name -> ApalacheOper.expand,
         ApalacheOper.constCard.name -> ApalacheOper.constCard,
-        ApalacheOper.distinct.name -> ApalacheOper.distinct,
+        ApalacheInternalOper.distinct.name -> ApalacheInternalOper.distinct,
         ApalacheOper.mkSeq.name -> ApalacheOper.mkSeq,
         ApalacheOper.foldSet.name -> ApalacheOper.foldSet,
         ApalacheOper.foldSeq.name -> ApalacheOper.foldSeq,
-        ApalacheOper.selectInSet.name -> ApalacheOper.selectInSet,
-        ApalacheOper.storeInSet.name -> ApalacheOper.storeInSet,
-        ApalacheOper.storeNotInSet.name -> ApalacheOper.storeNotInSet,
-        ApalacheOper.smtMap.name -> ApalacheOper.smtMap,
-        ApalacheOper.unconstrainArray.name -> ApalacheOper.unconstrainArray,
+        ApalacheInternalOper.selectInSet.name -> ApalacheInternalOper.selectInSet,
+        ApalacheInternalOper.storeInSet.name -> ApalacheInternalOper.storeInSet,
+        ApalacheInternalOper.storeNotInSet.name -> ApalacheInternalOper.storeNotInSet,
+        ApalacheInternalOper.smtMap.name -> ApalacheInternalOper.smtMap,
+        ApalacheInternalOper.unconstrainArray.name -> ApalacheInternalOper.unconstrainArray,
         ApalacheOper.setAsFun.name -> ApalacheOper.setAsFun,
     )
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
@@ -24,6 +24,20 @@ object ApalacheInternalOper {
   }
 
   /**
+   * The distinct operator that is equivalent to (distinct ...) in SMT-LIB. Formally, BMC!Distinct(x_1, ..., x_n) is
+   * equivalent to \A i, j \in 1..n: i /= j => x_i /= x_j.
+   *
+   * XXX: there seems to be no way of defining a user-defined variadic operator in Apalache.tla.
+   */
+  object distinct extends ApalacheOper {
+    override def name: String = "Apalache!Distinct"
+
+    override def arity: OperArity = AnyArity()
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
    * This operator returns the capacity of a given sequence, that is, a static upper bound on its length.
    */
   object apalacheSeqCapacity extends ApalacheInternalOper {
@@ -34,4 +48,61 @@ object ApalacheInternalOper {
     override val precedence: (Int, Int) = (100, 100)
   }
 
+  /**
+   * The selectInSet operator is a variant of TlaSetOper.in. It signals that set membership should be checked.
+   */
+  object selectInSet extends ApalacheOper {
+    override def name: String = "Apalache!SelectInSet"
+
+    override def arity: OperArity = FixedArity(2)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+   * The storeInSet operator is a variant of TlaSetOper.in when handling sets. It signals set membership. It is also
+   * used to update functions, in which case the updated value is provided as an additional argument.
+   */
+  object storeInSet extends ApalacheOper {
+    override def name: String = "Apalache!StoreInSet"
+
+    override def arity: OperArity = FixedArity(2) || FixedArity(3)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+   * The storeNotInSet operator is a variant of storeInSet. It signals that the negation of set membership should be
+   * enforced.
+   */
+  object storeNotInSet extends ApalacheOper {
+    override def name: String = "Apalache!UnchangedSet"
+
+    override def arity: OperArity = FixedArity(2)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+   * The smtMap operator applies an SMT map using conjunction to two cells encoded as SMT arrays. Its current use is to
+   * encoded set intersection when handling TLA+ filters.
+   */
+  object smtMap extends ApalacheOper {
+    override def name: String = "Apalache!SmtMap"
+
+    override def arity: OperArity = FixedArity(2)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
+
+  /**
+   * The unconstrainArray operator increases the SSA index of a cell encoded as an SMT array.
+   */
+  object unconstrainArray extends ApalacheOper {
+    override def name: String = "Apalache!UnconstrainArray"
+
+    override def arity: OperArity = FixedArity(1)
+
+    override def precedence: (Int, Int) = (5, 5)
+  }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
@@ -88,20 +88,6 @@ object ApalacheOper {
   }
 
   /**
-   * The distinct operator that is equivalent to (distinct ...) in SMT-LIB. Formally, BMC!Distinct(x_1, ..., x_n) is
-   * equivalent to \A i, j \in 1..n: i /= j => x_i /= x_j.
-   *
-   * XXX: there seems to be no way of defining a user-defined variadic operator in Apalache.tla.
-   */
-  object distinct extends ApalacheOper {
-    override def name: String = "Apalache!Distinct"
-
-    override def arity: OperArity = AnyArity()
-
-    override def precedence: (Int, Int) = (5, 5)
-  }
-
-  /**
    * <p>Attempt to dynamically cast an Int -> T function to a Seq(T). The first argument should be the function
    * expression and the second argument should be an integer, denoting the maximal length of the sequence.</p>
    *
@@ -193,63 +179,5 @@ object ApalacheOper {
     override def arity: OperArity = FixedArity(1)
 
     override def precedence: (Int, Int) = (100, 100)
-  }
-
-  /**
-   * The selectInSet operator is a variant of TlaSetOper.in. It signals that set membership should be checked.
-   */
-  object selectInSet extends ApalacheOper {
-    override def name: String = "Apalache!SelectInSet"
-
-    override def arity: OperArity = FixedArity(2)
-
-    override def precedence: (Int, Int) = (5, 5)
-  }
-
-  /**
-   * The storeInSet operator is a variant of TlaSetOper.in when handling sets. It signals set membership. It is also
-   * used to update functions, in which case the updated value is provided as an additional argument.
-   */
-  object storeInSet extends ApalacheOper {
-    override def name: String = "Apalache!StoreInSet"
-
-    override def arity: OperArity = FixedArity(2) || FixedArity(3)
-
-    override def precedence: (Int, Int) = (5, 5)
-  }
-
-  /**
-   * The storeNotInSet operator is a variant of storeInSet. It signals that the negation of set membership should be
-   * enforced.
-   */
-  object storeNotInSet extends ApalacheOper {
-    override def name: String = "Apalache!UnchangedSet"
-
-    override def arity: OperArity = FixedArity(2)
-
-    override def precedence: (Int, Int) = (5, 5)
-  }
-
-  /**
-   * The smtMap operator applies an SMT map using conjunction to two cells encoded as SMT arrays. Its current use is to
-   * encoded set intersection when handling TLA+ filters.
-   */
-  object smtMap extends ApalacheOper {
-    override def name: String = "Apalache!SmtMap"
-
-    override def arity: OperArity = FixedArity(2)
-
-    override def precedence: (Int, Int) = (5, 5)
-  }
-
-  /**
-   * The unconstrainArray operator increases the SSA index of a cell encoded as an SMT array.
-   */
-  object unconstrainArray extends ApalacheOper {
-    override def name: String = "Apalache!UnconstrainArray"
-
-    override def arity: OperArity = FixedArity(1)
-
-    override def precedence: (Int, Int) = (5, 5)
   }
 }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

The core of this PR is the move of six IR operators from `ApalacheOper` to `ApalacheInternalOper`. This affected many files. Most of them were handled by simple substitution, but I took the opportunity to rework some of the cases in which the touched operators were used, aiming to make the code clearer. Closes #1287.