### PR TITLE
Refactor CLI pipeline

### DIFF
--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/ExceptionAdapter.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/ExceptionAdapter.scala
@@ -5,21 +5,25 @@ import com.typesafe.scalalogging.LazyLogging
 /**
  * An abstract error message.
  */
-sealed abstract class ErrorMessage
+sealed abstract class ErrorMessage {
+
+  /** The concrete content of a message */
+  val msg: String
+}
 
 /**
  * A normal error that does not require a stack trace.
  * @param msg
  *   the message text
  */
-case class NormalErrorMessage(msg: String) extends ErrorMessage
+case class NormalErrorMessage(val msg: String) extends ErrorMessage
 
 /**
  * A failure message that should be printed along with a stack trace.
  * @param msg
  *   the message text
  */
-case class FailureMessage(msg: String) extends ErrorMessage
+case class FailureMessage(val msg: String) extends ErrorMessage
 
 /**
  * ExceptionAdapter allows us to convert an exception into a message string. The purpose of the adapter is to push the

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
@@ -1,0 +1,39 @@
+package at.forsyte.apalache.infra
+
+import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor, ToolModule, WriteablePassOptions}
+import com.google.inject.Guice
+
+/**
+ * This Executor abstracts the dependency injection and execution logic required for executing a PassChainExecutor
+ *
+ * @param toolModule
+ *   The tool module that specifies the sequence of passes
+ * @author
+ *   Shon Feder
+ */
+case class Executor(val toolModule: ToolModule) {
+  private val injector = Guice.createInjector(toolModule)
+
+  /** Exposes mutable access to options configuring the behavior of the [passChainExecutor] */
+  val passOptions = injector.getInstance(classOf[WriteablePassOptions])
+
+  private val exceptionAdapter = injector.getInstance(classOf[ExceptionAdapter])
+
+  private val passChainExecutor = {
+    val passes = toolModule.passes.zipWithIndex.map { case (p, i) =>
+      injector.getInstance(p).withNumber(i)
+    }
+    new PassChainExecutor(passOptions, passes)
+  }
+
+  /** Run the underlying PassChainExecutor, adapting exceptions as needed, and returning a `PassResult` */
+  def run(): Pass.PassResult = {
+    try {
+      passChainExecutor.run()
+    } catch {
+      case e: Throwable if exceptionAdapter.toMessage.isDefinedAt(e) =>
+        throw new AdaptedException(exceptionAdapter.toMessage(e))
+    }
+  }
+
+}

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
@@ -7,7 +7,7 @@ import com.google.inject.Guice
  * This Executor abstracts the dependency injection and execution logic required for executing a PassChainExecutor
  *
  * @param toolModule
- *   The tool module that specifies the sequence of passes
+ *   The [[ToolModule]] that specifies the sequence of passes
  * @author
  *   Shon Feder
  */

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
@@ -8,6 +8,8 @@ import com.google.inject.Guice
  *
  * @param toolModule
  *   The [[ToolModule]] that specifies the sequence of passes
+ * @throws [[AdaptedException]]
+ *   if any exceptions are caught by the configured [[ExceptionAdapter]]
  * @author
  *   Shon Feder
  */

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/exceptions.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/exceptions.scala
@@ -16,7 +16,7 @@ class PassExecException(message: String) extends Exception(message)
 class PassOptionException(message: String) extends Exception(message)
 
 /**
- * An error that is has been adapted by the [[ExceptionAdaptor]]
+ * An error that has been adapted by the [[ExceptionAdaptor]]
  * @param err
  *   the [[ErrorMessage]] into which the originating error was adapted
  */

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/exceptions.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/exceptions.scala
@@ -14,3 +14,10 @@ class PassExecException(message: String) extends Exception(message)
  *   an error message
  */
 class PassOptionException(message: String) extends Exception(message)
+
+/**
+ * An error that is has been adapted by the [[ExceptionAdaptor]]
+ * @param err
+ *   the [[ErrorMessage]] into which the originating error was adapted
+ */
+class AdaptedException(val err: ErrorMessage) extends Exception(err.msg)

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -127,6 +127,7 @@ object Tool extends LazyLogging {
                 }
                 ExitCodes.ERROR
 
