### PR TITLE
remove VariantMatch

### DIFF
--- a/src/tla/Variants.tla
+++ b/src/tla/Variants.tla
@@ -40,41 +40,6 @@ VariantFilter(__tagName, __S) ==
     \* default untyped implementation
     { __d \in { __e \in __S: __e.tag = __tagName }: __d.value }
 
-
-(**
- * WARNING: This operator is not supported by the Apalache model checker yet.
- * We are thinking about a reasonably simple implementation of it.
- *
- * Test the tag of `variant` against the value `tagValue`.
- * If `variant.tag = tagValue`, then apply `ThenOper(rec)`,
- * where `rec` is a record extracted from `variant`.
- * Otherwise, apply `ElseOper(reducedVariant)`,
- * where `reducedVariant` is a version of `variant` that does allow for
- * the tag `tagValue`.
- *
- * @param `variant` a variant that is constructed with `Variant(...)`
- * @param `tagValue` a constant string that is used to extract a record
- * @param `ThenOper` an operator that is called
- *        when `variant` is tagged with `tagValue`
- * @param `ElseOper` an operator that is called
- *        when `variant` is tagged with a value different from `tagValue`
- * @return the result returned by either `ThenOper`, or `ElseOper`
- *
- * The type could look like follows, when __tagName == "Tag":
- *
- *   (
- *     Str,
- *     Tag(a) | b,
- *     a => r,
- *     Variant(b) => r
- *   ) => r
- *)
-VariantMatch(__tagName, __variant, __ThenOper(_), __ElseOper(_)) ==
-    \* default untyped implementation
-    IF __variant.tag = __tagName
-    THEN __ThenOper(__variant.value)
-    ELSE __ElseOper(__variant)
-
 (**
  * In cases where `variant` allows for one value,
  * extract the associated value and return it.

--- a/test/tla/TestVariants.tla
+++ b/test/tla/TestVariants.tla
@@ -46,21 +46,11 @@ TestVariantGetOrElse ==
     \* When the tag name is different from the actual one, return the default value.
     VariantGetOrElse("A", VarB, 12) = 12
 
-TestVariantMatch ==
-    VariantMatch(
-        "A",
-        VarA,
-        LAMBDA i: i > 0,
-        LAMBDA v: FALSE
-    )
-
 AllTests ==
     /\ TestVariant
     /\ TestVariantFilter
     /\ TestVariantUnwrap
     /\ TestVariantGetUnsafe
     /\ TestVariantGetOrElse
-    \* Disabled as unsupported by the model checker yet
-    \*/\ TestVariantMatch
 
 ===============================================================================

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -70,7 +70,6 @@ object StandardLibrary {
         // Variants
         ("Variants", "Variant") -> VariantOper.variant,
         ("Variants", "VariantFilter") -> VariantOper.variantFilter,
-        ("Variants", "VariantMatch") -> VariantOper.variantMatch,
         ("Variants", "VariantUnwrap") -> VariantOper.variantUnwrap,
         ("Variants", "VariantGetUnsafe") -> VariantOper.variantGetUnsafe,
         ("Variants", "VariantGetOrElse") -> VariantOper.variantGetOrElse,

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
@@ -571,12 +571,6 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |\* @type: Set(T1a({ val: Int, found: Bool) | T2a({ bal: Int })) => Set({ val: Int, found: Bool });
         |TestVariantFilter == VariantFilter("T1a", { TestVariant })
         |
-        |\* @type: T1a({ val: Int, found: Bool }) | T2a({ bal: Int }) => Bool;
-        |TestVariantMatch(var) ==
-        |  LET ThenOper(v) == v.found IN
-        |  LET ElseOper(v) == FALSE IN
-        |  VariantMatch("T1a", var, ThenOper, ElseOper)
-        |
         |\* @type: T1a({ val: Int, found: Bool }) => { val: Int, found: Bool };
         |TestVariantUnwrap(var) ==
         |  VariantUnwrap("T1a", var)
@@ -623,29 +617,6 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
             ValEx(TlaStr("T1a")),
             OperEx(TlaSetOper.enumSet, OperEx(TlaOper.apply, NameEx("TestVariant"))),
         ),
-    )
-
-    // TestVariantMatch(var) ==
-    //   LET ThenOper(v) == v.found IN
-    //   LET ElseOper(v) == FALSE IN
-    //   VariantMatch("T1a", var, ThenOper, ElseOper)
-    val mtThen =
-      declOp("ThenOper", appFun(name("v"), str("found")), OperParam("v")).untypedOperDecl()
-    val mtElse =
-      declOp("ElseOper", bool(false), OperParam("v")).untypedOperDecl()
-    val applyMatchTag =
-      OperEx(
-          VariantOper.variantMatch,
-          ValEx(TlaStr("T1a")),
-          name("var"),
-          name("ThenOper"),
-          name("ElseOper"),
-      )
-
-    expectDecl(
-        "TestVariantMatch",
-        letIn(letIn(applyMatchTag, mtElse), mtThen),
-        OperParam("var"),
     )
 
     // TestVariantUnwrap(var) ==

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -785,29 +785,6 @@ class ToEtcExpr(
       case ex @ OperEx(VariantOper.variantFilter, tag @ _, _) =>
         throw new TypingInputException(s"The first argument of VariantFilter must be a string, found: $tag", ex.ID)
 
-      case OperEx(VariantOper.variantMatch, v @ ValEx(TlaStr(tagName)), variantEx, thenOper, elseOper) =>
-        val a = varPool.fresh
-        val b = varPool.fresh
-        val c = varPool.fresh
-        // a => c
-        val thenType = OperT1(Seq(a), c)
-        // Variant(b) => c
-        val elseType = OperT1(Seq(VariantT1(RowT1(b))), c)
-        // (Str, T1a(a) | b, thenOper, elseOper) => c
-        val operArgs =
-          Seq(
-              StrT1,
-              VariantT1(RowT1(b, tagName -> a)),
-              thenType,
-              elseType,
-          )
-
-        val opsig = OperT1(operArgs, c)
-        mkExRefApp(opsig, Seq(v, variantEx, thenOper, elseOper))
-
-      case OperEx(VariantOper.variantMatch, tag @ _, _, _, _) =>
-        throw new TypingInputException(s"The first argument of VariantMatch must be a string, found: $tag", ex.ID)
-
       case OperEx(VariantOper.variantUnwrap, v @ ValEx(TlaStr(tagName)), variantEx) =>
         val a = varPool.fresh
         // (Str, T1a(a)) => a

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -391,18 +391,6 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
     }
   }
 
