### PR TITLE
Add support for actions under temporal operators

### DIFF
--- a/.unreleased/bug-fixes/1871.md
+++ b/.unreleased/bug-fixes/1871.md
@@ -1,1 +1,1 @@
-Add support for checking temporal properties with primed expressions inside
+Add support for checking temporal properties with primed expressions inside, see #1879

--- a/.unreleased/bug-fixes/1871.md
+++ b/.unreleased/bug-fixes/1871.md
@@ -1,0 +1,1 @@
+Add support for checking temporal properties with primed expressions inside

--- a/test/tla/TemporalPropsOverActions.tla
+++ b/test/tla/TemporalPropsOverActions.tla
@@ -1,0 +1,20 @@
+---- MODULE TemporalPropsOverActions ----
+
+EXTENDS Integers
+
+VARIABLE
+    \* @type: Int;
+    x
+
+Init ==
+    x = 0
+
+Next ==
+    x' = IF x < 3 THEN x + 1 ELSE 0
+    
+Liveness ==
+    <>(<<x' = x + 1>>_x)
+
+FalseLiveness ==
+    <>[]([x' = x + 1]_x)
+====

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1537,6 +1537,21 @@ EXITCODE: ERROR (12)
 [12]
 ```
 
+### check actions in temporal operators (temporal)
+
+```sh
+$ apalache-mc check --temporal=Liveness TemporalPropsOverActions.tla
+...
+EXITCODE: OK
+```
+
+```sh
+$ apalache-mc check --temporal=FalseLiveness TemporalPropsOverActions.tla
+...
+EXITCODE: ERROR (12)
+[12]
+```
+
 ### check LetIn (temporal)
 
 ```sh

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -81,16 +81,16 @@ class Desugarer(gen: UniqueNameGenerator, stateVariables: Set[String], tracker: 
     case OperEx(TlaActionOper.stutter, body, vars) =>
       val builder = new ScopedBuilder
       transform(builder.or(
-          builder.useTrustedEx(body),
-          builder.unchanged(builder.useTrustedEx(vars)),
-      ))
+              builder.useTrustedEx(body),
+              builder.unchanged(builder.useTrustedEx(vars)),
+          ))
 
     case OperEx(TlaActionOper.nostutter, body, vars) =>
       val builder = new ScopedBuilder
       transform(builder.and(
-          builder.useTrustedEx(body),
-          builder.not(builder.unchanged(builder.useTrustedEx(vars))),
-      ))
+              builder.useTrustedEx(body),
+              builder.not(builder.unchanged(builder.useTrustedEx(vars))),
+          ))
 
     case OperEx(TlaOper.eq, OperEx(TlaFunOper.tuple, largs @ _*), OperEx(TlaFunOper.tuple, rargs @ _*)) =>
       // <<e_1, ..., e_k>> = <<f_1, ..., f_n>>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Desugarer.scala
