### PR TITLE
Update the types tutorial

### DIFF
--- a/.unreleased/documentation/1942.md
+++ b/.unreleased/documentation/1942.md
@@ -1,0 +1,1 @@
+Update the tutorial on the type checker, see #1942

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -23,11 +23,11 @@ feature is activated with the option `--features=rows`.
 
 ## Running example: Lamport's mutex
 
-As a running example, we are using the specification of [Lamport'S Mutex][]
+As a running example, we are using the specification of [Lamport's Mutex][]
 (written by [Stephan Merz][]). We recommend to reproduce the steps in this
 tutorial. So, go ahead and download the specification file
 [LamportMutex.tla][]. We will add type annotations to this file. Let's rename
-`LamportMutex.tla` to `LamportMutexTyped.tla`
+`LamportMutex.tla` to `LamportMutexTyped.tla`.
 
 ## Step 1: Running Snowcat
 
@@ -45,7 +45,7 @@ output:
 ...
 PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.                                           
-Typing input error: Expected a type annotation for VARIABLE clock 
+Typing input error: Expected a type annotation for VARIABLE clock
 ... 
 ```
 
@@ -246,7 +246,7 @@ our example, though it required some exploration of the specification.
 
 Hence, we did not have to run the type checker seven times to see the error
 messages.  The type annotations are useful on its own, since we do not have to
-traverse the spec, to figure out the types of constants and states. Our more
+traverse the spec to figure out the types of constants and states. Our more
 engineering-oriented peers find these annotations to be quite important.
 
 Sometimes, the type checker cannot find a unique type of an expression. This

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -2,27 +2,32 @@
 
 **Difficulty: Blue trail – Easy**
 
-In this tutorial, we introduce the Snowcat :snowflake: :cat: type checker
+**Revision:** July 8, 2022
+
+In this tutorial, we introduce the Snowcat :snowflake: :cat: type checker.
 We give concrete steps on running the type checker and
 annotating a specification with types.
 
 ## Related documents
 
-- [ADR002][] that introduces Type System 1, which is used by Snowcat.
+- [ADR002][] that introduces Type Systems 1 and 1.2, used by Snowcat.
 - A more technical [HOWTO on writing type annotations][].
 - [ADR004][] that introduces Java-like annotations in TLA+ comments.
 
 ## Setup
 
 We assume that you have Apalache installed. If not, check the manual page on
-[Apalache installation][]. The minimal required version is 0.15.0.
+[Apalache installation][]. The minimal required version is 0.25.9. We are
+using the new feature that makes type checking of records precise. This
+feature is activated with the option `--features=rows`.
 
-## Running example: Two-phase commit
+## Running example: Lamport's mutex
 
-As a running example, we are using the well-understood specification of
-[Two-phase commit][] by [Leslie Lamport][] (written by [Stephan Merz][]). We
-recommend to reproduce the steps in this tutorial. So, go ahead and download
-two specification files: [TwoPhase.tla][] and [TCommit.tla][].
+As a running example, we are using the specification of [Lamport'S Mutex][]
+(written by [Stephan Merz][]). We recommend to reproduce the steps in this
+tutorial. So, go ahead and download the specification file
+[LamportMutex.tla][]. We will add type annotations to this file. Let's rename
+`LamportMutex.tla` to `LamportMutexTyped.tla`
 
 ## Step 1: Running Snowcat
 
@@ -30,7 +35,7 @@ Before we start writing any type annotations, let's run the type checker and
 see, whether it complains:
 
 ```sh
-$ apalache-mc typecheck TwoPhase.tla
+$ apalache-mc typecheck LamportMutexTyped.tla
 ```
 
 The tool output is a bit verbose. Below, you can see the important lines of the
@@ -40,209 +45,209 @@ output:
 ...
 PASS #1: TypeCheckerSnowcat
  > Running Snowcat .::.                                           
-Typing input error: Expected a type annotation for VARIABLE tmPrepared
+Typing input error: Expected a type annotation for VARIABLE clock 
 ... 
 ```
 
-## Step 2: Annotating tmPrepared
+## Step 2: Annotating variables clock, req, ack, crit
 
-In Step 1, Snowcat complained about the name `tmPrepared`. The reason
-for that is very simple: tmPrepared is declared as a variable, but Snowcat 
-does not find a type annotation.
+In Step 1, Snowcat complained about the name `clock`. The reason
+for that is very simple: `clock` is declared as a variable, but Snowcat 
+does not find a type annotation for it.
 
-From the comment next to the declaration of `tmPrepared`, we see that `tmPrepared` is supposed
-to be a subset of `RM`, which in turn is a set of resource managers. We have plenty of choices here of what a
-resource manager could be. Let's keep it simple and say that a resource manager
-is simply a name. Hence, we say that `RM` and `tmPrepared` are sets of strings. Let's add 
-type annotations:
+The comment next to the declaration of `clock` does not tell us precisely
+what `clock` should be:
 
-```tla
-CONSTANT
-    \* @type: Set(Str);
-    RM \* The set of resource managers
+```
+  clock,    \* local clock of each process
 ```
 
+Let's dig a bit further and check `TypeOK`, which is usually a good source of
+type hints in untyped specifications:
+
 ```tla
-VARIABLES
-  (* ... *)
-  \* @type: Set(Str);
-  tmPrepared,    \* The set of RMs from which the TM has received $"Prepared"$
-                 \* messages.
+{{#include ../../../test/tla/LamportMutexTyped.tla:TypeOK}}
 ```
 
-Note that we had to put the annotation between the keyword `CONSTANT` and the
-identifier `RM`, and between `VARIABLES` and `tmPrepared`. 
-We used the one-line TLA+ comment: `\* @type: ...;`.
-Alternatively, we could use the multi-line comment: `(* @type: Set(Str); *)`.
+This is better, but we have to figure out the types of `Proc` and `Clock`.
+Let's have a look at their definitions.
+
+```tla
+{{#include ../../../test/tla/LamportMutexTyped.tla:ProcAndClock}}
+```
+
+From the definitions of `Proc` and `Clock`, it is clear that they are both
+subsets of integers. We could annotate these two definitions with the type
+`Set(Int)`, but this is not necessary, since Snowcat will infer these types
+itself.
+
+Together with `TypeOK`, this gives us enough information to annotate all but
+one variable (we will annotate the variable `network` later):
+
+```tla
+{{#include ../../../test/tla/LamportMutexTyped.tla:vars1}}
+```
+
+In our type annotations:
+
+ - `clock` belongs to the set `[Proc -> Clock]`. Hence, it is a function of
+   integers to integers, that is, `Int -> Int`.
+
+ - `req` belongs to the set `[Proc -> [Proc -> Nat]]`. Hence, it is a function
+   of integers to functions of integers to integers, that is, `Int -> (Int ->
+   Int)`.
+
+ - `ack` belongs to the set `[Proc -> SUBSET Proc]`. Hence, it is a function of
+   integers to sets of integers, that is, `Int -> Set(Int)`.
+
+ - `crit` is a subset of `Proc`, so it is a set of integers, that is,
+   `Set(Int)`.
+
+Note that we had to add the annotation for `clock` between the keyword
+`VARIABLES` and `clock`, not before the keyword `VARIABLES`. Similar to that,
+we had to add a type annotation in front of every variable name.
+
+We used the one-line TLA+ comment for `clock`:
+
+```tla
+\* @type: Int -> Int;
+```
+
+Alternatively, we could use the multi-line comment:
+
+```tla
+(*
+ Clock is a function of integers to integers.
+
+ @type: Int -> Int;
+ *)
+```
+
 Importantly, the type annotation should end with a semi-colon: `;`.
 
-**Warning**. If you want to write a type annotation on multiple lines, write it
-in a multi-line comment `(* ... *)` instead of starting multiple lines with a
-single-line comment `\* ...`. See [issue
-718](https://github.com/informalsystems/apalache/issues/718).
-
-## Step 3: Running Snowcat again
-
-Having introduced the type annotations for `RM` and `tmPrepared`, let's run the type checker again:
+Let's run the type checker again:
 
 ```sh
-$ apalache-mc typecheck TwoPhase.tla
+$ apalache-mc typecheck LamportMutexTyped.tla
+...
+Typing input error: Expected a type annotation for VARIABLE network
 ```
 
-Snowcat does not complain about `tmPrepared` anymore. Now we get another message:
+No magic happened. We have to annotate the variable `network`.
 
-```
-> Running Snowcat .::.
-Typing input error: Expected a type annotation for VARIABLE tmState
-```
+## Step 3: Annotating the variable network
 
-## Step 4: Annotating tmState
-
-Similar to Step 2, we are missing a type annotation. This time the type checker
-complains about the variable `tmState`:
+Let's have a look at the operator `TypeOK` again:
 
 ```tla
-VARIABLES
-  tmState,       \* The state of the transaction manager.
+{{#include ../../../test/tla/LamportMutexTyped.tla:TypeOK}}
 ```
 
-We can get a hint about the type of `tmState` from the type invariant
-`TPTypeOK`, where we see that `tmState` is just a string.
-
-Add the following type
-annotation:
+From this we can see that `network` is a function of integers to a function of
+integers to a sequence of messages. So its type should look like:
 
 ```tla
-VARIABLES
-  (* ... *)
-  \* @type: Str;  
-  tmState,       \* The state of the transaction manager.
+Int -> (Int -> Seq(MESSAGE))
 ```
 
-## Step 5: Getting one more type error by Snowcat
+But what is a message? To find out, we have to continue our archaeology trip
+and check the definition of `Message` and related operators:
 
-Guess what? Run the type checker again:
+```tla
+{{#include ../../../test/tla/LamportMutexTyped.tla:Message}}
+```
+
+From these four definitions, we can see that `Messages` is a set of records
+that have two fields: the field `type` that should be a string, and the field
+`clock` that should be an integer. In Apalache, we write such a record type as:
+
+```tla
+{ type: Str, clock: Int }
+```
+
+Hence, the type of `network` should be:
+
+```tla
+Int -> (Int -> Seq({ type: Str, clock: Int }))
+```
+
+We could write it as above, but that type is a bit hard to read. Hence, we
+split it into two parts: the type alias `MESSAGE` that defines the type of
+messages, and the type of `network` that refers to `MESSAGE`. This can be done
+in the following way:
+
+```tla
+{{#include ../../../test/tla/LamportMutexTyped.tla:vars2}}
+```
+
+Now we should run the type checker again:
 
 ```sh
-$ apalache-mc typecheck TwoPhase.tla
+$ apalache-mc typecheck --features=rows LamportMutexTyped.tla
+...
+Typing input error: Expected a type annotation for CONSTANT maxClock
 ```
 
-Snowcat does not complain about `tmState` anymore. But we are not done yet:
+The type checker is still not happy: We have not annotated `CONSTANTS`.
 
-```
-> Running Snowcat .::.   
-Typing input error: Expected a type annotation for VARIABLE rmState
-```
+Note that we had to pass the option `--features=rows`, as we are using the new
+syntax for record types `{ ... }`, which needs to be activated. This feature
+will become the default in September of 2022.
 
-## Step 6: Annotating rmState
+**Note:** We are lucky that `ReqMessage`, `AckMessage`, and `RelMessage` are
+producing records of the same shape. In some specifications, the shapes of
+records differ, while these records should be added to the same set. This is a
+bit problematic for the type checker, as it expects set elements to have the
+same type. In this case, we have three options:
 
-This time we need a type annotation for the variable `rmState`.
-By inspecting `TPTypeOK`, we see `rmState`
-should be a function that, given a resource manager, produces
-one of the following strings: `"working"`, `"prepared"`, `"committed"`,
-`"aborted"`. So we need the function type: `Str -> Str`. Add the following
-type annotation:
+ - Slightly rewrite the specification to homogenize records,
+
+ - Partition the set of messages into several sets, see [Idiom 15][], or
+
+ - Use variants. This is a more advanced topic, see the
+   [HOWTO on writing type annotations][].
+
+## Step 4: Annotating constants
+
+Now we have to figure out the types of the constants: `N` and `maxClock`.  This
+is fairly easy, as these constants are accompanied by the two assumptions:
 
 ```tla
-VARIABLES
-  \* @type: Str -> Str;
-  rmState,       \* $rmState[rm]$ is the state of resource manager RM.
+{{#include ../../../test/tla/LamportMutexTyped.tla:assumes}}
 ```
 
-## Step 7: Running Snowcat to see another error
+From these assumptions, we can conclude that both `N` and `maxClock` are
+integers. We add the type annotations:
 
-Run the type checker again:
+```tla
+{{#include ../../../test/tla/LamportMutexTyped.tla:constants}}
+```
+
+Let's run the type checker once again:
 
 ```sh
-$ apalache typecheck TwoPhase.tla
-```
-
-You must have guessed that the type checker complains about the variable
-`msgs`. Indeed, it just needs annotations for all CONSTANTS and
-VARIABLES:
-
-```
-> Running Snowcat .::. 
-Typing input error: Expected a type annotation for VARIABLE msgs
-```
-
-## Step 8: Annotating msgs
-
-In the previous steps, it was quite easy to annotate variables. We would just
-look at how the variable is used, or read the comments, and add a type annotation.
-Figuring out the type of `msgs` is a bit harder.
-
-Let's look at the definitions of `Messages` and `TPTypeOK`:
-
-```tla
-Message ==
-  ...
-  [type : {"Prepared"}, rm : RM]  \union  [type : {"Commit", "Abort"}]
-
-TPTypeOK ==  
-  ...  
-  /\ msgs \subseteq Message
-```
-
-Now you should be able to see that `msgs` is a set that may contain three
-kinds of records:
-
-1. The record `[type |-> "Commit"]`,
-1. The record `[type |-> "Abort"]`,
-1. A record `[type |-> "Prepared", rm |-> r]`, for some `r \in RM`.
-
-This looks like an issue for the type checker, as we always require
-the elements of a set to have the same type.
-
-Actually, the type checker allows records to be generalized to a type that
-contains additional fields. In the above definition of `Messages`, the set of
-records `[type: {"Prepared"}, rm: RM]` has the type `Set([type: Str, rm:
-Str])`.  (Note that the record has the field called "type", which has nothing
-to do with our types.) Likewise, the set of records `[type: {"Commit",
-"Abort"}]` has the type `Set([type: Str])`. Both of these types can be unified
-to the common type:
-
-```
-Set([type: Str, rm: Str])
-``` 
-
-The above type is actually what we need for the variable `msgs`. Let's annotate
-the variable with this type:
-
-```tla
-VARIABLES
-  (* ... *)
-  \* @type: Set([type: Str, rm: Str]);
-  msgs
-```
-
-## Step 9: Running Snowcat and seeing no errors
-
-Let's see whether Snowcat is happy about our types now:
-
-```sh
-$ apalache-mc typecheck TwoPhase.tla
-```
-
-The type checker is happy. It has computed the types of all expressions:
-
-```
- > Running Snowcat .::.
- > Your types are great!
+$ apalache-mc typecheck --features=rows LamportMutexTyped.tla
+...
  > All expressions are typed
+Type checker [OK]
 ```
+
+Snowcat is happy, and so we are too!
 
 # Discussion
 
-To see the complete code, check [TwoPhase.tla](./TwoPhase.tla). Note that we
-have not touched the file `TCommit.tla` at all! The type checker has figured
-out all the types in it by itself. We have added five type annotations for 248
-lines of code. Not bad.
+To see the complete code, check [LamportMutexTyped.tla][]. We have added seven
+type annotations for 184 lines of code. Not bad.
 
-It was quite easy to figure out the types of constants and variables in our
-example. As a rule, you always have to annotate constants and variables with
-types. Hence, we did not have to run the type checker five times to see the
-error messages.
+It was relatively easy to figure out the types of constants and variables in
+our example, though it required some exploration of the specification.
+
+*As a rule, you always have to annotate constants and variables with types*.
+
+Hence, we did not have to run the type checker seven times to see the error
+messages.  The type annotations are useful on its own, since we do not have to
+traverse the spec, to figure out the types of constants and states. Our more
+engineering-oriented peers find these annotations to be quite important.
 
 Sometimes, the type checker cannot find a unique type of an expression. This
 usually happens when you declare an operator of a parameter that can be: a
@@ -252,7 +257,7 @@ that has at least two elements). For instance, here is a definition from
 
 ```tla
 Pos ==
-    {<<x, y>>: x, y \in 1..N}
+    { <<x, y>>: x, y \in 1..N }
 ```
 
 Although it is absolutely clear that `x` and `y` have the type `Int`,
@@ -267,7 +272,7 @@ Pos ==
 ```
 
 Since it is common to have operators that take no arguments, Snowcat supports
-the following syntax sugar:
+the following syntax sugar for operators without arguments:
 
 ```tla
 \* @type: Set(<<Int, Int>>);
@@ -283,13 +288,14 @@ For more advanced type annotations, check the following examples:
 - [CarTalkPuzzleTyped.tla][],
 - [FunctionsTyped.tla][],
 - [QueensTyped.tla][].
+- [TwoPhaseTyped.tla][].
 
 We have not discussed type aliases, which are a more advanced feature of the
 type checker. To learn about type aliases, see [HOWTO on writing type
 annotations][].
 
-If you are experiencing a problem with Snowcat, feel free to [open an issue]
-or drop us a message on [Zulip chat].
+If you are experiencing a problem with Snowcat, feel free to [open an issue][]
+or drop us a message on [Zulip chat][].
 
 
 [ADR002]: ../adr/002adr-types.html
@@ -297,9 +303,11 @@ or drop us a message on [Zulip chat].
 [HOWTO on writing type annotations]: ../HOWTOs/howto-write-type-annotations.md
 [Apalache installation]: ../apalache/installation/index.md
 [Two-phase commit]: https://github.com/tlaplus/Examples/blob/master/specifications/transaction_commit
+[Lamport's mutex]: https://github.com/tlaplus/Examples/blob/master/specifications/lamport_mutex
 [TwoPhase.tla]: https://github.com/tlaplus/Examples/blob/911dac1462344337940779a797a5f329a77be98c/specifications/transaction_commit/TwoPhase.tla
-[TCommit.tla]: https://github.com/tlaplus/Examples/blob/911dac1462344337940779a797a5f329a77be98c/specifications/transaction_commit/TCommit.tla
-[Leslie Lamport]: https://lamport.azurewebsites.net/
+[LamportMutex.tla]: https://github.com/tlaplus/Examples/blob/master/specifications/lamport_mutex/LamportMutex.tla
+[LamportMutexTyped.tla]: https://github.com/informalsystems/apalache/blob/unstable/test/tla/LamportMutexTyped.tla
+[TwoPhaseTyped.tla]: https://github.com/informalsystems/apalache/blob/unstable/test/tla/TwoPhaseTyped.tla
 [Stephan Merz]: https://members.loria.fr/Stephan.Merz/
 [GameOfLifeTyped.tla]: https://github.com/informalsystems/apalache/blob/d5138a33fce3d77abc07a39bfb4f448942e6f641/test/tla/GameOfLifeTyped.tla 
 [CigaretteSmokersTyped.tla]: https://github.com/informalsystems/apalache/blob/d5138a33fce3d77abc07a39bfb4f448942e6f641/test/tla/CigaretteSmokersTyped.tla
@@ -308,3 +316,4 @@ or drop us a message on [Zulip chat].
 [QueensTyped.tla]: https://github.com/informalsystems/apalache/blob/d5138a33fce3d77abc07a39bfb4f448942e6f641/test/tla/QueensTyped.tla
 [open an issue]: https://github.com/informalsystems/apalache/issues
 [Zulip chat]: https://informal-systems.zulipchat.com/login/#narrow/stream/265309-apalache
+[Idiom 15]: ../idiomatic/003record-sets.md

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -180,20 +180,6 @@ in the following way:
 {{#include ../../../test/tla/LamportMutexTyped.tla:vars2}}
 ```
 
-Now we should run the type checker again:
-
-```sh
-$ apalache-mc typecheck --features=rows LamportMutexTyped.tla
-...
-Typing input error: Expected a type annotation for CONSTANT maxClock
-```
-
-The type checker is still not happy: We have not annotated `CONSTANTS`.
-
-Note that we had to pass the option `--features=rows`, as we are using the new
-syntax for record types `{ ... }`, which needs to be activated. This feature
-will become the default in September of 2022.
-
 **Note:** We are lucky that `ReqMessage`, `AckMessage`, and `RelMessage` are
 producing records of the same shape. In some specifications, the shapes of
 records differ, while these records should be added to the same set. This is a
@@ -206,6 +192,21 @@ same type. In this case, we have three options:
 
  - Use variants. This is a more advanced topic, see the
    [HOWTO on writing type annotations][].
+
+Now we should run the type checker again:
+
+```sh
+$ apalache-mc typecheck --features=rows LamportMutexTyped.tla
+...
+Typing input error: Expected a type annotation for CONSTANT maxClock
+```
+
+Note that we pass the option `--features=rows`, as we are using the new syntax
+for record types `{ ... }`, which needs to be activated. This feature will
+become the default in the future.
+<!-- TODO(#1943): Remove --features=rows when it becomes default. -->
+
+The type checker is still not happy: We have not annotated `CONSTANTS`.
 
 ## Step 4: Annotating constants
 

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -17,9 +17,12 @@ annotating a specification with types.
 ## Setup
 
 We assume that you have Apalache installed. If not, check the manual page on
-[Apalache installation][]. The minimal required version is 0.25.9. We are
-using the new feature that makes type checking of records precise. This
-feature is activated with the option `--features=rows`.
+[Apalache installation][]. The minimal required version is 0.25.9.
+
+**Note**: This tutorial uses a new feature in Apalache that makes type checking of
+records more precise. Currently, this experimental feature is activated with the
+option `--features=rows`.
+<!-- TODO(#1943): Remove --features=rows when it becomes default. -->
 
 ## Running example: Lamport's mutex
 
@@ -103,9 +106,9 @@ In our type annotations:
  - `crit` is a subset of `Proc`, so it is a set of integers, that is,
    `Set(Int)`.
 
-Note that we had to add the annotation for `clock` between the keyword
-`VARIABLES` and `clock`, not before the keyword `VARIABLES`. Similar to that,
-we had to add a type annotation in front of every variable name.
+**Note**: We place the annotation for `clock` between the keyword `VARIABLES`
+and `clock`, not before the keyword `VARIABLES`. Similarly, we added a type
+annotation immediately above every other variable name.
 
 We used the one-line TLA+ comment for `clock`:
 
@@ -123,7 +126,7 @@ Alternatively, we could use the multi-line comment:
  *)
 ```
 
-Importantly, the type annotation should end with a semi-colon: `;`.
+**Note**: Importantly, every type annotation must end with a semi-colon `;`.
 
 Let's run the type checker again:
 
@@ -133,7 +136,8 @@ $ apalache-mc typecheck LamportMutexTyped.tla
 Typing input error: Expected a type annotation for VARIABLE network
 ```
 
-No magic happened. We have to annotate the variable `network`.
+Not surprisingly, the type checker tells us that we still have to annotate the
+variable `network`.
 
 ## Step 3: Annotating the variable network
 

--- a/test/tla/LamportMutexTyped.tla
+++ b/test/tla/LamportMutexTyped.tla
@@ -15,23 +15,30 @@ EXTENDS Naturals, Sequences
 (* The parameter maxClock is used only for model checking in order to      *)
 (* keep the state space finite.                                            *)
 (***************************************************************************)
+\* ANCHOR: constants
 CONSTANT
     \* @type: Int;
     N,
     \* @type: Int;
     maxClock
+\* ANCHOR_END: constants
 
+\* ANCHOR: assumes
 ASSUME NType == N \in Nat
 ASSUME maxClockType == maxClock \in Nat
+\* ANCHOR_END: assumes
 
+\* ANCHOR: ProcAndClock
 Proc == 1 .. N
 Clock == Nat \ {0}
+\* ANCHOR_END: ProcAndClock
 (***************************************************************************)
 (* For model checking, add ClockConstraint as a state constraint to ensure *)
 (* a finite state space and override the definition of Clock by            *)
 (* 1 .. maxClock+1 so that TLC can evaluate the definition of Message.     *)
 (***************************************************************************)
 
+\* ANCHOR: vars1
 VARIABLES
   \* @type: Int -> Int;
   clock,    \* local clock of each process
@@ -39,27 +46,33 @@ VARIABLES
   req,      \* requests received from processes (clock transmitted with request)
   \* @type: Int -> Set(Int);
   ack,      \* acknowledgements received from processes
+  \* @type: Set(Int);
+  crit,     \* set of processes in critical section
+\* ANCHOR_END: vars1
+\* ANCHOR: vars2
   \* @typeAlias: MESSAGE = {
   \*     type: Str,
   \*     clock: Int
   \* };
   \* @type: Int -> (Int -> Seq(MESSAGE));
-  network,  \* messages sent but not yet received
-  \* @type: Set(Int);
-  crit      \* set of processes in critical section
+  network   \* messages sent but not yet received
+\* ANCHOR_END: vars2
 
 (***************************************************************************)
 (* Messages used in the algorithm.                                         *)
 (***************************************************************************)
+\* ANCHOR: Message
 ReqMessage(c) == [type |-> "req", clock |-> c]
 AckMessage == [type |-> "ack", clock |-> 0]
 RelMessage == [type |-> "rel", clock |-> 0]
 
 Message == {AckMessage, RelMessage} \union {ReqMessage(c) : c \in Clock}
+\* ANCHOR_END: Message
 
 (***************************************************************************)
 (* The type correctness predicate.                                         *)
 (***************************************************************************)  
+\* ANCHOR: TypeOK
 TypeOK ==
      (* clock[p] is the local clock of process p *)
   /\ clock \in [Proc -> Clock]
@@ -71,6 +84,7 @@ TypeOK ==
   /\ network \in [Proc -> [Proc -> Seq(Message)]]
      (* set of processes in critical section: should be empty or singleton *)
   /\ crit \in SUBSET Proc
+\* ANCHOR_END: TypeOK
 
 
 (***************************************************************************)


### PR DESCRIPTION
Closes #1939. This PR update the tutorial on the type checker, using the new records and giving pointers to variants. I have made it shorter and, hopefully, simpler.

- [x] Entries added to [./unreleased/][unreleased] for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
