### PR TITLE
Introduce VariantTag and remove VariantUnwrap

### DIFF
--- a/src/tla/Variants.tla
+++ b/src/tla/Variants.tla
@@ -41,24 +41,18 @@ VariantFilter(__tagName, __S) ==
     { __d \in { __e \in __S: __e.tag = __tagName }: __d.value }
 
 (**
- * In cases where `variant` allows for one value,
- * extract the associated value and return it.
- * The type checker must enforce that `variant` allows for one option.
+ * Get the tag name that is associated with a variant.
  *
- * @param `tagValue` the tag attached to the variant
  * @param `variant` a variant that is constructed with `Variant(...)`
- * @return the value extracted from the variant
+ * @return the tag name associated with a variant
  *
- * Its type could look like follows:
+ * Its type is as follows:
  *
- *   (Str, Tag(a)) => a
+ *   Variant(a) => Str
  *)
-VariantUnwrap(__tagName, __variant) ==
+VariantTag(__variant) ==
     \* default untyped implementation
-    IF __variant.tag = __tagName
-    THEN __variant.value
-    ELSE \* trigger an error in TLC by choosing a non-existent element
-         CHOOSE x \in { __variant }: x.tag = __tagName
+    __variant.tag
 
 (**
  * Return the value associated with the tag, when the tag equals to __tagName.

--- a/test/tla/TestVariants.tla
+++ b/test/tla/TestVariants.tla
@@ -33,10 +33,8 @@ TestVariantFilter ==
     \E v \in VariantFilter("B", { VarA, VarB }):
         v.value = "hello"
 
-TestVariantUnwrap ==
-    \* We could just pass "world", without wrapping it in a record.
-    \* But we want to see how it works with records too.
-    VariantUnwrap("C", VarC) = [ value |-> "world" ]
+TestVariantTag ==
+    VariantTag(VarC) = "C"
 
 TestVariantGetUnsafe ==
     \* The unsafe version gives us only a type guarantee.
@@ -49,7 +47,7 @@ TestVariantGetOrElse ==
 AllTests ==
     /\ TestVariant
     /\ TestVariantFilter
-    /\ TestVariantUnwrap
+    /\ TestVariantTag
     /\ TestVariantGetUnsafe
     /\ TestVariantGetOrElse
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -180,8 +180,7 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
 
   private def decodeVariantToTlaEx(arena: Arena, cell: ArenaCell, options: SortedMap[String, TlaType1]): TlaEx = {
     val tagName = decodeCellToTlaEx(arena, recordOps.getVariantTag(arena, cell)) match {
-      case ValEx(TlaStr(name)) if ModelValueHandler.isModelValue(name) =>
-        ModelValueHandler.typeAndIndex(name).get._2
+      case ValEx(TlaStr(name)) => name
 
       case e => throw new RewriterException(s"Expected a tag name in a variant $cell, found: $e", NullEx)
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -287,7 +287,7 @@ class SymbStateRewriterImpl(
           -> List(new VariantOpsRule(this)),
         key(tla.variantGetOrElse("Tag", tla.name("V"), tla.name("def")))
           -> List(new VariantOpsRule(this)),
-        key(tla.variantUnwrap("Tag", tla.name("V")))
+        key(tla.variantTag(tla.name("V")))
           -> List(new VariantOpsRule(this)),
         key(tla.variantFilter("Tag", tla.name("S")))
           -> List(new VariantOpsRule(this)),

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/VariantOpsRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/VariantOpsRule.scala
@@ -2,7 +2,6 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.RecordAndVariantOps
-import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.VariantOper
 import at.forsyte.apalache.tla.lir.values.TlaStr
@@ -118,20 +117,5 @@ class VariantOpsRule(rewriter: SymbStateRewriter) extends RewritingRule {
     val nextState = rewriter.rewriteUntilDone(state.setRex(variantEx))
     val tag = variantOps.getVariantTag(nextState.arena, nextState.asCell)
     nextState.setRex(tag.toBuilder)
-  }
-
-  // make sure that the expression is a variant that has only one option
-  private def assertSingletonVariant(variantEx: TlaEx) = {
-    def errorMsg(vt: TlaType1) = new TypingException(s"Expected a singleton variant, found: $vt", variantEx.ID)
-
-    variantEx.typeTag.asTlaType1() match {
-      case vt @ VariantT1(RowT1(fieldTypes, None)) =>
-        if (fieldTypes.size == 1) {
-          errorMsg(vt)
-        }
-
-      case vt =>
-        errorMsg(vt)
-    }
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.rules.aux.RecordAndVariantOps.tagSort
 import at.forsyte.apalache.tla.bmcmt.{Arena, ArenaCell, RewriterException, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir._
 
@@ -92,7 +91,7 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
       case variantT @ VariantT1(RowT1(options, None)) if options.nonEmpty =>
         // it would be better to call RecordAndVariantOps.makeVariant, but that would produce a circular dependency
         val tagName = options.head._1
-        val (arena2, tagAsCell) = rewriter.modelValueCache.getOrCreate(arena, (tagSort, tagName))
+        val (arena2, tagAsCell) = rewriter.modelValueCache.getOrCreate(arena, (StrT1.toString, tagName))
         var nextArena = arena2
         // introduce default values for all variant options
         val variantValues = options.map { case (t, tp) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/RecordAndVariantOps.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/RecordAndVariantOps.scala
@@ -1,12 +1,10 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.rules.aux.RecordAndVariantOps.tagSort
 import at.forsyte.apalache.tla.bmcmt.types.CellTFrom
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
-import at.forsyte.apalache.tla.typecheck.ModelValueHandler
 
 import scala.collection.immutable.SortedMap
 
@@ -68,7 +66,7 @@ class RecordAndVariantOps(rewriter: SymbStateRewriter) {
    *   a new symbolic state that contains the constructed tag cell as an expression
    */
   def getOrCreateVariantTag(state: SymbState, tagName: String): SymbState = {
-    val (newArena, tagAsCell) = rewriter.modelValueCache.getOrCreate(state.arena, (tagSort, tagName))
+    val (newArena, tagAsCell) = rewriter.modelValueCache.getOrCreate(state.arena, (StrT1.toString, tagName))
     state.setArena(newArena).setRex(tagAsCell.toNameEx)
   }
 
@@ -201,7 +199,7 @@ class RecordAndVariantOps(rewriter: SymbStateRewriter) {
     val tagCell = getVariantTag(state.arena, variantCell)
     val unsafeValueCell = getUnsafeVariantValue(state.arena, variantCell, tagName)
     // IF variant.__tag = tagName THEN variant.__value ELSE defaultValue
-    val tagNameOfSort = tla.str(ModelValueHandler.construct((tagSort, tagName))).as(ConstT1(tagSort))
+    val tagNameOfSort = tla.str(tagName).as(StrT1)
     val ite =
       tla
         .ite(tla.eql(tagCell.toNameEx, tagNameOfSort).as(BoolT1), unsafeValueCell.toNameEx, defaultValue.toNameEx)
@@ -356,9 +354,4 @@ object RecordAndVariantOps {
    * The name of the hidden tag field that is attached to every variant.
    */
   val variantTagField = "__tag"
-
-  /**
-   * The uninterpreted sort to use for storing the tag values.
-   */
-  val tagSort = "__TAG"
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
@@ -104,7 +104,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
 
   private def genVariant(state: SymbState, options: SortedMap[String, TlaType1]): SymbState = {
     // generate the tag name
-    var nextState = genBasic(state, ConstT1(RecordAndVariantOps.tagSort))
+    var nextState = genBasic(state, StrT1)
     val tagCell = nextState.asCell
     // assert that one of the options is selected
     val tags = options.keys.map { name =>

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterVariant.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterVariant.scala
@@ -8,7 +8,6 @@ import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.convenience.tla._
 
 trait TestSymbStateRewriterVariant extends RewriterBase {
-  private val tagSort = "__TAG"
   private val parser = DefaultType1Parser
   private val fieldA = int(33).typed()
 
@@ -24,7 +23,7 @@ trait TestSymbStateRewriterVariant extends RewriterBase {
     assert(variantT == cell.cellType.toTlaType1)
 
     expectTaggedValue(rewriter, nextState, cell, "Foo", fieldA)
-    expectTaggedValue(rewriter, nextState, cell, "__tag", tla.str(s"Foo_OF_${tagSort}").as(ConstT1(tagSort)))
+    expectTaggedValue(rewriter, nextState, cell, "__tag", tla.str(s"Foo").as(StrT1))
   }
 
   test("""Variant equality""") { rewriterType: SMTEncoding =>
@@ -103,11 +102,11 @@ trait TestSymbStateRewriterVariant extends RewriterBase {
     assertTlaExAndRestore(rewriter, state)
   }
 
-  test("""VariantUnwrap""") { rewriterType: SMTEncoding =>
+  test("""VariantTag""") { rewriterType: SMTEncoding =>
     val variantT = parser("Foo(Int)")
     val vrt1 = variant("Foo", int(33)).as(variantT)
-    val only = variantUnwrap("Foo", vrt1).as(IntT1)
-    val eq = eql(only, int(33)).as(BoolT1)
+    val tag = variantTag(vrt1).as(StrT1)
+    val eq = eql(tag, str("Foo")).as(BoolT1)
 
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/StandardLibrary.scala
@@ -70,7 +70,7 @@ object StandardLibrary {
         // Variants
         ("Variants", "Variant") -> VariantOper.variant,
         ("Variants", "VariantFilter") -> VariantOper.variantFilter,
-        ("Variants", "VariantUnwrap") -> VariantOper.variantUnwrap,
+        ("Variants", "VariantTag") -> VariantOper.variantTag,
         ("Variants", "VariantGetUnsafe") -> VariantOper.variantGetUnsafe,
         ("Variants", "VariantGetOrElse") -> VariantOper.variantGetOrElse,
         // internal modules

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
@@ -571,9 +571,9 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |\* @type: Set(T1a({ val: Int, found: Bool) | T2a({ bal: Int })) => Set({ val: Int, found: Bool });
         |TestVariantFilter == VariantFilter("T1a", { TestVariant })
         |
-        |\* @type: T1a({ val: Int, found: Bool }) => { val: Int, found: Bool };
-        |TestVariantUnwrap(var) ==
-        |  VariantUnwrap("T1a", var)
+        |\* @type: T1a({ val: Int, found: Bool }) => Str;
+        |TestVariantTag(var) ==
+        |  VariantTag(var)
         |
         |\* @type: T1a({ val: Int, found: Bool }) => { val: Int, found: Bool };
         |TestVariantGetUnsafe(var) ==
@@ -619,17 +619,16 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         ),
     )
 
-    // TestVariantUnwrap(var) ==
-    //   VariantUnwrap("T1a", var)
+    // TestVariantTag(var) ==
+    //   VariantTag("T1a", var)
     val applyMatchOnly =
       OperEx(
-          VariantOper.variantUnwrap,
-          str("T1a"),
+          VariantOper.variantTag,
           name("var"),
       )
 
     expectDecl(
-        "TestVariantUnwrap",
+        "TestVariantTag",
         applyMatchOnly,
         OperParam("var"),
     )

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -785,20 +785,13 @@ class ToEtcExpr(
       case ex @ OperEx(VariantOper.variantFilter, tag @ _, _) =>
         throw new TypingInputException(s"The first argument of VariantFilter must be a string, found: $tag", ex.ID)
 
-      case OperEx(VariantOper.variantUnwrap, v @ ValEx(TlaStr(tagName)), variantEx) =>
+      case OperEx(VariantOper.variantTag, variantEx) =>
         val a = varPool.fresh
-        // (Str, T1a(a)) => a
-        val operArgs =
-          Seq(
-              StrT1,
-              VariantT1(RowT1(tagName -> a)),
-          )
+        // Variant(a) => Str
+        val operArgs = Seq(VariantT1(RowT1(a)))
 
         val opsig = OperT1(operArgs, a)
-        mkExRefApp(opsig, Seq(v, variantEx))
-
-      case OperEx(VariantOper.variantUnwrap, tag @ _, _) =>
-        throw new TypingInputException(s"The first argument of VariantGetOnly must be a string, found: $tag", ex.ID)
+        mkExRefApp(opsig, Seq(variantEx))
 
       case OperEx(VariantOper.variantGetUnsafe, v @ ValEx(TlaStr(tagName)), variantEx) =>
         val a = varPool.fresh

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -790,7 +790,7 @@ class ToEtcExpr(
         // Variant(a) => Str
         val operArgs = Seq(VariantT1(RowT1(a)))
 
-        val opsig = OperT1(operArgs, a)
+        val opsig = OperT1(operArgs, StrT1)
         mkExRefApp(opsig, Seq(variantEx))
 
       case OperEx(VariantOper.variantGetUnsafe, v @ ValEx(TlaStr(tagName)), variantEx) =>

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -392,7 +392,7 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
   }
 
   test("""VariantTag("T1a", v)""") {
-    val operType = parser(s"""Variant(a) => a""")
+    val operType = parser(s"""Variant(a) => Str""")
     val expected = mkUniqApp(Seq(operType), mkUniqName("v"))
     val matchEx = tla.variantTag(tla.name("v"))
     val produced = gen(matchEx)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -391,10 +391,10 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
     }
   }
 
-  test("""VariantUnwrap("T1a", v)""") {
-    val operType = parser(s"""(Str, T1a(a)) => a""")
-    val expected = mkUniqApp(Seq(operType), mkUniqConst(StrT1), mkUniqName("v"))
-    val matchEx = tla.variantUnwrap("T1a", tla.name("v"))
+  test("""VariantTag("T1a", v)""") {
+    val operType = parser(s"""Variant(a) => a""")
+    val expected = mkUniqApp(Seq(operType), mkUniqName("v"))
+    val matchEx = tla.variantTag(tla.name("v"))
     val produced = gen(matchEx)
     produced should equal(expected)
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -697,19 +697,15 @@ class Builder {
   }
 
   /**
-   * Match a variant that admits only one option (one tag)
+   * Get the tag name associated with a variant.
    *
-   * @param tagName
-   *   a tag value (string)
    * @param variantEx
    *   a variant expression
    * @return
-   *   the value extracted from the variant
+   *   the tag name associated with the variant
    */
-  def variantUnwrap(
-      tagName: String,
-      variantEx: BuilderEx): BuilderEx = {
-    BuilderOper(VariantOper.variantUnwrap, str(tagName), variantEx)
+  def variantTag(variantEx: BuilderEx): BuilderEx = {
+    BuilderOper(VariantOper.variantTag, variantEx)
   }
 
   /**
@@ -843,7 +839,7 @@ class Builder {
         ApalacheOper.setAsFun.name -> ApalacheOper.setAsFun,
         ApalacheOper.guess.name -> ApalacheOper.guess,
         VariantOper.variant.name -> VariantOper.variant,
-        VariantOper.variantUnwrap.name -> VariantOper.variantUnwrap,
+        VariantOper.variantTag.name -> VariantOper.variantTag,
         VariantOper.variantGetUnsafe.name -> VariantOper.variantGetUnsafe,
         VariantOper.variantGetOrElse.name -> VariantOper.variantGetOrElse,
         VariantOper.variantFilter.name -> VariantOper.variantFilter,

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/VariantOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/VariantOper.scala
@@ -35,12 +35,12 @@ object VariantOper {
   }
 
   /**
-   * Match a single variant.
+   * Get the tag name of a variant.
    */
-  object variantUnwrap extends VariantOper {
-    override def name: String = "Variants!VariantUnwrap"
+  object variantTag extends VariantOper {
+    override def name: String = "Variants!VariantTag"
 
-    override def arity: OperArity = FixedArity(2)
+    override def arity: OperArity = FixedArity(1)
 
     override val precedence: (Int, Int) = (100, 100)
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
@@ -158,7 +158,7 @@ object KeraLanguagePred {
         ApalacheOper.assign,
         VariantOper.variant,
         VariantOper.variantGetUnsafe,
-        VariantOper.variantUnwrap,
+        VariantOper.variantTag,
         VariantOper.variantFilter,
         // for the future
         //      TlaActionOper.composition,

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
@@ -121,6 +121,7 @@ object KeraLanguagePred {
         TlaSeqOper.head,
         TlaSeqOper.tail,
         TlaSeqOper.len,
+        VariantOper.variantTag,
         ApalacheOper.skolem,
         ApalacheOper.gen,
         ApalacheOper.expand,
@@ -158,7 +159,6 @@ object KeraLanguagePred {
         ApalacheOper.assign,
         VariantOper.variant,
         VariantOper.variantGetUnsafe,
-        VariantOper.variantTag,
         VariantOper.variantFilter,
         // for the future
         //      TlaActionOper.composition,


### PR DESCRIPTION
Closes #1927 and closes #1928. Instead of doing PRs where I would remove `VariantUnwrap` and then introduce `VariantTag` in the same places again, I just renamed `VariantUnwrap` into `VariantTag`, fixed the type signature and the rewriting rule. It touches a number of files, but most of the changes are mechanical. I had to give up on rewriting tags with a special sort `TAG`, as we now have to returns tags as strings.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Entries added to [./unreleased/][unreleased] for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
