### PR TITLE
Set a unique java.io.tmpdir for each call to SANY

### DIFF
--- a/.unreleased/bug-fixes/1959-sany-tmpdir.md
+++ b/.unreleased/bug-fixes/1959-sany-tmpdir.md
@@ -1,0 +1,2 @@
+Add workaround for Sany parsing failures when running parallel instances of
+Apalache (see #1959)

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -70,7 +70,6 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
 
     // Set a unique tmpdir to avoid race-condition in SANY
     // TODO: RM once https://github.com/tlaplus/tlaplus/issues/688 is fixed
-    //       see
     System.setProperty("java.io.tmpdir", sanyTempDir().toString())
 
     // call SANY

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -68,8 +68,14 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
     // Resolver for filenames, patched for wired modules.
     val filenameResolver = SanyNameToStream(libraryPaths)
 
+    // Set a unique tmpdir to avoid race-condition in SANY
+    // TODO: RM once https://github.com/tlaplus/tlaplus/issues/688 is fixed
+    //       see
+    System.setProperty("java.io.tmpdir", sanyTempDir().toString())
+
     // call SANY
     val specObj = new SpecObj(file.getAbsolutePath, filenameResolver)
+
     SANY.frontEndMain(
         specObj,
         file.getAbsolutePath,
@@ -99,8 +105,7 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
    *   the pair (the root module name, a map of modules)
    */
   def loadFromSource(source: Source, aux: Seq[Source] = Seq()): (String, Map[String, TlaModule]) = {
-    val tempDir = Files.createTempDirectory("sanyimp").toFile
-
+    val tempDir = sanyTempDir()
     val nameAndModule = for {
       (rootName, rootFile) <- saveTlaFile(tempDir, source)
       // Save the aux modules to files, and get just the module names, if errors are hit, the first one will turn into a `Try`
@@ -112,6 +117,9 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
     // Raise any errors previously captures in the `Try`
     nameAndModule.get
   }
+
+  // Create a unique temp directory for use by the SANY importer
+  private def sanyTempDir() = Files.createTempDirectory("sanyimp").toFile
 
   private def ensureModuleNamesAreUnique(moduleNames: Seq[String]): Try[Unit] = {
     val duplicateNames = moduleNames.groupBy(identity).filter(_._2.size > 1)


### PR DESCRIPTION
This should provide a workaround for the concurrency bug noted
https://github.com/tlaplus/tlaplus/issues/688, while we wait on an upstream fix.

Note that this only allows concurrent executions of SANY in parallel processes.
AFAICT, the deeper issue noted at
https://github.com/informalsystems/apalache/issues/1114#issuecomment-1180534894
will still prevent concurrent runs of SANY within the same JVM.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Entries added to [./unreleased/][unreleased] for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased