### PR TITLE
Typed Builder implementation Part 3.5: Polymorphism support

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/BuilderUtil.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/BuilderUtil.scala
@@ -1,11 +1,9 @@
 package at.forsyte.apalache.tla.typecomp
 
-import at.forsyte.apalache.tla.lir.oper.{FixedArity, OperArity, TlaOper}
+import at.forsyte.apalache.tla.lir.oper.{OperArity, TlaOper}
 import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx, TlaType1, Typed}
 import scalaz._
 import scalaz.Scalaz._
-
-import scala.language.implicitConversions
 
 /**
  * Utility methods
@@ -69,8 +67,6 @@ object BuilderUtil {
       )
     }
   }
-
-  implicit def mkFixedArity(n: Int): OperArity = FixedArity(n)
 
   /** Wraps a signature with an arity check, to throw a more precise exception on arity mismatch */
   def checkForArityException(

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/BuilderUtil.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/BuilderUtil.scala
@@ -55,6 +55,7 @@ object BuilderUtil {
   /** generates a BuilderTypeException wrapped in a Left, containing the given message */
   def throwMsg(msg: String): TypeComputationResult = Left(new TBuilderTypeException(msg))
 
+  /** Generates a (total) signature from a partial one, by returning a Left outside the domain */
   def completePartial(name: String, partialSig: PartialSignature): Signature = {
     def onElse(badArgs: Seq[TlaType1]): TypeComputationResult =
       throwMsg(

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/BuilderUtil.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/BuilderUtil.scala
@@ -51,12 +51,12 @@ object BuilderUtil {
   } yield unsafeMethod(xEx, yEx)
 
   /** generates a BuilderTypeException wrapped in a Left, containing the given message */
-  def throwMsg(msg: String): TypeComputationResult = Left(new TBuilderTypeException(msg))
+  def leftTypeException(msg: String): TypeComputationResult = Left(new TBuilderTypeException(msg))
 
   /** Generates a (total) signature from a partial one, by returning a Left outside the domain */
   def completePartial(name: String, partialSig: PartialSignature): Signature = {
     def onElse(badArgs: Seq[TlaType1]): TypeComputationResult =
-      throwMsg(
+      leftTypeException(
           s"Operator $name cannot be applied to arguments of types (${badArgs.mkString(", ")})"
       )
 
@@ -74,10 +74,16 @@ object BuilderUtil {
       arity: OperArity,
       partialSig: PartialSignature): Signature = {
     case args if arity.cond(args.size) => completePartial(name, partialSig)(args)
-    case args                          => throwMsg(s"$name expects $arity arguments, found: ${args.size}")
+    case args                          => leftTypeException(s"$name expects $arity arguments, found: ${args.size}")
   }
 
-  def mkSigMapEntry(oper: TlaOper, partialSignature: PartialSignature): (TlaOper, Signature) =
+  /**
+   * Creates a SignatureMap entry from an operator (key), where the signature (value) is lifted from `partialSignature`
+   * via `checkForArityException` (with arity derived from the operator).
+   * @see
+   *   [[checkForArityException]]
+   */
+  def signatureMapEntry(oper: TlaOper, partialSignature: PartialSignature): (TlaOper, Signature) =
     oper -> checkForArityException(oper.name, oper.arity, partialSignature)
 
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.typecomp
 
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
 import at.forsyte.apalache.tla.typecomp.subbuilder.{
   ArithmeticBuilder, BaseBuilder, BoolBuilder, LiteralAndNameBuilder, SeqBuilder, SetBuilder,
 }
@@ -29,6 +28,6 @@ import at.forsyte.apalache.tla.typecomp.subbuilder.{
  * @author
  *   Jure Kukovec
  */
-class ScopedBuilder(val varPool: TypeVarPool)
+class ScopedBuilder
     extends BaseBuilder with BoolBuilder with ArithmeticBuilder with SetBuilder with SeqBuilder
     with LiteralAndNameBuilder

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.typecomp
 
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.typecomp.BuilderUtil.throwMsg
+import at.forsyte.apalache.tla.typecomp.BuilderUtil.leftTypeException
 import at.forsyte.apalache.tla.typecomp.signatures._
 
 /**
@@ -25,7 +25,7 @@ class TypeComputationFactory {
   def computationFromSignature(oper: TlaOper): PureTypeComputation = { args =>
     knownSignatures.get(oper) match {
       // Failure: bad identifier
-      case None      => throwMsg(s"Unknown signature for operator ${oper.name}")
+      case None      => leftTypeException(s"Unknown signature for operator ${oper.name}")
       case Some(sig) => sig(args)
     }
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
@@ -25,7 +25,7 @@ class TypeComputationFactory {
   def computationFromSignature(oper: TlaOper): PureTypeComputation = { args =>
     knownSignatures.get(oper) match {
       // Failure: bad identifier
-      case None      => throwMsg(s"Unknown signature for operator ${oper.name}.")
+      case None      => throwMsg(s"Unknown signature for operator ${oper.name}")
       case Some(sig) => sig(args)
     }
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
@@ -23,10 +23,9 @@ class TypeComputationFactory {
 
   /** Given an operator with a known signature, constructs a pure type computation for its return type */
   def computationFromSignature(oper: TlaOper): PureTypeComputation = { args =>
-    val arity = args.size
     knownSignatures.get(oper) match {
-      // Failure: bad identifier or arity
-      case None      => throwMsg(s"Unknown signature for operator ${oper.name} and arity $arity.")
+      // Failure: bad identifier
+      case None      => throwMsg(s"Unknown signature for operator ${oper.name}.")
       case Some(sig) => sig(args)
     }
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/TypeComputationFactory.scala
@@ -1,64 +1,33 @@
 package at.forsyte.apalache.tla.typecomp
 
-import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.typecheck.etc.{Substitution, TypeUnifier, TypeVarPool}
 import at.forsyte.apalache.tla.typecomp.BuilderUtil.throwMsg
-import at.forsyte.apalache.tla.typecomp.signatures.{
-  ArithOperSignatures, BaseOperSignatures, BoolOperSignatures, SeqOperSignatures, SetOperSignatures,
-}
+import at.forsyte.apalache.tla.typecomp.signatures._
 
 /**
- * Some TNT operators have signatures (see [[signatures]]). TypeComputationFactory collects [[SignatureGenerator]]s for
- * such operators and constructs signature-matching [[PureTypeComputation]]s on demand.
+ * Some TNT operators have signatures (see [[signatures]]). TypeComputationFactory collects [[SignatureMap]]s for such
+ * operators and constructs signature-matching [[PureTypeComputation]]s on demand.
  *
  * @author
  *   Jure Kukovec
  */
-class TypeComputationFactory(varPool: TypeVarPool) {
+class TypeComputationFactory {
 
-  private val baseOperMap: SignatureGenMap = BaseOperSignatures.getMap(varPool)
-  private val arithOperMap: SignatureGenMap = ArithOperSignatures.getMap
-  private val boolOperMap: SignatureGenMap = BoolOperSignatures.getMap(varPool)
-  private val setOperMap: SignatureGenMap = SetOperSignatures.getMap(varPool)
-  private val seqOperMap: SignatureGenMap = SeqOperSignatures.getMap(varPool)
+  private val baseOperMap: SignatureMap = BaseOperSignatures.getMap
+  private val aritOperMap: SignatureMap = ArithOperSignatures.getMap
+  private val boolOperMap: SignatureMap = BoolOperSignatures.getMap
+  private val setOperMap: SignatureMap = SetOperSignatures.getMap
+  private val seqOperMap: SignatureMap = SeqOperSignatures.getMap
 
-  private val unifier: TypeUnifier = new TypeUnifier(varPool)
-
-  private val knownSignatures: SignatureGenMap = baseOperMap ++ arithOperMap ++ boolOperMap ++ setOperMap ++ seqOperMap
-
-  /** Given an operator and arity (important for polyadic operators), returns a signature, if known */
-  def getSignature(oper: TlaOper, arity: Int): Option[OperT1] =
-    if (!oper.arity.cond(arity)) None
-    else knownSignatures.get(oper).map(_(arity))
+  private val knownSignatures: SignatureMap = baseOperMap ++ aritOperMap ++ boolOperMap ++ setOperMap ++ seqOperMap
 
   /** Given an operator with a known signature, constructs a pure type computation for its return type */
   def computationFromSignature(oper: TlaOper): PureTypeComputation = { args =>
     val arity = args.size
-    getSignature(oper, arity) match {
-      // Failure case 1: bad identifier or arity
-      case None                   => throwMsg(s"Unknown signature for operator ${oper.name} and arity $arity.")
-      case Some(OperT1(from, to)) =>
-        // Failure case 2: arity mismatch. This should only happen if one of the signatures is implemented incorrectly
-        val arityInMap = from.size
-        if (arityInMap != arity)
-          throwMsg(s"Incompatible arity for operator ${oper.name}: Expected $arityInMap arguments, got $arity")
-        else {
-          // If we have an operator signature, we need to construct a substitution (see ScopedBuilder guarantees)
-          // This substitution tells us what monotype is obtained by applying a polymorphic operator
-          // to arguments with monotypes
-          val totalSubOpt = from.zip(args).foldLeft(Option(Substitution.empty)) { case (subOpt, (argT, paramT)) =>
-            subOpt.flatMap(s => unifier.unify(s, argT, paramT).map(_._1))
-          }
-          totalSubOpt
-            .map(sub => liftRet(sub.subRec(to))) // we apply it to the (polymorphic) return type given by the signature
-            .getOrElse(
-                // Failure case 3: Can't unify
-                throwMsg(
-                    s"${oper.name} expects arguments of types (${from.mkString(", ")}), found: (${args.mkString(", ")})"
-                )
-            )
-        }
+    knownSignatures.get(oper) match {
+      // Failure: bad identifier or arity
+      case None      => throwMsg(s"Unknown signature for operator ${oper.name} and arity $arity.")
+      case Some(sig) => sig(args)
     }
   }
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -63,7 +63,7 @@ package object typecomp {
     wrapCollection.map(build)
 
   // Since some operators are polyadic, we parameterize signatures for the same operator by the # or arguments */
-  /** A signature, if it exists, is as a function from domain types to either a cdm type or an exception. */
+  /** A signature, if it exists, is as a function from domain types to either a codomain type or an exception. */
   type Signature = Seq[TlaType1] => TypeComputationResult
 
   /** A signature that is defined as a partial function. */

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -63,18 +63,12 @@ package object typecomp {
     wrapCollection.map(build)
 
   // Since some operators are polyadic, we parameterize signatures for the same operator by the # or arguments */
-  /** A signature, if it exists, is an operator type */
-  type Signature = OperT1
+  /** A signature, if it exists, is as a function from domain types to either a cdm type or an exception. */
+  type Signature = Seq[TlaType1] => TypeComputationResult
 
-  /**
-   * Given an arity hint `n`, returns an arity-aware signature sig: Signature. `sig.from.size` need not equal `n`,
-   * unless the associated operator is polyadic.
-   */
-  type SignatureGenerator = Int => OperT1
+  /** A signature that is defined as a partial function. */
+  type PartialSignature = PartialFunction[Seq[TlaType1], TypeComputationResult]
 
   /** Maps operators to their associated signature generators. */
-  type SignatureGenMap = Map[TlaOper, SignatureGenerator]
-
-  // Implicit lifting, for fixed-arity operators
-  implicit def liftOper(operT1: OperT1): SignatureGenerator = _ => operT1
+  type SignatureMap = Map[TlaOper, Signature]
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/ArithOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/ArithOperSignatures.scala
@@ -31,7 +31,7 @@ object ArithOperSignatures {
         div,
         mod,
         exp,
-    ).map { mkSigMapEntry(_, binaryPartial(IntT1())) }.toMap
+    ).map { signatureMapEntry(_, binaryPartial(IntT1())) }.toMap
 
     // Same as above, except they return BoolT1 instead of IntT1()
     // (Int, Int) => Bool
@@ -40,14 +40,14 @@ object ArithOperSignatures {
         gt,
         le,
         ge,
-    ).map { mkSigMapEntry(_, binaryPartial(BoolT1())) }.toMap
+    ).map { signatureMapEntry(_, binaryPartial(BoolT1())) }.toMap
 
     // - is unary and dotdot returns a set
     // (Int) => Int,
     // (Int,Int) => Set(Int)
     val rest: SignatureMap = Map(
-        mkSigMapEntry(uminus, { case Seq(IntT1()) => IntT1() }),
-        mkSigMapEntry(dotdot, binaryPartial(SetT1(IntT1()))),
+        signatureMapEntry(uminus, { case Seq(IntT1()) => IntT1() }),
+        signatureMapEntry(dotdot, binaryPartial(SetT1(IntT1()))),
     )
     intOpers ++ boolOpers ++ rest
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/ArithOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/ArithOperSignatures.scala
@@ -1,8 +1,8 @@
 package at.forsyte.apalache.tla.typecomp.signatures
 
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
-import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, OperT1, SetT1}
-import at.forsyte.apalache.tla.typecomp.{liftOper, SignatureGenMap}
+import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, TlaType1}
+import at.forsyte.apalache.tla.typecomp.{BuilderUtil, PartialSignature, SignatureMap}
 
 /**
  * Produces a SignatureMap for all arithmetic operators
@@ -12,36 +12,42 @@ import at.forsyte.apalache.tla.typecomp.{liftOper, SignatureGenMap}
  */
 object ArithOperSignatures {
   import TlaArithOper._
+  import BuilderUtil._
 
   /** Returns a map that assigns a signature generator to each TLaArithOper. */
-  def getMap: SignatureGenMap = {
+  def getMap: SignatureMap = {
+
+    def binaryPartial(retT: TlaType1): PartialSignature = { case Seq(IntT1(), IntT1()) =>
+      retT
+    }
+
     // All these operators have fixed arity 2 and none of them are polymorphic.
     // Signature generators for these operators ignore the arity hint.
     // (Int, Int) => Int
-    val intOpers: SignatureGenMap = Seq(
+    val intOpers: SignatureMap = Seq(
         plus,
         minus,
         mult,
         div,
         mod,
         exp,
-    ).map { _ -> liftOper(OperT1(Seq(IntT1(), IntT1()), IntT1())) }.toMap
+    ).map { mkSigMapEntry(_, binaryPartial(IntT1())) }.toMap
 
     // Same as above, except they return BoolT1 instead of IntT1()
     // (Int, Int) => Bool
-    val boolOpers: SignatureGenMap = Seq(
+    val boolOpers: SignatureMap = Seq(
         lt,
         gt,
         le,
         ge,
-    ).map { _ -> liftOper(OperT1(Seq(IntT1(), IntT1()), BoolT1())) }.toMap
+    ).map { mkSigMapEntry(_, binaryPartial(BoolT1())) }.toMap
 
     // - is unary and dotdot returns a set
     // (Int) => Int,
     // (Int,Int) => Set(Int)
-    val rest: SignatureGenMap = Map(
-        TlaArithOper.uminus -> OperT1(Seq(IntT1()), IntT1()),
-        TlaArithOper.dotdot -> OperT1(Seq(IntT1(), IntT1()), SetT1(IntT1())),
+    val rest: SignatureMap = Map(
+        mkSigMapEntry(uminus, { case Seq(IntT1()) => IntT1() }),
+        mkSigMapEntry(dotdot, binaryPartial(SetT1(IntT1()))),
     )
     intOpers ++ boolOpers ++ rest
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BaseOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BaseOperSignatures.scala
@@ -2,8 +2,7 @@ package at.forsyte.apalache.tla.typecomp.signatures
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
-import at.forsyte.apalache.tla.typecomp.SignatureGenMap
+import at.forsyte.apalache.tla.typecomp.{BuilderUtil, SignatureMap}
 
 /**
  * Produces a SignatureMap for all base operators
@@ -13,46 +12,28 @@ import at.forsyte.apalache.tla.typecomp.SignatureGenMap
  */
 object BaseOperSignatures {
   import TlaOper._
+  import BuilderUtil._
 
-  def getMap(varPool: TypeVarPool): SignatureGenMap = {
+  def getMap: SignatureMap = {
 
     // (t, t) => Bool
-    val cmpSigs: SignatureGenMap = Seq(
+    val cmpSigs: SignatureMap = Seq(
         TlaOper.eq,
         TlaOper.ne,
-    ).map {
-      _ -> { _: Int =>
-        val t = varPool.fresh
-        OperT1(Seq(t, t), BoolT1())
-      }
-    }.toMap
+    ).map { mkSigMapEntry(_, { case Seq(t, tt) if t == tt => BoolT1() }) }.toMap
 
     //  ( (t1, ..., tn) => t, t1, ..., tn ) => t
-    val applySig = TlaOper.apply -> { n: Int =>
-      val t +: ts = varPool.fresh(n)
-      OperT1(OperT1(ts, t) +: ts, t)
-    }
+    val applySig = mkSigMapEntry(TlaOper.apply, { case OperT1(ts, t) +: tts if ts == tts => t })
 
     // (t, Set(t), Bool) => t
-    val chooseBoundedSig = chooseBounded -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(t, SetT1(t), BoolT1()), t)
-    }
+    val chooseBoundedSig = mkSigMapEntry(chooseBounded, { case Seq(t, SetT1(tt), BoolT1()) if t == tt => t })
 
     // (t, Bool) => t
-    val chooseUnboundedSig = chooseUnbounded -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(t, BoolT1()), t)
-    }
+    val chooseUnboundedSig = mkSigMapEntry(chooseUnbounded, { case Seq(t, BoolT1()) => t })
 
     // (t, t1, ..., tn) => t
-    val labelSig = label -> { n: Int =>
-      val all @ t +: _ = varPool.fresh(n)
-      OperT1(all, t)
-
-    }
+    val labelSig = mkSigMapEntry(label, { case t +: ts if ts.nonEmpty => t })
 
     cmpSigs + applySig + chooseBoundedSig + chooseUnboundedSig + labelSig
-
   }
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BaseOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BaseOperSignatures.scala
@@ -20,19 +20,19 @@ object BaseOperSignatures {
     val cmpSigs: SignatureMap = Seq(
         TlaOper.eq,
         TlaOper.ne,
-    ).map { mkSigMapEntry(_, { case Seq(t, tt) if t == tt => BoolT1() }) }.toMap
+    ).map { signatureMapEntry(_, { case Seq(t, tt) if t == tt => BoolT1() }) }.toMap
 
     //  ( (t1, ..., tn) => t, t1, ..., tn ) => t
-    val applySig = mkSigMapEntry(TlaOper.apply, { case OperT1(ts, t) +: tts if ts == tts => t })
+    val applySig = signatureMapEntry(TlaOper.apply, { case OperT1(ts, t) +: tts if ts == tts => t })
 
     // (t, Set(t), Bool) => t
-    val chooseBoundedSig = mkSigMapEntry(chooseBounded, { case Seq(t, SetT1(tt), BoolT1()) if t == tt => t })
+    val chooseBoundedSig = signatureMapEntry(chooseBounded, { case Seq(t, SetT1(tt), BoolT1()) if t == tt => t })
 
     // (t, Bool) => t
-    val chooseUnboundedSig = mkSigMapEntry(chooseUnbounded, { case Seq(t, BoolT1()) => t })
+    val chooseUnboundedSig = signatureMapEntry(chooseUnbounded, { case Seq(t, BoolT1()) => t })
 
     // (t, t1, ..., tn) => t
-    val labelSig = mkSigMapEntry(label, { case t +: ts if ts.nonEmpty => t })
+    val labelSig = signatureMapEntry(label, { case t +: ts if ts.nonEmpty => t })
 
     cmpSigs + applySig + chooseBoundedSig + chooseUnboundedSig + labelSig
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BoolOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BoolOperSignatures.scala
@@ -1,9 +1,8 @@
 package at.forsyte.apalache.tla.typecomp.signatures
 
 import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
-import at.forsyte.apalache.tla.lir.{BoolT1, OperT1, SetT1}
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
-import at.forsyte.apalache.tla.typecomp.{liftOper, SignatureGenMap}
+import at.forsyte.apalache.tla.lir.{BoolT1, SetT1}
+import at.forsyte.apalache.tla.typecomp.{BuilderUtil, SignatureMap}
 
 /**
  * Produces a SignatureMap for all Boolean operators
@@ -13,58 +12,44 @@ import at.forsyte.apalache.tla.typecomp.{liftOper, SignatureGenMap}
  */
 object BoolOperSignatures {
   import TlaBoolOper._
+  import BuilderUtil._
 
   /**
    * Returns a map that assigns a signature generator to each TlaBoolOper. Because some of the operators (quantifiers)
    * are polymorphic, their signatures will contain type variables produced on-demand by varPool.
    */
-  def getMap(varPool: TypeVarPool): SignatureGenMap = {
+  def getMap: SignatureMap = {
 
     // And/or are polyadic, but all the args are Bool
     // (Bool, ..., Bool) => Bool
-    val polyadic: SignatureGenMap = Seq(
+    val polyadic: SignatureMap = Seq(
         and,
         or,
-    ).map {
-      _ -> { n: Int =>
-        OperT1(Seq.fill(n)(BoolT1()), BoolT1())
-      }
-    }.toMap
+    ).map { mkSigMapEntry(_, { case seq if seq.forall(_ == BoolT1()) => BoolT1() }) }.toMap
 
     // =>, <=> are binary, mono
     // (Bool, Bool) => Bool
-    val binary: SignatureGenMap = Seq(
+    val binary: SignatureMap = Seq(
         implies,
         equiv,
-    ).map { _ -> liftOper(OperT1(Seq.fill(2)(BoolT1()), BoolT1())) }.toMap
+    ).map { mkSigMapEntry(_, { case Seq(BoolT1(), BoolT1()) => BoolT1() }) }.toMap
 
     // Quantifiers are polymorphic in the elemet/set types
     // (t, Set(t), Bool) => Bool
-    val boundedQuant: SignatureGenMap = Seq(
+    val boundedQuant: SignatureMap = Seq(
         forall,
         exists,
-    ).map {
-      _ -> { _: Int =>
-        val t = varPool.fresh
-        val setT = SetT1(t)
-        OperT1(Seq(t, setT, BoolT1()), BoolT1())
-      }
-    }.toMap
+    ).map { mkSigMapEntry(_, { case Seq(t, SetT1(tt), BoolT1()) if t == tt => BoolT1() }) }.toMap
 
     // (t, Bool) => Bool
-    val unboundedQuant: SignatureGenMap = Seq(
+    val unboundedQuant: SignatureMap = Seq(
         forallUnbounded,
         existsUnbounded,
-    ).map {
-      _ -> { _: Int =>
-        val t = varPool.fresh
-        OperT1(Seq(t, BoolT1()), BoolT1())
-      }
-    }.toMap
+    ).map { mkSigMapEntry(_, { case Seq(_, BoolT1()) => BoolT1() }) }.toMap
 
     // ~ is unary
     // (Bool) => Bool
-    val notSig: (TlaBoolOper, Int => OperT1) = not -> OperT1(Seq(BoolT1()), BoolT1())
+    val notSig = mkSigMapEntry(not, { case Seq(BoolT1()) => BoolT1() })
 
     polyadic ++ binary ++ boundedQuant ++ unboundedQuant + notSig
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BoolOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/BoolOperSignatures.scala
@@ -25,31 +25,31 @@ object BoolOperSignatures {
     val polyadic: SignatureMap = Seq(
         and,
         or,
-    ).map { mkSigMapEntry(_, { case seq if seq.forall(_ == BoolT1()) => BoolT1() }) }.toMap
+    ).map { signatureMapEntry(_, { case seq if seq.forall(_ == BoolT1()) => BoolT1() }) }.toMap
 
     // =>, <=> are binary, mono
     // (Bool, Bool) => Bool
     val binary: SignatureMap = Seq(
         implies,
         equiv,
-    ).map { mkSigMapEntry(_, { case Seq(BoolT1(), BoolT1()) => BoolT1() }) }.toMap
+    ).map { signatureMapEntry(_, { case Seq(BoolT1(), BoolT1()) => BoolT1() }) }.toMap
 
     // Quantifiers are polymorphic in the elemet/set types
     // (t, Set(t), Bool) => Bool
     val boundedQuant: SignatureMap = Seq(
         forall,
         exists,
-    ).map { mkSigMapEntry(_, { case Seq(t, SetT1(tt), BoolT1()) if t == tt => BoolT1() }) }.toMap
+    ).map { signatureMapEntry(_, { case Seq(t, SetT1(tt), BoolT1()) if t == tt => BoolT1() }) }.toMap
 
     // (t, Bool) => Bool
     val unboundedQuant: SignatureMap = Seq(
         forallUnbounded,
         existsUnbounded,
-    ).map { mkSigMapEntry(_, { case Seq(_, BoolT1()) => BoolT1() }) }.toMap
+    ).map { signatureMapEntry(_, { case Seq(_, BoolT1()) => BoolT1() }) }.toMap
 
     // ~ is unary
     // (Bool) => Bool
-    val notSig = mkSigMapEntry(not, { case Seq(BoolT1()) => BoolT1() })
+    val notSig = signatureMapEntry(not, { case Seq(BoolT1()) => BoolT1() })
 
     polyadic ++ binary ++ boundedQuant ++ unboundedQuant + notSig
   }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SeqOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SeqOperSignatures.scala
@@ -18,22 +18,22 @@ object SeqOperSignatures {
   def getMap: SignatureMap = {
 
     // (Seq(t)) => t
-    val headSig = mkSigMapEntry(head, { case Seq(SeqT1(t)) => t })
+    val headSig = signatureMapEntry(head, { case Seq(SeqT1(t)) => t })
 
     // (Seq(t)) => Seq(t)
-    val tailSig = mkSigMapEntry(tail, { case Seq(st: SeqT1) => st })
+    val tailSig = signatureMapEntry(tail, { case Seq(st: SeqT1) => st })
 
     // (Seq(t), t) => Seq(t)
-    val appendSig = mkSigMapEntry(append, { case Seq(st @ SeqT1(t), tt) if t == tt => st })
+    val appendSig = signatureMapEntry(append, { case Seq(st @ SeqT1(t), tt) if t == tt => st })
 
     // (Seq(t), Seq(t)) => Seq(t)
-    val concatSig = mkSigMapEntry(concat, { case Seq(st @ SeqT1(t), SeqT1(tt)) if t == tt => st })
+    val concatSig = signatureMapEntry(concat, { case Seq(st @ SeqT1(t), SeqT1(tt)) if t == tt => st })
 
     // (Seq(t)) => Int
-    val lenSig = mkSigMapEntry(len, { case Seq(_: SeqT1) => IntT1() })
+    val lenSig = signatureMapEntry(len, { case Seq(_: SeqT1) => IntT1() })
 
     // (Seq(t), Int, Int) => Seq(t)
-    val subseqSig = mkSigMapEntry(subseq, { case Seq(st: SeqT1, IntT1(), IntT1()) => st })
+    val subseqSig = signatureMapEntry(subseq, { case Seq(st: SeqT1, IntT1(), IntT1()) => st })
 
     // (Seq(t), (Seq(t)) => Bool) => Seq(t)
     // selectseq is rewired in __rewire_sequences_in_apalache.tla and should not be created

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SeqOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SeqOperSignatures.scala
@@ -2,8 +2,7 @@ package at.forsyte.apalache.tla.typecomp.signatures
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaSeqOper
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
-import at.forsyte.apalache.tla.typecomp.SignatureGenMap
+import at.forsyte.apalache.tla.typecomp.{BuilderUtil, SignatureMap}
 
 /**
  * Produces a SignatureMap for all sequence operators
@@ -13,45 +12,28 @@ import at.forsyte.apalache.tla.typecomp.SignatureGenMap
  */
 object SeqOperSignatures {
   import TlaSeqOper._
+  import BuilderUtil._
 
   /** Returns a map that assigns a signature generator to each TLaArithOper. */
-  def getMap(varPool: TypeVarPool): SignatureGenMap = {
+  def getMap: SignatureMap = {
 
     // (Seq(t)) => t
-    val headSig = head -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SeqT1(t)), t)
-    }
+    val headSig = mkSigMapEntry(head, { case Seq(SeqT1(t)) => t })
 
     // (Seq(t)) => Seq(t)
-    val tailSig = tail -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SeqT1(t)), SeqT1(t))
-    }
+    val tailSig = mkSigMapEntry(tail, { case Seq(st: SeqT1) => st })
 
     // (Seq(t), t) => Seq(t)
-    val appendSig = append -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SeqT1(t), t), SeqT1(t))
-    }
+    val appendSig = mkSigMapEntry(append, { case Seq(st @ SeqT1(t), tt) if t == tt => st })
 
     // (Seq(t), Seq(t)) => Seq(t)
-    val concatSig = concat -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SeqT1(t), SeqT1(t)), SeqT1(t))
-    }
+    val concatSig = mkSigMapEntry(concat, { case Seq(st @ SeqT1(t), SeqT1(tt)) if t == tt => st })
 
     // (Seq(t)) => Int
-    val lenSig = len -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SeqT1(t)), IntT1())
-    }
+    val lenSig = mkSigMapEntry(len, { case Seq(_: SeqT1) => IntT1() })
 
     // (Seq(t), Int, Int) => Seq(t)
