### PR TITLE
Support builtin operators as arguments to other operators

### DIFF
--- a/test/tla/TestBuiltinAsArg1626.tla
+++ b/test/tla/TestBuiltinAsArg1626.tla
@@ -1,0 +1,29 @@
+------------------------- MODULE TestBuiltinAsArg1626 -------------------------
+(**
+  * A regression test for passing built-in operators as arguments.
+  * For details, see: https://github.com/informalsystems/apalache/issues/1626
+  *)
+EXTENDS Integers
+
+Sum(F(_, _), x, y) == F(x, y)
+
+IsMem(e, set) == e \in set
+
+TestPlus ==
+    Sum(+, 1, 2) = 3
+
+TestUnion ==
+    Sum(\union, { 1 }, { 2 }) = { 1, 2 }
+
+TestBool ==
+    IsMem(FALSE, BOOLEAN)
+
+Init == TRUE
+
+Next == TRUE
+
+AllTests ==
+    /\ TestPlus
+    /\ TestUnion
+    /\ TestBool
+===============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2028,6 +2028,14 @@ $ apalache-mc check --length=0 --inv=AllTests TestFunctions.tla | sed 's/[IEW]@.
 EXITCODE: OK
 ```
 
+### check TestBuiltinAsArg1626.tla reports no error (array-encoding)
+
+```sh
+$ apalache-mc check --length=0 --inv=AllTests TestBuiltinAsArg1626.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check TestHash2.tla reports no error (array-encoding)
 
 A regression test for using `--cinit` and hashes.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/Context.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/Context.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 /**
  * A unit that a context can hold, e.g., a TLA+ declaration.
  */
