### PR TITLE
Add .metals and .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ target/
 .directory
 .bsp
 .bloop
+.metals
+.vscode
 
 # output files produced by Apalache
 *.out


### PR DESCRIPTION
Folders that should not be pushed to the repo, containing local data for Metals and VSCode