### PR TITLE
Document review locking and code curation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,8 @@ of landing changes:
 
 ## Making a pull request
 
-We develop on the `unstable` branch and release stable code on `master`.
+We develop on the `unstable` branch and practice [trunk-based
+development](https://trunkbaseddevelopment.com/).
 
 Nontrivial changes should start with a [draft pull request][] against
 `unstable`. The draft signals that work is underway. When the work is ready for
@@ -135,13 +136,13 @@ ready for them to take a look.
 Where possible, implementation trajectories should aim to proceed as a series of
 small, logically distinct, incremental changes, in the form of small PRs that
 can be merged quickly. This helps manage the load for reviewers and reduces the
-likelihood that PRs will sit open for longer.
+likelihood of merge conflicts or strategically misdirected work.
 
 Each stage of the process is aimed at creating feedback cycles which align
 contributors and maintainers to make sure:
 
 - Contributors don’t waste their time implementing/proposing features which
-  won’t land in `main`.
+  won’t land in `unstable`.
 - Maintainers have the necessary context in order to support and review
   contributions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ Development on Apalache is distributed. As with any distributed system,
 establishing effective synchronization and consensus on key properties requires
 careful attention.
 
+### Claiming a token for WIP
+
 We synchronize and coordinate our work using GitHub issues. When an issue is
 assigned to someone (or to several people), it serves as a token indicating that
 substantive work on the item described on the issue is being done (or will be
@@ -75,6 +77,25 @@ A corollary is that untracked work, work for which no issue exists or no
 assignment has been claimed, cannot effectively be coordinated. To plan on, or
 engage in, substantive work that is untracked raises the risk of race conditions
 and disorganized effort.
+
+### Volunteering to curate a subset of the code
+
+Sometimes a contributor wants to be notified of any changes made to certain
+files. We refer to contributors who have taken on this responsibility as
+"curators" of the relevant code.
+
+To volunteer as a curator of some part of the codebase, add your GitHub handle
+to [.github/CODEOWNERS](.github/CODEOWNERS).
+
+### Locking WIP pending review
+
+Sometimes a contributor wants to ensure that they have a chance to review a
+[pull request](#making-a-pull-request) before the changes are landed in
+`unstable`. Contributors can lock the PR to prevent it from being merged before
+they can complete a review by leaving an empty review on the PR, requesting
+changes, along with a note like:
+
+> I'd like to be sure I review this before it is merged.
 
 ## Decision Making
 


### PR DESCRIPTION
As per our discussion in today's meeting, this PR documents our convention for
locking PRs until we a chance to review them (when desired) and for our use of
the CODEOWNERS file.

It also includes an unrelated update to the documentation of our branching model.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Documentation added for any new functionality