### PR TITLE
Infer module name in SanyImporter.loadFromSource

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
@@ -127,7 +127,7 @@ class TestVCGenerator extends AnyFunSuite {
   private def loadFromText(moduleName: String, text: String): TlaModule = {
     val locationStore = new SourceStore
     val (_, modules) =
-      new SanyImporter(locationStore, createAnnotationStore()).loadFromSource(moduleName, Source.fromString(text))
+      new SanyImporter(locationStore, createAnnotationStore()).loadFromSource(Source.fromString(text))
     modules(moduleName)
   }
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -29,7 +29,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |================================
       """.stripMargin
 
-    val (rootName, _) = sanyImporter.loadFromSource("justASimpleTest", Source.fromString(text))
+    val (rootName, _) = sanyImporter.loadFromSource(Source.fromString(text))
     assert("justASimpleTest" == rootName)
   }
 
@@ -62,7 +62,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource("onevar", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("onevar", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -84,7 +84,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("oneconst", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("oneconst", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -103,7 +103,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -128,7 +128,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -153,7 +153,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -178,7 +178,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -204,7 +204,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -228,7 +228,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -255,7 +255,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("constop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("constop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -277,7 +277,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("builtinop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("builtinop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -304,7 +304,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("localop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("localop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -328,7 +328,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("localop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("localop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -357,7 +357,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("localop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("localop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -372,7 +372,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("emptyset", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("emptyset", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -395,7 +395,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("builtinop", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("builtinop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -490,7 +490,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("builtins", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     expectSingleModule("builtins", rootName, modules)
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -786,7 +786,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("comprehensions", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     expectSingleModule("comprehensions", rootName, modules)
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -841,7 +841,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("composite", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("composite", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -941,7 +941,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("except", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("except", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1012,7 +1012,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("labels", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("labels", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1062,7 +1062,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("args", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("args", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1098,7 +1098,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("updates", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("updates", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1166,7 +1166,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("selects", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("selects", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1208,7 +1208,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("funCtor", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("funCtor", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1278,7 +1278,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("weird", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("weird", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1307,7 +1307,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("level1Operators", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("level1Operators", rootName, modules)
 
     def expectDecl(n: String, p: List[OperParam], b: TlaEx) =
@@ -1352,7 +1352,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("level2Operators", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("level2Operators", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1388,7 +1388,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin.format("\\union")
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("level2builtin", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = expectSingleModule("level2builtin", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1436,7 +1436,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("level2library", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     val mod = modules(rootName)
     expectSourceInfoInDefs(mod)
 
@@ -1485,7 +1485,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("let", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1540,7 +1540,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     assertThrows[SanyImporterException] {
-      sanyImporter.loadFromSource("subformulas", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     }
   }
 
@@ -1554,7 +1554,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("lambda", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1602,7 +1602,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("let", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1660,7 +1660,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("recOpers", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(2 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1752,7 +1752,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("globalFuns", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1818,7 +1818,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("assumptions", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1863,7 +1863,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("theorems", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size) // Naturals, Sequences, and our module
     // the root module and naturals
     val root = modules(rootName)

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
@@ -31,9 +31,9 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
     sanyImporter = new SanyImporter(sourceStore, annotationStore)
   }
 
-  private def loadModule(text: String, moduleName: String): TlaModule = {
+  private def loadModule(text: String): TlaModule = {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(moduleName, Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     modules(rootName)
   }
 
@@ -49,7 +49,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "oneconst")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "S") match {
       case Some(d @ TlaConstDecl(_)) =>
@@ -75,7 +75,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "onevar")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "S") match {
       case Some(d @ TlaVarDecl(_)) =>
@@ -100,7 +100,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "oper")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "X") match {
       case Some(d @ TlaOperDecl(_, _, _)) =>
@@ -127,7 +127,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "oper")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "Inc") match {
       case Some(d @ TlaOperDecl(_, _, _)) =>
@@ -160,7 +160,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "oper")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "A") match {
       // SanyImporter introduces a let-definition before application of a LOCAL operator
@@ -196,7 +196,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "oper")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "A") match {
       case Some(TlaOperDecl(_, _, LetInEx(_, incDecl))) =>
@@ -229,7 +229,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "oper")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "Fact") match {
       case Some(d @ TlaOperDecl(_, _, _)) =>
@@ -258,7 +258,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "fun")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "Fact") match {
       case Some(d @ TlaOperDecl(_, _, _)) =>
@@ -282,7 +282,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
       """.stripMargin
 
     // as explained in #1292, we are not throwing an exception anymore
-    val module = loadModule(text, "missing")
+    val module = loadModule(text)
 
     val action = module.declarations
       .find(_.name == "action")
@@ -306,7 +306,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
         |================================
       """.stripMargin
 
-    val module = loadModule(text, "corner")
+    val module = loadModule(text)
 
     module.declarations.find(_.name == "Corner") match {
       case Some(d @ TlaOperDecl(_, _, _)) =>

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterInstances.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterInstances.scala
@@ -44,7 +44,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("inst", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(2 == modules.size) // inst + Naturals
     // the root module and A
     val root = modules(rootName)
@@ -124,7 +124,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("imports", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -158,7 +158,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("Paxos", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     expectSourceInfoInDefs(modules(rootName))
   }
@@ -176,7 +176,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("localInInstance", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -221,7 +221,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("letInInstance", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -256,7 +256,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |===================================================""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("P", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -294,7 +294,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |==============================""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("test1254", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     val root = modules(rootName)
     val base = root.declarations
@@ -327,7 +327,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |===================================================""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("A", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -364,7 +364,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("recInInstance", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -390,7 +390,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("issue52", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     // the root module and naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -417,7 +417,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("issue295", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     // the root module and naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -444,7 +444,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("issue295", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     // the root module and naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
@@ -31,7 +31,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("imports", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(2 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -66,7 +66,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("nats", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(2 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -163,7 +163,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("ints", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(3 == modules.size) // Integers extends Naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -247,7 +247,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("myreals", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(4 == modules.size) // Reals include Integers that include Naturals
     val root = modules(rootName)
     // the definitions of the standard operators are filtered out
@@ -331,7 +331,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("sequences", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(3 == modules.size) // Naturals, Sequences, and our module
     // the root module and naturals
     val root = modules(rootName)
@@ -376,7 +376,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("myfinitesets", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(5 == modules.size) // Naturals, Sequences, FiniteSets, and our module
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -422,7 +422,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |""".stripMargin
 
     val (rootName, modules) = sanyImporter
-      .loadFromSource("tlc", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     // the root module and integers
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -471,7 +471,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |================================
       """.stripMargin
 
-    val (_, modules) = sanyImporter.loadFromSource("localSum", Source.fromString(text))
+    val (_, modules) = sanyImporter.loadFromSource(Source.fromString(text))
     assert(6 == modules.size) // Naturals, Sequences, TLC, FiniteSets, Bags, and our module
 
     val root = modules("localSum")
@@ -501,7 +501,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
     // Apalache source tree.
 
     val (_, modules) = sanyImporter
-      .loadFromSource("root", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
     assert(7 == modules.size) // root, Apalache, Integers, FiniteSets, and whatever they import
 
     val root = modules("root")
@@ -587,7 +587,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
     // Apalache source tree.
 
     val (_, modules) = sanyImporter
-      .loadFromSource("root", Source.fromString(text))
+      .loadFromSource(Source.fromString(text))
 
     val root = modules("root")
     expectSourceInfoInDefs(root)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
@@ -36,7 +36,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource("const", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     val root = modules(rootName)
     // we don't want to run a type checker, so we just hack the type of the declaration n
     val newDeclarations =
@@ -71,7 +71,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource("const", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     val root = modules(rootName)
     assertThrows[OverridingError](new ConstAndDefRewriter(new IdleTracker())(root))
   }
@@ -86,7 +86,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource("const", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     val root = modules(rootName)
     assertThrows[OverridingError](new ConstAndDefRewriter(new IdleTracker())(root))
   }
@@ -100,7 +100,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource("op", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     val root = modules(rootName)
     val rewritten = new ConstAndDefRewriter(new IdleTracker())(root)
     assert(rewritten.constDeclarations.isEmpty)
@@ -119,7 +119,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource("op", Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text))
     val root = modules(rootName)
     assertThrows[OverridingError](new ConstAndDefRewriter(new IdleTracker())(root))
   }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
@@ -34,7 +34,7 @@ class TestTlcConfigImporter extends AnyFunSuite with BeforeAndAfterEach {
   def configureAndCompare(tla: String, tlc: String, expected: String): Assertion = {
     val config = TlcConfigParserApalache(tlc)
     val (rootName, modules) =
-      sanyImporter.loadFromSource("test", Source.fromString(tla))
+      sanyImporter.loadFromSource(Source.fromString(tla))
 
     val mod = modules(rootName)
     // run the type checker

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
@@ -49,7 +49,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   test("the tool runs and reports no type errors") {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(megaSpec, loadSpecFromResource(megaSpec))
+      sanyImporter.loadFromSource(loadSpecFromResource(megaSpec))
 
     val mod = modules(rootName)
 
@@ -71,7 +71,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   test("the tool runs and tags all expressions") {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(megaSpec, loadSpecFromResource(megaSpec))
+      sanyImporter.loadFromSource(loadSpecFromResource(megaSpec))
 
     val mod = modules(rootName)
 
@@ -117,7 +117,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   private def typecheckSpecAndEncoding(specName: String): Unit = {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(specName, loadSpecFromResource(specName))
+      sanyImporter.loadFromSource(loadSpecFromResource(specName))
 
     val mod = modules(rootName)
 
@@ -156,7 +156,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   private def typecheckSpec(specName: String): Unit = {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(specName, loadSpecFromResource(specName))
+      sanyImporter.loadFromSource(loadSpecFromResource(specName))
 
     val mod = modules(rootName)
 


### PR DESCRIPTION
Supports #1114

Currently, the `SanyImporter.loadFromSource` method takes both a module name and
a `scala.io.Source`, before delegating to Sany to parse a `TlaModule` from the
given source.

Shai will want to use the `SanyImporter.loadFromSource` to load the blob
representing the module it receives via gRPC, but requiring users to submit the
module name separately seems clunky and like needless leakage of an
implementation detail into the API.

This small change lets us infer the module name from the content of the source
(rather than from files) without requiring the caller to supply the module name
explicitly. Since this method was only used in tests up to this point, this
change is very low impact.

I recommend reviewing by commit:

- 2cfc8cd819c743016ae8bfb691e6a2f9447efbfe includes the small change to logic
- aa8c4eb98e42411df247821ad491e910573a68d2 just updates the call sites in the tests to drop the unneeded argument