### PR TITLE
Parsing row types, records, and variants

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,11 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+
+### Features
+
+* Extend the type parser to support ADR014 (experimental), see #1602
+
 ### Bug fixes
 
 * Fix the generation of SMT instances with the `--debug` flag, see #1594

--- a/src/tla/Variants.tla
+++ b/src/tla/Variants.tla
@@ -17,6 +17,11 @@
  *
  * @param rec a record that contains a field `tag`
  * @return the record wrapped in the variant type
+ *
+ * The type could look like follows, if we supported string literals in types:
+ *
+ *   Rec({ tag: Str, a }) =>
+ *     { tag: "$tagValue", a } | b
  *)
 Variant(rec) ==
     \* default untyped implementation
@@ -28,6 +33,10 @@ Variant(rec) ==
  * @param `S` a set of variants that are constructed with `Variant(...)`
  * @param `tagValue` a string literal that is used to filter the set elements
  * @return the set of elements of S that are tagged with `tagValue`.
+ *
+ * The type could look like follows, if we supported string literals in types:
+ *
+ *   (Set({ tag: "$tagValue", a} | b), Str) => Set({ tag: Str, a })
  *)
 FilterByTag(S, tagValue) ==
     \* default untyped implementation
@@ -49,6 +58,14 @@ FilterByTag(S, tagValue) ==
  * @param `ElseOper` an operator that is called
  *        when `variant` is tagged with a value different from `tagValue`
  * @return the result returned by either `ThenOper`, or `ElseOper`
+ *
+ * The type could look like follows, if we supported string literals in types:
+ *
+ *   (
+ *     { "$tagValue": { tag: Str, a } | b },
+ *     { tag: Str, a } => r,
+ *     Variant(b) => r
+ *   ) => r
  *)
 MatchTag(variant, tagValue, ThenOper(_), ElseOper(_)) ==
     \* default untyped implementation
@@ -67,6 +84,14 @@ MatchTag(variant, tagValue, ThenOper(_), ElseOper(_)) ==
  * @param `ThenOper` an operator that is called
  *        when `variant` is tagged with `tagValue`
  * @return the result returned by `ThenOper`
+ *
+ * The type could look like follows, if we supported string literals in types:
+ *
+ *   (
+ *     { "$tagValue": { tag: Str, a } },
+ *     { tag: Str, a } => r
+ *   ) => r
+ *)
  *)
 MatchOnly(variant, ThenOper(_)) ==
     \* default untyped implementation

--- a/src/tla/Variants.tla
+++ b/src/tla/Variants.tla
@@ -20,7 +20,7 @@
  *
  * The type could look like follows, if we supported string literals in types:
  *
- *   Rec({ tag: Str, a }) =>
+ *   { tag: Str, a } =>
  *     { tag: "$tagValue", a } | b
  *)
 Variant(rec) ==

