### PR TITLE
Optimize membership for record sets

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,3 +19,4 @@
 * Add the operator `Apalache!Guess`, see #1590 and #888
 * Extend the type parser to support ADR014 (experimental), see #1602
 * Keramelizer now rewrites \subseteq using forall quantification, see #1408
+* Optimize set membership for record sets, see #1629

--- a/test/tla/RecMem1627.tla
+++ b/test/tla/RecMem1627.tla
@@ -1,0 +1,22 @@
+----------------------- MODULE RecMem1627 ----------------------------
+EXTENDS Integers
+
+VARIABLES 
+  \* @type: [ pos: Int, q: Int, color: Str ];
+  token       \* token structure
+
+N == 3
+Node == 0 .. N-1
+Color == {"white", "black"}
+Token == [pos : Node, q : Int, color : Color]
+
+TypeOK ==
+  token \in Token
+
+Init ==
+  token = [pos |-> 0, q |-> 0, color |-> "black"]
+
+Next ==
+  UNCHANGED token
+
+=====================================================================  

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2073,6 +2073,16 @@ $ apalache-mc check --inv=DriftInv --next=NextFast antipatterns/fold-except/MC_F
 EXITCODE: OK
 ```
 
+### check RecMem1627.tla reports no error
+
+A test for folds with excepts, the fast case.
+
+```sh
+$ apalache-mc check --inv=TypeOK --length=1 RecMem1627.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ## running the typecheck command
 
 ### typecheck ExistTuple476.tla reports no error: regression for issues 476 and 482


### PR DESCRIPTION
Closes #1627. This PR introduces an optimization for record membership, which is quite common in `TypeOK`:

```tla
r \in { [a |-> x, b |-> y]: x \in S, y \in T }
\* becomes
DOMAIN r = { "a", "b" } /\ r.a \in S /\ r.b \in T
```

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
