### PR TITLE
Fix SMT logging in the arrays encoding

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,6 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+### Bug fixes
+
+* Fix the generation of SMT instances with the `--debug` flag, see #1594

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -240,7 +240,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
 
     val oldEntry = s"${arrayT.signature}$arrayId[${indexT.signature}$IndexId]"
     val newEntry = s"${elemT.signature}$elemId"
-    log(s"s;; declare update of $oldEntry to $newEntry")
+    log(s";; declare update of $oldEntry to $newEntry")
 
     val updatedArray = updateArrayConst(arrayId)
     val store = z3context.mkStore(array.asInstanceOf[Expr[ArraySort[Sort, Sort]]], index.asInstanceOf[Expr[Sort]],
@@ -557,6 +557,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext {
         case arraySort: ArraySort[_, _] =>
           z3context.mkConstArray(arraySort.getDomain, getOrMkCellDefaultValue(arraySort.getRange))
         case _ =>
+          log(s"(declare-const $sig $cellSort)")
           z3context.mkConst(sig, cellSort)
       }
 


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

Closes #1594. This PR fixes a logging error and adds a missing constant declaration, both in `Z3SolverContext`. See the linked issue for details.