### PR TITLE
Fix function cherry picking relation propagation

### DIFF
--- a/.unreleased/bug-fixes/1840.md
+++ b/.unreleased/bug-fixes/1840.md
@@ -1,0 +1,1 @@
+Fix spurious counter-example generation with functions of records in the arrays encoding, see #1840

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRuleWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRuleWithArrays.scala
@@ -143,7 +143,7 @@ class SetInRuleWithArrays(rewriter: SymbStateRewriter) extends SetInRule(rewrite
 
   private def supportsSMTEq(cellType: CellT): Boolean = {
     cellType match {
-      case CellTFrom(_ @IntT1 | RealT1 | BoolT1 | StrT1 | ConstT1(_) | VarT1(_) | FunT1(_, _) | SetT1(_)) =>
+      case CellTFrom(_ @IntT1 | RealT1 | BoolT1 | StrT1 | ConstT1(_) | VarT1(_)) =>
         true
       case _ => false
     }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] Entries added to [./unreleased/][unreleased] for any new functionality

This PR makes cherry picking of functions equate the function's domain, for which SMT constraints are generated, to the domain components of the function's relation, for which no SMT constraints are generated. Without the newly added lazy equality constraints, equivalent but not identical records are treated differently by the decoder, leading to spurious counter-examples.

The PR also contain a small fix to the use of SMT equality in set membership, which ensures that lazy equality is used for sets and functions, which can themselves contain records.

Closes #1840.

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
