### PR TITLE
Typed Builder implementation Part 8.1: Uninterpreted constants

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/LiteralAndNameBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/LiteralAndNameBuilder.scala
@@ -23,6 +23,12 @@ trait LiteralAndNameBuilder extends UnsafeLiteralAndNameBuilder {
   /** b: Bool */
   def bool(b: Boolean): TBuilderInstruction = _bool(b).point[TBuilderInternalState]
 
+  /** root_OF_A : A */
+  def const(root: String, A: ConstT1): TBuilderInstruction = _const(root, A).point[TBuilderInternalState]
+
+  /** v : A */
+  def const(v: String): TBuilderInstruction = _const(v).point[TBuilderInternalState]
+
   /** BOOLEAN */
   def booleanSet(): TBuilderInstruction = _booleanSet().point[TBuilderInternalState]
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/LiteralAndNameBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/LiteralAndNameBuilder.scala
@@ -27,7 +27,7 @@ trait LiteralAndNameBuilder extends UnsafeLiteralAndNameBuilder {
   def const(root: String, A: ConstT1): TBuilderInstruction = _const(root, A).point[TBuilderInternalState]
 
   /** v : A */
-  def const(v: String): TBuilderInstruction = _const(v).point[TBuilderInternalState]
+  def constParsed(v: String): TBuilderInstruction = _constParsed(v).point[TBuilderInternalState]
 
   /** BOOLEAN */
   def booleanSet(): TBuilderInstruction = _booleanSet().point[TBuilderInternalState]

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeLiteralAndNameBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeLiteralAndNameBuilder.scala
@@ -38,7 +38,7 @@ trait UnsafeLiteralAndNameBuilder {
   }
 
   /** v : A */
-  protected def _const(v: String): TlaEx = {
+  protected def _constParsed(v: String): TlaEx = {
     if (!ModelValueHandler.isModelValue(v))
       throw new TBuilderTypeException(
           s"$v represents a string, not a value of an uninterpreted sort. Use [str] instead."

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestLiteralAndNameBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestLiteralAndNameBuilder.scala
@@ -25,14 +25,14 @@ class TestLiteralAndNameBuilder extends BuilderTest {
 
     assert(trueEx.eqTyped(ValEx(TlaBool(true))(Typed(BoolT1))))
 
-    val v1: TlaEx = builder.const("v_OF_A")
+    val v1: TlaEx = builder.constParsed("v_OF_A")
     val v2: TlaEx = builder.const("v", ConstT1("A"))
 
     assert(v1.eqTyped(v2))
     assert(v2.eqTyped(ValEx(TlaStr("v_OF_A"))(Typed(ConstT1("A")))))
 
     assertThrows[TBuilderTypeException] {
-      build(builder.const("x"))
+      build(builder.constParsed("x"))
     }
     assertThrows[TBuilderTypeException] {
       build(builder.const("1_OF_A", ConstT1("A")))

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestLiteralAndNameBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestLiteralAndNameBuilder.scala
@@ -10,20 +10,36 @@ class TestLiteralAndNameBuilder extends BuilderTest {
 
   test("literals") {
 
-    val oneW = builder.int(1)
-    val oneEx: TlaEx = build(oneW)
+    val oneEx: TlaEx = builder.int(1)
 
     assert(oneEx.eqTyped(ValEx(TlaInt(1))(Typed(IntT1))))
 
-    val xW = builder.str("x")
-    val xEx: TlaEx = build(xW)
+    val xEx: TlaEx = builder.str("x")
 
     assert(xEx.eqTyped(ValEx(TlaStr("x"))(Typed(StrT1))))
+    assertThrows[TBuilderTypeException] {
+      build(builder.str("1_OF_X"))
+    }
 
-    val trueW = builder.bool(true)
-    val trueEx: TlaEx = build(trueW)
+    val trueEx: TlaEx = builder.bool(true)
 
     assert(trueEx.eqTyped(ValEx(TlaBool(true))(Typed(BoolT1))))
+
+    val v1: TlaEx = builder.const("v_OF_A")
+    val v2: TlaEx = builder.const("v", ConstT1("A"))
+
+    assert(v1.eqTyped(v2))
+    assert(v2.eqTyped(ValEx(TlaStr("v_OF_A"))(Typed(ConstT1("A")))))
+
+    assertThrows[TBuilderTypeException] {
+      build(builder.const("x"))
+    }
+    assertThrows[TBuilderTypeException] {
+      build(builder.const("1_OF_A", ConstT1("A")))
+    }
+    assertThrows[TBuilderTypeException] {
+      build(builder.const("1_OF_A", ConstT1("B")))
+    }
 
   }
 


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to [./unreleased/][unreleased] for any new functionality

closes #1918

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
