### PR TITLE
Typed Builder implementation Part 11.6: Generalize the BuilderTest framework

### DIFF
--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestApalacheInternalBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestApalacheInternalBuilder.scala
@@ -49,7 +49,7 @@ class TestApalacheInternalBuilder extends BuilderTest {
 
     def run(tparam: TlaType1) = {
       (1 to 5).forall { n =>
-        runVariadic[TlaType1, TBuilderInstruction](
+        runVariadic[TlaType1, TBuilderInstruction, TBuilderResult](
             builder.distinct(_: _*),
             mkWellTyped(n),
             mkIllTyped(n),

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestFunBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestFunBuilder.scala
@@ -185,7 +185,7 @@ class TestFunBuilder extends BuilderTest {
 
     def run(tparam: TlaType1) = {
       (1 to 5).forall { n =>
-        runVariadic[TlaType1, TBuilderInstruction](
+        runVariadic[TlaType1, TBuilderInstruction, TBuilderResult](
             builder.seq(_: _*),
             mkWellTyped(n),
             mkIllTyped(n),

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSetBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestSetBuilder.scala
@@ -45,7 +45,7 @@ class TestSetBuilder extends BuilderTest {
 
     def run(tparam: TlaType1) = {
       (1 to 5).forall { n =>
-        runVariadic[TlaType1, TBuilderInstruction](
+        runVariadic[TlaType1, TBuilderInstruction, TBuilderResult](
             builder.enumSet(_: _*),
             mkWellTyped(n),
             mkIllTyped(n),
@@ -760,7 +760,7 @@ class TestSetBuilder extends BuilderTest {
     )
 
     checkRun(
-        runVariadic[TParam, TBuilderInstruction](
+        runVariadic[TParam, TBuilderInstruction, TBuilderResult](
             builder.times(_: _*),
             mkWellTyped,
             mkIllTyped,


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to [./unreleased/][unreleased] for any new functionality

closes #1969

Makes type parameters of `BuilderTest` methods more generic, but otherwise introduces no new code.

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