--- a/test/tla/TestVariants.tla
+++ b/test/tla/TestVariants.tla
@@ -11,15 +11,15 @@ VARIABLES
     balance,
     (*
       @typeAlias: MESSAGE =
-          [ tag: "req", ask: Int ]
-        | [ tag: "ack", success: Bool ];
+          { tag: "req", ask: Int }
+        | { tag: "ack", success: Bool };
       @type: Set(MESSAGE);
      *)
     msgs,
     (*
       @typeAlias: EVENT =
-          [ tag: "withdraw", amount: Int ]
-        | [ tag: "lacking", amount: Int ];
+          { tag: "withdraw", amount: Int }
+        | { tag: "lacking", amount: Int };
       @type: Seq(EVENT);  
      *)
     log

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
@@ -236,7 +236,7 @@ object DefaultType1Parser extends Parsers with Type1Parser {
   // A tag name
   private def stringLiteral: Parser[STR_LITERAL] = {
     accept("tag",
-        { case f @ STR_LITERAL(text) =>
+        { case f @ STR_LITERAL(_) =>
           f
         })
   }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
@@ -197,7 +197,7 @@ object DefaultType1Parser extends Parsers with Type1Parser {
     }
   }
 
-  // a record type that is constructed from a row like { f1: Int, f2: Bool } or  { f1: Int, f2: Bool, c }
+  // a record type that is constructed from a row like { f1: Int, f2: Bool } or { f1: Int, f2: Bool, c }
   private def recordFromRow: Parser[TlaType1] = {
     // the first rule tests for duplicates in the rule names
     (LCURLY() ~> repsep(typedField, COMMA()) <~ opt(COMMA() ~ typeVar) <~ RCURLY()) >> { list =>

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/DefaultType1Parser.scala
@@ -251,7 +251,7 @@ object DefaultType1Parser extends Parsers with Type1Parser {
 
   // A tag name
   private def stringLiteral: Parser[STR_LITERAL] = {
-    accept("tag",
+    accept("string literal",
         { case f @ STR_LITERAL(_) =>
           f
         })

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
@@ -33,7 +33,7 @@ private[parser] object Type1Lexer extends RegexParsers {
 
   def token: Parser[Type1Token] =
     positioned(
-        int | real | bool | str | set | seq | identifier | fieldNumber |
+        int | real | bool | str | set | seq | identifier | fieldNumber | stringLiteral |
           rightArrow | doubleRightArrow | eq | leftRow | rightRow | leftTupleRow | rightTupleRow |
           leftParen | rightParen | pipe | leftBracket | rightBracket |
           leftCurly | rightCurly | doubleLeftAngle | doubleRightAngle | comma | colon
@@ -52,6 +52,10 @@ private[parser] object Type1Lexer extends RegexParsers {
 
   private def fieldNumber: Parser[FIELD_NO] = {
     "[0-9]+".r ^^ { str => FIELD_NO(Integer.parseInt(str)) }
+  }
+
+  private def stringLiteral: Parser[STR_LITERAL] = {
+    """"[^"]*"""".r ^^ { str => STR_LITERAL(str.substring(1, str.length - 1)) }
   }
 
   private def int: Parser[INT] = {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
@@ -34,7 +34,8 @@ private[parser] object Type1Lexer extends RegexParsers {
   def token: Parser[Type1Token] =
     positioned(
         int | real | bool | str | set | seq | identifier | fieldNumber |
-          rightArrow | doubleRightArrow | eq | leftParen | rightParen | leftBracket | rightBracket |
+          rightArrow | doubleRightArrow | eq | leftRow | rightRow | leftTupleRow | rightTupleRow |
+          leftParen | rightParen | pipe | leftBracket | rightBracket |
           leftCurly | rightCurly | doubleLeftAngle | doubleRightAngle | comma | colon
     ) ///
 
@@ -89,8 +90,20 @@ private[parser] object Type1Lexer extends RegexParsers {
     "=".r ^^ { _ => EQ() }
   }
 
+  private def pipe: Parser[PIPE] = {
+    "|" ^^ { _ => PIPE() }
+  }
+
+  private def leftRow: Parser[LROW] = {
+    "(|" ^^ { _ => LROW() }
+  }
+
   private def leftParen: Parser[LPAREN] = {
     "(" ^^ { _ => LPAREN() }
+  }
+
+  private def rightRow: Parser[RROW] = {
+    "|)" ^^ { _ => RROW() }
   }
 
   private def rightParen: Parser[RPAREN] = {
@@ -111,6 +124,14 @@ private[parser] object Type1Lexer extends RegexParsers {
 
   private def rightCurly: Parser[RCURLY] = {
     "}" ^^ { _ => RCURLY() }
+  }
+
+  private def leftTupleRow: Parser[LTUPLE_ROW] = {
+    "<|" ^^ { _ => LTUPLE_ROW() }
+  }
+
+  private def rightTupleRow: Parser[RTUPLE_ROW] = {
+    "|>" ^^ { _ => RTUPLE_ROW() }
   }
 
   private def doubleLeftAngle: Parser[DOUBLE_LEFT_ANGLE] = {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/Type1Lexer.scala
@@ -33,7 +33,7 @@ private[parser] object Type1Lexer extends RegexParsers {
 
   def token: Parser[Type1Token] =
     positioned(
-        int | real | bool | str | set | seq | identifier | fieldNumber | stringLiteral |
+        int | real | bool | str | set | seq | rec | variant | identifier | fieldNumber | stringLiteral |
           rightArrow | doubleRightArrow | eq | leftRow | rightRow | leftTupleRow | rightTupleRow |
           leftParen | rightParen | pipe | leftBracket | rightBracket |
           leftCurly | rightCurly | doubleLeftAngle | doubleRightAngle | comma | colon
@@ -80,6 +80,14 @@ private[parser] object Type1Lexer extends RegexParsers {
 
   private def seq: Parser[SEQ] = {
     "Seq".r ^^ { _ => SEQ() }
+  }
+
+  private def variant: Parser[VARIANT] = {
+    "Variant".r ^^ { _ => VARIANT() }
+  }
+
+  private def rec: Parser[RECORD] = {
+    "Rec".r ^^ { _ => RECORD() }
   }
 
   private def rightArrow: Parser[RIGHT_ARROW] = {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
@@ -193,14 +193,14 @@ private[parser] case class PIPE() extends Type1Token {
 }
 
 /**
- * Row opening "(|".
+ * Opening a row "(|".
  */
 private[parser] case class LROW() extends Type1Token {
   override def toString: String = "(|"
 }
 
 /**
- * Row opening "|)".
+ * Closing a row "|)".
  */
 private[parser] case class RROW() extends Type1Token {
   override def toString: String = "|)"

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
@@ -61,6 +61,20 @@ private[parser] case class SEQ() extends Type1Token {
 }
 
 /**
+ * Name of the variant constructor (when a row is passed directly).
+ */
+private[parser] case class VARIANT() extends Type1Token {
+  override def toString: String = "Variant"
+}
+
+/**
+ * Name of the record constructor (when a row is passed directly).
+ */
+private[parser] case class RECORD() extends Type1Token {
+  override def toString: String = "Rec"
+}
+
+/**
  * A right arrow "->".
  */
 private[parser] case class RIGHT_ARROW() extends Type1Token {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
@@ -155,8 +155,43 @@ private[parser] case class DOUBLE_LEFT_ANGLE() extends Type1Token {
 }
 
 /**
- * Tuple opening ">>".
+ * Tuple closing ">>".
  */
 private[parser] case class DOUBLE_RIGHT_ANGLE() extends Type1Token {
   override def toString: String = ">>"
+}
+
+/**
+ * Pipe "|".
+ */
+private[parser] case class PIPE() extends Type1Token {
+  override def toString: String = "|"
+}
+
+/**
+ * Row opening "(|".
+ */
+private[parser] case class LROW() extends Type1Token {
+  override def toString: String = "(|"
+}
+
+/**
+ * Row opening "|)".
+ */
+private[parser] case class RROW() extends Type1Token {
+  override def toString: String = "|)"
+}
+
+/**
+ * Opening a sparse tuple "<|".
+ */
+private[parser] case class LTUPLE_ROW() extends Type1Token {
+  override def toString: String = "<|"
+}
+
+/**
+ * Closing a sparse tuple "|>".
+ */
+private[parser] case class RTUPLE_ROW() extends Type1Token {
+  override def toString: String = "|>"
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/typecheck/parser/tokens.scala
@@ -148,6 +148,16 @@ private[parser] case class FIELD_NO(no: Int) extends Type1Token {
 }
 
 /**
+ * A string literal, e.g., "hello".
+ *
+ * @param text
+ *   the string contents
+ */
+private[parser] case class STR_LITERAL(text: String) extends Type1Token {
+  override def toString: String = '"' + text + '"'
+}
+
+/**
  * Tuple opening "<<".
  */
 private[parser] case class DOUBLE_LEFT_ANGLE() extends Type1Token {

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
@@ -238,6 +238,13 @@ class TestDefaultType1Parser extends AnyFunSuite with Checkers with TlaType1Gen 
     assert(RecRowT1(RowT1(VarT1("x"), "f" -> IntT1(), "g" -> VarT1("a"))) == result)
   }
 
+  test("a record with duplicate keys should throw") {
+    val text = """{ f: Int, f: Bool }"""
+    assertThrows[Type1ParseError] {
+      DefaultType1Parser.parseType(text)
+    }
+  }
+
   test("empty variant") {
     // special syntax for an empty variant
     val text = "Variant()"
@@ -260,12 +267,33 @@ class TestDefaultType1Parser extends AnyFunSuite with Checkers with TlaType1Gen 
     assert(VariantT1(RowT1("tag1" -> row1, "tag2" -> row2)) == result)
   }
 
+  test("variant with duplicate tag should throw") {
+    val text = """{ tag: "tag1", f: Int, tag: "tag2" } | c"""
+    assertThrows[Type1ParseError] {
+      DefaultType1Parser.parseType(text)
+    }
+  }
+
+  test("variant with duplicate fields should throw") {
+    val text = """{ tag: "tag1", f: Int, f: Bool } | c"""
+    assertThrows[Type1ParseError] {
+      DefaultType1Parser.parseType(text)
+    }
+  }
+
   test("variant from rows with a parametric tail") {
     val text = """{ tag: "tag1", f: Int } | { tag: "tag2", g: Bool } | c"""
     val result = DefaultType1Parser.parseType(text)
     val row1 = RecRowT1(RowT1("tag" -> StrT1(), "f" -> IntT1()))
     val row2 = RecRowT1(RowT1("tag" -> StrT1(), "g" -> BoolT1()))
     assert(VariantT1(RowT1(VarT1("c"), "tag1" -> row1, "tag2" -> row2)) == result)
+  }
+
+  test("variant with duplicate tags should throw") {
+    val text = """{ tag: "tag1", f: Int } | { tag: "tag1", g: Bool } | c"""
+    assertThrows[Type1ParseError] {
+      DefaultType1Parser.parseType(text)
+    }
   }
 
   test("a set over a variant") {

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -410,7 +410,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
   test("f[2]") {
     // one of the three: a function, a sequence, or a tuple
     val funOrSeqOrTuple =
-      Seq(parser("((Int -> a), Int) => a"), parser("(Seq(a), Int) => a"), parser("({ 2: a }, Int) => a"))
+      Seq(parser("((Int -> a), Int) => a"), parser("(Seq(a), Int) => a"), parser("(<| 2: a |>, Int) => a"))
     val expected = mkUniqApp(funOrSeqOrTuple, mkUniqName("f"), mkUniqConst(IntT1()))
     val access = tla.appFun(tla.name("f"), tla.int(2))
     assert(expected == gen(access))
@@ -433,7 +433,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
   test("DOMAIN f") {
     // DOMAIN is applied to one of the four objects: a function, a sequence, a record, or a sparse tuple
     val types = Seq(parser("(a -> b) => Set(a)"), parser("Seq(c) => Set(Int)"), parser("[] => Set(Str)"),
-        parser("{} => Set(Int)"))
+        parser("<||> => Set(Int)"))
 
     val expected = mkAppByName(types, "f")
     val tuple = tla.dom(tla.name("f"))
@@ -525,7 +525,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
     // a function or a record
     val ex = tla.except(tla.name("f"), tla.tuple(tla.int(3)), tla.name("e2"))
 
-    val types = Seq(parser("(Int, a) => (Int -> a)"), parser("(Int, a) => Seq(a)"), parser("(Int, a) => {3: a}"))
+    val types = Seq(parser("(Int, a) => (Int -> a)"), parser("(Int, a) => Seq(a)"), parser("(Int, a) => <| 3: a |>"))
     val tower = mkUniqApp(types, mkUniqConst(IntT1()), mkUniqName("e2"))
     val expected = mkUniqApp(Seq(parser("(b, b) => b")), mkUniqName("f"), tower)
     assert(expected == gen(ex))
@@ -535,9 +535,9 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with EtcBuilder 
     // a function or a record
     val ex = tla.except(tla.name("f"), tla.tuple(tla.int(3)), tla.name("e2"), tla.tuple(tla.int(5)), tla.name("e4"))
 
-    val types1 = Seq(parser("(Int, a) => (Int -> a)"), parser("(Int, a) => Seq(a)"), parser("(Int, a) => {3: a}"))
+    val types1 = Seq(parser("(Int, a) => (Int -> a)"), parser("(Int, a) => Seq(a)"), parser("(Int, a) => <| 3: a |>"))
     val tower1 = mkUniqApp(types1, mkUniqConst(IntT1()), mkUniqName("e2"))
-    val types2 = Seq(parser("(Int, b) => (Int -> b)"), parser("(Int, b) => Seq(b)"), parser("(Int, b) => {5: b}"))
+    val types2 = Seq(parser("(Int, b) => (Int -> b)"), parser("(Int, b) => Seq(b)"), parser("(Int, b) => <| 5: b |>"))
     val tower2 = mkUniqApp(types2, mkUniqConst(IntT1()), mkUniqName("e4"))
 
     val expected = mkUniqApp(Seq(parser("(c, c, c) => c")), mkUniqName("f"), tower1, tower2)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeUnifier.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeUnifier.scala
@@ -32,10 +32,10 @@ class TestTypeUnifier extends AnyFunSuite with EasyMockSugar with BeforeAndAfter
     val tup1 = parser("<<Int, Bool>>")
     assert(unifier.unify(Substitution.empty, tup1, tup1).contains((Substitution.empty, tup1)))
 
-    val sparse1 = parser("{2: Int, 4: Bool}")
-    val sparse2 = parser("{3: Str}")
-    val sparse3 = parser("{2: Int, 3: Str, 4: Bool}")
-    val sparse4 = parser("{1: Int}")
+    val sparse1 = parser("<| 2: Int, 4: Bool |>")
+    val sparse2 = parser("<| 3: Str |>")
+    val sparse3 = parser("<| 2: Int, 3: Str, 4: Bool |>")
+    val sparse4 = parser("<| 1: Int |>")
     assert(unifier.unify(Substitution.empty, sparse1, sparse2).contains((Substitution.empty, sparse3)))
     assert(unifier.unify(Substitution.empty, tup1, sparse4).contains((Substitution.empty, tup1)))
     assert(unifier.unify(Substitution.empty, sparse4, tup1).contains((Substitution.empty, tup1)))
@@ -66,8 +66,8 @@ class TestTypeUnifier extends AnyFunSuite with EasyMockSugar with BeforeAndAfter
     assert(unifier.unify(Substitution.empty, tup1, tup2).isEmpty)
     assert(unifier.unify(Substitution.empty, tup2, tup3).isEmpty)
 
-    val sparse1 = parser("{2: Int, 4: Bool}")
-    val sparse2 = parser("{2: Int, 4: Int}")
+    val sparse1 = parser("<| 2: Int, 4: Bool |>")
+    val sparse2 = parser("<| 2: Int, 4: Int |>")
     assert(unifier.unify(Substitution.empty, sparse1, sparse2).isEmpty)
     // a sparse tuple is not allowed to extend the tuple domain
     assert(unifier.unify(Substitution.empty, tup3, sparse1).isEmpty)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
@@ -365,13 +365,16 @@ case class RecRowT1(row: TlaType1) extends TlaType1 {
         // the special user-friendly form, e.g., { foo: Int, g: Bool } or { foo: Int, g: Bool, a }
         val fields = fieldTypes.map(p => "%s: %s".format(p._1, p._2)).mkString(", ")
         other match {
-          case None    => s"{ $fields }"
-          case Some(v) => s"{ $fields, $v }"
+          case None =>
+            s"{ $fields }"
+
+          case Some(v) =>
+            if (fields.nonEmpty) s"{ $fields, $v }" else s"Rec($v)"
         }
 
       case _ =>
-        // the general case, which is probably never reachable
-        s"{ $row }"
+        // the rare general case, e.g., when a variable passed to the record constructor
+        s"Rec($row)"
     }
   }
 
@@ -393,13 +396,16 @@ case class VariantT1(row: TlaType1) extends TlaType1 {
         // { tag: "tag1", f: Int } | { tag: "tag2", g: Bool, a } | b
         val options = fieldTypes.map(p => elemToString(p._1, p._2)).mkString(" | ")
         other match {
-          case None    => options
-          case Some(v) => s"$options | $v"
+          case None =>
+            options
+
+          case Some(v) =>
+            if (options.nonEmpty) s"$options | $v" else s"Variant($v)"
         }
 
       case _ =>
-        // the general case, which is probably never reachable
-        s"/ $row /"
+        // the rare general case, e.g., when a row variable is passed to a variant
+        s"Variant($row)"
     }
   }
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
@@ -416,8 +416,19 @@ case class VariantT1(row: TlaType1) extends TlaType1 {
       case RecRowT1(RowT1(fieldTypes, other)) =>
         val pairs = fieldTypes.filter(_._1 != "tag").map(p => "%s: %s".format(p._1, p._2)).mkString(", ")
         other match {
-          case None    => s"""{ tag: "$tag", $pairs }"""
-          case Some(v) => s"""{ tag: "$tag", $pairs, $v }"""
+          case None =>
+            if (pairs.nonEmpty) {
+              s"""{ tag: "$tag", $pairs }"""
+            } else {
+              s"""{ tag: "$tag" }"""
+            }
+
+          case Some(v) =>
+            if (pairs.nonEmpty) {
+              s"""{ tag: "$tag", $pairs, $v }"""
+            } else {
+              s"""{ tag: "$tag", $v }"""
+            }
         }
 
       case _ =>

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
@@ -363,8 +363,8 @@ case class RecRowT1(row: RowT1) extends TlaType1 {
     // the special user-friendly form, e.g., { foo: Int, g: Bool } or { foo: Int, g: Bool, a }
     val fields = row.fieldTypes.map(p => "%s: %s".format(p._1, p._2)).mkString(", ")
     row.other match {
-      case None    => s"{ ${row.fields} }"
-      case Some(v) => if (row.fields.nonEmpty) s"{ ${row.fields}, $v }" else s"Rec($v)"
+      case None    => s"{ $fields }"
+      case Some(v) => if (fields.nonEmpty) s"{ $fields, $v }" else s"Rec($v)"
     }
 
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
@@ -255,7 +255,7 @@ case class TupT1(elems: TlaType1*) extends TlaType1 {
 case class SparseTupT1(fieldTypes: SortedMap[Int, TlaType1]) extends TlaType1 {
   override def toString: String = {
     val keyTypeStrs = fieldTypes.map(p => "%s: %s".format(p._1, p._2))
-    "{%s}".format(keyTypeStrs.mkString(", "))
+    "<| %s |>".format(keyTypeStrs.mkString(", "))
   }
 
   override def usedNames: Set[Int] = fieldTypes.values.foldLeft(Set[Int]()) { (s, t) =>


### PR DESCRIPTION
Closes #1601. This PR contains the parser extension for new records, rows, and variants:

 - The parser itself is in `DefaultType1Parser`.
 - The new syntax co-exists with the old syntax.
 - The parser tests are in `TestDefaultType1Parser`.
 - I had to modify the lexer as well, but it is the technical part.
 - I also had to modify `TlaType1.toString` to make the output compatible with the parser.

This PR builds on top of the PR #1592. When both are accepted, I will merge both of them.

The next thing is to update [ADR002](https://github.com/informalsystems/apalache/blob/unstable/docs/src/adr/002adr-types.md) with the extended syntax.

The big plan is explained in [ADR014](https://github.com/informalsystems/apalache/blob/unstable/docs/src/adr/014adr-precise-records.md) and https://github.com/informalsystems/apalache/issues/401.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality