### PR TITLE
Add silent logback config for unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,6 +301,14 @@ Run the units
 make test
 ```
 
+### Logging in unit tests
+
+We disable unit test log output for subprojects where necessary, to avoid output
+flooding the console. This affects unit tests only, and is configured in a
+per-subproject logback configuration file `test/resources/logback-test.xml`.
+This file also contains a commented-out console appender that can be enabled if
+needed for debugging purposes.
+
 ### Integration tests
 
 #### Installing Dependencies

--- a/mod-infra/src/test/resources/logback-test.xml
+++ b/mod-infra/src/test/resources/logback-test.xml
@@ -1,5 +1,14 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="debug">
-    <!-- no appender for unit tests -->
+    <!-- By default, we disable log output for unit tests. -->
+    <!-- Uncomment the following to get console output for debugging:
+      <appender-ref ref="STDOUT" />
+    -->
   </root>
 </configuration>

--- a/mod-infra/src/test/resources/logback-test.xml
+++ b/mod-infra/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<configuration>
+  <root level="debug">
+    <!-- no appender for unit tests -->
+  </root>
+</configuration>

--- a/tla-bmcmt/src/test/resources/logback-test.xml
+++ b/tla-bmcmt/src/test/resources/logback-test.xml
@@ -1,5 +1,14 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="debug">
-    <!-- no appender for unit tests -->
+    <!-- By default, we disable log output for unit tests. -->
+    <!-- Uncomment the following to get console output for debugging:
+      <appender-ref ref="STDOUT" />
+    -->
   </root>
 </configuration>

--- a/tla-bmcmt/src/test/resources/logback-test.xml
+++ b/tla-bmcmt/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<configuration>
+  <root level="debug">
+    <!-- no appender for unit tests -->
+  </root>
+</configuration>


### PR DESCRIPTION
Add silent logback configs for unit tests in in `mod-infra` and `tla-bmcmt`.

Since these are per (sub-)project, I'm starting with a minimal set for the unit tests in `TestPassChainExecutor` and `CrossTestEncodings`.

Closes #1666.