### PR TITLE
Bump scala runner dialect

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = "3.5.2"
 
-runner.dialect = scala212
+runner.dialect = scala213
 fileOverride {
   "glob:**/project/Dependencies.scala/**" {
      runner.dialect = scala212source3


### PR DESCRIPTION
Should this be bumped? It seems like our manual mandates scala 2.13 now.
