### PR TITLE
Set union optimization to the arrays encoding

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImplWithArrays.scala
@@ -42,7 +42,6 @@ class SymbStateRewriterImplWithArrays(
           -> List(new SetInRuleWithArrays(this)),
         key(tla.subseteq(tla.name("x"), tla.name("S")))
           -> List(new SetInclusionRuleWithArrays(this)),
-        // TODO: consider copying one array and storing the edges of the other in SetCupRule
         // functions
         key(tla.funDef(tla.name("e"), tla.name("x"), tla.name("S")))
           -> List(new FunCtorRuleWithArrays(this)),

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -37,44 +37,67 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val common = Set(leftElems: _*).intersect(Set(rightElems: _*))
         val onlyLeft = Set(leftElems: _*).diff(common)
         val onlyRight = Set(rightElems: _*).diff(common)
-
-        // introduce a new set
-        val newType = state.ex.typeTag.asTlaType1()
-        nextState = nextState.updateArena(_.appendCell(newType))
-        val newSetCell = nextState.arena.topCell
         val allDistinct = common.toSeq ++ onlyLeft.toSeq ++ onlyRight.toSeq
-        nextState = nextState.updateArena(_.appendHas(newSetCell, allDistinct: _*))
 
-        // require each cell to be in in the union iff it is exactly in its origin set
-        def addOnlyCellCons(thisSet: ArenaCell, thisElem: ArenaCell): Unit = {
-          val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, thisSet.toNameEx)
-          val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          rewriter.solverContext.assertGroundExpr(tla.ite(inThis, inCup, notInCup))
+        rewriter.solverContext.config.smtEncoding match {
+          case `arraysEncoding` =>
+            // introduce a new set, encoded as a unconstrained array
+            val newType = state.ex.typeTag.asTlaType1()
+            nextState = nextState.updateArena(_.appendCell(newType, isUnconstrained = true))
+            val newSetCell = nextState.arena.topCell
+            nextState = nextState.updateArena(_.appendHas(newSetCell, allDistinct: _*))
+
+            // since newSet is initially unconstrained, we equate it to leftSet to add leftSet's elements to newSet
+            rewriter.solverContext.assertGroundExpr(tla.eql(newSetCell.toNameEx, leftSetCell.toNameEx))
+            // having added the elements of leftSet to newSet, we use SMT map to add rightSet's elements to newSet
+            // we ensure that \forall e \in dom(newSet) : e \in newSet \iff e \in rightSet \lor e \in newSet
+            val smtMap = tla.apalacheSmtMap(tla.or(), rightSetCell.toNameEx, newSetCell.toNameEx)
+            rewriter.solverContext.assertGroundExpr(smtMap)
+
+            // that's it
+            nextState.setRex(newSetCell.toNameEx)
+
+          case `oopsla19Encoding` =>
+            // introduce a new set
+            val newType = state.ex.typeTag.asTlaType1()
+            nextState = nextState.updateArena(_.appendCell(newType))
+            val newSetCell = nextState.arena.topCell
+            nextState = nextState.updateArena(_.appendHas(newSetCell, allDistinct: _*))
+
+            // require each cell to be in in the union iff it is exactly in its origin set
+            def addOnlyCellCons(thisSet: ArenaCell, thisElem: ArenaCell): Unit = {
+              val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, thisSet.toNameEx)
+              val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
+              val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
+              rewriter.solverContext.assertGroundExpr(tla.ite(inThis, inCup, notInCup))
+            }
+
+            def addEitherCellCons(thisElem: ArenaCell): Unit = {
+              val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, leftSetCell.toNameEx)
+              val inOther = tla.apalacheSelectInSet(thisElem.toNameEx, rightSetCell.toNameEx)
+              val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
+              val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
+              rewriter.solverContext.assertGroundExpr(tla.ite(tla.or(inThis, inOther), inCup, notInCup))
+            }
+
+            // new implementation: as we are not using uninterpreted functions anymore, we do not have to care about
+            // the problem described below.
+            // Add equality constraints, e.g., for ({1} \ {1}) \cup {1}. Otherwise, we might require equal cells to be
+            // inside and outside the resulting set
+            //        val prodIter = new Prod2SeqIterator(leftElems, rightElems)
+            //        val eqState = rewriter.lazyEq.cacheEqConstraints(rightState.setArena(arena), prodIter.toSeq)
+            // bugfix: we have to compare the elements in both sets and thus to introduce a quadratic number of constraints
+            // add SMT constraints
+            onlyLeft.foreach(addOnlyCellCons(leftSetCell, _))
+            onlyRight.foreach(addOnlyCellCons(rightSetCell, _))
+            common.foreach(addEitherCellCons)
+
+            // that's it
+            nextState.setRex(newSetCell.toNameEx)
+
+          case oddEncodingType =>
+            throw new IllegalArgumentException(s"Unexpected SMT encoding of type $oddEncodingType")
         }
