### PR TITLE
a work-in-progress spec of the model checker

### DIFF
--- a/test/tla/specs/checker/BasicChecker.tla
+++ b/test/tla/specs/checker/BasicChecker.tla
@@ -1,0 +1,111 @@
+-------------------------- MODULE BasicChecker --------------------------------
+(*
+ * A basic specification of the exploration algorithm that is implemented in
+ * Apalache. We focus on the algorithm itself and omit the non-essential parts.
+ * Hence, we make the following assumptions:
+ *
+ * - The set of states and the transition relation are predefined.
+ * 
+ * - For simplicity, we consider all states to be encoded with integers,
+ * instead of considering complex data structures.
+ *
+ * Igor Konnov, Informal Systems, 2022
+ *)
+
+EXTENDS Integers, Sequences, Apalache, Solver_typedefs
+
+CONSTANTS
+    \* The set of all potential states.
+    \*
+    \* @type: Set(Int);
+    STATES,
+    \* The set of the initial states.
+    \*
+    \* @type: Set(Int);
+    INIT_STATES,
+    \* The set of all potential transitions.
+    \*
+    \* @type: Set(<<Int, Int>>);
+    TRANSITIONS,
+    \* The invariant to be checked.
+    \*
+    \* @type: Set(Int);
+    INVARIANT,
+    \* The maximal number of steps to consider.
+    \*
+    \* @type: Int;
+    MAX_STEPS
+
+VARIABLES
+    \* The state of the search.
+    \*
+    \* @type: { code: Str, trace: Seq(Int) };
+    searchState,
+    \* The current step.
+    \*
+    \* @type: Int;
+    stepNo,
+    \* The solver state
+    \*
+    \* @type: CONTEXT;
+    context
+
+INSTANCE Solver    
+
+TIME_FRAMES == 1..MAX_STEPS + 1
+
+CheckStep(ctx, trace) ==
+    IF ~IsModel(ctx, trace)
+    THEN [ code |-> "Deadlock", trace |-> <<>> ]
+    ELSE LET withNotInv == InsertPred(ctx, STATES \ INVARIANT) IN
+         IF IsModel(withNotInv, trace)
+         THEN [ code |-> "Error", trace |-> trace ]
+         ELSE [ code |-> "NoError", trace |-> <<>> ]
+
+Init ==
+    /\ stepNo = 0
+    /\ context = ContextPush(ContextEmpty, { INIT_STATES }, {})
+    /\ \E trace \in [ { 1 } -> STATES ]:
+        LET traceSeq == FunAsSeq(trace, 1, 1) IN
+        searchState = CheckStep(context, traceSeq)
+
+Next ==
+    /\ searchState.code = "NoError"
+    /\ stepNo < MAX_STEPS
+    /\ stepNo' = stepNo + 1
+    /\ \E trace \in [ TIME_FRAMES -> STATES ]:
+        LET traceSeq == FunAsSeq(trace, stepNo + 2, MAX_STEPS + 1) IN
+        LET newCtx == ContextPush(context, {}, { TRANSITIONS }) IN
+        /\ context' = newCtx
+        /\ searchState' = CheckStep(newCtx, traceSeq)
+
+\* Check this invariant to see, whether there is a counterexample
+NoError ==
+    searchState.code /= "Error"
+
+\* @type: Seq(Int) => Bool;
+IsExecution(trace) ==
+    /\ 1 \in DOMAIN trace
+    /\ trace[1] \in INIT_STATES
+    /\ \A i \in DOMAIN trace \ { 1 }:
+        <<trace[i - 1], trace[i]>> \in TRANSITIONS
+
+Soundness ==
+    LET trace == searchState.trace IN
+    searchState.code = "Error"
+        =>  /\ IsExecution(trace)
+            /\ trace[Len(trace)] \notin INVARIANT
+
+Completeness ==
+    \E n \in 1..MAX_STEPS + 1:
+        LET ExistsExecution ==
+            /\ \E trace \in [ TIME_FRAMES -> STATES ]:
+                LET traceSeq == FunAsSeq(trace, n, MAX_STEPS + 1) IN
+                /\ IsExecution(traceSeq)
+                /\ traceSeq[Len(traceSeq)] \notin INVARIANT
+            /\ stepNo >= n - 1
+        IN
+        ExistsExecution => searchState.code = "Error"
+
+=============================================================================== 
+

