### PR TITLE
make sure that FunT does not need PowSetT

### DIFF
--- a/test/tla/TestFunctions.tla
+++ b/test/tla/TestFunctions.tla
@@ -1,5 +1,5 @@
 -------------------------- MODULE TestFunctions --------------------------------
-EXTENDS Integers
+EXTENDS Integers, FiniteSets
 
 Init == TRUE
 Next == TRUE
@@ -18,9 +18,22 @@ TestFunCtorSetToSet ==
     LET fun == [ x \in Singletons |-> { x } ] IN
     fun[{ 50 }] = { { 50 } }
 
+TestFunCtorOnPowerset ==
+    [ S \in SUBSET BOOLEAN |-> Cardinality(S) ] =
+        [ S \in { {}, {FALSE}, {TRUE}, {FALSE, TRUE} } |->
+            Cardinality(S) ]
+
+TestFunSetToPowerset ==
+    \A f \in [ BOOLEAN -> SUBSET BOOLEAN ]:
+        /\ DOMAIN f = BOOLEAN
+        /\ \A x \in BOOLEAN:
+            f[x] \in SUBSET BOOLEAN
+
 AllTests ==
     /\ TestFunCtor
     /\ TestFunCtorSet
     /\ TestFunCtorSetToSet
+    /\ TestFunCtorOnPowerset
+    /\ TestFunSetToPowerset
 
 ================================================================================

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/types/package.scala
@@ -7,7 +7,6 @@ import at.forsyte.apalache.tla.lir.{
 import at.forsyte.apalache.tla.typecheck.ModelValueHandler
 
 import scala.collection.immutable.SortedMap
-import scala.math.Ordering.Implicits._
 
 package object types {
   // @Jure 29.10.2017: Change name, too ambiguous, especially with TLA Types in the other package -- Jure, 29.10.17
@@ -326,7 +325,7 @@ package object types {
    * TODO: in the future, we will replace domType with argType, as we are moving towards a minimalistic type system
    *
    * @param domType
-   *   the type of the domain (a finite set, a powerset, or a cross product).
+   *   the type of the domain a finite set.
    * @param resultType
    *   result type (not the co-domain!)
    */
@@ -335,7 +334,6 @@ package object types {
 
     val argType: CellT = domType match {
       case FinSetT(et) => et
-      case PowSetT(dt) => dt
       case _           => throw new TypingException(s"Unexpected domain type $domType", UID.nullId)
     }
 


### PR DESCRIPTION
Closes #1694. Actually, powersets are expanded before they reach functions. Hence `FunT` can be safely refactored in #1693.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality
