### PR TITLE
Switch symlink creation to use os-independent Files.createSymbolicLink

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,3 +13,4 @@
 ### Bug fixes
 
 * Fix the generation of SMT instances with the `--debug` flag, see #1594
+* Fix symbolic link generation in 'make' on Windows, see #1596

--- a/build.sbt
+++ b/build.sbt
@@ -292,7 +292,7 @@ lazy val root = (project in file("."))
         // See https://github.com/informalsystems/apalache/pull/1382
         (s"tar zxvf ${pkg} -C ${target_dir}" !)
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
-        val target_path: java.nio.file.Path = java.nio.file.Paths.get("", unzipped)
+        val target_path: java.nio.file.Path = java.nio.file.Paths.get(unzipped)
         if (!current_pkg.exists) {
           java.nio.file.Files.createSymbolicLink(current_pkg.toPath(), target_path)
         } else {

--- a/build.sbt
+++ b/build.sbt
@@ -293,9 +293,8 @@ lazy val root = (project in file("."))
         (s"tar zxvf ${pkg} -C ${target_dir}" !)
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
         val target_path: java.nio.file.Path = java.nio.file.Paths.get("", unzipped)
-        if (!current_pkg.exists) 
-        { 
-          java.nio.file.Files.createSymbolicLink(current_pkg.toPath(), target_path) 
+        if (!current_pkg.exists) {
+          java.nio.file.Files.createSymbolicLink(current_pkg.toPath(), target_path)
         } else {
           log.info(s"${current_pkg} already exists")
         }

--- a/build.sbt
+++ b/build.sbt
@@ -292,7 +292,13 @@ lazy val root = (project in file("."))
         // See https://github.com/informalsystems/apalache/pull/1382
         (s"tar zxvf ${pkg} -C ${target_dir}" !)
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
-        s"ln -sfn ${unzipped} ${current_pkg}" ! log
+        val target_path: java.nio.file.Path = java.nio.file.Paths.get("", unzipped)
+        if (!current_pkg.exists) 
+        { 
+          java.nio.file.Files.createSymbolicLink(current_pkg.toPath(), target_path) 
+        } else {
+          log.info(s"${current_pkg} already exists")
+        }
         file(unzipped)
       },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -292,12 +292,14 @@ lazy val root = (project in file("."))
         // See https://github.com/informalsystems/apalache/pull/1382
         (s"tar zxvf ${pkg} -C ${target_dir}" !)
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
-        val target_path: java.nio.file.Path = java.nio.file.Paths.get(unzipped)
         if (current_pkg.exists) {
           log.info(s"${current_pkg} already exists, overriding")
           current_pkg.delete
         }
-        java.nio.file.Files.createSymbolicLink(current_pkg.toPath, target_path)
+        java.nio.file.Files.createSymbolicLink(
+            current_pkg.toPath,
+            file(unzipped).toPath,
+        )
         file(unzipped)
       },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -293,11 +293,11 @@ lazy val root = (project in file("."))
         (s"tar zxvf ${pkg} -C ${target_dir}" !)
         log.info(s"Symlinking ${current_pkg} -> ${unzipped}")
         val target_path: java.nio.file.Path = java.nio.file.Paths.get(unzipped)
-        if (!current_pkg.exists) {
-          java.nio.file.Files.createSymbolicLink(current_pkg.toPath(), target_path)
-        } else {
-          log.info(s"${current_pkg} already exists")
+        if (current_pkg.exists) {
+          log.info(s"${current_pkg} already exists, overriding")
+          current_pkg.delete
         }
+        java.nio.file.Files.createSymbolicLink(current_pkg.toPath, target_path)
         file(unzipped)
       },
   )


### PR DESCRIPTION
Change build.sbt to use [Files.createSymbolicLink](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,%20java.nio.file.Path,%20java.nio.file.attribute.FileAttribute...))
for compatibility with more OS's