### PR TITLE
Add manual page on variants

### DIFF
--- a/.unreleased/documentation/1930.md
+++ b/.unreleased/documentation/1930.md
@@ -1,1 +1,1 @@
-add manual page on variants
+Add manual page on new variant types (see #1930)

--- a/.unreleased/documentation/1930.md
+++ b/.unreleased/documentation/1930.md
@@ -1,0 +1,1 @@
+add manual page on variants

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -54,9 +54,6 @@
 # TLA+ Language Manual for Engineers
 
 - [Introduction](./lang/index.md)
-- [Apalache extensions](./lang/apalache-extensions.md)
-  - [Apalache module](./lang/apalache-operators.md)
-  - [Variants](./lang/variants.md)
 - [The standard operators of TLA+](./lang/standard-operators.md)
     - [Booleans](./lang/booleans.md)
     - [Control And Nondeterminism](./lang/control-and-nondeterminism.md)
@@ -69,6 +66,9 @@
     - [Tuples](./lang/tuples.md)
     - [Sequences](./lang/sequences.md)
     - [Bags]()
+- [Apalache extensions](./lang/apalache-extensions.md)
+  - [Apalache module](./lang/apalache-operators.md)
+  - [Variants](./lang/variants.md)
 - [User-defined operators](./lang/user-operators.md)
     - [Top-level operator definitions](./lang/user/top-level-operators.md)
     - [LET-IN definitions](./lang/user/let-in.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -54,6 +54,9 @@
 # TLA+ Language Manual for Engineers
 
 - [Introduction](./lang/index.md)
+- [Apalache extensions](./lang/apalache-extensions.md)
+  - [Apalache module](./lang/apalache-operators.md)
+  - [Variants](./lang/variants.md)
 - [The standard operators of TLA+](./lang/standard-operators.md)
     - [Booleans](./lang/booleans.md)
     - [Control And Nondeterminism](./lang/control-and-nondeterminism.md)
@@ -72,7 +75,6 @@
     - [Higher-order operators definitions](./lang/user/higher-order-operators.md)
     - [Anonymous operator definitions](./lang/user/lambdas.md)
     - [Local operator definitions](./lang/user/local-operators.md)
-- [Apalache operators](./lang/apalache-operators.md)
 - [Modules, Extends, and Instances]()
 
 # Idiomatic TLA+

--- a/docs/src/lang/apalache-extensions.md
+++ b/docs/src/lang/apalache-extensions.md
@@ -1,0 +1,14 @@
+# Apalache extensions
+
+Apalache provides the user with several TLA+ modules. These modules introduce
+TLA+ operators to allow for more efficient model checking with Apalache. Since
+our users may run Apalache and TLC interchangeably, the modules contain the
+default definitions that are compatible with TLC. Apalache treats the operators
+defined in these modules more efficiently than if it was using the default
+definitions.
+
+Currently supported modules:
+
+ - [Apalache module](./apalache-operators.md)
+ - [Variants](./variants.md)
+

--- a/docs/src/lang/apalache-extensions.md
+++ b/docs/src/lang/apalache-extensions.md
@@ -2,9 +2,9 @@
 
 Apalache provides the user with several TLA+ modules. These modules introduce
 TLA+ operators to allow for more efficient model checking with Apalache. Since
-our users may run Apalache and TLC interchangeably, the modules contain the
-default definitions that are compatible with TLC. Apalache treats the operators
-defined in these modules more efficiently than if it was using the default
+our users may run Apalache and TLC interchangeably, the modules contain
+default definitions in TLA+ that are compatible with TLC. Apalache overrides
+these definitions internally for more efficient treatment compared to the default TLA+
 definitions.
 
 Currently supported modules:

--- a/docs/src/lang/variants.md
+++ b/docs/src/lang/variants.md
@@ -186,8 +186,7 @@ an invariant violation and will lead to a spurious counterexample.
 Note that `tagName` is an identifier in this notation. In this type, `b` is a
 type variable that captures other options in the variant type.
 
-**Effect:** The variant constructor returns a new value that keeps the
-pair `(tagName, associatedValue)`.
+**Effect:** The variant constructor returns a new value of the variant type.
 
 **Determinism:** Deterministic.
 

--- a/docs/src/lang/variants.md
+++ b/docs/src/lang/variants.md
@@ -191,6 +191,32 @@ Beer(malt, strength) == Variant("Beer", [ malt |-> malt, strength |-> strength ]
 
 ----------------------------------------------------------------------------
 
+<a name="variantTag"></a>
+### Variant tag
+
+**Notation:** `VariantTag(variant)`
+
+**LaTeX notation:** same
+
+**Arguments:** One argument: a variant constructed via `Variant`.
+
+**Apalache type:** `(tagName(a) | b => Str)`, for some types `a`
+and `b`. Note that `tagName` is an identifier in this notation.
+
+**Effect:** This operator simply returns the tag attached to the variant.
+
+**Determinism:** Deterministic.
+
+**Errors:** No errors.
+
+**Example in TLA+:**
+
+```tla
+VariantTag(Variant("Water", [ sparkling |-> sparkling ])) = "Water"
+```
+
+----------------------------------------------------------------------------
+
 <a name="variantFilter"></a>
 ### Variant filter
 

--- a/docs/src/lang/variants.md
+++ b/docs/src/lang/variants.md
@@ -8,9 +8,8 @@ support in Apalache, pass the option `--features=rows`.
 [Variants][] (also called *tagged unions* or *sum types*) are useful, when you want to combine
 values of different shapes in a single set or a sequence.
 
-**Idiomatic tagged unions in untyped TLA+.** In untyped TLA+, one can simply
-pack a value into a record and add an additional tag field. For instance, we
-could create a set that contains two records of different shapes:
+**Idiomatic tagged unions in untyped TLA+.** In untyped TLA+, one can construct sets, which contain records with different fields, where one filed is typically used as a disambiguation tag. 
+For instance, we could create a set that contains two records of different shapes:
 
 ```tla
 ApplesAndOranges == {
@@ -19,7 +18,7 @@ ApplesAndOranges == {
   }
 ```
 
-Now we can unpack the elements of `ApplesAndOranges` based on their tag:
+We can dynamically reason about the elements of `ApplesAndOranges` based on their tag:
 
 ```tla
   \E e \in ApplesAndOranges:
@@ -28,9 +27,13 @@ Now we can unpack the elements of `ApplesAndOranges` based on their tag:
 ```
 
 This idiom is quite common in untyped TLA+. [Tagged unions in Paxos][] is
-probably the most illuminating example of this idiom. Unfortunately, it is way
-too easy to make a typo in the tag name, since it is a string, or simply access
-a wrong record without checking its tag.
+probably the most illuminating example of this idiom. 
+Unfortunately, it is way too easy to make a typo in the tag name, since it is a string, or simply access a field, which records marked with the given tag do not have. For example,
+\`\`\`tla
+  \E e \in ApplesAndOranges:
+    /\ e.tag = "Apple"
+    /\ e.seedless
+\`\`\`
 
 **Variants module.** Apalache formalizes the above idiom in the module
 [Variants.tla][]. Apalache's type checker alerts users with a type error when
@@ -134,7 +137,7 @@ default case and returns the record `[ malt |-> "Non-alcoholic", strength |->
 0]`.
 
 **Type-unsafe get.** Sometimes, using `VariantFilter` and `VariantGetOrElse`
-is a nuisance, when we know exactly the value type. In this case, we can bypass
+is a nuisance, when we know the exact value type. In this case, we can bypass
 the type checker and get the value notwithstanding the tag:
 
 ```tla
@@ -316,7 +319,7 @@ constructed via `Variant`.
 **Effect:** The operator `VariantGetUnsafe` unconditionally returns some value
 that is compatible with the type of values tagged with `tagName`. If `variant`
 is tagged with `tagName`, the returned value is the value that was wrapped via
-the `Variant` constructor. Otherwise, it is some value of proper type. As such,
+the `Variant` constructor. Otherwise, it is some arbitrary value of proper type. As such,
 this operator does not guarantee that the retrieved value is always constructed
 via `Variant`, unless the operator is used with the right tag.
 


### PR DESCRIPTION
Closes #1923. Add the manual page on variants.

- [x] Documentation added for any new functionality
- [x] Entries added to [./unreleased/][unreleased] for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