-abstract class ContextUnit {
+sealed abstract class ContextUnit {
   def name: String
 }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ExprOrOpArgNodeTranslator.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.tla.imp.src.{SourceLocation, SourceStore}
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.{TlaFunOper, TlaOper}
+import at.forsyte.apalache.tla.lir.oper.{FixedArity, TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.{TlaDecimal, TlaInt, TlaStr}
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
@@ -138,19 +138,41 @@ class ExprOrOpArgNodeTranslator(
     // Hence, one has to take care of this, when printing the output to the user.
     val name = opArgNode.getName.toString
     opArgNode.getOp match {
-      // a lambda-definition is passed as an argument
       case defNode: OpDefNode if name == "LAMBDA" =>
+        // a lambda-definition is passed as an argument
         val decl = OpDefTranslator(sourceStore, annotationStore, context)
           .translate(defNode)
         // e.g., LET Foo(x) == e1 in Foo
         LetInEx(NameEx(name), decl)
 
-      // passing an operator
       case _: OpDefNode =>
+        // An operator is passed as an argument.
         // Return a reference to the operator by name.
         // Bugfix #1254: add the prefix, if the operator is inside an instantiated module.
-        val unit = context.lookup(name)
-        NameEx(unit.name)
+        // Bugfix #1626: the user may pass a built-in operator such as `\\union`, or a library operator such as `+`
+        context.lookup(name) match {
+          case DeclUnit(decl) =>
+            // a user-defined operator passed as an argument
+            NameEx(decl.name)
+
+          case OperAliasUnit(_, oper) =>
+            // An operator of the standard library. For example, I!+, where I == INSTANCE Integers.
+            wrapBuiltinWithLetIn(oper)
+
+          case ValueAliasUnit(_, tlaValue) =>
+            // The built-in value, e.g., Int.
+            ValEx(tlaValue)
+
+          case NoneUnit() =>
+            // No definition found. This may be a standard operator such as `\\union`.
+            OpApplTranslator.simpleOpcodeToTlaOper.get(name) match {
+              case Some(oper) =>
+                wrapBuiltinWithLetIn(oper)
+
+              case None =>
+                throw new SanyImporterException(s"Unknown built-in operator $name applied as an argument")
+            }
+        }
 
       // passing a parameter that carries an operator
       case _: FormalParamNode =>
@@ -162,6 +184,30 @@ class ExprOrOpArgNodeTranslator(
             "Expected an operator definition as an argument, found: " + e
         )
     }
+  }
+
+  // Similar to LAMBDA, wrap a built-in operator with a LET-IN definition.
+  // For instance, `+` becomes:
+  // LET __builtin_PLUS_123(__p120, __p121) == __p120 + __p121 IN
+  // __builtin_PLUS_123
+  private def wrapBuiltinWithLetIn(oper: TlaOper): TlaEx = {
+    val nparams = oper.arity match {
+      case FixedArity(n) => n
+      case _ =>
+        throw new SanyImporterException("Expected an operator with a fixed number of arguments, found: " + oper.name)
+    }
+
+    // Introduce `nparams` parameters.
+    // Note that they cannot be higher-order parameters, as they are used in a HO operator already.
+    // We are using unique identifiers to avoid name clashes.
+    val params = 1.to(nparams).map(_ => "__p" + UID.unique).toList
+    // Introduce a unique name for the auxiliary operator definition
+    val defName = "__%s_%s".format(oper.name, UID.unique.toString)
+    // the body of our definition just applies the built-in operator `oper` to the definition parameters
+    val body = OperEx(oper, params.map(name => NameEx(name)): _*)
+    val auxiliaryDef = TlaOperDecl(defName, params.map(OperParam(_, 0)), body)
+    // once we have defined the auxiliary operator, we return it by name
+    LetInEx(NameEx(defName), auxiliaryDef)
   }
 
   // substitute an expression with the declarations that come from INSTANCE M WITH ...

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -1378,6 +1378,101 @@ class TestSanyImporter extends SanyImporterTestBase {
     )
   }
 
+  test("passing a built-in operator as an argument") {
+    // passing a built-in operator as an argument ti another operator
+    val text =
+      """---- MODULE level2builtin ----
+        |A(F(_, _), x, y) == F(x, y)
+        |B(S, T) == A(%s, S, T)
+        |================================
+        |""".stripMargin.format("\\union")
+
+    val (rootName, modules) = sanyImporter
+      .loadFromSource("level2builtin", Source.fromString(text))
+    val mod = expectSingleModule("level2builtin", rootName, modules)
+    expectSourceInfoInDefs(mod)
+
+    modules(rootName).declarations.find {
+      _.name == "B"
+    } match {
+      case Some(TlaOperDecl(_, _,
+                  OperEx(TlaOper.apply, NameEx(callee), LetInEx(body, unionDef), NameEx(s), NameEx(t)))) =>
+        assert(callee == "A")
+        assert(s == "S")
+        assert(t == "T")
+
+        val defName = unionDef match {
+          case TlaOperDecl(name, List(OperParam(param1, 0), OperParam(param2, 0)),
+                  OperEx(TlaSetOper.cup, NameEx(x), NameEx(y))) =>
+            assert(param1 == x)
+            assert(param2 == y)
+            name
+
+          case e =>
+            fail("""Expected LET __SET_UNION2_NN(__p1, __p2) == __p1 \cup __p2, found: """ + e)
+        }
+
+        body match {
+          case NameEx(name) =>
+            assert(name == defName)
+
+          case e =>
+            fail("""Expected __SET_UNION2_NN, found: """ + e)
+        }
+
+      case e =>
+        fail("Expected B, found: " + e)
+    }
+  }
+
+  test("passing a library operator as an argument") {
+    // passing a library as an argument to another operator
+    val text =
+      """---- MODULE level2library ----
+        |EXTENDS Integers
+        |A(F(_, _), x, y) == F(x, y)
+        |B(a, b) == A(+, a, b)
+        |================================
+        |""".stripMargin
+
+    val (rootName, modules) = sanyImporter
+      .loadFromSource("level2library", Source.fromString(text))
+    val mod = modules(rootName)
+    expectSourceInfoInDefs(mod)
+
+    mod.declarations.find {
+      _.name == "B"
+    } match {
+      case Some(TlaOperDecl(_, _,
+                  OperEx(TlaOper.apply, NameEx(callee), LetInEx(body, plusDef), NameEx(a), NameEx(b)))) =>
+        assert(callee == "A")
+        assert(a == "a")
+        assert(b == "b")
+
+        val defName = plusDef match {
+          case TlaOperDecl(name, List(OperParam(param1, 0), OperParam(param2, 0)),
+                  OperEx(TlaArithOper.plus, NameEx(x), NameEx(y))) =>
+            assert(param1 == x)
+            assert(param2 == y)
+            name
+
+          case e =>
+            fail("""Expected LET __PLUS_NN(__p1, __p2) == __p1 + __p2, found: """ + e)
+        }
+
+        body match {
+          case NameEx(name) =>
+            assert(name == defName)
+
+          case e =>
+            fail("""Expected __PLUS_NN, found: """ + e)
+        }
+
+      case e =>
+        fail("Expected B, found: " + e)
+    }
+  }
+
   test("let-in") {
     val text =
       """---- MODULE let ----


### PR DESCRIPTION
Closes #1626. This PR addresses the case of passing a built-in operator as an argument to another operator, e.g.:

```tla
FoldSet(+, 0, {1, 2, 3})
```

Since we do not want to handle the built-in operators and library operators as a special case, we simply wrap them with an auxiliary definition, similar to `LAMBDA`:

```
FoldSet(
  LET __PLUS_22(__p1, __p2) == __p1 + __p2 IN
  __PLUS_22,
  0,
  { 1, 2, 3}
)
```

This approach is compatible with the new version of operator inlining. So it is working out of the box 🎸 

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
