### PR TITLE
Shai: Add logging

### DIFF
--- a/shai/README.md
+++ b/shai/README.md
@@ -31,13 +31,24 @@ noted here:
 
 ### The effect type `ZIO[Env, Failure, Success]`
 
-Values of type `ZIO[Environment, Failure, Success]` represent concurrent effects
-which execute within the `Environment`, and which may produce either a value of
-type `Failure` or value of type `Success`. The `Environment` supplies
-requirements that the effect may need (e.g., resources to interact with the
-outside world).
+ZIO is a concurrency library that works by lifting effects into typed values,
+and then running a scheduler that can execute the effects concurrently and in
+parallel, as appropriate given the available resources and context.
 
-Common type alias we use in Shai include:
+In order for ZIO to track effects, every effect (i.e. side-effects) must be
+lifted into ZIO values. If we execute side-effects without lifting them into ZIO
+values, they will escape the scheduler, and we lose the ability to reason about
+or manage the effects. The basic combinators for lifting effects into ZIO values
+are `ZIO.effect` and `ZIO.effectTotal`. The former is for effects that may abort
+with some exception. The latter is for effects which are guaranteed to complete.
+
+Values of type `ZIO[Environment, Failure, Success]` represent concurrent effects
+which execute within an environment tracked by a value of type `Environment`,
+and which may produce either a value of type `Failure` or value of type
+`Success`. The `Environment` supplies requirements that the effect may need
+(e.g., resources to interact with the outside world).
+
+Common type aliases we use in Shai include:
 
 - `IO[Failure, Succcess]`: an effect that can operate in any environment.
 - `UIO[Success]`: an effect that always succeeds

--- a/shai/src/main/scala/at/forsyte/apalache/shai/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/RpcServer.scala
@@ -4,8 +4,14 @@ import zio.{console, Ref, Semaphore, ZEnv, ZIO}
 import java.util.UUID
 import scalapb.zio_grpc.ServerMain
 import scalapb.zio_grpc.ServiceList
+import com.typesafe.scalalogging.LazyLogging
 
-object RpcServer extends ServerMain {
+/**
+ * The Shai RPC server handling gRPC requests to interact with the model checker
+ *
+ * We extend LazyLogging to give the server process access to the same logger configured for the rest of Apalache.
+ */
+object RpcServer extends ServerMain with LazyLogging {
   override def port: Int = 8822
 
   override def welcome: ZIO[ZEnv, Throwable, Unit] =
@@ -18,7 +24,7 @@ object RpcServer extends ServerMain {
     // Ensure atomic access to the parser
     // See https://github.com/informalsystems/apalache/issues/1114#issuecomment-1180534894
     parserSemaphore <- Semaphore.make(permits = 1)
-  } yield new TransExplorerService(connections, parserSemaphore)
+  } yield new TransExplorerService(connections, parserSemaphore, logger)
 
   def services: ServiceList[ZEnv] =
     ServiceList.addM(createService)

--- a/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
@@ -99,7 +99,11 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: S
   // any incoming requests.
   private type RequestConn = Option[Connection]
 
-  // A private object to give us ZIO managed access to an external logger
+  // A private object to give us ZIO managed access to an external logger.
+  //
+  // We need to lift the calls to the logger into ZIO effects so they can be
+  // managed by the ZIO schedular for concurrent execution. See the project documentation
+  // in shai/README.md for tips and references on understanding effects in ZIO.
   private object Log {
     private def shaiMsg(conn: RequestConn, msg: String): String = {
       val connId = conn.map(_.id).getOrElse("NO_CONNECTION")

--- a/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
@@ -109,10 +109,10 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: S
       val connId = conn.map(_.id).getOrElse("NO_CONNECTION")
       s"[Shai:${connId}]: ${msg}"
     }
-    def debug(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.debug(shaiMsg(conn, msg)))
-    def info(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.info(shaiMsg(conn, msg)))
-    def warn(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.warn(shaiMsg(conn, msg)))
-    def error(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.error(shaiMsg(conn, msg)))
+    def debug(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.debug(shaiMsg(conn, msg)))
+    def info(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.info(shaiMsg(conn, msg)))
+    def warn(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.warn(shaiMsg(conn, msg)))
+    def error(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.error(shaiMsg(conn, msg)))
   }
 
   /**

--- a/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
@@ -109,10 +109,10 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: S
       val connId = conn.map(_.id).getOrElse("NO_CONNECTION")
       s"[Shai:${connId}]: ${msg}"
     }
-    def debug(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.debug(shaiMsg(conn, msg)))
-    def info(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.info(shaiMsg(conn, msg)))
-    def warn(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.warn(shaiMsg(conn, msg)))
-    def error(conn: RequestConn, msg: String): Result[Unit] = ZIO.effectTotal(logger.error(shaiMsg(conn, msg)))
+    def debug(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.debug(shaiMsg(conn, msg)))
+    def info(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.info(shaiMsg(conn, msg)))
+    def warn(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.warn(shaiMsg(conn, msg)))
+    def error(conn: RequestConn, msg: String): Result[Unit] = ZIO.effect(logger.error(shaiMsg(conn, msg)))
   }
 
   /**

--- a/shai/src/test/resources/logback-test.xml
+++ b/shai/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <!-- By default, we disable log output for unit tests. -->
+    <!-- Uncomment the following to get console output for debugging:
+      <appender-ref ref="STDOUT" />
+    -->
+  </root>
+</configuration>


### PR DESCRIPTION
Closes #1849 

## Overview

Shai needs to log critical activities so we can monitor and debug the server.
This PR gives the `TransExplorerService` access to the existing logging
infrastructure we use throughout Apalache by providing a very thin ZIO wrapper
around an injected `Logger` instance.

## Notable changes

- Create a private object that wraps calls to a provided `Logger` inside ZIO effects
- Add some simple formatting to the logged message
- Add basic logging for the existing RPC handlers

## Reviewing

Should be straight forward and the changeset is small. I'd particular be
interested in learning if I should be managing the logging message formatting
differently or if there's a better way for me to be making the logger available
to the server.