+              // Raised on invalid or erroneous property files or tuning options arguments
               case e: PassOptionException =>
                 logger.error(e.getMessage)
                 ExitCodes.ERROR

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -132,8 +132,8 @@ object Tool extends LazyLogging {
                 ExitCodes.ERROR
 
               case e: Throwable =>
-                Console.err.println("Please report an issue at: " + ISSUES_LINK, e)
                 logger.error("Unhandled exception", e)
+                generateBugReport(e, cmd)
                 ExitCodes.ERROR
             } finally {
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -47,7 +47,7 @@ object Tool extends LazyLogging {
   }
 
   // Returns `Left(errmsg)` in case of configuration errors
-  private def outputAndLogConfig(cmd: General): Either[String, Unit] = {
+  private def outputAndLogConfig(cmd: ApalacheCommand): Either[String, Unit] = {
     ConfigManager(cmd).map { cfg =>
       try {
         OutputManager.configure(cfg)
@@ -130,7 +130,7 @@ object Tool extends LazyLogging {
   }
 
   // Execute the program specified by the subcommand cmd, handling errors as needed
-  private def runCommand(cmd: General): ExitCodes.TExitCode =
+  private def runCommand(cmd: ApalacheCommand): ExitCodes.TExitCode =
     try {
       cmd.run() match {
         case Left((errorCode, failMsg)) => { logger.info(failMsg); errorCode }
@@ -208,7 +208,7 @@ object Tool extends LazyLogging {
     }
   }
 
-  private def generateBugReport(e: Throwable, cmd: General): Unit = {
+  private def generateBugReport(e: Throwable, cmd: ApalacheCommand): Unit = {
     val absPath = ReportGenerator.prepareReportFile(
         cmd.invocation.split(" ").dropRight(1).mkString(" "),
         s"${BuildInfo.version} build ${BuildInfo.build}",

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -13,7 +13,7 @@ import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.tooling.opt._
 import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
 import at.forsyte.apalache.shai
-import com.google.inject.{Guice, Injector}
+import com.google.inject.Guice
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.configuration2.builder.fluent.Configurations
 import org.apache.commons.configuration2.ex.ConfigurationException
@@ -426,16 +426,16 @@ object Tool extends LazyLogging {
     }
     val options = injector.getInstance(classOf[WriteablePassOptions])
     val executor = new PassChainExecutor(options, passes)
+    val adapter = injector.getInstance(classOf[ExceptionAdapter])
 
-    handleExceptions(runner, injector, executor, cmd)
+    handleExceptions(runner, adapter, executor, cmd)
   }
 
   private def handleExceptions[C <: General](
       runner: (PassChainExecutor, C) => Int,
-      injector: Injector,
+      adapter: ExceptionAdapter,
       executor: PassChainExecutor,
       cmd: C): Int = {
-    val adapter = injector.getInstance(classOf[ExceptionAdapter])
     try {
       runner(executor, cmd)
     } catch {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -4,24 +4,12 @@ package at.forsyte.apalache.tla
 import apalache.BuildInfo
 import at.forsyte.apalache.infra._
 import at.forsyte.apalache.infra.log.LogbackConfigurator
-import at.forsyte.apalache.infra.passes.{PassChainExecutor, ToolModule, WriteablePassOptions}
 import at.forsyte.apalache.io.{ConfigManager, ConfigurationError, OutputManager, ReportGenerator}
-import at.forsyte.apalache.tla.bmcmt.config.{CheckerModule, ReTLAToVMTModule}
-import at.forsyte.apalache.tla.bmcmt.rules.vmt.TlaExToVMTWriter
-import at.forsyte.apalache.tla.imp.passes.ParserModule
-import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.tooling.opt._
-import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
-import at.forsyte.apalache.shai
-import com.google.inject.Guice
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.configuration2.builder.fluent.Configurations
-import org.apache.commons.configuration2.ex.ConfigurationException
 import org.backuity.clist.Cli
 import util.ExecutionStatisticsCollector
-import util.ExecutionStatisticsCollector.Selection
 
-import java.io.{File, FileNotFoundException}
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import scala.jdk.CollectionConverters._
@@ -124,32 +112,41 @@ object Tool extends LazyLogging {
           case Right(()) => {
             val startTime = LocalDateTime.now()
             try {
-              cmd match {
-                case parse: ParseCmd =>
-                  runForModule(runParse, new ParserModule, parse)
-
-                case simulate: SimulateCmd =>
-                  // simulation is just a special case of checking, which has additional parameters passed via SimulateCmd
-                  runForModule(runCheck, new CheckerModule, simulate)
-
-                case check: CheckCmd =>
-                  runForModule(runCheck, new CheckerModule, check)
-
-                case test: TestCmd =>
-                  runForModule(runTest, new CheckerModule, test)
-
-                case typecheck: TypeCheckCmd =>
-                  runForModule(runTypeCheck, new TypeCheckerModule, typecheck)
-
-                case server: ServerCmd =>
-                  runForModule(runServer, new CheckerModule, server)
-
-                case constrain: TranspileCmd =>
-                  runForModule(runConstrain, new ReTLAToVMTModule, constrain)
-
-                case config: ConfigCmd =>
-                  configure(config)
+              cmd.run() match {
+                case Left((errorCode, failMsg)) =>
+                  logger.info(failMsg)
+                  errorCode
+                case Right(msg) =>
+                  logger.info(msg)
+                  ExitCodes.OK
               }
+            } catch {
+              case e: AdaptedException =>
+                e.err match {
+                  case NormalErrorMessage(text) =>
+                    logger.error(text)
+
+                  case FailureMessage(text) =>
+                    logger.error(text, e)
+                    val absPath = ReportGenerator.prepareReportFile(
+                        cmd.invocation.split(" ").dropRight(1).mkString(" "),
+                        s"${BuildInfo.version} build ${BuildInfo.build}",
+                    )
+                    Console.err.println(
+                        s"Please report an issue at $ISSUES_LINK: $e\nA bug report template has been generated at [$absPath].\nIf you choose to use it, please complete the template with a description of the expected behavior."
+                    )
+
+                }
+                ExitCodes.ERROR
+
+              case e: PassOptionException =>
+                logger.error(e.getMessage)
+                ExitCodes.ERROR
+
+              case e: Throwable =>
+                Console.err.println("Please report an issue at: " + ISSUES_LINK, e)
+                logger.error("Unhandled exception", e)
+                ExitCodes.ERROR
             } finally {
               printTimeDiff(startTime)
             }
@@ -161,7 +158,6 @@ object Tool extends LazyLogging {
         } else {
           Console.out.println(s"EXITCODE: ERROR ($exitcode)")
         }
-
         exitcode
       }
     }
@@ -176,298 +172,6 @@ object Tool extends LazyLogging {
           .format(ChronoUnit.SECONDS.between(startTime, endTime), ChronoUnit.MILLIS.between(startTime, endTime) % 1000))
   }
 
-  // Set the pass options from the cli configs shared between all commands
-  private def setCommonOptions(cli: General, options: WriteablePassOptions): Unit = {
-    options.set("general.debug", cli.debug)
-    options.set("smt.prof", cli.smtprof)
-    options.set("general.features", cli.features)
-
-    // TODO: Remove pass option, and just rely on OutputManager config
-    options.set("io.outdir", OutputManager.outDir)
-  }
-
-  private def runAndExit(
-      executor: PassChainExecutor,
-      msgIfOk: TlaModule => String,
-      msgIfFail: String): ExitCodes.TExitCode = {
-    val result = executor.run()
-    result match {
-      case Left(errorCode) =>
-        logger.info(msgIfFail)
-        errorCode
-      case Right(module) =>
-        logger.info(msgIfOk(module))
-        ExitCodes.OK
-    }
-  }
-
-  private def setCoreOptions(executor: PassChainExecutor, cmd: AbstractCheckerCmd): Unit = {
-    logger.info {
-      val environment = if (cmd.env != "") s"(${cmd.env}) " else ""
-      s"Checker options: ${environment}${cmd.name} ${cmd.invocation}"
-    }
-    executor.options.set("parser.filename", cmd.file.getAbsolutePath)
-    if (cmd.config != "")
-      executor.options.set("checker.config", cmd.config)
-    if (cmd.init != "")
-      executor.options.set("checker.init", cmd.init)
-    if (cmd.next != "")
-      executor.options.set("checker.next", cmd.next)
-    if (cmd.inv != "")
-      executor.options.set("checker.inv", List(cmd.inv))
-    if (cmd.cinit != "")
-      executor.options.set("checker.cinit", cmd.cinit)
-    executor.options.set("checker.length", cmd.length)
-  }
-
-  private def runParse(executor: PassChainExecutor, parse: ParseCmd): Int = {
-    // here, we implement a terminal pass to get the parse results
-
-    // init
-    logger.info("Parse " + parse.file)
-
-    executor.options.set("parser.filename", parse.file.getAbsolutePath)
-    parse.output.foreach(executor.options.set("io.output", _))
-
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutmputManager configuration
-    setCommonOptions(parse, executor.options)
-
-    runAndExit(
-        executor,
-        m => {
-          s"Parsed successfully\nRoot module: ${m.name} with ${m.declarations.length} declarations."
-        },
-        "Parser has failed",
-    )
-  }
-
-  private def runCheck(executor: PassChainExecutor, check: CheckCmd): Int = {
-    setCoreOptions(executor, check)
-
-    var tuning =
-      if (check.tuningOptionsFile != "") loadProperties(check.tuningOptionsFile) else Map[String, String]()
-    tuning = overrideProperties(tuning, check.tuningOptions)
-
-    check match {
-      case sim: SimulateCmd =>
-        // propagate the simulator options to the tuning options, so the model checker can easily pick them
-        tuning += "search.simulation" -> "true"
-        tuning += "search.simulation.maxRun" -> sim.maxRun.toString
-        tuning += "search.simulation.saveRuns" -> sim.saveRuns.toString
-
-      case _ => ()
-    }
-    logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
-
-    executor.options.set("general.tuning", tuning)
-    executor.options.set("checker.nworkers", check.nworkers)
-    executor.options.set("checker.discardDisabled", check.discardDisabled)
-    executor.options.set("checker.noDeadlocks", check.noDeadlocks)
-    executor.options.set("checker.algo", check.algo)
-    executor.options.set("checker.smt-encoding", check.smtEncoding)
-    executor.options.set("checker.maxError", check.maxError)
-    if (check.view != "")
-      executor.options.set("checker.view", check.view)
-    // for now, enable polymorphic types. We probably want to disable this option for the type checker
-    executor.options.set("typechecker.inferPoly", true)
-
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutmputManager configuration
-    setCommonOptions(check, executor.options)
-
-    runAndExit(
-        executor,
-        _ => "Checker reports no error up to computation length " + check.length,
-        "Checker has found an error",
-    )
-  }
-
-  private def runTest(executor: PassChainExecutor, test: TestCmd): Int = {
-    // This is a special version of the `check` command that is tuned towards testing scenarios
-
-    logger.info("Checker options: filename=%s, before=%s, action=%s, after=%s"
-          .format(test.file, test.before, test.action, test.assertion))
-
-    // Tune for testing:
-    //   1. Check the invariant only after the action took place.
-    //   2. Randomize
-    val seed = Math.abs(System.currentTimeMillis().toInt)
-    val tuning = Map("search.invariantFilter" -> "1", "smt.randomSeed" -> seed.toString)
-    logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
-
-    executor.options.set("general.tuning", tuning)
-    executor.options.set("parser.filename", test.file.getAbsolutePath)
-    executor.options.set("checker.init", test.before)
-    executor.options.set("checker.next", test.action)
-    executor.options.set("checker.inv", List(test.assertion))
-    if (test.cinit != "") {
-      executor.options.set("checker.cinit", test.cinit)
-    }
-    executor.options.set("checker.nworkers", 1)
-    // check only one instance of the action
-    executor.options.set("checker.length", 1)
-    // no preliminary pruning of disabled transitions
-    executor.options.set("checker.discardDisabled", false)
-    executor.options.set("checker.noDeadlocks", false)
-    // prefer the offline mode as we have a single query
-    executor.options.set("checker.algo", "offline")
-    // for now, enable polymorphic types. We probably want to disable this option for the type checker
-    executor.options.set("typechecker.inferPoly", true)
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutmputManager configuration
-    setCommonOptions(test, executor.options)
-
-    runAndExit(
-        executor,
-        _ => "No example found",
-        "Found a violation of the postcondition. Check violation.tla.",
-    )
-  }
-
-  private def runTypeCheck(executor: PassChainExecutor, typecheck: TypeCheckCmd): Int = {
-    // type checker
-
-    logger.info("Type checking " + typecheck.file)
-
-    executor.options.set("parser.filename", typecheck.file.getAbsolutePath)
-    typecheck.output.foreach(executor.options.set("io.output", _))
-    executor.options.set("typechecker.inferPoly", typecheck.inferPoly)
-
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutmputManager configuration
-    setCommonOptions(typecheck, executor.options)
-
-    runAndExit(
-        executor,
-        _ => "Type checker [OK]",
-        "Type checker [FAILED]",
-    )
-  }
-
-  private def runServer(executor: PassChainExecutor, server: ServerCmd): Int = {
-    logger.info("Starting server...")
-
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutputManager configuration
-    setCommonOptions(server, executor.options)
-
-    shai.v1.RpcServer.main(Array())
-    ExitCodes.OK
-  }
-
-  private def runConstrain(executor: PassChainExecutor, constrain: TranspileCmd): Int = {
-    setCoreOptions(executor, constrain)
-    // for now, enable polymorphic types. We probably want to disable this option for the type checker
-    executor.options.set("typechecker.inferPoly", true)
-
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutmputManager configuration
-    setCommonOptions(constrain, executor.options)
-
-    val outFilePath = OutputManager.runDirPathOpt
-      .map { p =>
-        p.resolve(TlaExToVMTWriter.outFileName).toAbsolutePath
-      }
-      .getOrElse(TlaExToVMTWriter.outFileName)
-
-    runAndExit(
-        executor,
-        _ => s"VMT constraints successfully generated at\n$outFilePath",
-        "Failed to generate constraints",
-    )
-  }
-
-  private def loadProperties(filename: String): Map[String, String] = {
-    // use an apache-commons library, as it supports variable substitution
-    try {
-      val config = new Configurations().properties(new File(filename))
-      // access configuration properties
-      var map = Map[String, String]()
-      for (name: String <- config.getKeys.asScala) {
-        map += (name -> config.getString(name))
-      }
-      map
-    } catch {
-      case _: FileNotFoundException =>
-        throw new PassOptionException(s"The properties file $filename not found")
-
-      case e: ConfigurationException =>
-        throw new PassOptionException(s"Error in the properties file $filename: ${e.getMessage}")
-    }
-  }
-
-  private def overrideProperties(props: Map[String, String], propsAsString: String): Map[String, String] = {
-    def parseKeyValue(text: String): (String, String) = {
-      val parts = text.split('=')
-      if (parts.length != 2 || parts.head.trim == "" || parts(1) == "") {
-        throw new PassOptionException(s"Expected key=value in --tuning-options=$propsAsString")
-      } else {
-        // trim to remove surrounding whitespace from the key, but allow the value to have white spaces
-        (parts.head.trim, parts(1))
-      }
-    }
-
-    val hereProps = {
-      if (propsAsString.trim.nonEmpty) {
-        propsAsString.split(':').map(parseKeyValue).toMap
-      } else {
-        Map.empty
-      }
-    }
-    // hereProps may override the values in props
-    props ++ hereProps
-  }
-
-  private def runForModule[C <: General](runner: (PassChainExecutor, C) => Int, module: ToolModule, cmd: C): Int = {
-    val injector = Guice.createInjector(module)
-    val passes = module.passes.zipWithIndex.map { case (p, i) =>
-      injector.getInstance(p).withNumber(i)
-    }
-    val options = injector.getInstance(classOf[WriteablePassOptions])
-    val executor = new PassChainExecutor(options, passes)
-    val adapter = injector.getInstance(classOf[ExceptionAdapter])
-
-    handleExceptions(runner, adapter, executor, cmd)
-  }
-
-  private def handleExceptions[C <: General](
-      runner: (PassChainExecutor, C) => Int,
-      adapter: ExceptionAdapter,
-      executor: PassChainExecutor,
-      cmd: C): Int = {
-    try {
-      runner(executor, cmd)
-    } catch {
-      case e: Throwable if adapter.toMessage.isDefinedAt(e) =>
-        adapter.toMessage(e) match {
-          case NormalErrorMessage(text) =>
-            logger.error(text)
-
-          case FailureMessage(text) =>
-            logger.error(text, e)
-            val absPath = ReportGenerator.prepareReportFile(
-                cmd.invocation.split(" ").dropRight(1).mkString(" "),
-                s"${BuildInfo.version} build ${BuildInfo.build}",
-            )
-            Console.err.println(
-                s"Please report an issue at $ISSUES_LINK: $e\nA bug report template has been generated at [$absPath].\nIf you choose to use it, please complete the template with a description of the expected behavior."
-            )
-
-        }
-        ExitCodes.ERROR
-
-      case e: PassOptionException =>
-        logger.error(e.getMessage)
-        ExitCodes.ERROR
-
-      case e: Throwable =>
-        Console.err.println("Please report an issue at: " + ISSUES_LINK, e)
-        logger.error("Unhandled exception", e)
-        ExitCodes.ERROR
-    }
-  }
-
   private def printStatsConfig(): Unit = {
     if (new ExecutionStatisticsCollector().isEnabled) {
       // Statistic collection is enabled. Thank the user
@@ -480,59 +184,6 @@ object Tool extends LazyLogging {
           "# If you want to help our project, consider enabling statistics with config --enable-stats=true.")
     }
     Console.println("")
-  }
-
-  private def configure(config: ConfigCmd): Int = {
-    logger.info("Configuring Apalache")
-    config.submitStats match {
-      case Some(isEnabled) =>
-        val warning = "Unable to update statistics configuration. The other features will keep working."
-
-        if (!configDirExistsOrCreated()) {
-          logger.warn(warning)
-        } else {
-          val statCollector = new ExecutionStatisticsCollector()
-          // protect against potential exceptions in the tla2tools code
-          try {
-            if (isEnabled) {
-              statCollector.set(Selection.ON)
-              logger.info("Statistics collection is ON.")
-              logger.info("This also enabled TLC and TLA+ Toolbox statistics.")
-            } else {
-              statCollector.set(Selection.NO_ESC)
-              logger.info("Statistics collection is OFF.")
-              logger.info("This also disabled TLC and TLA+ Toolbox statistics.")
-            }
-          } catch {
-            case e: Exception =>
-              logger.warn(e.getMessage)
-              logger.warn(warning)
-          }
-        }
-
-      case None =>
-        ()
-    }
-
-    ExitCodes.OK
-  }
-
-  private def configDirExistsOrCreated(): Boolean = {
-    // A temporary fix for the issue #762: create ~/.tlaplus if it does not exist
-    val configDir = new File(System.getProperty("user.home", ""), ".tlaplus")
-    if (configDir.exists()) {
-      true
-    } else {
-      try {
-        configDir.mkdir()
-        true
-      } catch {
-        case e: Exception =>
-          logger.warn(e.getMessage)
-          logger.warn(s"Unable to create the directory $configDir.")
-          false
-      }
-    }
   }
 
   // If the user has opted-in, collect statistics with the code from tlatools:

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -3,10 +3,11 @@ package at.forsyte.apalache.tla.tooling.opt
 import org.backuity.clist.{arg, opt, Command}
 
 import java.io.File
+import com.typesafe.scalalogging.LazyLogging
 
 // Holds the minimal necessary info about a specification.
 abstract class AbstractCheckerCmd(val name: String, description: String)
-    extends Command(name, description) with General {
+    extends Command(name, description) with PassExecutorCmd with LazyLogging {
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var config: String = opt[String](name = "config", default = "", description = "configuration file in TLC format")
   var cinit: String = opt[String](name = "cinit", default = "",
@@ -21,4 +22,24 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
     opt[String](name = "inv", default = "", description = "the name of an invariant operator, e.g., Inv")
   var length: Int =
     opt[Int](name = "length", default = 10, description = "maximal number of Next steps, default: 10")
+
+  override def setCommonOptions(): Unit = {
+    logger.info {
+      val environment = if (env != "") s"(${env}) " else ""
+      s"Checker options: ${environment}${name} ${invocation}"
+    }
+    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    if (config != "")
+      executor.passOptions.set("checker.config", config)
+    if (init != "")
+      executor.passOptions.set("checker.init", init)
+    if (next != "")
+      executor.passOptions.set("checker.next", next)
+    if (inv != "")
+      executor.passOptions.set("checker.inv", List(inv))
+    if (cinit != "")
+      executor.passOptions.set("checker.cinit", cinit)
+    executor.passOptions.set("checker.length", length)
+    super.setCommonOptions()
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -1,13 +1,13 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-import org.backuity.clist.{arg, opt, Command}
+import org.backuity.clist.{arg, opt}
 
 import java.io.File
 import com.typesafe.scalalogging.LazyLogging
 
 // Holds the minimal necessary info about a specification.
 abstract class AbstractCheckerCmd(val name: String, description: String)
-    extends Command(name, description) with PassExecutorCmd with LazyLogging {
+    extends PassExecutorCmd(name, description) with LazyLogging {
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var config: String = opt[String](name = "config", default = "", description = "configuration file in TLC format")
   var cinit: String = opt[String](name = "cinit", default = "",

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -24,6 +24,7 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
     opt[Int](name = "length", default = 10, description = "maximal number of Next steps, default: 10")
 
   override def setCommonOptions(): Unit = {
+    super.setCommonOptions()
     logger.info {
       val environment = if (env != "") s"(${env}) " else ""
       s"Checker options: ${environment}${name} ${invocation}"
@@ -40,6 +41,5 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
     if (cinit != "")
       executor.passOptions.set("checker.cinit", cinit)
     executor.passOptions.set("checker.length", length)
-    super.setCommonOptions()
   }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -1,8 +1,15 @@
 package at.forsyte.apalache.tla.tooling.opt
 
+import at.forsyte.apalache.infra.Executor
+import at.forsyte.apalache.infra.PassOptionException
+import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
 import at.forsyte.apalache.tla.bmcmt.{arraysEncoding, oopsla19Encoding, SMTEncoding}
+import java.io.{File, FileNotFoundException}
+import org.apache.commons.configuration2.builder.fluent.Configurations
+import org.apache.commons.configuration2.ex.ConfigurationException
 import org.backuity.clist._
 import org.backuity.clist.util.Read
+import scala.jdk.CollectionConverters._
 
 /**
  * This command initiates the 'check' command line.
@@ -11,7 +18,9 @@ import org.backuity.clist.util.Read
  *   Igor Konnov
  */
 class CheckCmd(name: String = "check", description: String = "Check a TLA+ specification")
-    extends AbstractCheckerCmd(name, description) with General {
+    extends AbstractCheckerCmd(name, description) {
+
+  val executor = Executor(new CheckerModule)
 
   // Parses the smtEncoding option
   implicit val smtEncodingRead: Read[SMTEncoding] =
@@ -50,4 +59,75 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
   var view: String =
     opt[String](name = "view", description = "the state view to use with --max-error=n, default: transition index",
         default = "")
+
+  def setTuningOptions(): Map[String, String] = {
+    val tuning =
+      if (tuningOptionsFile != "") loadProperties(tuningOptionsFile) else Map[String, String]()
+    overrideProperties(tuning, tuningOptions)
+  }
+
+  def run() = {
+
+    val tuning = setTuningOptions()
+
+    logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
+
+    executor.passOptions.set("general.tuning", tuning)
+    executor.passOptions.set("checker.nworkers", nworkers)
+    executor.passOptions.set("checker.discardDisabled", discardDisabled)
+    executor.passOptions.set("checker.noDeadlocks", noDeadlocks)
+    executor.passOptions.set("checker.algo", algo)
+    executor.passOptions.set("checker.smt-encoding", smtEncoding)
+    executor.passOptions.set("checker.maxError", maxError)
+    if (view != "")
+      executor.passOptions.set("checker.view", view)
+    // for now, enable polymorphic types. We probably want to disable this option for the type checker
+    executor.passOptions.set("typechecker.inferPoly", true)
+    setCommonOptions()
+    executor.run() match {
+      case Right(_)   => Right("Checker reports no error up to computation length " + length)
+      case Left(code) => Left(code, "Checker has found an error")
+    }
+  }
+
+  private def loadProperties(filename: String): Map[String, String] = {
+    // use an apache-commons library, as it supports variable substitution
+    try {
+      val config = new Configurations().properties(new File(filename))
+      // access configuration properties
+      var map = Map[String, String]()
+      for (name: String <- config.getKeys.asScala) {
+        map += (name -> config.getString(name))
+      }
+      map
+    } catch {
+      case _: FileNotFoundException =>
+        throw new PassOptionException(s"The properties file $filename not found")
+
+      case e: ConfigurationException =>
+        throw new PassOptionException(s"Error in the properties file $filename: ${e.getMessage}")
+    }
+  }
+
+  private def overrideProperties(props: Map[String, String], propsAsString: String): Map[String, String] = {
+    def parseKeyValue(text: String): (String, String) = {
+      val parts = text.split('=')
+      if (parts.length != 2 || parts.head.trim == "" || parts(1) == "") {
+        throw new PassOptionException(s"Expected key=value in --tuning-options=$propsAsString")
+      } else {
+        // trim to remove surrounding whitespace from the key, but allow the value to have white spaces
+        (parts.head.trim, parts(1))
+      }
+    }
+
+    val hereProps = {
+      if (propsAsString.trim.nonEmpty) {
+        propsAsString.split(':').map(parseKeyValue).toMap
+      } else {
+        Map.empty
+      }
+    }
+    // hereProps may override the values in props
+    props ++ hereProps
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -60,7 +60,7 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
     opt[String](name = "view", description = "the state view to use with --max-error=n, default: transition index",
         default = "")
 
-  def setTuningOptions(): Map[String, String] = {
+  def collectTuningOptions(): Map[String, String] = {
     val tuning =
       if (tuningOptionsFile != "") loadProperties(tuningOptionsFile) else Map[String, String]()
     overrideProperties(tuning, tuningOptions)
@@ -68,7 +68,7 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
 
   def run() = {
 
-    val tuning = setTuningOptions()
+    val tuning = collectTuningOptions()
 
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
@@ -28,30 +28,23 @@ class ConfigCmd
   def run() = {
     logger.info("Configuring Apalache")
     submitStats.foreach { isEnabled =>
-      val warning = "Unable to update statistics configuration. The other features will keep working."
-
       if (!configDirExistsOrCreated()) {
-        logger.warn(warning)
+        logger.warn("Unable to update statistics configuration. The other features will keep working.")
       } else {
         val statCollector = new ExecutionStatisticsCollector()
         // protect against potential exceptions in the tla2tools code
-        try {
-          if (isEnabled) {
-            statCollector.set(Selection.ON)
-            logger.info("Statistics collection is ON.")
-            logger.info("This also enabled TLC and TLA+ Toolbox statistics.")
-          } else {
-            statCollector.set(Selection.NO_ESC)
-            logger.info("Statistics collection is OFF.")
-            logger.info("This also disabled TLC and TLA+ Toolbox statistics.")
-          }
-        } catch {
-          case e: Exception =>
-            logger.warn(e.getMessage)
-            logger.warn(warning)
+        if (isEnabled) {
+          statCollector.set(Selection.ON)
+          logger.info("Statistics collection is ON.")
+          logger.info("This also enabled TLC and TLA+ Toolbox statistics.")
+        } else {
+          statCollector.set(Selection.NO_ESC)
+          logger.info("Statistics collection is OFF.")
+          logger.info("This also disabled TLC and TLA+ Toolbox statistics.")
         }
       }
     }
+
     Right("Configuration complete")
   }
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.tooling.opt
 
+import org.backuity.clist.opt
+import java.io.File
+import com.typesafe.scalalogging.LazyLogging
+
 // imports from Sany utils
 import util.ExecutionStatisticsCollector
 import util.ExecutionStatisticsCollector.Selection
-
-// clist also has a `util`, so this import must be after the Sany imports
-import org.backuity.clist.{Command, _}
-import java.io.File
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * This command initiates the 'config' command line.
@@ -15,8 +14,7 @@ import com.typesafe.scalalogging.LazyLogging
  * @author
  *   Igor Konnov
  */
-class ConfigCmd
-    extends Command(name = "config", description = "Configure Apalache options") with General with LazyLogging {
+class ConfigCmd extends ApalacheCommand(name = "config", description = "Configure Apalache options") with LazyLogging {
 
   var submitStats: Option[Boolean] = opt[Option[Boolean]](name = "enable-stats",
       description = "Let Apalache submit usage statistics to tlapl.us\n"

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
@@ -2,6 +2,10 @@ package at.forsyte.apalache.tla.tooling.opt
 
 import org.backuity.clist.{Command, _}
 import java.io.File
+import com.typesafe.scalalogging.LazyLogging
+// FIXME Why "_root_"?
+import _root_.util.ExecutionStatisticsCollector
+import _root_.util.ExecutionStatisticsCollector.Selection
 
 /**
  * This command initiates the 'config' command line.
@@ -9,7 +13,8 @@ import java.io.File
  * @author
  *   Igor Konnov
  */
-class ConfigCmd extends Command(name = "config", description = "Configure Apalache options") with General {
+class ConfigCmd
+    extends Command(name = "config", description = "Configure Apalache options") with General with LazyLogging {
 
   var submitStats: Option[Boolean] = opt[Option[Boolean]](name = "enable-stats",
       description = "Let Apalache submit usage statistics to tlapl.us\n"
@@ -17,4 +22,52 @@ class ConfigCmd extends Command(name = "config", description = "Configure Apalac
 
   // Used for application (esp. output) configuration
   def file = new File("config")
+
+  def run() = {
+    logger.info("Configuring Apalache")
+    submitStats.foreach { isEnabled =>
+      val warning = "Unable to update statistics configuration. The other features will keep working."
+
+      if (!configDirExistsOrCreated()) {
+        logger.warn(warning)
+      } else {
+        val statCollector = new ExecutionStatisticsCollector()
+        // protect against potential exceptions in the tla2tools code
+        try {
+          if (isEnabled) {
+            statCollector.set(Selection.ON)
+            logger.info("Statistics collection is ON.")
+            logger.info("This also enabled TLC and TLA+ Toolbox statistics.")
+          } else {
+            statCollector.set(Selection.NO_ESC)
+            logger.info("Statistics collection is OFF.")
+            logger.info("This also disabled TLC and TLA+ Toolbox statistics.")
+          }
+        } catch {
+          case e: Exception =>
+            logger.warn(e.getMessage)
+            logger.warn(warning)
+        }
+      }
+    }
+    Right("Configuration complete")
+  }
+
+  private def configDirExistsOrCreated(): Boolean = {
+    // A temporary fix for the issue #762: create ~/.tlaplus if it does not exist
+    val configDir = new File(System.getProperty("user.home", ""), ".tlaplus")
+    if (configDir.exists()) {
+      true
+    } else {
+      try {
+        configDir.mkdir()
+        true
+      } catch {
+        case e: Exception =>
+          logger.warn(e.getMessage)
+          logger.warn(s"Unable to create the directory $configDir.")
+          false
+      }
+    }
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
@@ -3,7 +3,8 @@ package at.forsyte.apalache.tla.tooling.opt
 import org.backuity.clist.{Command, _}
 import java.io.File
 import com.typesafe.scalalogging.LazyLogging
-// FIXME Why "_root_"?
+
+// From tlatools.jar
 import _root_.util.ExecutionStatisticsCollector
 import _root_.util.ExecutionStatisticsCollector.Selection
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ConfigCmd.scala
@@ -1,12 +1,13 @@
 package at.forsyte.apalache.tla.tooling.opt
 
+// imports from Sany utils
+import util.ExecutionStatisticsCollector
+import util.ExecutionStatisticsCollector.Selection
+
+// clist also has a `util`, so this import must be after the Sany imports
 import org.backuity.clist.{Command, _}
 import java.io.File
 import com.typesafe.scalalogging.LazyLogging
-
-// From tlatools.jar
-import _root_.util.ExecutionStatisticsCollector
-import _root_.util.ExecutionStatisticsCollector.Selection
 
 /**
  * This command initiates the 'config' command line.

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -9,14 +9,15 @@ import org.backuity.clist._
 import org.backuity.clist.util.Read
 
 /**
- * The general commands.
+ * The base class used by all Apalache CLI subcommands.
  *
  * See: https://github.com/backuity/clist
  *
  * @author
  *   Igor Konnov, Shon Feder
  */
-trait General extends Command with CliConfig {
+abstract class ApalacheCommand(name: String, description: String)
+    extends Command(name: String, description: String) with CliConfig {
   // TODO Fix excessively long strings
   var configFile = opt[Option[File]](description =
         "configuration to read from (JSON and HOCON formats supported). Overrides any local .aplache.cfg files. (overrides envvar CONFIG_FILE)",

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/General.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.tla.tooling.opt
 
 import at.forsyte.apalache.io.CliConfig
 import at.forsyte.apalache.tla.lir.Feature
+import at.forsyte.apalache.infra.ExitCodes
 
 import java.io.File
 import org.backuity.clist._
@@ -13,7 +14,7 @@ import org.backuity.clist.util.Read
  * See: https://github.com/backuity/clist
  *
  * @author
- *   Igor Konnov
+ *   Igor Konnov, Shon Feder
  */
 trait General extends Command with CliConfig {
   // TODO Fix excessively long strings
@@ -39,6 +40,18 @@ trait General extends Command with CliConfig {
         val featureDescriptions = Feature.all.map(f => s"  ${f.name}: ${f.description}")
         ("a comma-separated list of experimental features:" :: featureDescriptions).mkString("\n")
       })
+
+  /**
+   * Run the process corresponding to the specified subcommand
+   *
+   * All execution logic specific to the subcommand should be triggered encapsulated in the [[run]] method.
+   *
+   * @return
+   *   `Right(msg)` on a successful execution or `Left((errCode, msg))` if the process fails, where `errCode` is the
+   *   return code with the which the program will be terminated. In either case `msg` is the final message reported to
+   *   the user.
+   */
+  def run(): Either[(ExitCodes.TExitCode, String), String]
 
   private var _invocation = ""
   private var _env = ""

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.tooling.opt
 
 import java.io.File
 
-import org.backuity.clist.{Command, _}
+import org.backuity.clist._
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.Executor
 import at.forsyte.apalache.tla.imp.passes.ParserModule
@@ -14,8 +14,7 @@ import at.forsyte.apalache.tla.imp.passes.ParserModule
  *   Igor Konnov
  */
 class ParseCmd
-    extends Command(name = "parse", description = "Parse a TLA+ specification and quit") with PassExecutorCmd
-    with LazyLogging {
+    extends PassExecutorCmd(name = "parse", description = "Parse a TLA+ specification and quit") with LazyLogging {
 
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var output: Option[String] = opt[Option[String]](name = "output",

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -3,6 +3,9 @@ package at.forsyte.apalache.tla.tooling.opt
 import java.io.File
 
 import org.backuity.clist.{Command, _}
+import com.typesafe.scalalogging.LazyLogging
+import at.forsyte.apalache.infra.Executor
+import at.forsyte.apalache.tla.imp.passes.ParserModule
 
 /**
  * This command initiates the 'parse' command line.
@@ -10,9 +13,27 @@ import org.backuity.clist.{Command, _}
  * @author
  *   Igor Konnov
  */
-class ParseCmd extends Command(name = "parse", description = "Parse a TLA+ specification and quit") with General {
+class ParseCmd
+    extends Command(name = "parse", description = "Parse a TLA+ specification and quit") with PassExecutorCmd
+    with LazyLogging {
 
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var output: Option[String] = opt[Option[String]](name = "output",
       description = "file to which the parsed source is written (.tla or .json), default: None")
+
+  val executor = Executor(new ParserModule)
+
+  def run() = {
+    logger.info("Parse " + file)
+
+    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    output.foreach(executor.passOptions.set("io.output", _))
+
+    setCommonOptions()
+
+    executor.run() match {
+      case Right(m) => Right(s"Parsed successfully\nRoot module: ${m.name} with ${m.declarations.length} declarations.")
+      case Left(code) => Left(code, "Parser has failed")
+    }
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.infra.Executor
 
 /**
- * Interface for the subcommands commands that run an [[Executor]]
+ * Interface for the subcommands that run an [[Executor]]
  *
  * @author
  *   Shon Feder

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
@@ -9,7 +9,8 @@ import at.forsyte.apalache.infra.Executor
  * @author
  *   Shon Feder
  */
-trait PassExecutorCmd extends General {
+abstract class PassExecutorCmd(name: String, description: String)
+    extends ApalacheCommand(name: String, description: String) {
 
   /**
    * The executor used to sequence a chain of passes
@@ -35,9 +36,9 @@ trait PassExecutorCmd extends General {
   /**
    * Sets the common options in the [[executor]]
    *
-   * This may be overrided by classes to change which options the class considers common.
+   * This may be overridden by classes to change which options the class considers common.
    *
-   * NOTE: It is not invoked autmoatically, and you should invoke it explicitly in your `Cmd` classe's [[run]] method.
+   * NOTE: It is not invoked automatically, and you should invoke it explicitly in your `Cmd` class' [[run]] method.
    */
   def setCommonOptions(): Unit = {
     executor.passOptions.set("general.debug", debug)

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
@@ -1,0 +1,50 @@
+package at.forsyte.apalache.tla.tooling.opt
+
+import at.forsyte.apalache.io.OutputManager
+import at.forsyte.apalache.infra.Executor
+
+/**
+ * Interface for the subcommands commands that run an [[Executor]]
+ *
+ * @author
+ *   Shon Feder
+ */
+trait PassExecutorCmd extends General {
+
+  /**
+   * The executor used to sequence a chain of passes
+   *
+   * Executors are created using [[at.forsyte.apalache.infra.passes.ToolModule]]. E.g.,
+   *
+   * {{{
+   * val executor = Executor(new TypeCheckerModule)
+   * }}}
+   *
+   * The [[run]] methods of a subcommand implementing this trait will generally end with an invication of
+   * [[executor.run]], such as
+   *
+   * {{{
+   * executor.run() match {
+   *   case Right(module) => Right("Success msg")
+   *   case Left(errCode) => Left(errorCode, "Failure msg")
+   * }
+   * }}}
+   */
+  val executor: Executor
+
+  /**
+   * Sets the common options in the [[executor]]
+   *
+   * This may be overrided by classes to change which options the class considers common.
+   *
+   * NOTE: It is not invoked autmoatically, and you should invoke it explicitly in your `Cmd` classe's [[run]] method.
+   */
+  def setCommonOptions(): Unit = {
+    executor.passOptions.set("general.debug", debug)
+    executor.passOptions.set("smt.prof", smtprof)
+    executor.passOptions.set("general.features", features)
+
+    // TODO: Remove pass option, and just rely on OutputManager config
+    executor.passOptions.set("io.outdir", OutputManager.outDir)
+  }
+}

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
@@ -2,12 +2,11 @@ package at.forsyte.apalache.tla.tooling.opt
 
 import java.io.File
 
-import org.backuity.clist.Command
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.shai
 
 class ServerCmd
-    extends Command(name = "server", description = "Run in server mode (in early development)") with General
+    extends ApalacheCommand(name = "server", description = "Run in server mode (in early development)")
     with LazyLogging {
 
   // Dummy file used for application (esp. output) configuration

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
@@ -3,10 +3,19 @@ package at.forsyte.apalache.tla.tooling.opt
 import java.io.File
 
 import org.backuity.clist.Command
+import com.typesafe.scalalogging.LazyLogging
+import at.forsyte.apalache.shai
 
 class ServerCmd
-    extends Command(name = "server", description = "Run in server mode (in early development)") with General {
+    extends Command(name = "server", description = "Run in server mode (in early development)") with General
+    with LazyLogging {
 
   // Dummy file used for application (esp. output) configuration
   def file = new File("server")
+
+  def run() = {
+    logger.info("Starting server...")
+    shai.v1.RpcServer.main(Array())
+    Right("Server terminated")
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
@@ -13,4 +13,12 @@ class SimulateCmd extends CheckCmd(name = "simulate", "Symbolically simulate a T
     opt[Boolean](name = "save-runs", description = "save an example trace for each simulated run, default: false",
         default = false)
 
+  override def setTuningOptions(): Map[String, String] = {
+    super.setTuningOptions() ++ Map(
+        "search.simulation" -> "true",
+        "search.simulation.maxRun" -> maxRun.toString,
+        "search.simulation.saveRuns" -> saveRuns.toString,
+    )
+  }
+
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
@@ -13,8 +13,8 @@ class SimulateCmd extends CheckCmd(name = "simulate", "Symbolically simulate a T
     opt[Boolean](name = "save-runs", description = "save an example trace for each simulated run, default: false",
         default = false)
 
-  override def setTuningOptions(): Map[String, String] = {
-    super.setTuningOptions() ++ Map(
+  override def collectTuningOptions(): Map[String, String] = {
+    super.collectTuningOptions() ++ Map(
         "search.simulation" -> "true",
         "search.simulation.maxRun" -> maxRun.toString,
         "search.simulation.saveRuns" -> saveRuns.toString,

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -60,8 +60,6 @@ class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ 
     executor.passOptions.set("checker.algo", "offline")
     // for now, enable polymorphic types. We probably want to disable this option for the type checker
     executor.passOptions.set("typechecker.inferPoly", true)
-    // NOTE Must go after all other options are set due to side-effecting
-    // behavior of current OutmputManager configuration
     setCommonOptions()
 
     executor.run() match {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-import org.backuity.clist.{Command, _}
+import org.backuity.clist._
 
 import java.io.File
 import at.forsyte.apalache.infra.Executor
@@ -13,8 +13,8 @@ import com.typesafe.scalalogging.LazyLogging
  * @author
  *   Igor Konnov
  */
-class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ specification")
-    with PassExecutorCmd with LazyLogging {
+class TestCmd
+    extends PassExecutorCmd(name = "test", description = "Quickly test a TLA+ specification") with LazyLogging {
 
   val executor = Executor(new CheckerModule)
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -3,6 +3,9 @@ package at.forsyte.apalache.tla.tooling.opt
 import org.backuity.clist.{Command, _}
 
 import java.io.File
+import at.forsyte.apalache.infra.Executor
+import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
+import com.typesafe.scalalogging.LazyLogging
 
 /**
  * This command initiates the 'test' command line.
@@ -10,7 +13,10 @@ import java.io.File
  * @author
  *   Igor Konnov
  */
-class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ specification") with General {
+class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ specification")
+    with PassExecutorCmd with LazyLogging {
+
+  val executor = Executor(new CheckerModule)
 
   var file: File = arg[File](description = "a file containing a TLA+ specification (.tla or .json)")
   var before: String =
@@ -23,4 +29,45 @@ class TestCmd extends Command(name = "test", description = "Quickly test a TLA+ 
   var cinit: String = opt[String](name = "cinit", default = "",
       description = "the name of an operator that initializes CONSTANTS,\n" +
         "default: None")
+
+  def run() = {
+    // This is a special version of the `check` command that is tuned towards testing scenarios
+    logger.info("Checker passOptions: filename=%s, before=%s, action=%s, after=%s"
+          .format(file, before, action, assertion))
+
+    // Tune for testing:
+    //   1. Check the invariant only after the action took place.
+    //   2. Randomize
+    val seed = Math.abs(System.currentTimeMillis().toInt)
+    val tuning = Map("search.invariantFilter" -> "1", "smt.randomSeed" -> seed.toString)
+    logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
+
+    executor.passOptions.set("general.tuning", tuning)
+    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    executor.passOptions.set("checker.init", before)
+    executor.passOptions.set("checker.next", action)
+    executor.passOptions.set("checker.inv", List(assertion))
+    if (cinit != "") {
+      executor.passOptions.set("checker.cinit", cinit)
+    }
+    executor.passOptions.set("checker.nworkers", 1)
+    // check only one instance of the action
+    executor.passOptions.set("checker.length", 1)
+    // no preliminary pruning of disabled transitions
+    executor.passOptions.set("checker.discardDisabled", false)
+    executor.passOptions.set("checker.noDeadlocks", false)
+    // prefer the offline mode as we have a single query
+    executor.passOptions.set("checker.algo", "offline")
+    // for now, enable polymorphic types. We probably want to disable this option for the type checker
+    executor.passOptions.set("typechecker.inferPoly", true)
+    // NOTE Must go after all other options are set due to side-effecting
+    // behavior of current OutmputManager configuration
+    setCommonOptions()
+
+    executor.run() match {
+      case Right(_)   => Right("No example found")
+      case Left(code) => Left(code, "Found a violation of the postcondition. Check violation.tla.")
+    }
+
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
@@ -9,6 +9,7 @@ class TranspileCmd extends AbstractCheckerCmd(name = "transpile", description = 
   val executor = Executor(new ReTLAToVMTModule)
 
   def run() = {
+    // for now, enable polymorphic types. We probably want to disable this option for the type checker
     executor.passOptions.set("typechecker.inferPoly", true)
     setCommonOptions()
     val outFilePath = OutputManager.runDirPathOpt

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
@@ -1,3 +1,24 @@
 package at.forsyte.apalache.tla.tooling.opt
 
-class TranspileCmd extends AbstractCheckerCmd(name = "transpile", description = "Transpile and quit")
+import at.forsyte.apalache.infra.Executor
+import at.forsyte.apalache.io.OutputManager
+import at.forsyte.apalache.tla.bmcmt.config.ReTLAToVMTModule
+import at.forsyte.apalache.tla.bmcmt.rules.vmt.TlaExToVMTWriter
+
+class TranspileCmd extends AbstractCheckerCmd(name = "transpile", description = "Transpile and quit") {
+  val executor = Executor(new ReTLAToVMTModule)
+
+  def run() = {
+    executor.passOptions.set("typechecker.inferPoly", true)
+    setCommonOptions()
+    val outFilePath = OutputManager.runDirPathOpt
+      .map { p =>
+        p.resolve(TlaExToVMTWriter.outFileName).toAbsolutePath
+      }
+      .getOrElse(TlaExToVMTWriter.outFileName)
+    executor.run() match {
+      case Right(_)   => Right(s"VMT constraints successfully generated at\n$outFilePath")
+      case Left(code) => Left(code, "Failed to generate constraints")
+    }
+  }
+}

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -3,6 +3,9 @@ package at.forsyte.apalache.tla.tooling.opt
 import java.io.File
 
 import org.backuity.clist.{Command, _}
+import at.forsyte.apalache.infra.Executor
+import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
+import com.typesafe.scalalogging.LazyLogging
 
 /**
  * This command initiates the 'typecheck' command line.
@@ -11,7 +14,10 @@ import org.backuity.clist.{Command, _}
  *   Igor Konnov
  */
 class TypeCheckCmd
-    extends Command(name = "typecheck", description = "Check types in a TLA+ specification") with General {
+    extends Command(name = "typecheck", description = "Check types in a TLA+ specification") with PassExecutorCmd
+    with LazyLogging {
+
+  val executor = Executor(new TypeCheckerModule)
 
   var file: File = arg[File](description = "a TLA+ specification (.tla or .json)")
   var inferPoly: Boolean = opt[Boolean](name = "infer-poly", default = true,
@@ -19,4 +25,15 @@ class TypeCheckCmd
   var output: Option[String] = opt[Option[String]](name = "output",
       description = "file to which the typechecked source is written (.tla or .json), default: None")
 
+  override def run() = {
+    logger.info("Type checking " + file)
+    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    output.foreach(executor.passOptions.set("io.output", _))
+    executor.passOptions.set("typechecker.inferPoly", inferPoly)
+    setCommonOptions()
+    executor.run() match {
+      case Right(_)   => Right("Type checker [OK]")
+      case Left(code) => Left(code, "Type checker [FAILED]")
+    }
+  }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.tooling.opt
 
 import java.io.File
 
-import org.backuity.clist.{Command, _}
+import org.backuity.clist._
 import at.forsyte.apalache.infra.Executor
 import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
 import com.typesafe.scalalogging.LazyLogging
@@ -14,8 +14,7 @@ import com.typesafe.scalalogging.LazyLogging
  *   Igor Konnov
  */
 class TypeCheckCmd
-    extends Command(name = "typecheck", description = "Check types in a TLA+ specification") with PassExecutorCmd
-    with LazyLogging {
+    extends PassExecutorCmd(name = "typecheck", description = "Check types in a TLA+ specification") with LazyLogging {
 
   val executor = Executor(new TypeCheckerModule)
 


### PR DESCRIPTION
## Context

As preparation for #1114, we'll need to abstract the parsing logic, making it possible to parse from a supplied string, rather than reading from a file. However, the current state of the logic in the `Tool.scala` module makes it quite difficult to consider how the logic of the various subcommands can be effectively abstracted (at least, it has been difficult for me). This PR tries to follow the tactic [first make the change easy, then make the easy change](https://twitter.com/kentbeck/status/250733358307500032?lang=en).

## Changes

The general tendency of this change makes the logic quite a bit clearer than before: It enables viewing (or discovering) all of the essential logic belonging to a subcommand by looking at the module that defines the subcommand; and it removes the convoluted knot of functions which had organically developed as the command logic evolved, replacing it with a succinct sequence of invocations and checks.  

I am also hopeful that this change will also make it easier to address #1174 and #1177, and generally improve the maintainability of the CLI.

## Reviewing

While I think this makes some definite improvements, I am not convinced that the design I've hit on here is as clear as it could be, so any suggestion very welcome.

I recommend reviewing by commit. The largest commit is a mostly mechanical extraction of methods from `Tool.scala` into the respective subcommand classes. The main design elements are all included in the preceding commits.




<!-- Please ensure that your PR includes the following, as needed -->

- [x] Documentation added for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