-  test("""VariantMatch("T1a", v, ThenOper, ElseOper)""") {
-    val thenType = parser("a => c")
-    val elseType = parser("Variant(b) => c")
-    val operType = parser(s"""(Str, T1a(a) | b, $thenType, $elseType) => c""")
-    val expected =
-      mkUniqApp(Seq(operType), mkUniqConst(StrT1), mkUniqName("v"), mkUniqName("ThenOper"), mkUniqName("ElseOper"))
-    val matchEx =
-      tla.variantMatch("T1a", tla.name("v"), tla.name("ThenOper"), tla.name("ElseOper"))
-    val produced = gen(matchEx)
-    produced should equal(expected)
-  }
-
   test("""VariantUnwrap("T1a", v)""") {
     val operType = parser(s"""(Str, T1a(a)) => a""")
     val expected = mkUniqApp(Seq(operType), mkUniqConst(StrT1), mkUniqName("v"))

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -697,27 +697,6 @@ class Builder {
   }
 
   /**
-   * Match a variant by a tag
-   *
-   * @param tagName
-   *   a tag value (string)
-   * @param variantEx
-   *   a variant expression
-   * @param thenOper
-   *   the operator to be applied when the variant is tagged with `tagName`; the associated value is passed to it
-   * @param elseOper
-   *   the operator te be applied when the variant is not tagged with `tagName`; the reduced invariant is passed to it
-   * @return
-   */
-  def variantMatch(
-      tagName: String,
-      variantEx: BuilderEx,
-      thenOper: BuilderEx,
-      elseOper: BuilderEx): BuilderEx = {
-    BuilderOper(VariantOper.variantMatch, str(tagName), variantEx, thenOper, elseOper)
-  }
-
-  /**
    * Match a variant that admits only one option (one tag)
    *
    * @param tagName
@@ -867,7 +846,6 @@ class Builder {
         VariantOper.variantUnwrap.name -> VariantOper.variantUnwrap,
         VariantOper.variantGetUnsafe.name -> VariantOper.variantGetUnsafe,
         VariantOper.variantGetOrElse.name -> VariantOper.variantGetOrElse,
-        VariantOper.variantMatch.name -> VariantOper.variantMatch,
         VariantOper.variantFilter.name -> VariantOper.variantFilter,
     )
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/VariantOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/VariantOper.scala
@@ -35,17 +35,6 @@ object VariantOper {
   }
 
   /**
-   * Match a variant by tag.
-   */
-  object variantMatch extends VariantOper {
-    override def name: String = "Variants!VariantMatch"
-
-    override def arity: OperArity = FixedArity(4)
-
-    override val precedence: (Int, Int) = (100, 100)
-  }
-
-  /**
    * Match a single variant.
    */
   object variantUnwrap extends VariantOper {


### PR DESCRIPTION
This PR removes the operator `VariantMatch` and the code associated with it. It was too hard to implement in the model checker. If we find a way later, we can bring it back.