### PR TITLE
Add counterexample writer and --temporal flag

### DIFF
--- a/docs/src/apalache/features.md
+++ b/docs/src/apalache/features.md
@@ -3,12 +3,9 @@ Here is the list of the TLA+ language features that are currently supported by A
 ## Safety vs. Liveness
 
 At the moment, Apalache is able to check state invariants, action invariants,
-trace invariants as well as inductive invariants. (See the [page on
+temporal properties, trace invariants as well as inductive invariants. (See the [page on
 invariants](https://apalache.informal.systems/docs/apalache/principles/invariants.html) in
-the manual.) Which means that you can only check safety properties with
-Apalache, unless you employ a [liveness-to-safety] transformation in your spec.
-In general, we do not support checking liveness properties.  If you would like
-to see liveness implemented, upvote the [liveness feature].
+the manual.) To check liveness/temporal properties, we employ a [liveness-to-safety][] transformation.
 
 ## Language
 
@@ -120,20 +117,28 @@ multi-line `/\` and `\/` | ✔ | - |
 Construct  | Supported? | Milestone | Comment
 ------------------------|:------------------:|:---------------:|--------------
 `e'` | ✔ | - |
-`[A]_e` | ✖ | - | It does not matter for safety
-`< A >_e` | ✖ | - |
-`ENABLED A` | ✖ | - |
+`[A]_e` | ✔ | - |
+`< A >_e` | ✔ | - |
+`ENABLED A` | ✖ | - | Has to be specified manually
 `UNCHANGED <<e_1, ..., e_k>>` | ✔ | - |Always replaced with `e_1' = e_1 /\ ... /\ e_k' = e_k`
 `A ∙ B` | ✖ | - |
 
 ### The Temporal Operators
 
-The model checker assumes that the specification has the form `Init /\
-[][Next]_e`. Given an invariant candidate `Inv`, the tool checks, whether
-`Inv` is violated by an execution whose length is bounded by the given
-argument.
+Construct  | Supported? | Milestone | Comment
+------------------------|:------------------:|:---------------:|--------------
+`[]F` | ✔ | - | 
+`<>F` | ✔ | - |
+`WF_e(A)` | ✖ | - | Has to be specified manually (see ENABLED)
+`SF_e(A)` | ✖ | - | Has to be specified manually (see ENABLED)
+`F ~> G` | ✔ | - | Always replaced with `[](F => <>G)`
+`F -+-> G` | ✖ | - |
+`\EE x: F` | ✖ | - |
+`\AA x: F` | ✖ | - |
 
-Except the standard form `Init /\ [][Next]_e`, no temporal operators are supported.
+The model checker assumes that the specification has the form `Init /\
+[][Next]_e`. Other than that, temporal operators 
+may only appear in temporal properties, not in e.g. actions.
 
 ## Standard modules
 

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -38,7 +38,7 @@ The model checker can be run as follows:
 
 ```bash
 $ apalache-mc check [--config=filename] [--init=Init] [--cinit=ConstInit] \
-    [--next=Next] [--inv=Inv] [--length=10] [--algo=(incremental|offline)] \
+    [--next=Next] [--inv=Inv] [--length=10] [--temporal=TemporalProp] [--algo=(incremental|offline)] \
     [--discard-disabled] [--no-deadlock] \
     [--tuning-options-file=filename] [--tuning-options=key1=val1:...:keyn=valn] \
     [--smt-encoding=(oopsla19|arrays)] \
@@ -58,6 +58,7 @@ The arguments are as follows:
     - `--cinit` specifies the constant initialization predicate, *optional*
     - `--inv` specifies the invariant to check, *optional*
     - `--length` specifies the maximal number of `Next` steps, *10 by default*
+    - `--temporal` specifies the temporal property to check, *optional*
 
 * Advanced parameters:
     - `--algo` lets you to choose the search algorithm: `incremental` is using the incremental SMT solver, `offline` is

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -20,6 +20,8 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
     opt[String](name = "next", default = "", description = "the name of a transition operator, default: Next")
   var inv: String =
     opt[String](name = "inv", default = "", description = "the name of an invariant operator, e.g., Inv")
+  var temporal: String =
+    opt[String](name = "temporal", default = "", description = "the name of a temporal property, e.g. Property")
   var length: Int =
     opt[Int](name = "length", default = 10, description = "maximal number of Next steps, default: 10")
 
@@ -38,6 +40,8 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
       executor.passOptions.set("checker.next", next)
     if (inv != "")
       executor.passOptions.set("checker.inv", List(inv))
+    if (temporal != "")
+      executor.passOptions.set("checker.temporal", List(temporal))
     if (cinit != "")
       executor.passOptions.set("checker.cinit", cinit)
     executor.passOptions.set("checker.length", length)

--- a/test/tla/NoTemporalOperatorsInTemporalProp.tla
+++ b/test/tla/NoTemporalOperatorsInTemporalProp.tla
@@ -1,0 +1,26 @@
+---- MODULE NoTemporalOperatorsInTemporalProp ----
+
+\* Tests behaviour when boolean and temporal operators are mixed
+
+EXTENDS Integers
+
+VARIABLES
+    \* @type: Int;
+    x,
+    \* @type: Int;
+    y
+
+Init ==
+    /\ x = 0
+    /\ y = 1
+
+Next ==
+    /\ x' = y
+    /\ y' = x
+
+\* the following two should give the same result
+Property == x = 0
+PropertyWithTemporal == x = 0 /\ []TRUE
+ExplicitInvariant == [] (x = 0)
+
+====

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1384,10 +1384,19 @@ Bug1126.tla:15:14-15:27: unsupported expression: Seq(_) produces an infinite set
 EXITCODE: ERROR (75)
 ```
 
-### check FalseLiveness fails (temporal)
+### check --inv with a temporal property fails (temporal)
 
 ```sh
 $ apalache-mc check --inv=FalseLiveness LongPrefix.tla
+...
+EXITCODE: ERROR (255)
+[255]
+```
+
+### check FalseLiveness fails (temporal)
+
+```sh
+$ apalache-mc check --temporal=FalseLiveness LongPrefix.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1396,7 +1405,7 @@ EXITCODE: ERROR (12)
 ### check Liveness succeeds (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness LongPrefix.tla
+$ apalache-mc check --temporal=Liveness LongPrefix.tla
 ...
 EXITCODE: OK
 ```
@@ -1404,7 +1413,7 @@ EXITCODE: OK
 ### check LongLoops: Liveness succeeds (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness LongLoops.tla
+$ apalache-mc check --temporal=Liveness LongLoops.tla
 ...
 EXITCODE: OK
 ```
@@ -1412,7 +1421,7 @@ EXITCODE: OK
 ### check LongLoops: FalseLiveness fails (temporal)
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness LongLoops.tla
+$ apalache-mc check --temporal=FalseLiveness LongLoops.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1421,13 +1430,13 @@ EXITCODE: ERROR (12)
 ### check NoLoopsNoProblems succeeds (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness NoLoopsNoProblems.tla
+$ apalache-mc check --temporal=Liveness NoLoopsNoProblems.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness NoLoopsNoProblems.tla
+$ apalache-mc check --temporal=FalseLiveness NoLoopsNoProblems.tla
 ...
 EXITCODE: OK
 ```
@@ -1435,13 +1444,13 @@ EXITCODE: OK
 ### check ManyBoxes (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness ManyBoxes.tla
+$ apalache-mc check --temporal=Liveness ManyBoxes.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness ManyBoxes.tla
+$ apalache-mc check --temporal=FalseLiveness ManyBoxes.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1450,13 +1459,13 @@ EXITCODE: ERROR (12)
 ### check ManyDiamonds (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness ManyDiamonds.tla
+$ apalache-mc check --temporal=Liveness ManyDiamonds.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness ManyDiamonds.tla
+$ apalache-mc check --temporal=FalseLiveness ManyDiamonds.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1465,13 +1474,13 @@ EXITCODE: ERROR (12)
 ### check DiamondBox (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness DiamondBox.tla
+$ apalache-mc check --temporal=Liveness DiamondBox.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness DiamondBox.tla
+$ apalache-mc check --temporal=FalseLiveness DiamondBox.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1480,13 +1489,13 @@ EXITCODE: ERROR (12)
 ### check BoxDiamond (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness BoxDiamond.tla
+$ apalache-mc check --temporal=Liveness BoxDiamond.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness BoxDiamond.tla
+$ apalache-mc check --temporal=FalseLiveness BoxDiamond.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1495,13 +1504,34 @@ EXITCODE: ERROR (12)
 ### check NestedTemporalInBool (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness NestedTemporalInBool.tla
+$ apalache-mc check --temporal=Liveness NestedTemporalInBool.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness NestedTemporalInBool.tla
+$ apalache-mc check --temporal=FalseLiveness NestedTemporalInBool.tla
+...
+EXITCODE: ERROR (12)
+[12]
+```
+
+### check NoTemporalOperatorsInTemporalProp (temporal)
+
+```sh
+$ apalache-mc check --temporal=Property NoTemporalOperatorsInTemporalProp.tla
+...
+EXITCODE: OK
+```
+
+```sh
+$ apalache-mc check --temporal=PropertyWithTemporal NoTemporalOperatorsInTemporalProp.tla
+...
+EXITCODE: OK
+```
+
+```sh
+$ apalache-mc check --temporal=ExplicitInvariant NoTemporalOperatorsInTemporalProp.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1510,13 +1540,13 @@ EXITCODE: ERROR (12)
 ### check LetIn (temporal)
 
 ```sh
-$ apalache-mc check --inv=Liveness LetIn.tla
+$ apalache-mc check --temporal=Liveness LetIn.tla
 ...
 EXITCODE: OK
 ```
 
 ```sh
-$ apalache-mc check --inv=FalseLiveness LetIn.tla
+$ apalache-mc check --temporal=FalseLiveness LetIn.tla
 ...
 EXITCODE: ERROR (12)
 [12]
@@ -1660,15 +1690,12 @@ $ apalache-mc check --config=Config1.cfg Config.tla | sed 's/[IEW]@.*//'
 ...
   > Config1.cfg: Loading TLC configuration
 ...
-  > Config1.cfg: PROPERTY AwesomeLiveness is ignored. Only INVARIANTS are supported.
-...
   > Set the initialization predicate to Init1
   > Set the transition predicate to Next1
   > Set an invariant to Inv1
+  > Set a temporal property to AwesomeLiveness
 ...
-Config.tla:58:5-58:14: unsupported expression: ♢(x > 10)
-...
-EXITCODE: ERROR (75)
+EXITCODE: OK
 ```
 
 ### configure via TLC config and override it via CLI
@@ -1682,9 +1709,13 @@ $ apalache-mc check --config=Config1.cfg --init=Init2 --next=Next2 Config.tla | 
   > Set the transition predicate to Next2
   > Set an invariant to Inv1
 ...
-Config.tla:58:5-58:14: unsupported expression: ♢(x > 10)
 ...
-EXITCODE: ERROR (75)
+State 7: state invariant 0 violated.
+Found 1 error(s)
+The outcome is: Error
+Checker has found an error
+...
+EXITCODE: ERROR (12)
 ```
 
 ### configure missing property in TLC config

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/VCGenerator.scala
@@ -47,7 +47,8 @@ class VCGenerator(tracker: TransformationTracker) extends LazyLogging {
               TlaModule(module.name, module.declarations ++ introConditions(level, inv.body))
 
             case TlaLevelTemporal =>
-              val message = s"Expected a state invariant or an action invariant in $invName, found a temporal property"
+              val message =
+                s"Expected a state invariant or an action invariant in $invName, found a temporal property (did you mean to use --temporal?)"
               throw new TlaInputError(message, Some(inv.body.ID))
           }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/CounterexampleWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/CounterexampleWriter.scala
@@ -58,10 +58,10 @@ class TlaCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
           pretty.writeComment(s"Transition ${state._1} to State$i")
         }
         val decl = tla.declOp(s"State$i", stateToEx(state._2))
-        pretty.write(decl)
+        pretty.writeWithNameReplacementComment(decl)
     }
     pretty.writeComment("The following formula holds true in the last state and violates the invariant")
-    pretty.write(TlaOperDecl("InvariantViolation", List(), notInvariant))
+    pretty.writeWithNameReplacementComment(TlaOperDecl("InvariantViolation", List(), notInvariant))
 
     pretty.writeFooter()
     pretty.writeComment("Created by Apalache on %s".format(Calendar.getInstance().getTime))

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/NameReplacementMap.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/NameReplacementMap.scala
@@ -1,0 +1,13 @@
+package at.forsyte.apalache.io.lir
+
+import scala.collection.mutable.HashMap
+
+/**
+ * Maps names of variables to more readable strings. Variable names need to be valid TLA variable names, while the
+ * readable strings do not have such restrictions.
+ * @author
+ *   Philip Offtermatt
+ */
+package object NameReplacementMap {
+  var store = new HashMap[String, String]()
+}

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -41,12 +41,55 @@ class PrettyWriter(
   private def prettyWriteDoc(doc: Doc): Unit = writer.write(pretty(doc, layout.textWidth).layout)
 
   def write(mod: TlaModule, extendedModuleNames: List[String] = List.empty): Unit =
-    prettyWriteDoc(toDoc(mod, extendedModuleNames))
+    prettyWriteDoc(modToDoc(mod, extendedModuleNames))
+
+  /**
+   * Pretty-prints the given decl twice: Once as valid TLA, and once (before the TLA expression) in a comment, where
+   * names of NameExs are replaced by their mapping in the nameReplacementMap. The output looks, for example, like this:
+   *
+   * {{{
+   *  (* State0 ==
+   *    ♢(x = 11) = FALSE
+   * /\ ♢(x = 11)_unroll = FALSE *)
+   * State0 ==
+   *    __temporal_t_1 = FALSE
+   * /\ __temporal_t_1_unroll = FALSE
+   * }}}
+   *
+   * Here, the NameReplacementMap used was
+   * {{{
+   *  "__temporal_t_1" -> "♢(x = 11)",
+   *  "__temporal_t_1_unroll" -> "♢(x = 11)_unroll"
+   * }}}
+   *
+   * Here, the nameReplacementMap used was
+   * {{{
+   *  "__temporal_t_1" -> "♢(x = 11)",
+   *  "__temporal_t_1_unroll" -> "♢(x = 11)_unroll"
+   * }}}
+   *
+   * Note that the expression and its comment are the same, but the names for {{{__temporal_t_1}}} and
+   * {{{__temporal_t_1_unroll}}} were substituted.
+   * @see
+   *   NameReplacementMap
+   */
+  def writeWithNameReplacementComment(decl: TlaDecl): Unit = {
+    val declDoc = declToDoc(decl) <> line <> line
+    if (NameReplacementMap.store.isEmpty) {
+      prettyWriteDoc(declDoc)
+    } else {
+      val declComment = toCommentDoc(decl)
+      prettyWriteDoc(declComment <> line <> declDoc)
+    }
+  }
 
   // Declarations have a trailing empty line
-  def write(decl: TlaDecl): Unit = prettyWriteDoc(toDoc(decl) <> line <> line)
+  def write(decl: TlaDecl): Unit = {
+    prettyWriteDoc(declToDoc(decl) <> line <> line)
+  }
 
-  def write(expr: TlaEx): Unit = prettyWriteDoc(toDoc((0, 0), expr))
+  private def identity(x: String): String = x
+  def write(expr: TlaEx): Unit = prettyWriteDoc(exToDoc((0, 0), expr, identity))
 
   def writeComment(commentStr: String): Unit = {
     prettyWriteDoc(wrapWithComment(commentStr) <> line)
@@ -72,13 +115,21 @@ class PrettyWriter(
   private def moduleTerminalDoc: Doc =
     s"${List.fill(layout.textWidth)("=").mkString}" <> line
 
-  def toDoc(mod: TlaModule, extensionModuleNames: List[String] = List.empty): Doc = {
+  def modToDoc(mod: TlaModule, extensionModuleNames: List[String] = List.empty): Doc = {
     moduleNameDoc(mod.name) <>
       moduleExtendsDoc(extensionModuleNames) <>
-      lsep((mod.declarations.toList.map(toDoc)) :+ moduleTerminalDoc, line)
+      lsep((mod.declarations.toList.map(declToDoc(_))) :+ moduleTerminalDoc, line)
   }
 
-  def toDoc(parentPrecedence: (Int, Int), expr: TlaEx): Doc = {
+  /**
+   * Writes the provided expr as a doc. parentPrecedence determines whether and how to wrap expressions with braces.
+   * nameResolver substitutes NameExs by the value that results from applying it to the name. If no substitution is
+   * wanted, use (x: String) => x.
+   */
+  def exToDoc(
+      parentPrecedence: (Int, Int),
+      expr: TlaEx,
+      nameResolver: String => String): Doc = {
     expr match {
       case NameEx(x) if x == "LAMBDA" =>
         // this is reference to the lambda expression that was introduced ealier
@@ -94,12 +145,11 @@ class PrettyWriter(
                 ssep(top.formalParams.map(toDoc), "," <> softline)
 
             group("LAMBDA" <> space <> paramsDoc <> text(":") <> space <>
-              toDoc((0, 0), top.body))
+              exToDoc((0, 0), top.body, nameResolver))
         }
 
       case NameEx(x) =>
-        text(x)
-
+        text(nameResolver(x))
       case ValEx(TlaStr(str))   => text("\"%s\"".format(str))
       case ValEx(TlaInt(value)) => text(value.toString)
       case ValEx(TlaBool(b))    => text(if (b) "TRUE" else "FALSE")
@@ -112,7 +162,7 @@ class PrettyWriter(
       case NullEx => text("\"NOP\"")
 
       case OperEx(op @ TlaActionOper.prime, e) =>
-        toDoc(op.precedence, e) <> "'"
+        exToDoc(op.precedence, e, nameResolver) <> "'"
 
       case OperEx(TlaSetOper.enumSet) =>
         // an empty set
@@ -120,17 +170,17 @@ class PrettyWriter(
 
       case OperEx(op @ TlaSetOper.enumSet, arg) =>
         // a singleton set
-        group("{" <> toDoc(op.precedence, arg) <> "}")
+        group("{" <> exToDoc(op.precedence, arg, nameResolver) <> "}")
 
       case OperEx(op @ TlaSetOper.enumSet, args @ _*) =>
         // a set enumeration, e.g., { 1, 2, 3 }
-        val argDocs = args.map(toDoc(op.precedence, _))
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver))
         val commaSeparated = folddoc(argDocs.toList, _ <> text(",") <@> _)
         group(braces(group(softline <> nest(commaSeparated, layout.indent)) <> softline))
 
       case OperEx(op @ TlaFunOper.tuple, args @ _*) =>
         // a tuple, e.g., <<1, 2, 3>>
-        val argDocs = args.map(toDoc(op.precedence, _))
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver))
         val commaSeparated = ssep(argDocs.toList, text(",") <> softline)
         group(text("<<") <> nest(linebreak <> commaSeparated, layout.indent) <> linebreak <> ">>")
 
@@ -140,9 +190,9 @@ class PrettyWriter(
 
         if (args.isEmpty) {
           val const = tla.bool(op == TlaBoolOper.and)
-          toDoc(parentPrecedence, const)
+          exToDoc(parentPrecedence, const, nameResolver)
         } else {
-          val argDocs = args.map(toDoc(op.precedence, _)).toList
+          val argDocs = args.map(exToDoc(op.precedence, _, nameResolver)).toList
           val grouped =
             if (argDocs.length <= 3) {
               val doc = nest(folddoc(argDocs, _ <> line <> sign <> space <> _))
@@ -161,8 +211,8 @@ class PrettyWriter(
           group(
               group(text(sign) <> space <> text(x.toString) <> space <>
                 text(PrettyWriter.binaryOps(TlaSetOper.in)) <> softline <>
-                toDoc(op.precedence, set) <> text(":")) <>
-                nest(line <> toDoc(op.precedence, pred))
+                exToDoc(op.precedence, set, nameResolver) <> text(":")) <>
+                nest(line <> exToDoc(op.precedence, pred, nameResolver))
           ) ///
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
@@ -172,7 +222,7 @@ class PrettyWriter(
         val doc =
           group(
               group(text(sign) <> space <> text(x.toString) <> ":") <>
-                nest(line <> toDoc(op.precedence, pred))
+                nest(line <> exToDoc(op.precedence, pred, nameResolver))
           ) ///
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
@@ -183,7 +233,10 @@ class PrettyWriter(
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k |-> v
         val boxes =
-          keys.zip(values).map(p => group(strNoQuotes(p._1) <> space <> "|->" <> nest(line <> toDoc((0, 0), p._2)))) ///
+          keys
+            .zip(values)
+            .map(p =>
+              group(strNoQuotes(p._1) <> space <> "|->" <> nest(line <> exToDoc((0, 0), p._2, nameResolver)))) ///
 
         group(brackets(nest(ssep(boxes.toList, comma <> line))))
 
@@ -193,7 +246,9 @@ class PrettyWriter(
         val (keys, values) = (ks.map(_._1), vs.map(_._1))
         // format each key-value pair (k, v) into k: v
         val boxes =
-          keys.zip(values).map(p => group(strNoQuotes(p._1) <> ":" <> nest(line <> toDoc((0, 0), p._2)))) ///
+          keys
+            .zip(values)
+            .map(p => group(strNoQuotes(p._1) <> ":" <> nest(line <> exToDoc((0, 0), p._2, nameResolver)))) ///
 
         group(brackets(nest(ssep(boxes.toList, comma <> line))))
 
@@ -204,10 +259,12 @@ class PrettyWriter(
         val boxes =
           keys
             .zip(values)
-            .map(p => group(toDoc((0, 0), p._1) <> space <> "\\in" <> nest(line <> toDoc((0, 0), p._2)))) ///
+            .map(p =>
+              group(exToDoc((0, 0), p._1, nameResolver) <> space <> "\\in" <> nest(line <> exToDoc((0, 0), p._2,
+                  nameResolver)))) ///
 
         val binders = ssep(boxes.toList, comma <> line)
-        val bodyDoc = toDoc((0, 0), body)
+        val bodyDoc = exToDoc((0, 0), body, nameResolver)
         group(
             text("[") <>
               nest(line <> binders <> space <> "|->" <> nest(line <> bodyDoc)) <> line <>
@@ -222,46 +279,47 @@ class PrettyWriter(
           keys
             .zip(values)
             .map(p =>
-              group(toDoc(TlaSetOper.in.precedence, p._1) <> space <>
-                "\\in" <> nest(line <> toDoc(TlaSetOper.in.precedence, p._2)))) ///
+              group(exToDoc(TlaSetOper.in.precedence, p._1, nameResolver) <> space <>
+                "\\in" <> nest(line <> exToDoc(TlaSetOper.in.precedence, p._2, nameResolver)))) ///
 
         val binders = ssep(boxes.toList, comma <> line)
-        val bodyDoc = toDoc((0, 0), body)
+        val bodyDoc = exToDoc((0, 0), body, nameResolver)
         group(braces(nest(line <> bodyDoc <> text(":") <> nest(line <> binders)) <> line))
 
       case OperEx(TlaSetOper.filter, name, set, pred) =>
         val binding = group(
-            toDoc(TlaSetOper.in.precedence, name) <> softline <> "\\in" <>
-              nest(line <> toDoc(TlaSetOper.in.precedence, set))
+            exToDoc(TlaSetOper.in.precedence, name, nameResolver) <> softline <> "\\in" <>
+              nest(line <> exToDoc(TlaSetOper.in.precedence, set, nameResolver))
         ) ///
         // use the precedence (0, 0), as there is no need for parentheses around the predicate
-        val filter = toDoc((0, 0), pred)
+        val filter = exToDoc((0, 0), pred, nameResolver)
         group(
             text("{") <> nest(line <> binding <> ":" <> nest(line <> filter)) <> line <> text("}")
         ) ///
 
       // a function of multiple arguments that are packed into a tuple: don't print the angular brackets <<...>>
       case OperEx(op @ TlaFunOper.app, funEx, OperEx(TlaFunOper.tuple, args @ _*)) =>
-        val argDocs = args.map(toDoc(op.precedence, _))
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver))
         val commaSeparatedArgs = folddoc(argDocs.toList, _ <> text(",") <@> _)
         group(
-            toDoc(TlaFunOper.app.precedence, funEx) <> brackets(commaSeparatedArgs)
+            exToDoc(TlaFunOper.app.precedence, funEx, nameResolver) <> brackets(commaSeparatedArgs)
         ) ///
 
       // a function of a single argument
       case OperEx(TlaFunOper.app, funEx, argEx) =>
         group(
-            toDoc(TlaFunOper.app.precedence, funEx) <>
-              text("[") <> nest(linebreak <> toDoc(TlaFunOper.app.precedence, argEx)) <> linebreak <> text("]")
+            exToDoc(TlaFunOper.app.precedence, funEx, nameResolver) <>
+              text("[") <> nest(linebreak <> exToDoc(TlaFunOper.app.precedence, argEx,
+                  nameResolver)) <> linebreak <> text("]")
         ) ///
 
       case OperEx(TlaControlOper.ifThenElse, pred, thenEx, elseEx) =>
         val prec = TlaControlOper.ifThenElse.precedence
         val doc =
           group(
-              text("IF") <> space <> toDoc(prec, pred) <> line <>
-                text("THEN") <> space <> toDoc(prec, thenEx) <> line <>
-                text("ELSE") <> space <> toDoc(prec, elseEx)
+              text("IF") <> space <> exToDoc(prec, pred, nameResolver) <> line <>
+                text("THEN") <> space <> exToDoc(prec, thenEx, nameResolver) <> line <>
+                text("ELSE") <> space <> exToDoc(prec, elseEx, nameResolver)
           ) ///
 
         wrapWithParen(parentPrecedence, prec, doc)
@@ -275,14 +333,14 @@ class PrettyWriter(
           guards
             .zip(updates)
             .map(p =>
-              group(toDoc(prec, p._1) <>
-                nest(line <> text("->") <> space <> toDoc(prec, p._2)))) ///
+              group(exToDoc(prec, p._1, nameResolver) <>
+                nest(line <> text("->") <> space <> exToDoc(prec, p._2, nameResolver)))) ///
 
         val pairsWithOther =
           if (otherEx == NullEx) {
             pairs
           } else {
-            pairs :+ group("OTHER" <> nest(line <> "->" <> space <> toDoc(prec, otherEx)))
+            pairs :+ group("OTHER" <> nest(line <> "->" <> space <> exToDoc(prec, otherEx, nameResolver)))
           }
 
         val doc = group(text("CASE") <> nest(space <> folddoc(pairsWithOther.toList, _ <> line <> "[]" <> space <> _)))
@@ -290,21 +348,22 @@ class PrettyWriter(
 
       case opex @ OperEx(TlaControlOper.caseNoOther, guardsAndUpdates @ _*) =>
         // delegate this case to CASE with OTHER by passing NullEx
-        toDoc(parentPrecedence, OperEx(TlaControlOper.caseWithOther, NullEx +: guardsAndUpdates: _*)(opex.typeTag))
+        exToDoc(parentPrecedence, OperEx(TlaControlOper.caseWithOther, NullEx +: guardsAndUpdates: _*)(opex.typeTag),
+            nameResolver)
 
       case OperEx(TlaFunOper.except, funEx, keysAndValues @ _*) =>
         val (ks, vs) = TlaOper.deinterleave(keysAndValues)
 
         val indexDocs = ks.collect {
           case OperEx(TlaFunOper.tuple, indices @ _*) =>
-            val docs = indices.map(toDoc((0, 0), _))
+            val docs = indices.map(exToDoc((0, 0), _, nameResolver))
             ssep(docs.toList, text(",") <> softline)
 
           case _ =>
             throw new MalformedTlaError("Malformed expression", expr)
         }
 
-        val valueDocs = vs.map(v => toDoc((0, 0), v))
+        val valueDocs = vs.map(v => exToDoc((0, 0), v, nameResolver))
 
         // format each key-value pair (k, v) into ![k] = v
         val boxes =
@@ -318,7 +377,7 @@ class PrettyWriter(
         val updates = ssep(boxes.toList, comma <> line)
 
         val doc =
-          text("[") <> nest(line <> toDoc(TlaFunOper.except.precedence, funEx) <>
+          text("[") <> nest(line <> exToDoc(TlaFunOper.except.precedence, funEx, nameResolver) <>
             nest(softline <> text("EXCEPT") <> line <> updates)) <> line <>
             text("]")
 
@@ -327,10 +386,10 @@ class PrettyWriter(
       // a set of functions [S -> T]
       case OperEx(TlaSetOper.funSet, domain, coDomain) =>
         val doc =
-          toDoc(TlaSetOper.funSet.precedence, domain) <>
+          exToDoc(TlaSetOper.funSet.precedence, domain, nameResolver) <>
             nest(line <>
               text("->") <> space <>
-              toDoc(TlaSetOper.funSet.precedence, coDomain))
+              exToDoc(TlaSetOper.funSet.precedence, coDomain, nameResolver))
         group(brackets(doc))
 
       // a labelled expression L3(a, b) :: 42
@@ -347,7 +406,7 @@ class PrettyWriter(
 
         val doc =
           text(name) <> optionalArgs <> space <> "::" <>
-            nest(line <> toDoc(oper.precedence, decoratedExpr))
+            nest(line <> exToDoc(oper.precedence, decoratedExpr, nameResolver))
         group(wrapWithParen(parentPrecedence, oper.precedence, doc))
 
       // [A]_vars or <A>_vars
@@ -355,28 +414,28 @@ class PrettyWriter(
         def wrapper = if (op == TlaActionOper.stutter) brackets _ else angles _
 
         val doc =
-          wrapper(toDoc(op.precedence, action)) <>
-            "_" <> toDoc(op.precedence, vars)
+          wrapper(exToDoc(op.precedence, action, nameResolver)) <>
+            "_" <> exToDoc(op.precedence, vars, nameResolver)
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
       case OperEx(op, vars, action) if op == TlaTempOper.weakFairness || op == TlaTempOper.strongFairness =>
         val sign = if (op == TlaTempOper.weakFairness) "WF" else "SF"
         val doc =
-          sign <> "_" <> toDoc(op.precedence, vars) <>
-            parens(toDoc(op.precedence, action))
+          sign <> "_" <> exToDoc(op.precedence, vars, nameResolver) <>
+            parens(exToDoc(op.precedence, action, nameResolver))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
       case OperEx(op, arg @ NameEx(_)) if PrettyWriter.unaryOps.contains(op) =>
-        val doc = text(PrettyWriter.unaryOps(op)) <> toDoc(op.precedence, arg)
+        val doc = text(PrettyWriter.unaryOps(op)) <> exToDoc(op.precedence, arg, nameResolver)
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
       case OperEx(op, arg @ ValEx(_)) if PrettyWriter.unaryOps.contains(op) =>
-        val doc = text(PrettyWriter.unaryOps(op)) <> toDoc(op.precedence, arg)
+        val doc = text(PrettyWriter.unaryOps(op)) <> exToDoc(op.precedence, arg, nameResolver)
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
       case OperEx(op, arg @ OperEx(_, _)) if PrettyWriter.unaryOps.contains(op) =>
         // a unary operator over unary operator, no parentheses needed
-        val doc = text(PrettyWriter.unaryOps(op)) <> toDoc(op.precedence, arg)
+        val doc = text(PrettyWriter.unaryOps(op)) <> exToDoc(op.precedence, arg, nameResolver)
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
       case OperEx(TlaFunOper.recFunRef) =>
@@ -386,36 +445,36 @@ class PrettyWriter(
       case OperEx(op, arg) if PrettyWriter.unaryOps.contains(op) =>
         // in all other cases, introduce parentheses.
         // Yse the minimal precedence, as we are introducing the parentheses in any case.
-        text(PrettyWriter.unaryOps(op)) <> parens(toDoc((0, 0), arg))
+        text(PrettyWriter.unaryOps(op)) <> parens(exToDoc((0, 0), arg, nameResolver))
 
       // a binary infix operator that is mapped to Apalache IR
       case OperEx(op, lhs, rhs) if PrettyWriter.binaryOps.contains(op) =>
         val doc =
-          toDoc(op.precedence, lhs) <>
+          exToDoc(op.precedence, lhs, nameResolver) <>
             nest(line <>
               text(PrettyWriter.binaryOps(op)) <> space <>
-              toDoc(op.precedence, rhs))
+              exToDoc(op.precedence, rhs, nameResolver))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
       // a user-defined binary infix operator such as :> or @@
       case OperEx(TlaOper.apply, NameEx(operName), lhs, rhs) if PrettyWriter.userDefinedBinaryOps.contains(operName) =>
         val doc =
-          toDoc((0, 0), lhs) <>
+          exToDoc((0, 0), lhs, nameResolver) <>
             nest(line <>
               text(operName) <> space <>
-              toDoc((0, 0), rhs))
+              exToDoc((0, 0), rhs, nameResolver))
         wrapWithParen(parentPrecedence, (0, 0), group(doc))
 
       // a n-ary operator that is mapped to Apalache IR
       case OperEx(op, args @ _*) if PrettyWriter.naryOps.contains(op) =>
         val sign = PrettyWriter.naryOps(op)
-        val argDocs = args.map(toDoc(op.precedence, _)).toList
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver)).toList
         val doc = nest(folddoc(argDocs, _ <> line <> sign <> space <> _))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
       case OperEx(op @ TlaOper.apply, NameEx(name), args @ _*) =>
         // apply an operator by its name, e.g., F(x)
-        val argDocs = args.map(toDoc(op.precedence, _)).toList
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver)).toList
         val commaSeparated = ssep(argDocs, "," <> softline)
         val doc =
           if (args.isEmpty) {
@@ -428,14 +487,14 @@ class PrettyWriter(
 
       case OperEx(op @ TlaOper.apply, operEx, args @ _*) =>
         // apply an operator by its definition, e.g., (LAMBDA x: x)(y)
-        val argDocs = args.map(toDoc(op.precedence, _)).toList
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver)).toList
         val commaSeparated = ssep(argDocs, "," <> softline)
-        val doc = group(parens(toDoc((0, 0), operEx)) <> parens(commaSeparated))
+        val doc = group(parens(exToDoc((0, 0), operEx, nameResolver)) <> parens(commaSeparated))
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
       case OperEx(op, args @ _*) =>
-        val argDocs = args.map(toDoc(op.precedence, _)).toList
+        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver)).toList
         val commaSeparated = ssep(argDocs, "," <> softline)
         // The standard operators may contain a '!' that refers to the standard module. Remove it.
         val lastIndexOfBang = op.name.lastIndexOf("!")
@@ -452,23 +511,34 @@ class PrettyWriter(
       case LetInEx(body, d @ TlaOperDecl("LAMBDA", _, _)) =>
         // save the declaration and unpack it later, when NameEx(LAMBDA) is met
         lambdaStack = d :: lambdaStack // push the lambda definition on the top
-        val doc = toDoc((0, 0), body)
+        val doc = exToDoc((0, 0), body, nameResolver)
         lambdaStack = lambdaStack.tail // pop the lambda definition
         doc
 
       case LetInEx(body, decls @ _*) =>
         def eachDecl(d: TlaOperDecl) = {
-          group("LET" <> space <> toDoc(d) <> line <> "IN")
+          group("LET" <> space <> declToDoc(d) <> line <> "IN")
         }
 
         group(ssep(decls.map(eachDecl).toList, line) <>
-          line <> toDoc((0, 0), body))
+          line <> exToDoc((0, 0), body, nameResolver))
 
       case expr => throw new PrettyPrinterError(s"PrettyPrinter failed toDoc conversion on expression ${expr}")
     }
   }
 
-  def toDoc(decl: TlaDecl): Doc = {
+  /**
+   * Pretty-writes the given decl, while replacing names with the values in the NameReplacementMap. Then, wrap the
+   * result as a comment, since the substituted names might not be valid TLA.
+   */
+  def toCommentDoc(decl: TlaDecl): Doc = {
+    wrapWithComment(declToDoc(decl,
+            nameResolver = (x: String) => {
+          NameReplacementMap.store.getOrElse(x, x)
+        }))
+  }
+
+  def declToDoc(decl: TlaDecl, nameResolver: String => String = (x: String) => x): Doc = {
     val annotations = declAnnotator(layout)(decl)
 
     decl match {
@@ -487,7 +557,7 @@ class PrettyWriter(
         }
 
       case TlaAssumeDecl(body) =>
-        val doc = group("ASSUME" <> parens(toDoc((0, 0), body)))
+        val doc = group("ASSUME" <> parens(exToDoc((0, 0), body, nameResolver)))
         if (annotations.isEmpty) {
           doc
         } else {
@@ -503,7 +573,13 @@ class PrettyWriter(
         val boxes =
           keys
             .zip(values)
-            .map(p => group(toDoc((0, 0), p._1) <> space <> "\\in" <> nest(line <> toDoc((0, 0), p._2)))) ///
+            .map(p =>
+              group(
+                  exToDoc((0, 0), p._1, nameResolver)
+                    <> space
+                    <> "\\in"
+                    <> nest(line <> exToDoc((0, 0), p._2, nameResolver))
+              )) ///
 
         val binders = ssep(boxes.toList, comma <> line)
 
@@ -512,7 +588,8 @@ class PrettyWriter(
         // [x \in S]
         val binding = brackets(binders)
         // f[x \in S] == e
-        val doc = parseableName(name) <> binding <> space <> "==" <> space <> toDoc((0, 0), body)
+        val doc =
+          parseableName(name) <> binding <> space <> "==" <> space <> exToDoc((0, 0), body, nameResolver)
         recFunName = REC_FUN_UNDEFINED
         if (annotations.isEmpty) {
           group(doc)
@@ -536,7 +613,8 @@ class PrettyWriter(
             parens(ssep(params.map(toDoc), "," <> softline))
           }
 
-        val declDoc = group(parseableName(name) <> paramsDoc <> space <> "==" <> nest(line <> toDoc((0, 0), body)))
+        val declDoc =
+          group(parseableName(name) <> paramsDoc <> space <> "==" <> nest(line <> exToDoc((0, 0), body, nameResolver)))
         if (annotations.isEmpty) {
           recPreambule.map(_ <> line <> declDoc).getOrElse(declDoc)
         } else {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/NormalizedNames.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/NormalizedNames.scala
@@ -24,7 +24,7 @@ object NormalizedNames {
   val VC_VIEW = "VCView$0"
 
   // the names of the options that capture the critical specification pieces
-  val STANDARD_OPTION_NAMES = Seq("init", "cinit", "next", "inv", "temporalProps")
+  val STANDARD_OPTION_NAMES = Seq("init", "cinit", "next", "inv", "temporal")
 
   /**
    * Extract operator names from the standard option names.
@@ -37,7 +37,7 @@ object NormalizedNames {
     // first, get the operators whose names are passed as single strings
     val single: List[String] = List("init", "cinit", "next", "view").flatMap(options.get[String]("checker", _))
     // second, get the operators whose names are passed as lists of strings
-    val multiple: List[String] = List("inv", "temporalProps").flatMap(options.get[List[String]]("checker", _)).flatten
+    val multiple: List[String] = List("inv", "temporal").flatMap(options.get[List[String]]("checker", _)).flatten
     single ++ multiple
   }
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -230,10 +230,18 @@ class ConfigurationPassImpl @Inject() (
       }
 
       if (config.temporalProps.nonEmpty) {
-        // set the temporal properties, but warn the user that they are not used
-        outOptions.set("checker.temporalProps", config.temporalProps)
-        for (prop <- config.temporalProps) {
-          logger.warn(s"  > $basename: PROPERTY $prop is ignored. Only INVARIANTS are supported.")
+        val msg = s"  > $basename: found PROPERTIES: " + String.join(", ", config.invariants: _*)
+        logger.info(msg)
+
+        outOptions.get[List[String]]("checker", "temporal") match {
+          case None =>
+            outOptions.set("checker.temporal", config.temporalProps)
+
+          case Some(temporalProps) =>
+            val temporalPropsStr = temporalProps.map(s => "--temporal " + s)
+            val msg = s"  > Overriding with command line arguments: " + String.join(" ", temporalPropsStr: _*)
+            logger.warn(msg)
+            outOptions.set("checker.temporal", temporalProps)
         }
       }
 
@@ -252,7 +260,7 @@ class ConfigurationPassImpl @Inject() (
     }
   }
 
-  // Make sure that all operators passed via --init, --cinit, --next, --inv are present.
+  // Make sure that all operators passed via --init, --cinit, --next, --inv, --temporal are present.
   private def ensureDeclarationsArePresent(
       mod: TlaModule,
       configOptions: PassOptions): Unit = {
@@ -295,12 +303,12 @@ class ConfigurationPassImpl @Inject() (
         () // this is fine, invariants are optional
     }
 
-    configOptions.get[List[String]]("checker", "temporalProps") match {
+    configOptions.get[List[String]]("checker", "temporal") match {
       case Some(props) =>
         props.foreach(assertDecl("a temporal property", _))
 
       case None =>
-        () // this is fine, temporal properties are not supported anyway
+        () // this is fine, temporal properties are optional
     }
   }
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/TemporalPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/TemporalPassImpl.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.pp.passes
 
-import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
 import at.forsyte.apalache.io.lir.TlaWriterFactory
 import at.forsyte.apalache.tla.pp.temporal.{LoopEncoder, TableauEncoder}
@@ -10,6 +9,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 import at.forsyte.apalache.infra.passes.Pass.PassResult
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
+import at.forsyte.apalache.infra.passes.WriteablePassOptions
 import at.forsyte.apalache.tla.pp.Inliner
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 
@@ -19,7 +19,7 @@ import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
  * formula. The encoding is described in https://lmcs.episciences.org/2236, Sections 3.2 and 4.
  */
 class TemporalPassImpl @Inject() (
-    val options: PassOptions,
+    val options: WriteablePassOptions,
     tracker: TransformationTracker,
     gen: UniqueNameGenerator,
     writerFactory: TlaWriterFactory,
@@ -31,14 +31,15 @@ class TemporalPassImpl @Inject() (
   override def execute(tlaModule: TlaModule): PassResult = {
     logger.info("  > Rewriting temporal operators...")
 
-    val newModule = options.get[List[String]]("checker", "inv") match {
+    val temporalProps = options.get[List[String]]("checker", "temporal")
+    val newModule = temporalProps match {
       case None =>
-        logger.info("  > No invariants specified, nothing to encode")
+        logger.info("  > No temporal property specified, nothing to encode")
         tlaModule
-      case Some(invariants) =>
+      case Some(formulas) =>
         val init = options.get[String]("checker", "init")
         val next = options.get[String]("checker", "next")
-        temporalToInvariants(tlaModule, invariants, init.get, next.get)
+        temporalToInvariants(tlaModule, formulas, init.get, next.get)
     }
 
     writeOut(writerFactory, newModule)
@@ -59,9 +60,13 @@ class TemporalPassImpl @Inject() (
       })
       .filter(propOption =>
         propOption match {
-          case Some(inv: TlaOperDecl) if inv.formalParams.isEmpty =>
-            val level = levelFinder.getLevelOfDecl(inv)
-            level == TlaLevelTemporal
+          case Some(temporalProp: TlaOperDecl) if temporalProp.formalParams.isEmpty =>
+            val level = levelFinder.getLevelOfDecl(temporalProp)
+            if (level != TlaLevelTemporal) {
+              logger.warn(
+                  s"  > Temporal property ${temporalProp.name} has no temporal operators, so it specifies a property of the initial state. Should ${temporalProp.name} be an invariant instead (--inv)?")
+            }
+            true
           case _ => false
         })
       .map(propOption => propOption.get.asInstanceOf[TlaOperDecl])
@@ -89,6 +94,11 @@ class TemporalPassImpl @Inject() (
       val transformation = inliner.transform(scope = Inliner.emptyScope)
       val inlinedTemporalFormulas =
         temporalFormulas.map(operDecl => operDecl.copy(body = transformation(operDecl.body)))
+
+      // the encoding will transform the temporal properties into invariants, so add them to the
+      // list of invariants (otherwise, they would not be treated as invariants by later passes)
+      val newInvs = options.get[List[String]]("checker", "inv").getOrElse(List()) ++ inlinedTemporalFormulas.map(_.name)
+      options.set("checker.inv", newInvs)
 
       val tableauEncoder = new TableauEncoder(loopModWithPreds.module, gen, loopEncoder, tracker)
       tableauEncoder.temporalsToInvariants(loopModWithPreds, inlinedTemporalFormulas: _*)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 import at.forsyte.apalache.tla.pp.IrrecoverablePreprocessingError
 import at.forsyte.apalache.tla.pp.temporal.utils.builder
 import at.forsyte.apalache.tla.pp.temporal.DeclUtils._
+import at.forsyte.apalache.io.lir.NameReplacementMap
 import at.forsyte.apalache.tla.lir.oper.TlaTempOper
 import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
@@ -140,6 +141,8 @@ class TableauEncoder(
                 "Expected to find no LET-IN expressions. They should have been rewritten by the inliner.")
           case OperEx(oper, args @ _*) =>
             val nodeIdentifier = TableauEncoder.NAME_PREFIX + gen.newName()
+            NameReplacementMap.store = NameReplacementMap.store
+              .addOne(nodeIdentifier, curNode.toString().replace("\"", "\'"))
 
             /* create a new variable for this node.
             e.g.
@@ -155,6 +158,9 @@ class TableauEncoder(
             __saved___temporal_curNode
              */
             val nodeLoopVarDecl = loopEnc.createVarCopyVariableInLoop(nodeVarDecl)
+
+            NameReplacementMap.store = NameReplacementMap.store
+              .addOne(nodeLoopVarDecl.name, LoopEncoder.NAME_PREFIX + curNode.toString().replace("\"", "\'"))
 
             val nodeVarEx = builder.varDeclAsNameEx(nodeVarDecl)
             val nodeLoopVarEx = builder.varDeclAsNameEx(nodeLoopVarDecl)


### PR DESCRIPTION
This PR is meant to clean up the git troubles encountered in #1830 and #1873. If we move forward with this PR, it should replace those two.

The "fix" attempted here was to squash merge all changes from branch `1815-with-unstable-merged-in` into a new branch off of unstable.

To try to confirm that his branch includes all the changes, I created a new branch off `unstable` and merged in `1815-with-unstable-merged-in` then did a git diff:

```diff
$  git diff 1815-with-unstable-merged-in..1815-try-to-fix-git
diff --git a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
index 570db1cef..4bb18e190 100644
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -40,6 +40,8 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
       executor.passOptions.set("checker.next", next)
     if (inv != "")
       executor.passOptions.set("checker.inv", List(inv))
+    if (temporal != "")
+      executor.passOptions.set("checker.temporal", List(temporal))
     if (cinit != "")
       executor.passOptions.set("checker.cinit", cinit)
     executor.passOptions.set("checker.length", length)
``` 

You can verify this yourself by pulling down the `1815-with-unstable-merged-in` branch and running this yourself.

The two line difference is due to changes needed to adapt to #1858.

Let me know what you think about using this PR to add your changes, @p-offtermatt! Should probably involve a careful check to ensure it includes everything you would expect.