### PR TITLE
Add separate CI workflow to check for compiler warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,35 @@ jobs:
       - name: Check formatting
         run: make fmt-check
 
-  unit-tests:
+  compiler-warnings:
     env:
       APALACHE_FATAL_WARNINGS: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Coursier cache
+        uses: coursier/cache-action@v6
+      - name: Set APALACHE_HOME env
+        # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+        run: echo "APALACHE_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: Build and Unit Test
+        run: make compile-strict
+      - name: Cleanup before cache
+        # See https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html#Caching
+        shell: bash
+        run: |
+          rm -rf "$HOME/.ivy2/local" || true
+          find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
+          find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
+          find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
+          find $HOME/.sbt                              -name "*.lock"               -delete || true
+
+  unit-tests:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       # Allows other OS tests to proceed even if one fails
@@ -77,8 +103,6 @@ jobs:
           find $HOME/.sbt                              -name "*.lock"               -delete || true
 
   integration-tests:
-    env:
-      APALACHE_FATAL_WARNINGS: true
     runs-on: ${{ matrix.operating-system }}
     strategy:
       # Allows other OS tests to proceed even if one fails
@@ -131,8 +155,6 @@ jobs:
           TEST_FILTER: ${{ matrix.smt-encoding == 'arrays' && 'array-encoding' || '' }}
 
   docker-tests:
-    env:
-      APALACHE_FATAL_WARNINGS: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ compile:
 test:
 	sbt test
 
+# Compile code with fatal warnings enables
+compile-strict: export APALACHE_FATAL_WARNINGS=true
+compile-strict:
+	sbt Test/compile compile
+
 # Run tests with scoverage report
 test-coverage:
 	sbt coverage test coverageAggregate


### PR DESCRIPTION
Closes #1741

Removes the fatal warnings configuration from all our other CI jobs, and instead
runs a separate job that just compiles the code (including test code) with
fatal warnings enabled. This should provide fast feedback for compiler warnings
without interfering with other tests.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality