### PR TITLE
Renaming in `Inliner` fix

### DIFF
--- a/test/tla/Bug1682.tla
+++ b/test/tla/Bug1682.tla
@@ -1,0 +1,101 @@
+---- MODULE Bug1682 ----
+
+EXTENDS Integers
+
+Server == {"s1", "s2", "s3"}
+Quorum == {{"s1","s2"},{"s2","s3"},{"s1","s3"}}
+Term == 0..2
+
+Message ==  
+    [type : {"RequestVote"}, term : Term, from: Server]
+    \cup [type : {"Vote"}, from : Server, to: Server, term : Term]
+    \cup [type : {"AppendEntries"}, term : Term, from: Server]
+
+VARIABLE 
+    \* @type: Str -> Int;
+    currentTerm,
+     \* @type: Set([type: Str, term: Int, from: Str, to:Str]);
+    messages
+
+vars == <<currentTerm, messages>>
+
+Init ==
+    /\ currentTerm = [s \in Server |-> 0]
+    /\ messages = {}
+
+BecomeCandidate(s) ==
+    /\ currentTerm[s]<2
+    /\ currentTerm' = [currentTerm EXCEPT ![s] = currentTerm[s] + 1]
+    /\ messages' = messages \union {[type |-> "RequestVote", term |-> currentTerm[s]+1, from |-> s]}
+
+Vote(s) ==
+    /\ \E m \in messages:
+        /\ m.type = "RequestVote"
+        /\ m.term > currentTerm[s]
+        /\ currentTerm' = [currentTerm EXCEPT ![s] = m.term]
+        /\ messages' = messages \union {[type |-> "Vote", 
+                                            term |-> m.term, from |-> s, to |-> m.from]}
+
+BecomeLeader(s) ==
+    /\ \E Q \in Quorum:
+        \A s1 \in Q: 
+            \E m \in messages: 
+                /\ m.type = "Vote"
+                /\ m.term = currentTerm[s]
+                /\ m.from = s1
+                /\ m.to = s
+    /\ messages' = messages \union {[type |-> "AppendEntries", 
+                                        term |-> currentTerm[s], from |-> s]}
+    /\ UNCHANGED <<currentTerm>>
+
+Noop ==
+    /\ UNCHANGED <<currentTerm,messages>>    
+
+Next ==
+    \/ \E s \in Server:
+        \/ BecomeCandidate(s)
+        \/ Vote(s)
+        \/ BecomeLeader(s)
+    \/ Noop
+
+Spec == Init /\ [][Next]_vars
+
+Safety ==
+    \A t \in Term: \A m1,m2 \in messages: 
+        /\ m1.type = "AppendEntries" 
+        /\ m2.type = "AppendEntries" 
+        /\ m1.term = m2.term 
+        => m1.from = m2.from 
+
+TypeOK ==
+    /\ currentTerm \in [Server -> Term]
+    /\ messages \in SUBSET Message
+
+\* True if server s is a leader in term t
+IsLeader(s,t) ==
+    \E Q \in Quorum:
+        \A s1 \in Q: 
+            \E m \in messages: 
+                /\ m.type = "Vote"
+                /\ m.term = t
+                /\ m.from = s1
+                /\ m.to = s
+
+
+Inv == 
+    /\ TypeOK
+    /\ \A s \in Server, m \in messages: 
+        m.from = s => currentTerm[s] \geq m.term
+    /\ \A m1,m2 \in messages: \A s \in Server: 
+       /\ m1.type = "Vote" 
+       /\ m2.type = "Vote" 
+       /\ m1.from = s 
+       /\ m2.from = s 
+       /\ m1.term = m2.term 
+       => m1.to = m2.to
+    /\ \A t \in Term: \A s1,s2 \in Server:
+       /\ IsLeader(s1,t) 
+       /\ IsLeader(s2,t) 
+       => s1=s2
+
+=================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1815,6 +1815,14 @@ Bug931.tla:6:20-6:21: type input error: Found a polymorphic type: Set(b)
 EXITCODE: ERROR (255)
 ```
 
+### check Bug1682.tla
+
+```sh
+$ apalache-mc check --init=Inv --inv=Inv --length=1 Bug1682.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check profiling
 
 Check that the profiler output is produced as explained in

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAuto.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAuto.scala
@@ -7,6 +7,8 @@ import at.forsyte.apalache.tla.bmcmt.caches.{
 import at.forsyte.apalache.tla.bmcmt.rewriter.{RewriterConfig, SymbStateRewriterSnapshot}
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.TlaEx
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 
 /**
  * A decorator of SymbStateRewriter that automatically preprocesses every given expression. Normally, TLA+
@@ -17,7 +19,11 @@ import at.forsyte.apalache.tla.lir.TlaEx
  * @author
  *   Igor Konnov
  */
-class SymbStateRewriterAuto(private var _solverContext: SolverContext) extends SymbStateRewriter {
+class SymbStateRewriterAuto(
+    private var _solverContext: SolverContext,
+    nameGenerator: UniqueNameGenerator,
+    renaming: IncrementalRenaming)
+    extends SymbStateRewriter {
 
   /**
    * The names that are treated as constants.
@@ -49,7 +55,7 @@ class SymbStateRewriterAuto(private var _solverContext: SolverContext) extends S
 
   private val exprGradeStoreImpl = new ExprGradeStoreImpl()
   private val exprGradeAnalysis = new ExprGradeAnalysis(exprGradeStoreImpl)
-  protected val impl = new SymbStateRewriterImpl(solverContext, exprGradeStore)
+  protected val impl = new SymbStateRewriterImpl(solverContext, nameGenerator, renaming, exprGradeStore)
 
   override def contextLevel: Int = impl.contextLevel
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAutoWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterAutoWithArrays.scala
@@ -1,7 +1,14 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 
-class SymbStateRewriterAutoWithArrays(_solverContext: SolverContext) extends SymbStateRewriterAuto(_solverContext) {
-  override protected val impl = new SymbStateRewriterImplWithArrays(solverContext, exprGradeStore)
+class SymbStateRewriterAutoWithArrays(
+    _solverContext: SolverContext,
+    nameGenerator: UniqueNameGenerator,
+    renaming: IncrementalRenaming)
+    extends SymbStateRewriterAuto(_solverContext, nameGenerator, renaming) {
+  override protected val impl =
+    new SymbStateRewriterImplWithArrays(solverContext, nameGenerator, renaming, exprGradeStore)
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -15,6 +15,8 @@ import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBoolSet, TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 
 import scala.collection.mutable
 
@@ -39,6 +41,8 @@ import scala.collection.mutable
  */
 class SymbStateRewriterImpl(
     private var _solverContext: SolverContext,
+    val nameGenerator: UniqueNameGenerator,
+    val renaming: IncrementalRenaming,
     val exprGradeStore: ExprGradeStore = new ExprGradeStoreImpl(),
     val profilerListener: Option[MetricProfilerListener] = None)
     extends SymbStateRewriter with Serializable with Recoverable[SymbStateRewriterSnapshot] {
@@ -299,11 +303,11 @@ class SymbStateRewriterImpl(
           -> List(new GenRule(this)),
         // folds and MkSeq
         key(OperEx(ApalacheOper.foldSet, tla.name("A"), tla.name("v"), tla.name("S")))
-          -> List(new FoldSetRule(this)),
+          -> List(new FoldSetRule(this, nameGenerator, renaming)),
         key(OperEx(ApalacheOper.foldSeq, tla.name("A"), tla.name("v"), tla.name("s")))
-          -> List(new FoldSeqRule(this)),
+          -> List(new FoldSeqRule(this, nameGenerator, renaming)),
         key(OperEx(ApalacheOper.mkSeq, tla.int(10), tla.name("A")))
-          -> List(new MkSeqRule(this)),
+          -> List(new MkSeqRule(this, nameGenerator, renaming)),
     )
   } ///// ADD YOUR RULES ABOVE
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
@@ -6,6 +6,8 @@ import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.rules._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 
 /**
  * This class extends SymbStateRewriterImpl with encoding rules for the encoding with SMT arrays.
@@ -22,9 +24,11 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
  */
 class SymbStateRewriterImplWithArrays(
     _solverContext: SolverContext,
+    nameGenerator: UniqueNameGenerator,
+    renaming: IncrementalRenaming,
     exprGradeStore: ExprGradeStore = new ExprGradeStoreImpl(),
     profilerListener: Option[MetricProfilerListener] = None)
-    extends SymbStateRewriterImpl(_solverContext, exprGradeStore, profilerListener) {
+    extends SymbStateRewriterImpl(_solverContext, nameGenerator, renaming, exprGradeStore, profilerListener) {
 
   @transient
   override lazy val ruleLookupTable: Map[String, List[RewritingRule]] = defaultRuleLookupTable ++ newRules

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSeqRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSeqRule.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.pp.{Inliner, UniqueNameGenerator}
 
 /**
@@ -16,7 +17,8 @@ import at.forsyte.apalache.tla.pp.{Inliner, UniqueNameGenerator}
  * @author
  *   Jure Kukovec, Igor Konnov
  */
-class FoldSeqRule(rewriter: SymbStateRewriter) extends RewritingRule {
+class FoldSeqRule(rewriter: SymbStateRewriter, nameGenerator: UniqueNameGenerator, renaming: IncrementalRenaming)
+    extends RewritingRule {
   private val picker = new CherryPick(rewriter)
   private val proto = new ProtoSeqOps(rewriter)
 
@@ -54,7 +56,7 @@ class FoldSeqRule(rewriter: SymbStateRewriter) extends RewritingRule {
       val operT = OperT1(Seq(resultT, elemT), resultT)
 
       // expressions are transient, we don't need tracking
-      val inliner = new Inliner(new IdleTracker, new UniqueNameGenerator)
+      val inliner = new Inliner(new IdleTracker, nameGenerator, renaming)
       // We can make the scope directly, since InlinePass already ensures all is well.
       val seededScope: Inliner.Scope = Map(opDecl.name -> opDecl)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FoldSetRule.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.pp.{Inliner, UniqueNameGenerator}
 
 /**
@@ -15,7 +16,8 @@ import at.forsyte.apalache.tla.pp.{Inliner, UniqueNameGenerator}
  * @author
  *   Jure Kukovec
  */
-class FoldSetRule(rewriter: SymbStateRewriter) extends RewritingRule {
+class FoldSetRule(rewriter: SymbStateRewriter, nameGenerator: UniqueNameGenerator, renaming: IncrementalRenaming)
+    extends RewritingRule {
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
@@ -76,7 +78,7 @@ class FoldSetRule(rewriter: SymbStateRewriter) extends RewritingRule {
       )
 
       // expressions are transient, we don't need tracking
-      val inliner = new Inliner(new IdleTracker, new UniqueNameGenerator)
+      val inliner = new Inliner(new IdleTracker, nameGenerator, renaming)
       // We can make the scope directly, since InlinePass already ensures all is well.
       val seededScope: Inliner.Scope = Map(opDecl.name -> opDecl)
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/MkSeqRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/MkSeqRule.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.{ApalacheInternalOper, ApalacheOper, TlaArithOper}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.pp.{Inliner, TlaInputError, UniqueNameGenerator}
 
@@ -17,7 +18,8 @@ import at.forsyte.apalache.tla.pp.{Inliner, TlaInputError, UniqueNameGenerator}
  * @author
  *   Igor Konnov
  */
-class MkSeqRule(rewriter: SymbStateRewriter) extends RewritingRule {
+class MkSeqRule(rewriter: SymbStateRewriter, nameGenerator: UniqueNameGenerator, renaming: IncrementalRenaming)
+    extends RewritingRule {
   private val proto = new ProtoSeqOps(rewriter)
 
   override def isApplicable(symbState: SymbState): Boolean = symbState.ex match {
@@ -39,7 +41,7 @@ class MkSeqRule(rewriter: SymbStateRewriter) extends RewritingRule {
       }
 
       // expressions are transient, we don't need tracking
-      val inliner = new Inliner(new IdleTracker, new UniqueNameGenerator)
+      val inliner = new Inliner(new IdleTracker, nameGenerator, renaming)
       // We can make the scope directly, since InlinePass already ensures all is well.
       val seededScope: Inliner.Scope = Map(opDecl.name -> opDecl)
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
@@ -3,6 +3,9 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
+import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 import org.scalatest.funsuite.FixtureAnyFunSuite
 
 import java.io.StringWriter
@@ -13,10 +16,13 @@ trait RewriterBase extends FixtureAnyFunSuite {
   protected var solverContext: SolverContext = _
   protected var arena: Arena = _
 
+  protected val nameGenerator = new UniqueNameGenerator
+  protected val renaming = new IncrementalRenaming(new IdleTracker)
+
   protected def create(rewriterType: SMTEncoding): SymbStateRewriter = {
     rewriterType match {
-      case `oopsla19Encoding` => new SymbStateRewriterAuto(solverContext)
-      case `arraysEncoding`   => new SymbStateRewriterAutoWithArrays(solverContext)
+      case `oopsla19Encoding` => new SymbStateRewriterAuto(solverContext, nameGenerator, renaming)
+      case `arraysEncoding`   => new SymbStateRewriterAutoWithArrays(solverContext, nameGenerator, renaming)
       case oddRewriterType    => throw new IllegalArgumentException(s"Unexpected rewriter of type $oddRewriterType")
     }
   }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
@@ -62,6 +62,8 @@ class Inliner(
     decls.foldLeft((initialScope, List.empty[TlaDecl])) { case ((scope, decls), decl) =>
       decl match {
         case opDecl: TlaOperDecl =>
+          // update the renaming
+          renaming.syncFrom(opDecl.body)
           // First, process the operator body in the current scope
           val newDeclBody = transform(scope)(opDecl.body)
           // Source tracking

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
@@ -31,10 +31,10 @@ import at.forsyte.apalache.tla.typecheck.etc.{Substitution, TypeUnifier, TypeVar
 class Inliner(
     tracker: TransformationTracker,
     nameGenerator: UniqueNameGenerator,
+    renaming: IncrementalRenaming,
     keepNullary: Boolean = true,
     moduleLevelFilter: Inliner.DeclFilter = FilterFun.ALL) {
 
-  private val renaming = new IncrementalRenaming(tracker)
   private val deepcopy = DeepCopy(tracker)
   private def deepCopy(ex: TlaEx): TlaEx = renaming(deepcopy.deepCopyEx(ex))
 
@@ -62,8 +62,6 @@ class Inliner(
     decls.foldLeft((initialScope, List.empty[TlaDecl])) { case ((scope, decls), decl) =>
       decl match {
         case opDecl: TlaOperDecl =>
-          // update the renaming
-          renaming.syncFrom(opDecl.body)
           // First, process the operator body in the current scope
           val newDeclBody = transform(scope)(opDecl.body)
           // Source tracking

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/InlinePassImpl.scala
@@ -51,7 +51,7 @@ class InlinePassImpl @Inject() (
     //
     val renamedModule = renaming.renameInModule(module)
 
-    val inliner = new Inliner(tracker, gen, keepNullary = true, moduleLevelFilter = moduleFilter)
+    val inliner = new Inliner(tracker, gen, renaming, keepNullary = true, moduleLevelFilter = moduleFilter)
     val inlined = inliner.transformModule(renamedModule)
 
     // Inline the primitive constants now

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestInliner.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestInliner.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.oper.ApalacheOper
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import at.forsyte.apalache.tla.pp.Inliner.emptyScope
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
@@ -18,14 +19,16 @@ class TestInliner extends AnyFunSuite with BeforeAndAfterEach {
 
   def mkModule(decls: TlaDecl*): TlaModule = TlaModule("M", decls)
 
-  var inlinerKeepNullary = new Inliner(new IdleTracker, new UniqueNameGenerator)
-  var inlinerInlineNullary = new Inliner(new IdleTracker, new UniqueNameGenerator, keepNullary = false)
+  var renaming = new IncrementalRenaming(new IdleTracker)
+  var inlinerKeepNullary = new Inliner(new IdleTracker, new UniqueNameGenerator, renaming)
+  var inlinerInlineNullary = new Inliner(new IdleTracker, new UniqueNameGenerator, renaming, keepNullary = false)
 
   def runFresh[T](scopeFn: Scope => T): T = scopeFn(Inliner.emptyScope)
 
   override def beforeEach(): Unit = {
-    inlinerKeepNullary = new Inliner(new IdleTracker, new UniqueNameGenerator)
-    inlinerInlineNullary = new Inliner(new IdleTracker, new UniqueNameGenerator, keepNullary = false)
+    renaming = new IncrementalRenaming(new IdleTracker)
+    inlinerKeepNullary = new Inliner(new IdleTracker, new UniqueNameGenerator, renaming)
+    inlinerInlineNullary = new Inliner(new IdleTracker, new UniqueNameGenerator, renaming, keepNullary = false)
   }
 
   test("LET inline: LET A(p) == e IN A(x) ~~> e[x/p]") {

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSourceLocator.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSourceLocator.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.lir.aux._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.src.{SourceLocation, SourcePosition, SourceRegion}
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator, SourceMap}
-import at.forsyte.apalache.tla.lir.transformations.impl.TrackerWithListeners
+import at.forsyte.apalache.tla.lir.transformations.impl.{IdleTracker, TrackerWithListeners}
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.transformations.{decorateWithPrime, TlaExTransformation, TransformationListener}
 import org.junit.runner.RunWith
@@ -45,6 +45,7 @@ class TestSourceLocator extends AnyFunSuite {
   )
 
   val nameGen = new UniqueNameGenerator
+  val renaming = new IncrementalRenaming(new IdleTracker)
 
   // x' /\ y
   val ex1 = and(prime(name("x") ? "b") ? "b", name("y") ? "b").typed(types, "b")
@@ -169,7 +170,7 @@ class TestSourceLocator extends AnyFunSuite {
   }
 
   test("Test Inline") {
-    val transformation = new Inliner(tracker, nameGen).transformEx
+    val transformation = new Inliner(tracker, nameGen, renaming).transformEx
 
     testTransformation(transformation)
   }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

Closes #1682

The diff is large, but most of it is syntactic: 
`Inliner` now inherits `IncrementalRenaming` as a class parameter, which means
`FoldSe(q|t)` rule now inherits `IncrementalRenaming` (and `nameGenerator`, to prevent similar bugs in the future), which means
the various `SymbStateRewriter-` classes inherit, ...
up until `BoundedCheckerPassImpl`, where these values are injected.