### PR TITLE
Add printer for tla identifiers

### DIFF
--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -442,7 +442,7 @@ object UsableAsIdentifierPrinter extends Printer {
         throw new NotImplementedError("Printing Let-In expressions as identifiers is not supported")
       case _ =>
         throw new NotImplementedError(
-            s"Printing expression as identifier is not supported for expression ${p_ex.toString()}"
+            s"Printing expression as identifier is not supported for expression ${p_ex.toString()} of type ${p_ex.getClass()}"
         )
     }
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -304,8 +304,10 @@ object FullPrinter extends Printer {
 }
 
 object UsableAsIdentifierPrinter extends Printer {
-  val leftBracket = "d"
-  val rightBracket = "b"
+  /* Represents left brackets, since ( is not legal in identifiers */
+  val leftBracket = "_LEFTBRACKET_"
+  /* Represents right brackets, since ( is not legal in identifiers */
+  val rightBracket = "_RIGHTBRACKET_"
 
   def printInfixOperator(implicit args: Seq[String], operatorName: String): String = {
     leftBracket + args.mkString(s"${rightBracket}_${operatorName}_${leftBracket}") + rightBracket

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -312,11 +312,11 @@ object UsableAsIdentifierPrinter extends Printer {
   }
 
   def printPostfixOperator(args: Seq[String], operatorName: String): String = {
-    s"${leftBracket}_${args.mkString(",")}_${rightBracket}${operatorName}"
+    s"${leftBracket}_${args.mkString("_")}_${rightBracket}${operatorName}"
   }
 
   def printPrefixOperator(args: Seq[String], operatorName: String): String = {
-    s"${operatorName}${leftBracket}_${args.mkString(",")}_${rightBracket}"
+    s"${operatorName}${leftBracket}_${args.mkString("_")}_${rightBracket}"
   }
 
   def printUnboundedQuantiOperator(variable: String, body: String, operatorName: String): String = {
@@ -335,8 +335,8 @@ object UsableAsIdentifierPrinter extends Printer {
     p_ex match {
       case NameEx(name) => return name
       case NullEx       => return "null"
-      case OperEx(oper, args: Seq[_]) =>
-        val strArgs = args.map(arg => this(arg.asInstanceOf[TlaEx]))
+      case OperEx(oper, args @ _*) =>
+        val strArgs = args.map(arg => this(arg))
         oper match {
           case TlaOper.eq              => printInfixOperator(strArgs, "EQ")
           case TlaOper.ne              => printInfixOperator(strArgs, "NEQ")
@@ -396,7 +396,7 @@ object UsableAsIdentifierPrinter extends Printer {
           case TlaFunOper.enum   => printPrefixOperator(strArgs, "ENUM")
           case TlaFunOper.except => printPrefixOperator(strArgs, "EXCEPT")
           case TlaFunOper.funDef => printPrefixOperator(strArgs, "FUNDEF")
-          case TlaFunOper.tuple  => s"TUPLE${leftBracket}_${strArgs.mkString(",")}_${rightBracket}"
+          case TlaFunOper.tuple  => s"TUPLE${leftBracket}_${strArgs.mkString("_")}_${rightBracket}"
 
           case TlaSeqOper.append => printPrefixOperator(strArgs, "APPEND")
           case TlaSeqOper.concat => printInfixOperator(strArgs, "CONCAT")

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -386,7 +386,7 @@ object UsableAsIdentifierPrinter extends Printer {
           case TlaTempOper.guarantees     => printInfixOperator(strArgs, "GUARANTEES")
           case TlaTempOper.leadsTo        => printInfixOperator(strArgs, "LEADSTO")
           case TlaTempOper.strongFairness => printPrefixOperator(strArgs, "STRONGFAIR")
-          case TlaTempOper.weakFairness   => printPrefixOperator(strArgs, "WEAKFAIr")
+          case TlaTempOper.weakFairness   => printPrefixOperator(strArgs, "WEAKFAIR")
 
           case TlaFiniteSetOper.cardinality => printPrefixOperator(strArgs, "CARDINALITY")
           case TlaFiniteSetOper.isFiniteSet => printPrefixOperator(strArgs, "ISFINITESET")

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -331,6 +331,11 @@ object UsableAsIdentifierPrinter extends Printer {
     s"${operatorName}_${variable}_IN_${set}_COLON_${leftBracket}_${body}_${rightBracket}"
   }
 
+  def printOperDecl(decl: TlaOperDecl): String = {
+    s"${decl.name}_DEFINEDAS_${leftBracket}" +
+      s"${decl.formalParams.map(param => param.name).mkString("_")}${rightBracket}"
+  }
+
   override def apply(p_ex: TlaEx): String = {
     p_ex match {
       case NameEx(name) => return name
@@ -420,7 +425,7 @@ object UsableAsIdentifierPrinter extends Printer {
           case TlaSetOper.subseteq => printInfixOperator(strArgs, "SUBSETEQ")
           case TlaSetOper.times    => printInfixOperator(strArgs, "TIMES")
           case TlaSetOper.union    => printInfixOperator(strArgs, "UNION")
-          case TlaOper.label       => throw new NotImplementedError("Printing labels as identifiers is not supported")
+          case TlaOper.label       => printPrefixOperator(strArgs, "LABEL")
 
           case _ =>
             if (args.isEmpty)
@@ -438,8 +443,8 @@ object UsableAsIdentifierPrinter extends Printer {
           case s: TlaPredefSet => s.name.replaceAll("/[^A-Za-z0-9_]/", "_")
           case _               => ""
         }
-      case LetInEx(_, _) =>
-        throw new NotImplementedError("Printing Let-In expressions as identifiers is not supported")
+      case LetInEx(body, decls @ _*) =>
+        s"LET_${leftBracket}${decls.map(printOperDecl).mkString("_AND_")}${rightBracket}_IN_${this(body)}"
       case _ =>
         throw new NotImplementedError(
             s"Printing expression as identifier is not supported for expression ${p_ex.toString()} of type ${p_ex.getClass()}"

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -335,8 +335,8 @@ object UsableAsIdentifierPrinter extends Printer {
     p_ex match {
       case NameEx(name) => return name
       case NullEx       => return "null"
-      case OperEx(oper, args: Seq[TlaEx]) =>
-        val strArgs = args.map(arg => this(arg))
+      case OperEx(oper, args: Seq[_]) =>
+        val strArgs = args.map(arg => this(arg.asInstanceOf[TlaEx]))
         oper match {
           case TlaOper.eq              => printInfixOperator(strArgs, "EQ")
           case TlaOper.ne              => printInfixOperator(strArgs, "NEQ")

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -11,7 +11,6 @@ import org.scalacheck.Prop._
 import org.scalatestplus.scalacheck.Checkers._
 import org.scalatestplus.junit.JUnitRunner
 
-
 import org.scalatest.funsuite.AnyFunSuite
 
 @RunWith(classOf[JUnitRunner])
@@ -227,7 +226,7 @@ class TestPrinter extends AnyFunSuite with TestingPredefs {
       } catch {
         // only errors caught should be because printing some part is not implemented
         case _: NotImplementedError => true
-        case e: Throwable           => 
+        case e: Throwable =>
           assert(false, s"Got exception ${e}")
           false
       }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -5,13 +5,13 @@ import at.forsyte.apalache.tla.lir.values.TlaInt
 import at.forsyte.apalache.tla.lir.convenience._
 
 import org.junit.runner.RunWith
-import at.forsyte.apalache.tla.lir.UntypedPredefs._
-
 import org.scalacheck.Prop._
+
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers._
 import org.scalatestplus.junit.JUnitRunner
 
-import org.scalatest.funsuite.AnyFunSuite
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
 @RunWith(classOf[JUnitRunner])
 class TestPrinter extends AnyFunSuite with TestingPredefs {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -224,7 +224,6 @@ class TestPrinter extends AnyFunSuite with TestingPredefs {
         assert(badCharacters.isEmpty(), s": \"${strResult}\" contains bad characters: ${badCharacters.mkString(", ")}")
         propBoolean(true)
       } catch {
-        // all operators should be 
         case e: Throwable =>
           assert(false, s"Got exception ${e}")
           propBoolean(false)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -222,17 +222,15 @@ class TestPrinter extends AnyFunSuite with TestingPredefs {
         val badCharacters = strResult.filterNot(x => x.isLetterOrDigit || x == '_')
 
         assert(badCharacters.isEmpty(), s": \"${strResult}\" contains bad characters: ${badCharacters.mkString(", ")}")
-        true
+        propBoolean(true)
       } catch {
-        // only errors caught should be because printing some part is not implemented
-        case _: NotImplementedError => true
+        // all operators should be 
         case e: Throwable =>
           assert(false, s"Got exception ${e}")
-          false
+          propBoolean(false)
       }
     }
 
-    check(prop, minSuccessful(500), sizeRange(4))
-
+    check(prop, minSuccessful(2000), sizeRange(7))
   }
 }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- ~~[ ] Documentation added for any new functionality~~
- ~~[ ] Entry added to [UNRELEASED.md](./UNRELEASED.md) for any new functionality~~

This is needed for the tableau encoding, where in a TLA spec, variables stand for expressions.
The names of the variables should reflect which expression they stand for.
This printer takes an expression and outputs a string representing it which is usable as an identifier in TLA, i.e. it contains only alphanumeric characters and '_'
