### PR TITLE
Refactor `ExitCodes.OK`

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -35,7 +35,6 @@ import scala.util.Random
  */
 object Tool extends LazyLogging {
   lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
-  lazy val OK_EXIT_CODE = 0
 
   /**
    * Run the tool in the standalone mode with the provided arguments. This method calls System.exit with the computed
@@ -99,7 +98,7 @@ object Tool extends LazyLogging {
 
     cli match {
       // A standard option, e.g., --version or --help. No header, no timer, no noise
-      case None => OK_EXIT_CODE
+      case None => ExitCodes.OK
       // One of our commands.
       case Some(cmd) => {
 
@@ -141,7 +140,7 @@ object Tool extends LazyLogging {
           }
         }
 
-        if (exitcode == OK_EXIT_CODE) {
+        if (exitcode == ExitCodes.OK) {
           Console.out.println("EXITCODE: OK")
         } else {
           Console.out.println(s"EXITCODE: ERROR ($exitcode)")
@@ -179,7 +178,7 @@ object Tool extends LazyLogging {
     val result = executor.run()
     if (result.isDefined) {
       logger.info(msgIfOk(result.get))
-      ExitCodes.NO_ERROR
+      ExitCodes.OK
     } else {
       logger.info(msgIfFail)
       errCode
@@ -490,7 +489,7 @@ object Tool extends LazyLogging {
         ()
     }
 
-    ExitCodes.NO_ERROR
+    ExitCodes.OK
   }
 
   private def configDirExistsOrCreated(): Boolean = {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/ExitCodes.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/ExitCodes.scala
@@ -14,7 +14,7 @@ object ExitCodes {
   /**
    * This exit code should be used when the tool is reporting no error in a specification.
    */
-  val NO_ERROR: Int = EC.ExitStatus.SUCCESS
+  val OK: Int = EC.ExitStatus.SUCCESS
 
   /**
    * This exit code should be used when the model checker has found a counterexample. We do not distinguish between


### PR DESCRIPTION
Rename (unused) `ExitCodes.NO_ERROR` to `ExitCodes.OK` and use it in `Tool` instead of the locally declared constant.