-    val subseqSig = subseq -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SeqT1(t), IntT1(), IntT1()), SeqT1(t))
-    }
+    val subseqSig = mkSigMapEntry(subseq, { case Seq(st: SeqT1, IntT1(), IntT1()) => st })
 
     // (Seq(t), (Seq(t)) => Bool) => Seq(t)
     // selectseq is rewired in __rewire_sequences_in_apalache.tla and should not be created

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SetOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SetOperSignatures.scala
@@ -27,14 +27,14 @@ object SetOperSignatures {
         cup,
         cap,
         setminus,
-    ).map { mkSigMapEntry(_, { case Seq(st @ SetT1(t), SetT1(tt)) if t == tt => st }) }.toMap
+    ).map { signatureMapEntry(_, { case Seq(st @ SetT1(t), SetT1(tt)) if t == tt => st }) }.toMap
 
     // \in, \notin are similar, but asymm w.r.t arg types
     // (t, Set(t)) => Bool
     val binaryAsymm: SignatureMap = Seq(
         in,
         notin,
-    ).map { mkSigMapEntry(_, { case Seq(t, SetT1(tt)) if t == tt => BoolT1() }) }.toMap
+    ).map { signatureMapEntry(_, { case Seq(t, SetT1(tt)) if t == tt => BoolT1() }) }.toMap
 
     val mapPartial: PartialSignature = {
       case t +: pairs if pairs.size % 2 == 0 && pairs.grouped(2).forall {
@@ -46,21 +46,21 @@ object SetOperSignatures {
 
     // map is polyadic, with 2k + 1 args in general
     // (t, t1, Set(t1), ..., tk, Set(tk)) => Set(t)
-    val mapSig = mkSigMapEntry(map, mapPartial)
+    val mapSig = signatureMapEntry(map, mapPartial)
 
     // { x \in S: p } is polymorphic
     // (t, Set(t), Bool) => Set(t)
-    val filterSig = mkSigMapEntry(filter, { case Seq(t, st @ SetT1(tt), BoolT1()) if t == tt => st })
+    val filterSig = signatureMapEntry(filter, { case Seq(t, st @ SetT1(tt), BoolT1()) if t == tt => st })
 
     // recSet does NOT have a signature (the return type depends on the field value)
 
     // Seq(S) is polymorphic, fixed arity 1
     // (Set(t)) => Set(Seq(t))
-    val seqSetSig = mkSigMapEntry(seqSet, { case Seq(SetT1(t)) => SetT1(SeqT1(t)) })
+    val seqSetSig = signatureMapEntry(seqSet, { case Seq(SetT1(t)) => SetT1(SeqT1(t)) })
 
     // SUBSET S is polymorphic, fixed arity 1
     // (Set(t)) => Set(Set(t))
-    val powSetSig = mkSigMapEntry(powerset, { case Seq(st: SetT1) => SetT1(st) })
+    val powSetSig = signatureMapEntry(powerset, { case Seq(st: SetT1) => SetT1(st) })
 
     val timesPartial: PartialSignature = {
       case SetT1(t1) +: SetT1(t2) +: rest if rest.forall(_.isInstanceOf[SetT1]) =>
@@ -73,15 +73,15 @@ object SetOperSignatures {
 
     // \X is polyadic with n = 2 + k args
     // (Set(t1), ..., Set(tn)) => Set(<<t1,...,tn>>)
-    val timesSig = mkSigMapEntry(times, timesPartial)
+    val timesSig = signatureMapEntry(times, timesPartial)
 
     // [_ -> _] is polymorphic
     // (Set(t1), Set(t2)) => Set(t1 -> t2)
-    val funSetSig = mkSigMapEntry(funSet, { case Seq(SetT1(t1), SetT1(t2)) => SetT1(FunT1(t1, t2)) })
+    val funSetSig = signatureMapEntry(funSet, { case Seq(SetT1(t1), SetT1(t2)) => SetT1(FunT1(t1, t2)) })
 
     // UNION is polymorphic, fixed arity 1
     // (Set(Set(t))) => Set(t)
-    val unionSig = mkSigMapEntry(union, { case Seq(SetT1(st: SetT1)) => st })
+    val unionSig = signatureMapEntry(union, { case Seq(SetT1(st: SetT1)) => st })
 
     // { _ } is polyadic
     // (t, ..., t) => Set(t)
@@ -94,7 +94,7 @@ object SetOperSignatures {
 
     // \subseteq is polymorphic
     // (Set(t), Set(t)) => Bool
-    val subseteqSig = mkSigMapEntry(subseteq, { case Seq(SetT1(t), SetT1(tt)) if t == tt => BoolT1() })
+    val subseteqSig = signatureMapEntry(subseteq, { case Seq(SetT1(t), SetT1(tt)) if t == tt => BoolT1() })
 
     val rest: SignatureMap = Seq(
         mapSig,

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SetOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/SetOperSignatures.scala
@@ -1,9 +1,9 @@
 package at.forsyte.apalache.tla.typecomp.signatures
 
-import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, OperT1, SeqT1, SetT1, TupT1}
-import at.forsyte.apalache.tla.lir.oper.TlaSetOper
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
-import at.forsyte.apalache.tla.typecomp.SignatureGenMap
+import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, SeqT1, SetT1, TupT1}
+import at.forsyte.apalache.tla.lir.oper.{AnyPositiveArity, TlaSetOper}
+import at.forsyte.apalache.tla.typecomp.BuilderUtil
+import at.forsyte.apalache.tla.typecomp.{PartialSignature, SignatureMap}
 
 /**
  * Produces a SignatureMap for all set operators
@@ -13,110 +13,90 @@ import at.forsyte.apalache.tla.typecomp.SignatureGenMap
  */
 object SetOperSignatures {
   import TlaSetOper._
+  import BuilderUtil._
 
   /**
    * Returns a map that assigns a signature generator to each TlaSetOper. Because most operators are polymorphic, their
    * signatures will contain type variables produced on-demand by varPool.
    */
-  def getMap(varPool: TypeVarPool): SignatureGenMap = {
+  def getMap: SignatureMap = {
 
     // \cup, \cap, \ are binary, polymorphic and symm (w.r.t. arg types)
     // (Set(t), Set(t)) => Set(t)
-    val binarySymm: SignatureGenMap = Seq(
+    val binarySymm: SignatureMap = Seq(
         cup,
         cap,
         setminus,
-    ).map {
-      _ -> { _: Int =>
-        val t = varPool.fresh
-        OperT1(Seq.fill(2)(SetT1(t)), SetT1(t))
-      }
-    }.toMap
+    ).map { mkSigMapEntry(_, { case Seq(st @ SetT1(t), SetT1(tt)) if t == tt => st }) }.toMap
 
     // \in, \notin are similar, but asymm w.r.t arg types
     // (t, Set(t)) => Bool
-    val binaryAsymm: SignatureGenMap = Seq(
+    val binaryAsymm: SignatureMap = Seq(
         in,
         notin,
-    ).map {
-      _ -> { _: Int =>
-        val t = varPool.fresh
-        OperT1(Seq(t, SetT1(t)), BoolT1())
-      }
-    }.toMap
+    ).map { mkSigMapEntry(_, { case Seq(t, SetT1(tt)) if t == tt => BoolT1() }) }.toMap
+
+    val mapPartial: PartialSignature = {
+      case t +: pairs if pairs.size % 2 == 0 && pairs.grouped(2).forall {
+            case Seq(tt, SetT1(tt2)) => tt == tt2
+            case _                   => false
+          } =>
+        SetT1(t)
+    }
 
     // map is polyadic, with 2k + 1 args in general
     // (t, t1, Set(t1), ..., tk, Set(tk)) => Set(t)
-    val mapSig = map -> { n: Int =>
-      val npairs = (n - 1) / 2
-      val t = varPool.fresh
-      val ts = varPool.fresh(npairs)
-
-      val elemSetParis = ts.flatMap { tt =>
-        Seq(tt, SetT1(tt))
-      }
-      OperT1(t +: elemSetParis, SetT1(t))
-    }
+    val mapSig = mkSigMapEntry(map, mapPartial)
 
     // { x \in S: p } is polymorphic
     // (t, Set(t), Bool) => Set(t)
-    val filterSig = filter -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(t, SetT1(t), BoolT1()), SetT1(t))
-    }
+    val filterSig = mkSigMapEntry(filter, { case Seq(t, st @ SetT1(tt), BoolT1()) if t == tt => st })
 
     // recSet does NOT have a signature (the return type depends on the field value)
 
     // Seq(S) is polymorphic, fixed arity 1
     // (Set(t)) => Set(Seq(t))
-    val seqSetSig = seqSet -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SetT1(t)), SetT1(SeqT1(t)))
-    }
+    val seqSetSig = mkSigMapEntry(seqSet, { case Seq(SetT1(t)) => SetT1(SeqT1(t)) })
 
     // SUBSET S is polymorphic, fixed arity 1
     // (Set(t)) => Set(Set(t))
-    val powSetSig = powerset -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SetT1(t)), SetT1(SetT1(t)))
+    val powSetSig = mkSigMapEntry(powerset, { case Seq(st: SetT1) => SetT1(st) })
+
+    val timesPartial: PartialSignature = {
+      case SetT1(t1) +: SetT1(t2) +: rest if rest.forall(_.isInstanceOf[SetT1]) =>
+        val ts = rest.map {
+          case SetT1(t) => t
+          case t        => t // impossible, but needed for warning suppression
+        }
+        SetT1(TupT1(t1 +: t2 +: ts: _*))
     }
 
     // \X is polyadic with n = 2 + k args
     // (Set(t1), ..., Set(tn)) => Set(<<t1,...,tn>>)
-    val timesSig = times -> { n: Int =>
-      val ts = varPool.fresh(n)
-      OperT1(ts.map(SetT1), SetT1(TupT1(ts: _*)))
-    }
+    val timesSig = mkSigMapEntry(times, timesPartial)
 
     // [_ -> _] is polymorphic
     // (Set(t1), Set(t2)) => Set(t1 -> t2)
-    val funSetSig = funSet -> { _: Int =>
-      val ts @ Seq(domT, cdmT) = varPool.fresh(2)
-      OperT1(ts.map(SetT1), SetT1(FunT1(domT, cdmT)))
-    }
+    val funSetSig = mkSigMapEntry(funSet, { case Seq(SetT1(t1), SetT1(t2)) => SetT1(FunT1(t1, t2)) })
 
     // UNION is polymorphic, fixed arity 1
     // (Set(Set(t))) => Set(t)
-    val unionSig = union -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SetT1(SetT1(t))), SetT1(t))
-    }
+    val unionSig = mkSigMapEntry(union, { case Seq(SetT1(st: SetT1)) => st })
 
     // { _ } is polyadic
     // (t, ..., t) => Set(t)
