### PR TITLE
Handle heap memory exhaustion gracefully

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,3 +14,4 @@
 
  * Fix usage of sets of function sets in the arrays encoding, see #1680
  * Fix an uncaught exception when setting up the output manager, see #1706
+ * Handle heap memory exhaustion gracefully, see #1711

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/DefaultExceptionAdapter.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/DefaultExceptionAdapter.scala
@@ -12,5 +12,5 @@ class DefaultExceptionAdapter extends ExceptionAdapter {
    * Given an exception, the adapter produces an error message along with its severity.
    * @return
    */
-  override def toMessage: PartialFunction[Exception, ErrorMessage] = PartialFunction.empty
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = PartialFunction.empty
 }

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/DefaultExceptionAdapter.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/DefaultExceptionAdapter.scala
@@ -6,11 +6,4 @@ import javax.inject.Singleton
  * The default adapter does nothing.
  */
 @Singleton
-class DefaultExceptionAdapter extends ExceptionAdapter {
-
-  /**
-   * Given an exception, the adapter produces an error message along with its severity.
-   * @return
-   */
-  override def toMessage: PartialFunction[Throwable, ErrorMessage] = PartialFunction.empty
-}
+class DefaultExceptionAdapter extends ExceptionAdapter {}

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/ExceptionAdapter.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/ExceptionAdapter.scala
@@ -27,5 +27,5 @@ case class FailureMessage(msg: String) extends ErrorMessage
  *   Igor Konnov
  */
 trait ExceptionAdapter {
-  def toMessage: PartialFunction[Exception, ErrorMessage]
+  def toMessage: PartialFunction[Throwable, ErrorMessage]
 }

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/ExceptionAdapter.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/ExceptionAdapter.scala
@@ -1,5 +1,7 @@
 package at.forsyte.apalache.infra
 
+import com.typesafe.scalalogging.LazyLogging
+
 /**
  * An abstract error message.
  */
@@ -26,6 +28,11 @@ case class FailureMessage(msg: String) extends ErrorMessage
  * @author
  *   Igor Konnov
  */
