### PR TITLE
Note support for aarch64 in release notes

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,11 @@
          * Some bug fix, see #124
 
      DO NOT LEAVE A BLANK LINE BELOW THIS PREAMBLE -->
+     
+### Features
+
+ * Support for native ARM64/AArch64 JVMs (and thus Apple Silicon), see #751
+
 ### Bug fixes
 
  * Fix usage of sets of function sets in the arrays encoding, see #1680


### PR DESCRIPTION
Note support of AArch64 through #751 and #1718 in the release notes.

⚠️ Set to auto-merge.