### PR TITLE
Handle undefined results from model evaluation

### DIFF
--- a/.unreleased/bug-fixes/1819.md
+++ b/.unreleased/bug-fixes/1819.md
@@ -1,0 +1,1 @@
+Fix nested set membership in the arrays encoding, see #1819


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entries added to [./unreleased/][unreleased] for any new functionality

This PR makes makes the solver context query Z3 if a model evaluation returns an undefined result. See the linked issue for details. Closes #1819.

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