-trait ExceptionAdapter {
-  def toMessage: PartialFunction[Throwable, ErrorMessage]
+trait ExceptionAdapter extends LazyLogging {
+  def toMessage: PartialFunction[Throwable, ErrorMessage] = { case err: OutOfMemoryError =>
+    logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
+    logger.error(s"To increase available heap memory, see the manual:")
+    logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
+    NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -45,7 +45,18 @@ object Tool extends LazyLogging {
    *   the command line arguments
    */
   def main(args: Array[String]): Unit = {
-    System.exit(run(args))
+    try {
+      System.exit(run(args))
+    } catch {
+      case _: OutOfMemoryError =>
+        // We're usually catching this in `handleExceptions` below.
+        // If it is caught here, logging has not been set up yet, so print directly to `Console.err`.
+        Console.err.println(s"Error: Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
+        Console.err.println(s"To increase available heap memory, see the manual:")
+        Console.err.println("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
+        Console.out.println(s"EXITCODE: ERROR (${ExitCodes.ERROR})")
+        System.exit(ExitCodes.ERROR)
+    }
   }
 
   // Returns `Left(errmsg)` in case of configuration errors

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -49,7 +49,7 @@ object Tool extends LazyLogging {
       System.exit(run(args))
     } catch {
       case _: OutOfMemoryError =>
-        // We're usually catching this in `handleExceptions` below.
+        // We usually catch this in `handleExceptions` below.
         // If it is caught here, logging has not been set up yet, so print directly to `Console.err`.
         Console.err.println(s"Error: Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
         Console.err.println(s"To increase available heap memory, see the manual:")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -415,7 +415,7 @@ object Tool extends LazyLogging {
     try {
       runner(executor, cmd)
     } catch {
-      case e: Exception if adapter.toMessage.isDefinedAt(e) =>
+      case e: Throwable if adapter.toMessage.isDefinedAt(e) =>
         adapter.toMessage(e) match {
           case NormalErrorMessage(text) =>
             logger.error(text)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -29,6 +29,13 @@ class CheckerExceptionAdapter @Inject() (sourceStore: SourceStore, changeListene
   private lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
 
   override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
+    // system issues
+    case err: OutOfMemoryError =>
+      logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
+      logger.error(s"To increase available heap memory, see the manual:")
+      logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
+      NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
+
     // normal errors
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -28,14 +28,7 @@ class CheckerExceptionAdapter @Inject() (sourceStore: SourceStore, changeListene
     extends ExceptionAdapter with LazyLogging {
   private lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
 
-  override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
-    // system issues
-    case err: OutOfMemoryError =>
-      logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
-      logger.error(s"To increase available heap memory, see the manual:")
-      logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
-      NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
-
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = super.toMessage.orElse {
     // normal errors
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -28,7 +28,7 @@ class CheckerExceptionAdapter @Inject() (sourceStore: SourceStore, changeListene
     extends ExceptionAdapter with LazyLogging {
   private lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
 
-  override def toMessage: PartialFunction[Exception, ErrorMessage] = {
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
     // normal errors
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, NormalErrorMessage}
 import at.forsyte.apalache.io.annotations.AnnotationParserError
+import com.typesafe.scalalogging.LazyLogging
 
 import javax.inject.{Inject, Singleton}
 
@@ -12,8 +13,14 @@ import javax.inject.{Inject, Singleton}
  *   Igor Konnv
  */
 @Singleton
-class ParserExceptionAdapter @Inject() () extends ExceptionAdapter {
+class ParserExceptionAdapter @Inject() () extends ExceptionAdapter with LazyLogging {
   override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
+    case err: OutOfMemoryError =>
+      logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
+      logger.error(s"To increase available heap memory, see the manual:")
+      logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
+      NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
+
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
@@ -14,13 +14,7 @@ import javax.inject.{Inject, Singleton}
  */
 @Singleton
 class ParserExceptionAdapter @Inject() () extends ExceptionAdapter with LazyLogging {
-  override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
-    case err: OutOfMemoryError =>
-      logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
-      logger.error(s"To increase available heap memory, see the manual:")
-      logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
-      NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
-
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = super.toMessage.orElse {
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
@@ -13,7 +13,7 @@ import javax.inject.{Inject, Singleton}
  */
 @Singleton
 class ParserExceptionAdapter @Inject() () extends ExceptionAdapter {
-  override def toMessage: PartialFunction[Exception, ErrorMessage] = {
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
@@ -19,13 +19,7 @@ import com.typesafe.scalalogging.LazyLogging
 @Singleton
 class EtcTypeCheckerAdapter @Inject() (sourceStore: SourceStore, changeListener: ChangeListener)
     extends ExceptionAdapter with LazyLogging {
-  override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
-    case err: OutOfMemoryError =>
-      logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
-      logger.error(s"To increase available heap memory, see the manual:")
-      logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
-      NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
-
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = super.toMessage.orElse {
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
@@ -20,6 +20,12 @@ import com.typesafe.scalalogging.LazyLogging
 class EtcTypeCheckerAdapter @Inject() (sourceStore: SourceStore, changeListener: ChangeListener)
     extends ExceptionAdapter with LazyLogging {
   override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
+    case err: OutOfMemoryError =>
+      logger.error(s"Ran out of heap memory (max JVM memory: ${Runtime.getRuntime.maxMemory})")
+      logger.error(s"To increase available heap memory, see the manual:")
+      logger.error("  [https://apalache.informal.systems/docs/apalache/running.html#supplying-jvm-arguments]")
+      NormalErrorMessage(s"Ran out of heap memory: ${err.getMessage}")
+
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerAdapter.scala
@@ -19,7 +19,7 @@ import com.typesafe.scalalogging.LazyLogging
 @Singleton
 class EtcTypeCheckerAdapter @Inject() (sourceStore: SourceStore, changeListener: ChangeListener)
     extends ExceptionAdapter with LazyLogging {
-  override def toMessage: PartialFunction[Exception, ErrorMessage] = {
+  override def toMessage: PartialFunction[Throwable, ErrorMessage] = {
     case err: SanyException =>
       NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
 


### PR DESCRIPTION
Handle `java.lang.OutOfMemoryError` (i.e., out of heap memory) gracefully:

* Refactor exception adapters to accept `Throwable` ➞ [0cd916f](https://github.com/informalsystems/apalache/pull/1711/commits/0cd916f33fa8e22d3b2928c170d0413eba6fe570)
  (`OutOfMemoryError` derives from `Error`, not `Exception`)
* Add cases to the exception adapters ➞ [7ccc716](https://github.com/informalsystems/apalache/pull/1711/commits/7ccc716dd063b4bfcce27642cfdf9aa73a12d592)
* Add an early catch handler for when logging and injection aren't set up yet ➞ [3236762](https://github.com/informalsystems/apalache/pull/1711/commits/3236762e76ec5b2cf1afa9f327e2a6efe980b51e)

Fixes #466