### PR TITLE
Fix selectInSet signature

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/ApalacheInternalOperSignatures.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/ApalacheInternalOperSignatures.scala
@@ -26,12 +26,15 @@ object ApalacheInternalOperSignatures {
     val apalacheSeqCapacitySig = signatureMapEntry(apalacheSeqCapacity, { case Seq(_: SeqT1) => IntT1 })
 
     // (t, Set(t)) => Bool
-    val membershipSigs = Seq(
-        selectInSet,
-        storeNotInSet,
-    ).map {
-      signatureMapEntry(_, { case Seq(t, SetT1(tt)) if t == tt => BoolT1 })
-    }.toMap
+    // (a, a -> b) => b
+    val selectInSetSig =
+      signatureMapEntry(
+          selectInSet,
+          {
+            case Seq(t, SetT1(tt)) if t == tt    => BoolT1
+            case Seq(aa, FunT1(a, b)) if a == aa => b
+          },
+      )
 
     // storeInSet is separate, because it has variable arity.
     // (t, SetT1(t)) => Bool
@@ -46,6 +49,9 @@ object ApalacheInternalOperSignatures {
           },
       )
 
+    // (t, Set(t)) => Bool
+    val storeNotInSetSig = signatureMapEntry(storeNotInSet, { case Seq(t, SetT1(tt)) if t == tt => BoolT1 })
+
     // (Set(t), Set(t)) => Set(t)
     val smtMapSig = Seq(
         TlaBoolOper.and,
@@ -55,6 +61,6 @@ object ApalacheInternalOperSignatures {
     // (Set(t)) => Bool
     val unconstrainArraySig = signatureMapEntry(unconstrainArray, { case Seq(_: SetT1) => BoolT1 })
 
-    (membershipSigs ++ smtMapSig) + distinctSig + apalacheSeqCapacitySig + storeInSetSig + unconstrainArraySig
+    smtMapSig + distinctSig + apalacheSeqCapacitySig + selectInSetSig + storeInSetSig + storeNotInSetSig + unconstrainArraySig
   }
 }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entries added to [./unreleased/][unreleased] for any new functionality~

I missed a problem when I had a look at #1924. `selectInSet` can currently be [used with functions](https://github.com/informalsystems/apalache/blob/edea24845cc53f25de700c2f16f90e687fe3f50e/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala#L641) as well. This PR fixes the wrong signature.

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased