### PR TITLE
Stop forking JVMs for unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,14 @@ lazy val testSettings = Seq(
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oCDEH")
 )
 
+lazy val testSanyBugSettings = Seq(
+    // FIXME: https://github.com/informalsystems/apalache/issues/1577
+    // SANY contains a race condition that unpacks temporary module files into
+    // the same directory: https://github.com/tlaplus/tlaplus/issues/688
+    // Tests calling SanyImporter must execute sequentially until fixed.
+    Test / parallelExecution := false
+)
+
 /////////////////////////////
 // Sub-project definitions //
 /////////////////////////////
@@ -120,7 +128,7 @@ lazy val tla_io = (project in file("tla-io"))
   )
   .settings(
       testSettings,
-      tlaModuleTestSettings,
+      testSanyBugSettings,
       libraryDependencies ++= Seq(
           Deps.commonsIo,
           Deps.pureConfig,
@@ -134,7 +142,7 @@ lazy val tla_types = (project in file("tla-types"))
       tlair % "test->test", tla_io)
   .settings(
       testSettings,
-      tlaModuleTestSettings,
+      testSanyBugSettings,
       libraryDependencies += Deps.commonsIo,
   )
 
@@ -150,7 +158,7 @@ lazy val tla_pp = (project in file("tla-pp"))
   )
   .settings(
       testSettings,
-      tlaModuleTestSettings,
+      testSanyBugSettings,
       libraryDependencies += Deps.commonsIo,
   )
 
@@ -168,6 +176,7 @@ lazy val tla_bmcmt = (project in file("tla-bmcmt"))
       tlair % "test->test", infra, tla_io, tla_pp, tla_assignments)
   .settings(
       testSettings,
+      testSanyBugSettings,
       libraryDependencies += Deps.scalaCollectionContrib,
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,13 +84,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Test configuration //
 ///////////////////////////////
 
-// NOTE: Include these settings in any projects that require Apalache's TLA+ modules
-lazy val tlaModuleTestSettings = Seq(
-    // This ensures that tests run from their respective sub-project directories
-    // and sequentially. FIXME: https://github.com/informalsystems/apalache/issues/1577
-    Test / fork := true
-)
-
 lazy val testSettings = Seq(
     // Configure the test reporters for concise but informative output.
     // See https://www.scalatest.org/user_guide/using_scalatest_with_sbt

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
@@ -44,7 +44,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
   def loadSpecFromResource(name: String): Source = {
     // Previously, we were using fromResource, but it was too unstable across environments
     // (e.g., it failed in Intellij Idea). Now we are just reading it from the current working directory.
-    Source.fromFile(s"src/test/resources/$name.tla")
+    Source.fromFile(s"tla-types/src/test/resources/$name.tla")
   }
 
   test("the tool runs and reports no type errors") {


### PR DESCRIPTION
Towards #1577

Stop forking JVMs for unit tests.
This enables unit tests to run in parallel (forked tests [run sequentially by default](https://www.scala-sbt.org/1.x/docs/Testing.html#Forking+tests)).

This fixes some paths, because tests now run from the project root (instead of subproject directories).

Due to [this race in SANY](https://github.com/tlaplus/tlaplus/issues/688) we still need to run some unit tests sequentially.