--- a/test/tla/specs/checker/MC_BasicChecker.tla
+++ b/test/tla/specs/checker/MC_BasicChecker.tla
@@ -1,0 +1,31 @@
+--------------------------- MODULE MC_BasicChecker ----------------------------
+EXTENDS Integers, Solver_typedefs
+
+STATES == 0..6
+
+INIT_STATES == { 0, 2 }
+
+\* @type: Set(<<Int, Int>>);
+TRANSITIONS == {
+  <<0, 2>>,
+  <<1, 2>>,
+  <<2, 3>>,
+  <<3, 1>>,
+  <<3, 4>>,
+  <<4, 3>>
+}
+
+INVARIANT == 0..3
+
+MAX_STEPS == 10
+
+VARIABLES
+    \* @type: { code: Str, trace: Seq(Int) };
+    searchState,
+    \* @type: Int;
+    stepNo,
+    \* @type: CONTEXT;
+    context
+
+INSTANCE BasicChecker
+===============================================================================

--- a/test/tla/specs/checker/Solver.tla
+++ b/test/tla/specs/checker/Solver.tla
@@ -1,0 +1,54 @@
+---------------------------- MODULE Solver ------------------------------------
+(*
+ * An abstract model of a constraint solver:
+ *
+ * 1. The states are represented with integers.
+ *
+ * 2. The constraints are represented with sets of integers (predicates) and
+ * sets of pairs of integers (relations).
+ *
+ * Igor Konnov, Informal Systems, 2022
+ *)
+
+EXTENDS Integers, Sequences, Solver_typedefs
+
+CONSTANTS
+    \* The set of all potential states.
+    \*
+    \* @type: Set(Int);
+    STATES
+
+(*
+ * context.unary contains constraints over states that are layered by time
+ * frames.  Every set S of integers in unary is understood as a predicate
+ * that evaluates to true on the elements of the set.
+ *
+ * context.binary contains constraints over pairs of states that are
+ * layered by time frames. Every set R of integer pairs in binary is
+ * understood as a predicate that evaluates to true on the elements of the
+ * set.
+ *
+ * @type: (CONTEXT, Seq(Int)) => Bool;
+ *)
+IsModel(ctx, trace) ==
+    /\  \A i \in DOMAIN trace:
+          \A Pred \in ctx.unary[i]:
+            trace[i] \in Pred
+    /\  \A i \in DOMAIN trace \ { 1 }:
+          \A Relation \in ctx.binary[i]:
+            <<trace[i - 1], trace[i]>> \in Relation
+
+\* @type: CONTEXT;
+ContextEmpty ==
+    [ unary |-> <<>>, binary |-> <<>> ]
+
+\* @type: (CONTEXT, Set(Set(Int)), Set(Set(<<Int, Int>>))) => CONTEXT;
+ContextPush(ctx, predicates, relations) ==
+    [ unary |-> Append(ctx.unary, predicates),
+      binary |-> Append(ctx.binary, relations) ]
+
+\* @type: (CONTEXT, Set(Int)) => CONTEXT;
+InsertPred(ctx, cons) ==
+    [ ctx EXCEPT !.unary[Len(ctx.unary)] = @ \union { cons } ]
+
+===============================================================================

--- a/test/tla/specs/checker/Solver_typedefs.tla
+++ b/test/tla/specs/checker/Solver_typedefs.tla
@@ -1,0 +1,11 @@
+------------------------- MODULE Solver_typedefs ------------------------------
+
+(*
+ @typeAlias: CONTEXT = {
+      unary: Seq(Set(Set(Int))),
+      binary: Seq(Set(Set(<<Int, Int>>)))
+ };
+ *)
+Solver_aliases == TRUE
+
+================================================================================


### PR DESCRIPTION
Closes #1756. This is a work-in-progress specification of the basic model checking mode. While this specification may be checked with Apalache, it is not entirely faithful in representing the interaction with the solver. Currently, it is blocked by #1452.

- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
