### PR TITLE
Add a `SourceOption` type for loading specs from non-file sources

### DIFF
--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/PassOptions.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/PassOptions.scala
@@ -5,7 +5,7 @@ import scala.reflect.ClassTag
  * The central store for various options given to the passes. An option is a key-value pair. By convention, a key is a
  * string of the shape pass.option, where pass is the pass name and option is the option name. A pass name does not have
  * to match exactly the name of the pass that is accessing the option, but of a class of passes. For instance, the
- * option parser.filename can be used by all parsing passes, not just the pass called 'parser'.
+ * option parser.source can be used by all parsing passes, not just the pass called 'parser'.
  *
  * @author
  *   Igor Konnov

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
@@ -1,14 +1,13 @@
 package at.forsyte.apalache.infra.passes
 
 /** Defines the data sources supported in the [[PassOptions]] */
+sealed abstract class SourceOption
+
 object SourceOption {
 
-  /** Supported data sources */
-  sealed trait T
-
   /** Data to be loaded from a file */
-  final case class FileSource(file: java.io.File) extends T
+  final case class FileSource(file: java.io.File) extends SourceOption
 
   /** Data supplied as a string */
-  final case class StringSource(content: String) extends T
+  final case class StringSource(content: String) extends SourceOption
 }

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
@@ -7,8 +7,8 @@ object SourceOption {
   sealed trait T
 
   /** Data to be loaded from a file */
-  case class File(file: java.io.File) extends T
+  final case class FileSource(file: java.io.File) extends T
 
   /** Data supplied as a string */
-  case class String(content: java.lang.String) extends T
+  final case class StringSource(content: String) extends T
 }

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
@@ -1,0 +1,14 @@
+package at.forsyte.apalache.infra.passes
+
+/** Defines the data sources supported in the [[PassOptions]] */
+object SourceOption {
+
+  /** Supported data sources */
+  sealed trait T
+
+  /** Data to be loaded from a file */
+  case class File(file: java.io.File) extends T
+
+  /** Data supplied as a string */
+  case class String(content: java.lang.String) extends T
+}

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/WriteablePassOptions.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/WriteablePassOptions.scala
@@ -7,12 +7,9 @@ import com.google.inject.Singleton
 import scala.collection.mutable
 
 /**
- * <p>The central store for various options given to the passes. An option is a key-value pair. By convention, a key is
- * a string of the shape pass.option, where pass is the pass name and option is the option name. A pass name does not
- * have to match exactly the name of the pass that is accessing the option, but of a class of passes. For instance, the
- * option parser.filename can be used by all parsing passes, not just the pass called 'parser'.</p>
+ * A writeable (mutable) extension of [[PassOptions]]
  *
- * <p>This class is used only internally. When you implement your own pass, use the trait PassOptions.</p>
+ * This class is used only internally. When you implement your own pass, use the trait [[PassOptions]].
  *
  * @author
  *   Igor Konnov

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -32,7 +32,7 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
       val environment = if (env != "") s"(${env}) " else ""
       s"Checker options: ${environment}${name} ${invocation}"
     }
-    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
+    executor.passOptions.set("parser.source", SourceOption.FileSource(file.getAbsoluteFile))
     if (config != "")
       executor.passOptions.set("checker.config", config)
     if (init != "")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -32,7 +32,7 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
       val environment = if (env != "") s"(${env}) " else ""
       s"Checker options: ${environment}${name} ${invocation}"
     }
-    executor.passOptions.set("parser.source", SourceOption.File(file))
+    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
     if (config != "")
       executor.passOptions.set("checker.config", config)
     if (init != "")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -4,6 +4,7 @@ import org.backuity.clist.{arg, opt}
 
 import java.io.File
 import com.typesafe.scalalogging.LazyLogging
+import at.forsyte.apalache.infra.passes.SourceOption
 
 // Holds the minimal necessary info about a specification.
 abstract class AbstractCheckerCmd(val name: String, description: String)
@@ -31,7 +32,7 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
       val environment = if (env != "") s"(${env}) " else ""
       s"Checker options: ${environment}${name} ${invocation}"
     }
-    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    executor.passOptions.set("parser.source", SourceOption.File(file))
     if (config != "")
       executor.passOptions.set("checker.config", config)
     if (init != "")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -26,7 +26,7 @@ class ParseCmd
   def run() = {
     logger.info("Parse " + file)
 
-    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
+    executor.passOptions.set("parser.source", SourceOption.FileSource(file.getAbsoluteFile))
     output.foreach(executor.passOptions.set("io.output", _))
 
     setCommonOptions()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -26,7 +26,7 @@ class ParseCmd
   def run() = {
     logger.info("Parse " + file)
 
-    executor.passOptions.set("parser.source", SourceOption.File(file))
+    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
     output.foreach(executor.passOptions.set("io.output", _))
 
     setCommonOptions()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -6,6 +6,7 @@ import org.backuity.clist._
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.Executor
 import at.forsyte.apalache.tla.imp.passes.ParserModule
+import at.forsyte.apalache.infra.passes.SourceOption
 
 /**
  * This command initiates the 'parse' command line.
@@ -25,7 +26,7 @@ class ParseCmd
   def run() = {
     logger.info("Parse " + file)
 
-    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    executor.passOptions.set("parser.source", SourceOption.File(file))
     output.foreach(executor.passOptions.set("io.output", _))
 
     setCommonOptions()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -44,7 +44,7 @@ class TestCmd
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
     executor.passOptions.set("general.tuning", tuning)
-    executor.passOptions.set("parser.source", SourceOption.File(file))
+    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
     executor.passOptions.set("checker.init", before)
     executor.passOptions.set("checker.next", action)
     executor.passOptions.set("checker.inv", List(assertion))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -44,7 +44,7 @@ class TestCmd
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
     executor.passOptions.set("general.tuning", tuning)
-    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
+    executor.passOptions.set("parser.source", SourceOption.FileSource(file.getAbsoluteFile))
     executor.passOptions.set("checker.init", before)
     executor.passOptions.set("checker.next", action)
     executor.passOptions.set("checker.inv", List(assertion))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -6,6 +6,7 @@ import java.io.File
 import at.forsyte.apalache.infra.Executor
 import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
 import com.typesafe.scalalogging.LazyLogging
+import at.forsyte.apalache.infra.passes.SourceOption
 
 /**
  * This command initiates the 'test' command line.
@@ -43,7 +44,7 @@ class TestCmd
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
     executor.passOptions.set("general.tuning", tuning)
-    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    executor.passOptions.set("parser.source", SourceOption.File(file))
     executor.passOptions.set("checker.init", before)
     executor.passOptions.set("checker.next", action)
     executor.passOptions.set("checker.inv", List(assertion))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -6,6 +6,7 @@ import org.backuity.clist._
 import at.forsyte.apalache.infra.Executor
 import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
 import com.typesafe.scalalogging.LazyLogging
+import at.forsyte.apalache.infra.passes.SourceOption
 
 /**
  * This command initiates the 'typecheck' command line.
@@ -26,7 +27,7 @@ class TypeCheckCmd
 
   override def run() = {
     logger.info("Type checking " + file)
-    executor.passOptions.set("parser.filename", file.getAbsolutePath)
+    executor.passOptions.set("parser.source", SourceOption.File(file))
     output.foreach(executor.passOptions.set("io.output", _))
     executor.passOptions.set("typechecker.inferPoly", inferPoly)
     setCommonOptions()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -27,7 +27,7 @@ class TypeCheckCmd
 
   override def run() = {
     logger.info("Type checking " + file)
-    executor.passOptions.set("parser.source", SourceOption.File(file))
+    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
     output.foreach(executor.passOptions.set("io.output", _))
     executor.passOptions.set("typechecker.inferPoly", inferPoly)
     setCommonOptions()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -27,7 +27,7 @@ class TypeCheckCmd
 
   override def run() = {
     logger.info("Type checking " + file)
-    executor.passOptions.set("parser.source", SourceOption.File(file.getAbsoluteFile))
+    executor.passOptions.set("parser.source", SourceOption.FileSource(file.getAbsoluteFile))
     output.foreach(executor.passOptions.set("io.output", _))
     executor.passOptions.set("typechecker.inferPoly", inferPoly)
     setCommonOptions()

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -84,7 +84,7 @@ class SanyParserPassImpl @Inject() (
   }
 
   override def execute(module: TlaModule): PassResult = {
-    val source = options.getOrError[SourceOption.T]("parser", "source")
+    val source = options.getOrError[SourceOption]("parser", "source")
     for {
       rootModule <-
         source match {

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -88,9 +88,9 @@ class SanyParserPassImpl @Inject() (
     for {
       rootModule <-
         source match {
-          case SourceOption.String(content) =>
+          case SourceOption.StringSource(content) =>
             loadFromTlaString(content)
-          case SourceOption.File(file) =>
+          case SourceOption.FileSource(file) =>
             if (file.getName().endsWith(".json")) {
               loadFromJsonFile(file)
             } else {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -147,7 +147,7 @@ class ConfigurationPassImpl @Inject() (
     var configuredModule = module
     // read a TLC config if it was passed by the user
     val configFilename = options.getOrElse[String]("checker", "config", "")
-    options.getOrError[SourceOption.T]("parser", "source") match {
+    options.getOrError[SourceOption]("parser", "source") match {
       case SourceOption.StringSource(_) =>
         // NOTE: Implicit loading of .cfg files not supported when loading from a string
         ()

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -148,10 +148,10 @@ class ConfigurationPassImpl @Inject() (
     // read a TLC config if it was passed by the user
     val configFilename = options.getOrElse[String]("checker", "config", "")
     options.getOrError[SourceOption.T]("parser", "source") match {
-      case SourceOption.String(_) =>
+      case SourceOption.StringSource(_) =>
         // NOTE: Implicit loading of .cfg files not supported when loading from a string
         ()
-      case SourceOption.File(f) =>
+      case SourceOption.FileSource(f) =>
         if (configFilename.isEmpty) {
           // The older versions of apalache were loading a TLC config file of the same basename as the spec.
           // We have flipped this behavior in version 0.25.0.


### PR DESCRIPTION
## Changes

The key change here is to replace the "filename" option, storing a
string, with an instance of the newly added `SourceOption` class, that
lets us statically encode a data source which is (currently] either a
file or a string.

## Context

The immediate use for this will be supporting Shai to load modules from
a string (while maximizing code reuse), but this could also be used
to read in specs (or other data) from stdin or a socket etc.

This change, again, aims to be minimally invasive while extending functionality
in generally (and specifically) useful ways. As such, no tests are included
here, since no new functionality is yet exposed (i.e., the PR doesn't expose the
ability to load specs from stdin).

Tests to exercise the relevant portion in the `SanyParserPassImpl` will be
forthcoming in #1855.

## Reviewing

This is a small changeset, but reviewing by commit should make it even easier to review.

---

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased