### PR TITLE
Integrate features flag into ConfigManager

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -28,7 +28,6 @@ import util.ExecutionStatisticsCollector.Selection
 
 import scala.collection.JavaConverters._
 import scala.util.Random
-import at.forsyte.apalache.io.ApalacheConfig
 import at.forsyte.apalache.io.ConfigManager
 import at.forsyte.apalache.tla.bmcmt.rules.vmt.TlaExToVMTWriter
 
@@ -53,21 +52,23 @@ object Tool extends LazyLogging {
     System.exit(run(args))
   }
 
-  private def outputAndLogConfig(cmd: General): Unit = {
-    val cfg: ApalacheConfig = ConfigManager(cmd)
-    OutputManager.configure(cfg)
-    // We currently use dummy files for some commands, so we skip here on non-existing files
-    if (cmd.file.getName.endsWith(".tla") && cmd.file.exists()) {
-      OutputManager.initSourceLines(cmd.file)
+  // Returns `Left(errmsg)` in case of configuration errors
+  private def outputAndLogConfig(cmd: General): Either[String, Unit] = {
+    ConfigManager(cmd).map { cfg =>
+      OutputManager.configure(cfg)
+      // We currently use dummy files for some commands, so we skip here on non-existing files
+      if (cmd.file.getName.endsWith(".tla") && cmd.file.exists()) {
+        OutputManager.initSourceLines(cmd.file)
+      }
+      println(s"Output directory: ${OutputManager.runDir.normalize()}")
+      OutputManager.withWriterInRunDir(OutputManager.Names.RunFile)(
+          _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
+      )
+      // force our programmatic logback configuration, as the autoconfiguration works unpredictably
+      new LogbackConfigurator(OutputManager.runDirPathOpt, OutputManager.customRunDirPathOpt).configureDefaultContext()
+      // TODO: update workers when the multicore branch is integrated
+      submitStatisticsIfEnabled(Map("tool" -> "apalache", "mode" -> cmd.label, "workers" -> "1"))
     }
-    println(s"Output directory: ${OutputManager.runDir.normalize()}")
-    OutputManager.withWriterInRunDir(OutputManager.Names.RunFile)(
-        _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
-    )
-    // force our programmatic logback configuration, as the autoconfiguration works unpredictably
-    new LogbackConfigurator(OutputManager.runDirPathOpt, OutputManager.customRunDirPathOpt).configureDefaultContext()
-    // TODO: update workers when the multicore branch is integrated
-    submitStatisticsIfEnabled(Map("tool" -> "apalache", "mode" -> cmd.label, "workers" -> "1"))
   }
 
   /**
@@ -102,39 +103,41 @@ object Tool extends LazyLogging {
 
         printHeaderAndStatsConfig()
 
-        val exitcode = {
-
-          outputAndLogConfig(cmd)
-
-          // Start measuring time
-          val startTime = LocalDateTime.now()
-
-          try {
-            cmd match {
-              case parse: ParseCmd =>
-                runForModule(runParse, new ParserModule, parse)
-
-              case check: CheckCmd =>
-                runForModule(runCheck, new CheckerModule, check)
-
-              case test: TestCmd =>
-                runForModule(runTest, new CheckerModule, test)
-
-              case typecheck: TypeCheckCmd =>
-                runForModule(runTypeCheck, new TypeCheckerModule, typecheck)
-
-              case server: ServerCmd =>
-                runForModule(runServer, new CheckerModule, server)
-
-              case constrain: TranspileCmd =>
-                runForModule(runConstrain, new ReTLAToVMTModule, constrain)
-
-              case config: ConfigCmd =>
-                configure(config)
-            }
-          } finally {
-            printTimeDiff(startTime)
+        val exitcode = outputAndLogConfig(cmd) match {
+          case Left(configurationErrorMessage) => {
+            logger.error(s"Configuration error: ${configurationErrorMessage}")
+            ExitCodes.ERROR
           }
+          case Right(()) => {
+            val startTime = LocalDateTime.now()
+            try {
+              cmd match {
+                case parse: ParseCmd =>
+                  runForModule(runParse, new ParserModule, parse)
+
+                case check: CheckCmd =>
+                  runForModule(runCheck, new CheckerModule, check)
+
+                case test: TestCmd =>
+                  runForModule(runTest, new CheckerModule, test)
+
+                case typecheck: TypeCheckCmd =>
+                  runForModule(runTypeCheck, new TypeCheckerModule, typecheck)
+
+                case server: ServerCmd =>
+                  runForModule(runServer, new CheckerModule, server)
+
+                case constrain: TranspileCmd =>
+                  runForModule(runConstrain, new ReTLAToVMTModule, constrain)
+
+                case config: ConfigCmd =>
+                  configure(config)
+              }
+            } finally {
+              printTimeDiff(startTime)
+            }
+          }
+        }
 
         if (exitcode == OK_EXIT_CODE) {
           Console.out.println("EXITCODE: OK")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -97,16 +97,18 @@ object Tool extends LazyLogging {
     cli match {
       // A standard option, e.g., --version or --help. No header, no timer, no noise
       case None => OK_EXIT_CODE
+      // One of our commands.
       case Some(cmd) => {
 
         printHeaderAndStatsConfig()
 
-        // One of our commands. Print the header and measure time
-        val startTime = LocalDateTime.now()
+        val exitcode = {
 
-        outputAndLogConfig(cmd)
+          outputAndLogConfig(cmd)
 
-        val exitcode =
+          // Start measuring time
+          val startTime = LocalDateTime.now()
+
           try {
             cmd match {
               case parse: ParseCmd =>

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -53,7 +53,8 @@ object Tool extends LazyLogging {
     System.exit(run(args))
   }
 
-  private def outputAndLogConfig(cmd: General, cfg: ApalacheConfig): Unit = {
+  private def outputAndLogConfig(cmd: General): Unit = {
+    val cfg: ApalacheConfig = ConfigManager(cmd)
     OutputManager.configure(cfg)
     // We currently use dummy files for some commands, so we skip here on non-existing files
     if (cmd.file.getName.endsWith(".tla") && cmd.file.exists()) {
@@ -103,7 +104,7 @@ object Tool extends LazyLogging {
         // One of our commands. Print the header and measure time
         val startTime = LocalDateTime.now()
 
-        outputAndLogConfig(cmd, ConfigManager(cmd))
+        outputAndLogConfig(cmd)
 
         val exitcode =
           try {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -36,7 +36,7 @@ trait General extends Command with CliConfig {
       useEnv = true)
   var features = opt[Seq[Feature]](default = Seq(),
       description = {
-        val featureDescriptions = Feature.all.map(f => s" - ${f.name}: ${f.description}")
+        val featureDescriptions = Feature.all.map(f => s"  ${f.name}: ${f.description}")
         ("a comma-separated list of experimental features:" :: featureDescriptions).mkString("\n")
       })
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.tooling.opt
 
 import at.forsyte.apalache.io.CliConfig
-import at.forsyte.apalache.tla.lir.{Feature, RowsFeature}
+import at.forsyte.apalache.tla.lir.Feature
 
 import java.io.File
 import org.backuity.clist._
@@ -35,23 +35,26 @@ trait General extends Command with CliConfig {
         "write intermediate output files to `out-dir`, default: false (overrides envvar WRITE_INTERMEDIATE)",
       useEnv = true)
   var features = opt[Seq[Feature]](default = Seq(),
-      description = """a comma-separated list of experimental features:
-        | - rows: enable row typing as explained in ADR-014
-        |""".stripMargin)
+      description = {
+        val featureDescriptions = Feature.all.map(f => s" - ${f.name}: ${f.description}")
+        ("a comma-separated list of experimental features:" :: featureDescriptions).mkString("\n")
+      })
 
   private var _invocation = ""
   private var _env = ""
 
+  // A comma separated name of supported features
+  private val featureList = Feature.all.map(_.name).mkString(", ")
+
   // Parse a feature
   implicit def featureRead: Read[Feature] = {
-    Read.reads[Feature]("a feature: rows") {
-      case "rows"     => RowsFeature()
-      case unexpected => throw new IllegalArgumentException(s"Unexpected feature: $unexpected")
+    Read.reads[Feature](s"a feature: ${featureList}") { str =>
+      Feature.fromString(str).getOrElse(throw new IllegalArgumentException(s"Unexpected feature: ${str}"))
     }
   }
 
   implicit def featureSeqRead: Read[Seq[Feature]] = {
-    Read.reads[Seq[Feature]](expecting = "a comma-separated list of features: rows") { str =>
+    Read.reads[Seq[Feature]](expecting = s"a comma-separated list of features: ${featureList}") { str =>
       str.split(",").map(featureRead.reads)
     }
   }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2903,6 +2903,7 @@ $ rm -rf ./run-dir ./.apalache.cfg
 ```sh
 $ echo "features: [ invalid-feature ]" > .apalache.cfg
 $ apalache-mc check --length=0 Counter.tla | grep -o -e "Configuration error: at 'features.0'" -e "Cannot convert 'invalid-feature' to at.forsyte.apalache.tla.lir.Feature"
+...
 Configuration error: at 'features.0'
 Cannot convert 'invalid-feature' to at.forsyte.apalache.tla.lir.Feature
 $ rm -rf ./.apalache.cfg

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2898,6 +2898,16 @@ $ test -d ./run-dir
 $ rm -rf ./run-dir ./.apalache.cfg
 ```
 
+### configuration management: invalid features are rejected with error
+
+```sh
+$ echo "features: [ invalid-feature ]" > .apalache.cfg
+$ apalache-mc check --length=0 Counter.tla | grep -o -e "Configuration error: at 'features.0'" -e "Cannot convert 'invalid-feature' to at.forsyte.apalache.tla.lir.Feature"
+Configuration error: at 'features.0'
+Cannot convert 'invalid-feature' to at.forsyte.apalache.tla.lir.Feature
+$ rm -rf ./.apalache.cfg
+```
+
 ## module lookup
 
 ### module lookup: looks up dummy module from standard library

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -24,7 +24,11 @@ private object Converters {
   implicit val featureReader = ConfigReader.fromString[Feature](optF(Feature.fromString))
 }
 
-/** The configuration values that can be overriden based on CLI arguments */
+/**
+ * The configuration values that can be overriden based on CLI arguments
+ *
+ * For documentation on the use and meaning of these fields, see [[at.forsyte.apalache.tla.tooling.opt.General]].
+ */
 trait CliConfig {
 
   /** Input file */

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -4,6 +4,7 @@ import pureconfig._
 import pureconfig.generic.auto._
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
+import at.forsyte.apalache.tla.lir.Feature
 
 // Provides implicit conversions used when deserializing into configurable values.
 private object Converters {
@@ -13,12 +14,14 @@ private object Converters {
     Paths.get(if (s.startsWith("~")) s.replaceFirst("~", System.getProperty("user.home")) else s)
   }
 
-  // Briniging these implicits in scope lets us override the existing File and
+  // Bringing these implicits in scope lets us override the existing File and
   // Path deserialization behavior, so we get path expansion in all configured
   // paths.
   // See https://pureconfig.github.io/docs/overriding-behavior-for-types.html
   implicit val overridePathReader = ConfigReader.fromString[Path](catchReadError(expandedFilePath))
   implicit val overrideFileReader = ConfigReader.fromString[File](catchReadError(expandedFilePath(_).toFile()))
+  // PureConfig's optF will convert None values to appropriate configuration errors
+  implicit val featureReader = ConfigReader.fromString[Feature](optF(Feature.fromString))
 }
 
 /** The configuration values that can be overriden based on CLI arguments */
@@ -31,6 +34,7 @@ trait CliConfig {
   def writeIntermediate: Option[Boolean]
   def profiling: Option[Boolean]
   def configFile: Option[File]
+  def features: Seq[Feature]
 }
 
 /** The application's configurable values, along with their base defaults */
@@ -40,7 +44,8 @@ case class ApalacheConfig(
     runDir: Option[File] = None,
     configFile: Option[File] = None,
     writeIntermediate: Boolean = false,
-    profiling: Boolean = false)
+    profiling: Boolean = false,
+    features: Seq[Feature] = Seq())
 
 case class ConfigManager(cmd: CliConfig) {
   private val TLA_PLUS_DIR = ".tlaplus"
@@ -76,7 +81,7 @@ case class ConfigManager(cmd: CliConfig) {
     val home = System.getProperty("user.home")
     val globalConfig = ConfigSource.file(Paths.get(home, TLA_PLUS_DIR, APALACHE_CFG))
 
-    localConfig
+    localConfig()
       .getOrElse(ConfigSource.empty)
       // `withFallback` supplies configuration sources that only apply if the preceding configs aren't set
       .withFallback(globalConfig.optional)
@@ -90,6 +95,7 @@ case class ConfigManager(cmd: CliConfig) {
             configFile = cmd.configFile.orElse(cfg.configFile),
             writeIntermediate = cmd.writeIntermediate.getOrElse(cfg.writeIntermediate),
             profiling = cmd.profiling.getOrElse(cfg.profiling),
+            features = if (cmd.features.nonEmpty) cmd.features else cfg.features,
         ))
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -102,11 +102,7 @@ case class ConfigManager(cmd: CliConfig) {
 
 object ConfigManager {
 
-  /** Load the application configuration, or raise a configuration error */
-  def apply(cmd: CliConfig): ApalacheConfig = {
-    new ConfigManager(cmd).load() match {
-      case Left(err)  => throw new ConfigurationError(err.toString())
-      case Right(cfg) => cfg
-    }
-  }
+  /** Load the application configuration, converting any configuration error into a pretty printed message */
+  def apply(cmd: CliConfig): Either[String, ApalacheConfig] =
+    new ConfigManager(cmd).load().left.map(_.prettyPrint())
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Feature.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Feature.scala
@@ -3,10 +3,28 @@ package at.forsyte.apalache.tla.lir
 /**
  * An experimental feature.
  */
-sealed trait Feature {}
+sealed trait Feature {
+  val name: String
+  val description: String
+}
 
 /**
  * Enable rows, new records, and variants, as described in <a
  * href="https://github.com/informalsystems/apalache/blob/unstable/docs/src/adr/014adr-precise-records.md">ADR-014</a>.
  */
-case class RowsFeature() extends Feature
+case class RowsFeature(
+    name: String = "rows",
+    description: String = "enable row typing as explained in ADR-014")
+    extends Feature
+
+object Feature {
+
+  /**
+   * A list of all supported features.
+   *
+   * This provides the source of truth for all valid feature names and descriptions.
+   */
+  val all = List(RowsFeature())
+
+  val fromString: String => Option[Feature] = str => all.find(_.name == str)
+}


### PR DESCRIPTION
As per our discussion in the meeting today, this integrates the `--feature` CLI
flag into the configuration manager, allowing users to enable features via their
global or local config files.

Along the way, it reworks some of the base PR in order to improve code reuse,
and also fixes uncaught exceptions resulting from invalid config files.

Note that  this PR is into Igor's feature branch.

It should be easiest to review by commit, but the changes are hopefully pretty clear and well motivated anyhow.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality