### PR TITLE
Remove unused parameter `ModelCheckerParams.debug`

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -61,12 +61,12 @@ class BoundedCheckerPassImpl @Inject() (
     val nworkers = options.getOrElse("checker", "nworkers", 1)
      */
     val stepsBound = options.getOrElse[Int]("checker", "length", 10)
-    val tuning = options.getOrElse[Map[String, String]]("general", "tuning", Map[String, String]())
     val debug = options.getOrElse[Boolean]("general", "debug", false)
+    val tuning = options.getOrElse[Map[String, String]]("general", "tuning", Map[String, String]())
     // TODO: default smtEncoding option is needed here for executions with TestCmd, add encoding option to TestCmd instead
     val smtEncoding = options.getOrElse[SMTEncoding]("checker", "smt-encoding", oopsla19Encoding)
 
-    val params = new ModelCheckerParams(input, stepsBound, tuning, debug)
+    val params = new ModelCheckerParams(input, stepsBound, tuning)
     params.discardDisabled = options.getOrElse[Boolean]("checker", "discardDisabled", true)
     params.checkForDeadlocks = !options.getOrElse[Boolean]("checker", "noDeadlocks", false)
     params.nMaxErrors = options.getOrElse[Int]("checker", "maxError", 1)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -27,8 +27,7 @@ object ModelCheckerParams {
 class ModelCheckerParams(
     checkerInput: CheckerInput,
     val stepsBound: Int,
-    tuningOptions: Map[String, String] = Map(),
-    val debug: Boolean = true) {
+    tuningOptions: Map[String, String] = Map()) {
 
   /**
    * If pruneDisabled is set to false, there will be no check of whether a transition is enabled.

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCollectCounterexamplesSeqModelCheckerListener.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCollectCounterexamplesSeqModelCheckerListener.scala
@@ -32,7 +32,7 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
     // construct checker input + parameters
     val notInv = not(inv).typed(types, "b")
     val checkerInput = new CheckerInput(module, initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, 1, Map(), false) { nMaxErrors = maxErrors }
+    val params = new ModelCheckerParams(checkerInput, 1, Map()) { nMaxErrors = maxErrors }
 
     // create utility objects
     val solver = RecordingSolverContext.createZ3(None, SolverConfig.default)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerTrait.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerTrait.scala
@@ -43,7 +43,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val inv = not(notInv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map())
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
@@ -60,7 +60,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val inv = not(notInv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map())
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
@@ -80,7 +80,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val inv = not(notInv).typed(types, "b")
 
     val checkerInput = new CheckerInput(module, initTrans, nextTrans, Some(cinit), CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map())
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
@@ -100,7 +100,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val inv = not(notInv).typed(types, "b")
 
     val checkerInput = new CheckerInput(module, initTrans, nextTrans, Some(cinit), CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map())
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
@@ -113,7 +113,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val initTrans = List(and(mkAssign("x", 2), mkNotAssign("x", 1)).typed(BoolT1()))
     val nextTrans = List(mkAssign("x", 2))
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -127,7 +127,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val initTrans = List(mkAssign("x", 2), mkAssign("x", 1))
     val nextTrans = List(mkAssign("x", 2))
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 0, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -142,7 +142,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     // x' <- x + 1
     val nextTrans = List(mkAssign("x", plus(name("x") ? "i", int(1)) ? "i", IntT1()))
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 1, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 1, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -162,7 +162,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.BeforeJoin
     // initialize the model checker
@@ -184,7 +184,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.BeforeJoin
     // initialize the model checker
@@ -206,7 +206,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.BeforeJoin
     // initialize the model checker
@@ -228,7 +228,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.BeforeJoin
     // initialize the model checker
@@ -250,7 +250,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.AfterJoin
     // initialize the model checker
@@ -272,7 +272,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.AfterJoin
     // initialize the model checker
@@ -294,7 +294,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.AfterJoin
     // initialize the model checker
@@ -316,7 +316,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.AfterJoin
     // initialize the model checker
@@ -338,7 +338,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.BeforeJoin
     // initialize the model checker
@@ -360,7 +360,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.BeforeJoin
     // initialize the model checker
@@ -382,7 +382,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.AfterJoin
     // initialize the model checker
@@ -404,7 +404,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.AfterJoin
     // initialize the model checker
@@ -432,7 +432,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None,
           CheckerInputVC(List(), List(), List((invDecl, notInvDecl))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -458,7 +458,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None,
           CheckerInputVC(List(), List(), List((invDecl, notInvDecl))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -485,7 +485,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
 
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -510,7 +510,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
 
     val checkerInput =
       new CheckerInput(mkModuleWithXandY(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -527,7 +527,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       List(and(gt(name("x") ? "i", int(3)) ? "b", mkAssign("x", plus(name("x") ? "i", int(1)) ? "i", IntT1())).typed(
               types, "b"))
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 1, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 1, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -542,7 +542,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     // x' <- x + 1
     val nextTrans = List(mkAssign("x", plus(name("x") ? "i", int(1)) ? "i", IntT1()))
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -559,7 +559,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       List(and(lt(name("x") ? "i", int(10)) ? "b", mkAssign("x", plus(name("x") ? "i", int(1)) ? "i", IntT1())).typed(
               types, "b"))
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -580,7 +580,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -603,7 +603,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(BoolT1())
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 3, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 3, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -625,7 +625,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(BoolT1())
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -649,7 +649,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     // initialize the model checker
     // We require the invariant to be checked only after the second step. So we will miss invariant violation.
     val tuning = Map("search.invariantFilter" -> "2")
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, tuning, false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, tuning)
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex =
       new FilteredTransitionExecutor("", params.invFilter, new TransitionExecutorImpl(params.consts, params.vars, ctx))
@@ -667,7 +667,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val nextTrans = List(trans1, trans2)
     val checkerInput = new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC())
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 3, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 3, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -691,7 +691,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -725,7 +725,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val dummyModule = TlaModule("root", List(TlaConstDecl("N")(intTag), TlaVarDecl("x")(intTag)))
     val checkerInput =
       new CheckerInput(dummyModule, initTrans, nextTrans, Some(cInit), CheckerInputVC(List((inv, notInv))))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
@@ -750,7 +750,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List((inv, notInv))))
     // initialize the model checker
     val tuning = Map.empty[String, String] // Map("search.transitionFilter" -> filter)
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, tuning, false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 10, tuning)
     val ctx = new IncrementalExecutionContext(rewriter)
     val impl = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val trex = new FilteredTransitionExecutor("([0-9]|10)->0", "", impl)
@@ -777,7 +777,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val checkerInput =
       new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None,
           CheckerInputVC(List((inv, notInv)), List.empty, List.empty, Some(view)))
-    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map(), false)
+    val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map())
     // we expect 4 errors, but an upper bound may be larger
     params.nMaxErrors = 10
     params.discardDisabled = true


### PR DESCRIPTION
Small fix to remove the unused parameter `ModelCheckerParams.debug`