@@ -80,17 +80,17 @@ class Desugarer(gen: UniqueNameGenerator, stateVariables: Set[String], tracker: 
 
     case OperEx(TlaActionOper.stutter, body, vars) =>
       val builder = new ScopedBuilder
-      builder.or(
+      transform(builder.or(
           builder.useTrustedEx(body),
           builder.unchanged(builder.useTrustedEx(vars)),
-      )
+      ))
 
     case OperEx(TlaActionOper.nostutter, body, vars) =>
       val builder = new ScopedBuilder
-      builder.and(
+      transform(builder.and(
           builder.useTrustedEx(body),
           builder.not(builder.unchanged(builder.useTrustedEx(vars))),
-      )
+      ))
 
     case OperEx(TlaOper.eq, OperEx(TlaFunOper.tuple, largs @ _*), OperEx(TlaFunOper.tuple, rargs @ _*)) =>
       // <<e_1, ..., e_k>> = <<f_1, ..., f_n>>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -306,10 +306,6 @@ class TableauEncoder(
 
                 /* update loopOK:
                   /\ (__temporal_curNode_globally => __temporal_curNode) or (__temporal_curNode => __temporal_curNode_finally)
-
-                  \* necessary to ensure the value of __temporal_curNode_unroll is fine in the very last state,
-                  \* which is not checked by the next predicate, since it can reason only about the current state
-                  /\ (__temporal_curNode_unroll_prev = __temporal_curNode_unroll)
                  */
                 val auxVarLoopOKEx =
                   oper match {
@@ -317,11 +313,13 @@ class TableauEncoder(
                     case TlaTempOper.diamond => builder.impl(nodeVarEx, auxVarEx)
                   }
 
+                /* necessary to ensure the value of __temporal_curNode_unroll is fine in the very last state,
+                   which is not checked by the next predicate, since it can reason only about the current state
+
+                  /\ (__temporal_curNode_unroll_prev = __temporal_curNode_unroll)
+                 */
                 val prevAuxVarLoopOKEx =
-                  oper match {
-                    case TlaTempOper.box     => builder.impl(auxVarEx, nodeVarEx)
-                    case TlaTempOper.diamond => builder.impl(nodeVarEx, auxVarEx)
-                  }
+                  builder.eql(prevAuxVarEx, auxVarEx)
 
                 (
                     Seq(

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -393,8 +393,12 @@ class TableauEncoder(
     }}}
     Encoding the property as an invariant would produce an assignment for an auxiliary variable like
     {{{
-      auxVar := (x := 2)
-    }}}, which is invalid for the transition finder
+      auxVar := (x' := 2)
+    }}}, which is invalid for the transition finder.
+    So we rewrite this as
+    {{{
+      auxVar := (x' = 2)
+    }}}
      */
     val assignmentlessBody = rewriteAssignmentsAsEquality(formula.body)
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -200,7 +200,7 @@ class TableauEncoder(
               case TlaTempOper.box | TlaTempOper.diamond => /* curNode has the form []A or <>A */
                 /* create new auxiliary variables curNode_globally or curNode_finally,
                 and curNode_globally_prev or curNode_finally_prev
-                when it doesn't matter whether variable is for a [] or <> operator, we'll call it curNode_unroll in the comments
+                when it doesn't matter whether a variable is for a [] or <> operator, we'll call it curNode_unroll in the comments
                  */
                 val nameSuffix = oper match {
                   case TlaTempOper.box     => TableauEncoder.BOX_SUFFIX

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -384,6 +384,18 @@ class TableauEncoder(
    * Encodes a given formula, using the Tableau encoding by adjusting init, next, loopOK and the given formula.
    */
   def singleTemporalToInvariant(formula: TlaOperDecl): (Seq[TlaVarDecl], PredExs, TlaVarDecl) = {
+
+    /* formula is a temporal property, never an action, so removing assignments never hurts.
+    It's necessary to remove assignments when the formula uses an action as a condition. For example,
+    {{{Action == x' := 2
+
+    Property == <>[Action]_x
+    }}}
+    Encoding the property as an invariant would produce an assignment for an auxiliary variable like
+    {{{
+      auxVar := (x := 2)
+    }}}, which is invalid for the transition finder
+     */
     val assignmentlessBody = rewriteAssignmentsAsEquality(formula.body)
 
     var (varDecls, preds, (formulaEx)) = encodeSyntaxTreeInPredicates(assignmentlessBody)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -34,7 +34,8 @@ class TableauEncoder(
 
   private def inBoolSet(element: TBuilderInstruction): TBuilderInstruction = builder.in(element, builder.booleanSet())
 
-  /* replaces all occurences of foo := bar with foo = bar */
+  /* replaces all occurences of := with =.
+  For example, x' := foo becomes x' = foo. */
   private def rewriteAssignmentsAsEquality(ex: TlaEx): TlaEx = {
     ex match {
       case OperEx(oper, args @ _*) =>

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
@@ -803,7 +803,7 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
     val output = desugarer.transform(input)
 
     val expected =
-      tla.or(tla.name("A").typed(BoolT1), tla.unchanged(tla.name("B").typed(IntT1)).typed(BoolT1)).typed(BoolT1)
+      desugarer.transform(tla.or(tla.name("A").typed(BoolT1), tla.unchanged(tla.name("B").typed(IntT1)).typed(BoolT1)).typed(BoolT1))
     assert(expected.eqTyped(output))
   }
 
@@ -814,7 +814,7 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
     val output = desugarer.transform(input)
 
     val expected =
-      tla
+      desugarer.transform(tla
         .and(
             tla.name("A").typed(BoolT1),
             tla
@@ -824,6 +824,7 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
               .typed(BoolT1),
         )
         .typed(BoolT1)
+      )
     assert(expected.eqTyped(output))
   }
 }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
@@ -803,7 +803,8 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
     val output = desugarer.transform(input)
 
     val expected =
-      desugarer.transform(tla.or(tla.name("A").typed(BoolT1), tla.unchanged(tla.name("B").typed(IntT1)).typed(BoolT1)).typed(BoolT1))
+      desugarer.transform(
+          tla.or(tla.name("A").typed(BoolT1), tla.unchanged(tla.name("B").typed(IntT1)).typed(BoolT1)).typed(BoolT1))
     assert(expected.eqTyped(output))
   }
 
@@ -815,16 +816,15 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
 
     val expected =
       desugarer.transform(tla
-        .and(
-            tla.name("A").typed(BoolT1),
-            tla
-              .not(
-                  tla.unchanged(tla.name("B").typed(IntT1)).typed(BoolT1)
-              )
-              .typed(BoolT1),
-        )
-        .typed(BoolT1)
-      )
+            .and(
+                tla.name("A").typed(BoolT1),
+                tla
+                  .not(
+                      tla.unchanged(tla.name("B").typed(IntT1)).typed(BoolT1)
+                  )
+                  .typed(BoolT1),
+            )
+            .typed(BoolT1))
     assert(expected.eqTyped(output))
   }
 }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTableauEncoder.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTableauEncoder.scala
@@ -104,8 +104,8 @@ class TestTableauEncoder extends AnyFunSuite with Checkers {
           .filter(decl =>
             decl.name.startsWith(TableauEncoder.NAME_PREFIX)
               && !decl.name.contains(LoopEncoder.NAME_PREFIX)
-              && !decl.name.endsWith(TableauEncoder.BOX_SUFFIX)
-              && !decl.name.endsWith(TableauEncoder.DIAMOND_SUFFIX))
+              && !decl.name.contains(TableauEncoder.BOX_SUFFIX)
+              && !decl.name.contains(TableauEncoder.DIAMOND_SUFFIX))
           .length
 
         nodesInFormulaSyntaxTree ?= predicateVariables
@@ -140,7 +140,7 @@ class TestTableauEncoder extends AnyFunSuite with Checkers {
 
   if (TableauEncoder.DIAMOND_SUFFIX != TableauEncoder.BOX_SUFFIX) {
 
-    test("test: for each box operator, there is an extra variable") {
+    test("test: for each box operator, there are two extra variables") {
       val prop = forAll(formulaGen) { formula =>
         if (levelFinder.getLevelOfExpression(Set.empty, formula) != TlaLevelTemporal) {
           Prop.undecided
@@ -157,11 +157,17 @@ class TestTableauEncoder extends AnyFunSuite with Checkers {
           .length
 
         boxApplications ?= boxVariables
+
+        val prevBoxVariables = output.varDeclarations
+          .filter(decl => decl.name.endsWith(TableauEncoder.BOX_SUFFIX + TableauEncoder.LOOKBACK_SUFFIX))
+          .length
+
+        boxApplications ?= prevBoxVariables
       }
       check(prop, minSuccessful(500), sizeRange(4))
     }
 
-    test("test: for each diamond operator, there is an extra variable") {
+    test("test: for each diamond operator, there are two extra variables") {
       val prop = forAll(formulaGen) { formula =>
         if (levelFinder.getLevelOfExpression(Set.empty, formula) != TlaLevelTemporal) {
           Prop.undecided
@@ -178,11 +184,17 @@ class TestTableauEncoder extends AnyFunSuite with Checkers {
           .length
 
         diamondApplications ?= diamondVariables
+
+        val prevDiamondVariables = output.varDeclarations
+          .filter(decl => decl.name.endsWith(TableauEncoder.DIAMOND_SUFFIX + TableauEncoder.LOOKBACK_SUFFIX))
+          .length
+
+        diamondApplications ?= prevDiamondVariables
       }
       check(prop, minSuccessful(500), sizeRange(4))
     }
   } else { // TableauEncoder.DIAMOND_SUFFIX == TableauEncoder.BOX_SUFFIX)
-    test("test: for each diamond and box operator, there is an extra variable") {
+    test("test: for each diamond and box operator, there are two extra variables") {
       val prop = forAll(formulaGen) { formula =>
         if (levelFinder.getLevelOfExpression(Set.empty, formula) != TlaLevelTemporal) {
           Prop.undecided
@@ -196,10 +208,17 @@ class TestTableauEncoder extends AnyFunSuite with Checkers {
 
         // identify predicate variables by the variable names
         val temporalAuxVars = output.varDeclarations
+          // since BOX_SUFFIX and DIAMOND_SUFFIX are the same, doesn't matter which we choose
           .filter(decl => decl.name.endsWith(TableauEncoder.DIAMOND_SUFFIX))
           .length
 
         temporalApplications ?= temporalAuxVars
+
+        val prevTemporalAuxVars = output.varDeclarations
+          .filter(decl => decl.name.endsWith(TableauEncoder.DIAMOND_SUFFIX + TableauEncoder.LOOKBACK_SUFFIX))
+          .length
+
+        temporalApplications ?= prevTemporalAuxVars
       }
       check(prop, minSuccessful(500), sizeRange(4))
     }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

Fixes buggy behaviour when actions are inside temporal operators by subtly changing the encoding.
It necessitates a change from the way the encoding is specified in the paper, which is necessary due to the technicalities of TLA+.
Essentially, double-priming is not allowed, while in LTL stacking next operators is no issue, so the subtle changes account for this.

- [x] Tests added for any new code
- [x] Entries added to [./unreleased/][unreleased] for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