-    val enumSig = enumSet -> { n: Int =>
-      val t = varPool.fresh
-      OperT1(Seq.fill(n)(t), SetT1(t))
-    }
+    // We force a check against AnyPositiveArity, as the empty set is not built by an enumSet call.
+    // This should be caught by a require(_) in the builder method ahead of time, but having fallback
+    // sanity checking here helps with bugfixing.
+    val enumSig =
+      enumSet -> checkForArityException(enumSet.name, AnyPositiveArity(),
+          { case t +: ts if ts.forall(_ == t) => SetT1(t) })
 
     // \subseteq is polymorphic
-    // (t, ..., t) => Set(t)
-    val subseteqSig = subseteq -> { _: Int =>
-      val t = varPool.fresh
-      OperT1(Seq(SetT1(t), SetT1(t)), BoolT1())
-    }
+    // (Set(t), Set(t)) => Bool
+    val subseteqSig = mkSigMapEntry(subseteq, { case Seq(SetT1(t), SetT1(tt)) if t == tt => BoolT1() })
 
-    val rest: SignatureGenMap = Seq(
+    val rest: SignatureMap = Seq(
         mapSig,
         filterSig,
         seqSetSig,

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/ProtoBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/ProtoBuilder.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.typecomp.unsafe
 
 import at.forsyte.apalache.tla.lir.TlaEx
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
 import at.forsyte.apalache.tla.typecomp.{BuilderUtil, TypeComputationFactory}
 
 /**
@@ -14,8 +13,7 @@ import at.forsyte.apalache.tla.typecomp.{BuilderUtil, TypeComputationFactory}
  *   Jure Kukovec
  */
 trait ProtoBuilder {
-  protected val varPool: TypeVarPool
-  protected val cmpFactory: TypeComputationFactory = new TypeComputationFactory(varPool)
+  protected val cmpFactory: TypeComputationFactory = new TypeComputationFactory
 
   /**
    * Specialized `composeAndValidateTypes`, applicable when the TNT operator has a signature, that is, it is not

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeSetBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeSetBuilder.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.typecomp.unsafe
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.{TlaOper, TlaSetOper}
 import at.forsyte.apalache.tla.lir.values.TlaStr
-import at.forsyte.apalache.tla.typecomp.BuilderUtil.throwMsg
+import at.forsyte.apalache.tla.typecomp.BuilderUtil.leftTypeException
 import at.forsyte.apalache.tla.typecomp.{BuilderUtil, TBuilderTypeException, TypeComputation, TypeComputationResult}
 
 import scala.collection.immutable.SortedMap
@@ -110,7 +110,7 @@ trait UnsafeSetBuilder extends ProtoBuilder {
       def getSetElemT(ex: TlaEx): TypeComputationResult =
         ex.typeTag match {
           case Typed(SetT1(t)) => t
-          case other => throwMsg(s"Expected $ex in record set constructor to have a Set(_) type, found $other")
+          case other => leftTypeException(s"Expected $ex in record set constructor to have a Set(_) type, found $other")
         }
 
       type exOrMap = Either[TBuilderTypeException, SortedMap[String, TlaType1]]

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/BuilderTest.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/BuilderTest.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.typecomp
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.typecheck.etc.TypeVarPool
 import org.junit.runner.RunWith
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
@@ -34,15 +33,21 @@ import shapeless._
  */
 @RunWith(classOf[JUnitRunner])
 trait BuilderTest extends AnyFunSuite with BeforeAndAfter with Checkers with AppendedClues with Matchers {
-  var varPool = new TypeVarPool()
-  var builder = new ScopedBuilder(varPool)
-  var cmpFactory = new TypeComputationFactory(varPool)
+  var builder = new ScopedBuilder
+  var cmpFactory = new TypeComputationFactory
 
   before {
-    varPool = new TypeVarPool()
-    builder = new ScopedBuilder(varPool)
-    cmpFactory = new TypeComputationFactory(varPool)
+    builder = new ScopedBuilder
+    cmpFactory = new TypeComputationFactory
   }
+
+  private val tt1gen: TlaType1Gen = new TlaType1Gen {}
+
+  implicit val singleTypeGen: Gen[TlaType1] = tt1gen.genType1
+  implicit val doubleTypeGen: Gen[(TlaType1, TlaType1)] = for {
+    t1 <- singleTypeGen
+    t2 <- singleTypeGen
+  } yield (t1, t2)
 
   // Useful methods for defining mkIllTypedArgs
   object InvalidTypeMethods {

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
@@ -193,16 +193,14 @@ class TestBaseBuilder extends BuilderTest {
         resultIsExpected,
     ) _
 
-    run(IntT1())
-
-//    checkRun(
-//        runBinary(
-//            builder.choose,
-//            mkWellTyped,
-//            mkIllTyped,
-//            resultIsExpected,
-//        )
-//    )
+    checkRun(
+        runBinary(
+            builder.choose,
+            mkWellTyped,
+            mkIllTyped,
+            resultIsExpected,
+        )
+    )
   }
 
   test("label") {

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
@@ -186,13 +186,6 @@ class TestBaseBuilder extends BuilderTest {
         tt => tt,
     )
 
-    val run = runBinary(
-        builder.choose,
-        mkWellTyped,
-        mkIllTyped,
-        resultIsExpected,
-    ) _
-
     checkRun(
         runBinary(
             builder.choose,

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
@@ -10,14 +10,6 @@ import scalaz.unused
 @RunWith(classOf[JUnitRunner])
 class TestBaseBuilder extends BuilderTest {
 
-  private val tt1gen: TlaType1Gen = new TlaType1Gen {}
-
-  implicit val singleTypeGen: Gen[TlaType1] = tt1gen.genPrimitiveMono
-  implicit val doubleTypeGen: Gen[(TlaType1, TlaType1)] = for {
-    t1 <- singleTypeGen
-    t2 <- singleTypeGen
-  } yield (t1, t2)
-
   test("eq/neq") {
     type T = (TBuilderInstruction, TBuilderInstruction)
     def mkWellTyped(tt: TlaType1): T =
@@ -194,14 +186,23 @@ class TestBaseBuilder extends BuilderTest {
         tt => tt,
     )
 
-    checkRun(
-        runBinary(
-            builder.choose,
-            mkWellTyped,
-            mkIllTyped,
-            resultIsExpected,
-        )
-    )
+    val run = runBinary(
+        builder.choose,
+        mkWellTyped,
+        mkIllTyped,
+        resultIsExpected,
+    ) _
+
+    run(IntT1())
+
+//    checkRun(
+//        runBinary(
+//            builder.choose,
+//            mkWellTyped,
+//            mkIllTyped,
+//            resultIsExpected,
+//        )
+//    )
   }
 
   test("label") {

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSeqBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSeqBuilder.scala
@@ -3,20 +3,11 @@ package at.forsyte.apalache.tla.typecomp
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaSeqOper
 import org.junit.runner.RunWith
-import org.scalacheck.Gen
 import org.scalatestplus.junit.JUnitRunner
 import scalaz.unused
 
 @RunWith(classOf[JUnitRunner])
 class TestSeqBuilder extends BuilderTest {
-
-  private val tt1gen: TlaType1Gen = new TlaType1Gen {}
-
-  implicit val singleTypeGen: Gen[TlaType1] = tt1gen.genPrimitiveMono
-  implicit val doubleTypeGen: Gen[(TlaType1, TlaType1)] = for {
-    t1 <- singleTypeGen
-    t2 <- singleTypeGen
-  } yield (t1, t2)
 
   test("append") {
     type T = (TBuilderInstruction, TBuilderInstruction)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSetBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSetBuilder.scala
@@ -12,7 +12,6 @@ import scala.collection.immutable.SortedMap
 @RunWith(classOf[JUnitRunner])
 class TestSetBuilder extends BuilderTest {
 
-  // TODO: fix signatures to allow polymorphism testing
   test("polyTest") {
     val t = VarT1("c")
 

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSetBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSetBuilder.scala
@@ -12,16 +12,8 @@ import scala.collection.immutable.SortedMap
 @RunWith(classOf[JUnitRunner])
 class TestSetBuilder extends BuilderTest {
 
-  private val tt1gen: TlaType1Gen = new TlaType1Gen {}
-
-  implicit val singleTypeGen: Gen[TlaType1] = tt1gen.genPrimitiveMono
-  implicit val doubleTypeGen: Gen[(TlaType1, TlaType1)] = for {
-    t1 <- singleTypeGen
-    t2 <- singleTypeGen
-  } yield (t1, t2)
-
   // TODO: fix signatures to allow polymorphism testing
-  ignore("polyTest") {
+  test("polyTest") {
     val t = VarT1("c")
 
     def n_a = builder.name("a", t)


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality

In order to support `Builder` construction of expressions with type variables we needed to redesign the old approach to signatures. Now, instead of constructing a signature as `OperT1(from, to)`, where `from` contains freshly generated typevars, which have to be unified (and would need to be substituted later if we continued with the old approach), we construct signatures as (partial) functions `from => to`. 
This also simplifies the code, as there is no longer a need for a) `varPool`s and b) arity-hints.