-
-        def addEitherCellCons(thisElem: ArenaCell): Unit = {
-          val inThis = tla.apalacheSelectInSet(thisElem.toNameEx, leftSetCell.toNameEx)
-          val inOther = tla.apalacheSelectInSet(thisElem.toNameEx, rightSetCell.toNameEx)
-          val inCup = tla.apalacheStoreInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          val notInCup = tla.apalacheStoreNotInSet(thisElem.toNameEx, newSetCell.toNameEx)
-          rewriter.solverContext.assertGroundExpr(tla.ite(tla.or(inThis, inOther), inCup, notInCup))
-        }
-
-        // new implementation: as we are not using uninterpreted functions anymore, we do not have to care about
-        // the problem described below.
-        // Add equality constraints, e.g., for ({1} \ {1}) \cup {1}. Otherwise, we might require equal cells to be
-        // inside and outside the resulting set
-//        val prodIter = new Prod2SeqIterator(leftElems, rightElems)
-//        val eqState = rewriter.lazyEq.cacheEqConstraints(rightState.setArena(arena), prodIter.toSeq)
-        // bugfix: we have to compare the elements in both sets and thus to introduce a quadratic number of constraints
-        // add SMT constraints
-        onlyLeft.foreach(addOnlyCellCons(leftSetCell, _))
-        onlyRight.foreach(addOnlyCellCons(rightSetCell, _))
-        common.foreach(addEitherCellCons)
-
-        // that's it
-        nextState.setRex(newSetCell.toNameEx)
 
       case _ =>
         throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
@@ -88,7 +88,8 @@ class SetFilterRule(rewriter: SymbStateRewriter) extends RewritingRule {
             rewriter.solverContext.assertGroundExpr(tla.apalacheUnconstrainArray(newSetCell.toNameEx))
             for ((cell, pred) <- filteredCellsAndPreds)
               addCellConsForUnconstrainedNewSetCell(cell, pred)
-            rewriter.solverContext.assertGroundExpr(tla.apalacheSmtMap(setCell.toNameEx, newSetCell.toNameEx))
+            val smtMap = tla.apalacheSmtMap(tla.and(), setCell.toNameEx, newSetCell.toNameEx)
+            rewriter.solverContext.assertGroundExpr(smtMap)
 
           case `oopsla19Encoding` =>
             for ((cell, pred) <- filteredCellsAndPreds)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -658,8 +658,8 @@ class Builder {
     BuilderOper(ApalacheInternalOper.storeNotInSet, elem, fun)
   }
 
-  def apalacheSmtMap(inputSet: BuilderEx, resultSet: BuilderEx): BuilderEx = {
-    BuilderOper(ApalacheInternalOper.smtMap, inputSet, resultSet)
+  def apalacheSmtMap(mapOper: BuilderEx, inputSet: BuilderEx, resultSet: BuilderEx): BuilderEx = {
+    BuilderOper(ApalacheInternalOper.smtMap, mapOper, inputSet, resultSet)
   }
 
   def apalacheUnconstrainArray(arrayElemName: BuilderEx): BuilderEx = {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
@@ -85,12 +85,12 @@ object ApalacheInternalOper {
 
   /**
    * The smtMap operator applies an SMT map using conjunction to two cells encoded as SMT arrays. Its current use is to
-   * encoded set intersection when handling TLA+ filters.
+   * encoded set intersection, when handling TLA+ filters, and set union.
    */
   object smtMap extends ApalacheOper {
     override def name: String = "Apalache!SmtMap"
 
-    override def arity: OperArity = FixedArity(2)
+    override def arity: OperArity = FixedArity(3)
 
     override def precedence: (Int, Int) = (5, 5)
   }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~

This PR optimizes set union in the arrays encoding in the following manner:

1) The result set is created as an unconstrained array, `resSet_0`.
1) The result set is equated to the set in the LHS of the union, i.e., `resSet_0 = leftSet`.
2) The elements of the set in the RHS of the union are added via SMT map using disjunction, which ensures that `\forall e \in dom(resSet_1) : e \in resSet_1 \iff e \in resSet_0 \lor e \in rightSet`; `resSet_1` is initially unconstrained.

The optimization partially addresses #1737. @konnov reported that the `PickPerf` spec [run for more than 5 hours in the CI](https://github.com/informalsystems/apalache/runs/6375891174?check_suite_focus=true) without the optimization. With these changes it run in approximately 7 minutes in my local machine.