### PR TITLE
Support loading auxiliary modules from Source

### DIFF
--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/SourceOption.scala
@@ -8,6 +8,13 @@ object SourceOption {
   /** Data to be loaded from a file */
   final case class FileSource(file: java.io.File) extends SourceOption
 
-  /** Data supplied as a string */
-  final case class StringSource(content: String) extends SourceOption
+  /**
+   * Data supplied as a string
+   *
+   * @param content
+   *   the principle data source
+   * @param aux
+   *   auxiliary data sources
+   */
+  final case class StringSource(content: String, aux: Seq[String] = Seq()) extends SourceOption
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -102,8 +102,8 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
   }
 
   /**
-   * Load a TLA+ specification from a text source. This method creates a temporary file and saves the source's contents
-   * into it, in order to call SANY.
+   * Load a TLA+ specification from a text source, possibly including auxiliary modules needed for imports. This method
+   * creates temporary files and saves the sources contents into it, in order to call SANY.
    *
    * @param source
    *   the text source for the root module

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success, Try}
  * This is the entry point for parsing TLA+ code with SANY and constructing an intermediate representation.
  *
  * @author
- *   Igor Konnov, Thomas Pani
+ *   Igor Konnov, Thomas Pani, Shon Feder
  */
 class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) extends LazyLogging {
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -87,20 +87,6 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
     (specObj.getName, modmap)
   }
 
-  // Regex to match the module line and capture the module name
-  val MODULE_LINE_RE = """-+ +MODULE +(\w*) -+""".r
-
-  // Extract the name of a module from the source specifying it
-  // This function copies the Source [s] and doesn't consume it.
-  def moduleNameOfSource(s: Source): Option[String] = {
-    // Copy the source so we don't consume iterator
-    val copy = s.reset()
-    copy.getLines().find(MODULE_LINE_RE.matches(_)).flatMap {
-      case MODULE_LINE_RE(name) => Some(name)
-      case _                    => None
-    }
-  }
-
   /**
    * Load a TLA+ specification from a text source, possibly including auxiliary modules needed for imports. This method
    * creates temporary files and saves the sources contents into it, in order to call SANY.
@@ -120,6 +106,20 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
       loadFromFile(rootModule)
     } finally {
       tempDir.delete()
+    }
+  }
+
+  // Regex to match the module line and capture the module name
+  private val MODULE_LINE_RE = """-+ +MODULE +(\w*) -+""".r
+
+  // Extract the name of a module from the source specifying it
+  // This function copies the Source [s] and doesn't consume it.
+  private def moduleNameOfSource(s: Source): Option[String] = {
+    // Copy the source so we don't consume iterator
+    val copy = s.reset()
+    copy.getLines().find(MODULE_LINE_RE.matches(_)).flatMap {
+      case MODULE_LINE_RE(name) => Some(name)
+      case _                    => None
     }
   }
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -58,10 +58,10 @@ class SanyParserPassImpl @Inject() (
     Right(modules.get(rootName).get)
   }
 
-  private def loadFromTlaString(content: String): PassResult = {
+  private def loadFromTlaString(content: String, aux: Seq[String]): PassResult = {
     val (rootName, modules) =
       new SanyImporter(sourceStore, annotationStore)
-        .loadFromSource(Source.fromString(content))
+        .loadFromSource(Source.fromString(content), aux.map(Source.fromString(_)))
     Right(modules.get(rootName).get)
   }
 
@@ -88,8 +88,8 @@ class SanyParserPassImpl @Inject() (
     for {
       rootModule <-
         source match {
-          case SourceOption.StringSource(content) =>
-            loadFromTlaString(content)
+          case SourceOption.StringSource(content, aux) =>
+            loadFromTlaString(content, aux)
           case SourceOption.FileSource(file) =>
             if (file.getName().endsWith(".json")) {
               loadFromJsonFile(file)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -148,7 +148,7 @@ class ConfigurationPassImpl @Inject() (
     // read a TLC config if it was passed by the user
     val configFilename = options.getOrElse[String]("checker", "config", "")
     options.getOrError[SourceOption]("parser", "source") match {
-      case SourceOption.StringSource(_) =>
+      case SourceOption.StringSource(_, _) =>
         // NOTE: Implicit loading of .cfg files not supported when loading from a string
         ()
       case SourceOption.FileSource(f) =>


### PR DESCRIPTION
Supports #1114

The server API is able must support load a model by receiving a string
representing the root module and a sequence of strings representing any
auxiliary modules needed due to imports or refinement. This changeset extends
our SanyParser wrapper to support loading auxiliary modules supplied as a
sequence of `scala.io.Source`s.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased