### PR TITLE
Fix formatting of changelog entries

### DIFF
--- a/.unreleased/features/1870.md
+++ b/.unreleased/features/1870.md
@@ -1,1 +1,1 @@
- - Support variants in the model checker with `--features=rows`, see #1870
+Support variants in the model checker with `--features=rows`, see #1870

--- a/.unreleased/features/1898.md
+++ b/.unreleased/features/1898.md
@@ -1,1 +1,1 @@
- - serialize variants to the ITF format, see #1898
+serialize variants to the ITF format, see #1898

--- a/.unreleased/features/remove-posttype.md
+++ b/.unreleased/features/remove-posttype.md
@@ -1,1 +1,1 @@
- - Replace PostTypeChecker pass with an additional predicate, see #1878
+Replace PostTypeChecker pass with an additional predicate, see #1878


### PR DESCRIPTION
This is a followup to several PRs that added redundant bullet points to
the change long entries. This change removes the redundant bullet points.

This is a precondition for preparing this week's release.

See https://github.com/informalsystems/apalache/pull/1904#discussion_r912921195 for the erroneous formatting.