### PR TITLE
Documentation for `typecomp`

### DIFF
--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
@@ -38,7 +38,7 @@ class ScopedBuilder
     with ActionBuilder with FunBuilder with ControlBuilder with TemporalBuilder with ApalacheInternalBuilder
     with ApalacheBuilder with VariantBuilder with LiteralAndNameBuilder {
 
-  private def parser = DefaultType1Parser
+  private val parser = DefaultType1Parser
 
   /**
    * Creates a `TBuilderInstruction` from a precomputed `TlaEx`. Voids correctness guarantees.

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -76,7 +76,7 @@ import scala.language.implicitConversions
  * values. For the most part, we focus on [[OperEx]] values, as literals can be trivially constructed as type-safe.
  *
  * We solve the following problem: Given [[TlaEx]] arguments `x1,...,xn` and a [[TlaOper]] argument `oper`, what type,
- * if any, can be assigned to `e @ OperEx(oper, x1, ..., xn)`, such that `e` is validly typed w.r.t. the type signature
+ * if any, can be assigned to `e @ OperEx(oper, x1, ..., xn)`, such that `e` is soundly typed w.r.t. the type signature
  * of the TLA+ operator represented by `oper` in the type system.
  *
  * [[TypeComputation]] describes a solution to the above problem. It is a function that takes a sequence of [[TlaEx]]

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -19,19 +19,18 @@ import scala.language.implicitConversions
  *
  * ==The signature layer==
  *
- * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. Most operators have
- * type signatures, that is, they restrict the types of arguments allowed to construct valid [[OperEx]]
- * expressions. For instance, [[TlaArithOper.plus]] represents the arithmetic operator `+` and has the signature `(Int,
- * Int) => Int` in the type system, meaning that `e @ OperEx(TlaArithOper.plus, x, y)` is considered valid iff `x`, `y`,
- * and `e` are all tagged with `Typed(IntT1)`. Similarly, [[TlaOper.chooseBounded]] has the signature `(t, Set(t), Bool)
- * \=> t`, meaning that `e @ OperEx(TlaOper.chooseBounded, x, S, p)` is considered valid if `x` and `e` are tagged with
- * `Typed(t)`, for some `t`, `S` is tagged with `Typed(SetT1(t))` (for the same `t`), and `p` is tagged with
- * `Typed(BoolT1)`.
+ * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. Most operators have type signatures, that is,
+ * they restrict the types of arguments allowed to construct valid [[OperEx]] expressions. For instance,
+ * [[TlaArithOper.plus]] represents the arithmetic operator `+` and has the signature `(Int, Int) => Int` in the type
+ * system, meaning that `e @ OperEx(TlaArithOper.plus, x, y)` is considered valid iff `x`, `y`, and `e` are all tagged
+ * with `Typed(IntT1)`. Similarly, [[TlaOper.chooseBounded]] has the signature `(t, Set(t), Bool) => t`, meaning that an
+ * expression`e @ OperEx(TlaOper.chooseBounded, x, S, p)` is considered valid if `x` and `e` are tagged with `Typed(t)`,
+ * for some `t`, `S` is tagged with `Typed(SetT1(t))` (for the same `t`), and `p` is tagged with `Typed(BoolT1)`.
  *
  * You can think of a signature `(a1,...,an) => b` as a partial function; given a sequence of argument types `v1, ...
  * vn`, it returns some type `c` (derived from `b`), if the types `v1, ..., vn` match the pattern `a1, ..., an`. More
- * precisely, the return value is `s(b)`, if there exists some type substitution `s`, such that `s(ai) = vi` for all `i
- * \= 1,...,n`.
+ * precisely, the return value is `s(b)`, if there exists some type substitution `s`, such that `s(ai) = vi` for all
+ * indices `i = 1,...,n`.
  *
  * To reason about signatures, we define two types, [[PartialSignature]] and [[Signature]]. They serve the same purpose,
  * but differ in the way they behave on mis-matches. [[PartialSignature]]s are bare-bones descriptions of the
@@ -50,8 +49,8 @@ import scala.language.implicitConversions
  * signature to `Seq(IntT1, SetT1(IntT1), BoolT1)`, would return `IntT1` while applying it to `Seq(StrT1, SetT1(StrT1),
  * BoolT1)` would return `StrT1`. It is not applicable to `Seq(IntT1, SetT1(StrT1), BoolT1)`.
  *
- * [[Signature]]s complete [[PartialSignature]]s, by equipping them with an exception, to be thrown should the
- * input sequence not match the pattern defined by the corresponding [[PartialSignature]]. This lifting is done by
+ * [[Signature]]s complete [[PartialSignature]]s, by equipping them with an exception, to be thrown should the input
+ * sequence not match the pattern defined by the corresponding [[PartialSignature]]. This lifting is done by
  * [[BuilderUtil.completePartial completePartial]], if all we want is a total function, or
  * [[BuilderUtil.checkForArityException checkForArityException]], to output a more precise error message, outlining
  * whether [[PartialSignature]] application failed because of the non-existence of a type substitution, or simply

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -9,7 +9,7 @@ import scala.language.implicitConversions
 /**
  * This package defines key types and conversions related to [[ScopedBuilder]].
  *
- * <h2> A brief introduction to [[ScopedBuilder]] </h2>
+ * =A brief introduction to [[ScopedBuilder]]=
  *
  * [[ScopedBuilder]] is a utility class for generating TLA+ IR expressions. It can be conceptually separated into three
  * distinct layers:
@@ -17,7 +17,7 @@ import scala.language.implicitConversions
  *   1. The type-safe, scope-unsafe layer
  *   1. The type-safe, scope-safe layer
  *
- * <h1> The signature layer </h1>
+ * ==The signature layer==
  *
  * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. The majority (but not all) of operators have
  * type signatures, that is, they restrict the types of the arguments, that may be used to construct valid [[OperEx]]
@@ -70,7 +70,7 @@ import scala.language.implicitConversions
  * [[TypeComputationFactory.knownSignatures knownSignatures]] stores all operator signatures that are considered known
  * to [[ScopedBuilder]].
  *
- * <h1> The type-safe, scope-unsafe layer </h1>
+ * ==The type-safe, scope-unsafe layer==
  *
  * In this layer, we define builder methods, which generate type-safe (though potentially scope-unsafe) [[TlaEx]]
  * values. For the most part, we focus on [[OperEx]] values, as literals can be trivially constructed as type-safe.
@@ -122,7 +122,7 @@ import scala.language.implicitConversions
  * [[unsafe]] contains collections of builder methods, categorized by the type of IR operator they build
  * ([[TlaBoolOper]], [[TlaArithOper]], [[ApalacheOper]], etc.)
  *
- * <h1> The type-safe, scope-safe layer </h1>
+ * ==The type-safe, scope-safe layer==
  *
  * In practice, it is not enough to construct type-safe expressions (w.r.t. signatures). Consider the following example:
  * `CHOOSE (x: Int) \in (S: Set(Int)): (x: Bool)`. We know `CHOOSE` has the signature `(t, Set(t), Bool) => t`, so from

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -9,7 +9,7 @@ import scala.language.implicitConversions
 /**
  * This package defines key types and conversions related to [[ScopedBuilder]].
  *
- * =A brief introduction to [[ScopedBuilder]]=
+ * =A brief introduction to [[ScopedBuilder]] development=
  *
  * [[ScopedBuilder]] is a utility class for generating TLA+ IR expressions. It can be conceptually separated into three
  * distinct layers:
@@ -19,8 +19,8 @@ import scala.language.implicitConversions
  *
  * ==The signature layer==
  *
- * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. The majority (but not all) of operators have
- * type signatures, that is, they restrict the types of the arguments, that may be used to construct valid [[OperEx]]
+ * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. Most operators have
+ * type signatures, that is, they restrict the types of arguments allowed to construct valid [[OperEx]]
  * expressions. For instance, [[TlaArithOper.plus]] represents the arithmetic operator `+` and has the signature `(Int,
  * Int) => Int` in the type system, meaning that `e @ OperEx(TlaArithOper.plus, x, y)` is considered valid iff `x`, `y`,
  * and `e` are all tagged with `Typed(IntT1)`. Similarly, [[TlaOper.chooseBounded]] has the signature `(t, Set(t), Bool)
@@ -50,8 +50,8 @@ import scala.language.implicitConversions
  * signature to `Seq(IntT1, SetT1(IntT1), BoolT1)`, would return `IntT1` while applying it to `Seq(StrT1, SetT1(StrT1),
  * BoolT1)` would return `StrT1`. It is not applicable to `Seq(IntT1, SetT1(StrT1), BoolT1)`.
  *
- * [[Signature]]s complete [[PartialSignature]]s, by equipping them with an exception message, to be thrown should the
- * input sequence not match the pattern defined by the [[PartialSignature]]. This lifting is done by
+ * [[Signature]]s complete [[PartialSignature]]s, by equipping them with an exception, to be thrown should the
+ * input sequence not match the pattern defined by the corresponding [[PartialSignature]]. This lifting is done by
  * [[BuilderUtil.completePartial completePartial]], if all we want is a total function, or
  * [[BuilderUtil.checkForArityException checkForArityException]], to output a more precise error message, outlining
  * whether [[PartialSignature]] application failed because of the non-existence of a type substitution, or simply
@@ -179,7 +179,7 @@ import scala.language.implicitConversions
  * [[subbuilder]], following the same grouping strategy (by [[TlaOper]] sort).
  *
  * For every scope-safe method `method` there is a 2nd-layer method `method(arg1: TlaEx, ..., argN: TlaEx): TlaEx`
- * defined ins some `unsafeBuilder` used as a basis (a few methods take arguments, which are not `TlaEx`, we omit them
+ * defined in some `unsafeBuilder` used as a basis (a few methods take arguments, which are not `TlaEx`, we omit them
  * here). Then, the scope-safe `method` has the signature `method(arg1: TBuilderInstruction, ..., argN:
  * TBuilderInstruction): TBuilderInstruction`. This way, it composes nicely with other scope-safe methods. The general
  * implementation of a scope-safe method from a scope-unsafe method is fairly simple:

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla
 
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.TlaOper
+import at.forsyte.apalache.tla.lir.oper._
 import scalaz._
 
 import scala.language.implicitConversions
@@ -21,12 +21,12 @@ import scala.language.implicitConversions
  *
  * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. The majority (but not all) of operators have
  * type signatures, that is, they restrict the types of the arguments, that may be used to construct valid [[OperEx]]
- * expressions. For instance, [[at.forsyte.apalache.tla.lir.oper.TlaArithOper.plus]] represents the arithmetic operator
- * `+` and has the signature `(Int, Int) => Int` in the type system, meaning that `e @ OperEx(TlaArithOper.plus, x, y)`
- * is considered valid iff `x`, `y`, and `e` are all tagged with `Typed(IntT1)`. Similarly,
- * [[at.forsyte.apalache.tla.lir.oper.TlaOper.chooseBounded]] has the signature `(t, Set(t), Bool) => t`, meaning that
- * `e @ OperEx(TlaOper.chooseBounded, x, S, p)` is considered valid if `x` and `e` are tagged with `Typed(t)`, for some
- * `t`, `S` is tagged with `Typed(SetT1(t))` (for the same `t`), and `p` is tagged with `Typed(BoolT1)`.
+ * expressions. For instance, [[TlaArithOper.plus]] represents the arithmetic operator `+` and has the signature `(Int,
+ * Int) => Int` in the type system, meaning that `e @ OperEx(TlaArithOper.plus, x, y)` is considered valid iff `x`, `y`,
+ * and `e` are all tagged with `Typed(IntT1)`. Similarly, [[TlaOper.chooseBounded]] has the signature `(t, Set(t), Bool)
+ * \=> t`, meaning that `e @ OperEx(TlaOper.chooseBounded, x, S, p)` is considered valid if `x` and `e` are tagged with
+ * `Typed(t)`, for some `t`, `S` is tagged with `Typed(SetT1(t))` (for the same `t`), and `p` is tagged with
+ * `Typed(BoolT1)`.
  *
  * You can think of a signature `(a1,...,an) => b` as a partial function; given a sequence of argument types `v1, ...
  * vn`, it returns some type `c` (derived from `b`), if the types `v1, ..., vn` match the pattern `a1, ..., an`. More
@@ -46,28 +46,29 @@ import scala.language.implicitConversions
  *   { case Seq(t, SetT1(tt), BoolT1) if t == tt => t }
  * }}}
  * that is, given an input sequence of exactly three arguments, the first two of which are `t` and `Set(t)`, for some
- * `t`, and the last of which is `BoolT1, it deduces the result type to be `t`. This means that applying this partial
+ * `t`, and the last of which is `BoolT1`, it deduces the result type to be `t`. This means that applying this partial
  * signature to `Seq(IntT1, SetT1(IntT1), BoolT1)`, would return `IntT1` while applying it to `Seq(StrT1, SetT1(StrT1),
  * BoolT1)` would return `StrT1`. It is not applicable to `Seq(IntT1, SetT1(StrT1), BoolT1)`.
  *
  * [[Signature]]s complete [[PartialSignature]]s, by equipping them with an exception message, to be thrown should the
  * input sequence not match the pattern defined by the [[PartialSignature]]. This lifting is done by
- * [[BuilderUtil.completePartial]], if all we want is a total function, or [[BuilderUtil.checkForArityException]], to
- * output a more precise error message, outlining whether [[PartialSignature]] application failed because of the
- * non-existence of a type substitution, or simply because of an invalid arity.
+ * [[BuilderUtil.completePartial completePartial]], if all we want is a total function, or
+ * [[BuilderUtil.checkForArityException checkForArityException]], to output a more precise error message, outlining
+ * whether [[PartialSignature]] application failed because of the non-existence of a type substitution, or simply
+ * because of an invalid arity.
  *
- * [[SignatureMap]] represents a map from [[at.forsyte.apalache.tla.lir.oper.ApalacheOper]]s to their [[Signature]]s
- * (for those that have one). The module [[signatures]] defines [[SignatureMap]]s for various subtypes of
- * [[at.forsyte.apalache.tla.lir.oper.ApalacheOper]], grouped by their category. Each object in [[signatures]] defines a
+ * [[SignatureMap]] represents a map from [[TlaOper]]s to their [[Signature]]s (for those that have one). The module
+ * [[signatures]] defines [[SignatureMap]]s for various subtypes of [[TlaOper]], grouped by their category. Each object
+ * in [[signatures]] defines a
  * {{{
  *   def getMap: SignatureMap
  * }}}
- * A convenience method [[BuilderUtil.signatureMapEntry]] is provided, which creates a [[SignatureMap]] entry from a
- * partial signature and operator. Internally, it invokes [[BuilderUtil.checkForArityException]], by reading the
- * operator's name and arity.
+ * A convenience method [[BuilderUtil.signatureMapEntry signatureMapEntry]] is provided, which creates a
+ * [[SignatureMap]] entry from a partial signature and operator. Internally, it invokes
+ * [[BuilderUtil.checkForArityException]], by reading the operator's name and arity.
  *
- * [[TypeComputationFactory]] stores all operator signatures that are considered known to [[ScopedBuilder]] in
- * `knownSignatures`.
+ * [[TypeComputationFactory.knownSignatures knownSignatures]] stores all operator signatures that are considered known
+ * to [[ScopedBuilder]].
  *
  * <h1> The type-safe, scope-unsafe layer </h1>
  *
@@ -96,30 +97,118 @@ import scala.language.implicitConversions
  * There are two distinct cases:
  *   1. `oper` is associated with some [[Signature]], i.e. `TypeComputationFactory.knownSignatures.contains(oper)`. This
  *      is the case for most operators.
- *   1. `oper` does not have a signature in [[TypeComputationFactory.knownSignatures]]. This is the case for operators
- *      such as [[at.forsyte.apalache.tla.lir.oper.TlaFunOper.app]] or
- *      [[at.forsyte.apalache.tla.lir.oper.ApalacheInternalOper.notSupportedByModelChecker]] (and more).
+ *   1. `oper` does not have a signature in [[TypeComputationFactory.knownSignatures knownSignatures]]. This is the case
+ *      for operators such as [[TlaFunOper.app]] or [[ApalacheInternalOper.notSupportedByModelChecker]] (and more).
  *
  * Observe that a [[Signature]] is already a [[PureTypeComputation]]. Therefore, any operator with an associated
  * signature has a naturally associated [[TypeComputation]] (obtained by applying [[fromPure]] to the [[Signature]]). In
- * particular, we can access the [[PureTypeComputation]]s via [[TypeComputationFactory.computationFromSignature]]. For
- * operators, which do not have [[Signature]]s, we need to manually implement these [[TypeComputation]]s on an
- * individual basis.
+ * particular, we can access the [[PureTypeComputation]]s via
+ * [[TypeComputationFactory.computationFromSignature computationFromSignature]]. For operators, which do not have
+ * [[Signature]]s, we need to manually implement these [[TypeComputation]]s on an individual basis.
  *
  * In both cases [[BuilderUtil.composeAndValidateTypes]] performs the composition task for us: given an operator `oper`,
  * a [[TypeComputation]] `cmp` and arguments `args` [[BuilderUtil.composeAndValidateTypes]] computes `cmp(args)`. If it
  * produces an exception, it is thrown, otherwise `OperEx(oper, args:_*)(Typed(t))` is produced, where `t` is the type
  * determined by `cmp(args)`.
  *
- * [[unsafe.ProtoBuilder]] defines the utility method [[unsafe.ProtoBuilder.buildBySignatureLookup]], which uses
- * [[TypeComputationFactory.computationFromSignature]] to get the (Pure)[[TypeComputation]]s associated with an
- * operator, then calls [[BuilderUtil.composeAndValidateTypes]] internally. Thus, is a builder method constructs
- * expressions for an operator `oper`, associated with a [[Signature]], the typical way to implement the method
- * `method(arg1, ..., argN)` is by `buildBySignatureLookup(oper, arg1, ..., argN)`.
+ * [[unsafe.ProtoBuilder]] defines the utility method
+ * [[unsafe.ProtoBuilder.buildBySignatureLookup buildBySignatureLookup]], which uses
+ * [[TypeComputationFactory.computationFromSignature computationFromSignature]] to get the (Pure)[[TypeComputation]]s
+ * associated with an operator, then calls [[BuilderUtil.composeAndValidateTypes composeAndValidateTypes]] internally.
+ * Thus, is a builder method in [[unsafe]] constructs expressions for an operator `oper`, associated with a
+ * [[Signature]], the typical way to implement the method `method(arg1, ..., argN)` is by `buildBySignatureLookup(oper,
+ * arg1, ..., argN)`.
  *
  * [[unsafe]] contains collections of builder methods, categorized by the type of IR operator they build
- * ([[at.forsyte.apalache.tla.lir.oper.TlaBoolOper]], [[at.forsyte.apalache.tla.lir.oper.TlaArithOper]],
- * [[at.forsyte.apalache.tla.lir.oper.ApalacheOper]], etc.)
+ * ([[TlaBoolOper]], [[TlaArithOper]], [[ApalacheOper]], etc.)
+ *
+ * <h1> The type-safe, scope-safe layer </h1>
+ *
+ * In practice, it is not enough to construct type-safe expressions (w.r.t. signatures). Consider the following example:
+ * `CHOOSE (x: Int) \in (S: Set(Int)): (x: Bool)`. We know `CHOOSE` has the signature `(t, Set(t), Bool) => t`, so from
+ * the perspective of type-correctness, the arguments `x: Int`, `S: Set(Int)` and `x: Bool` match the pattern and the
+ * constructed expression is considered well-typed (with a result type of `Int`). Notice, however, that the variable `x`
+ * is used with two different types in the same expression, once with `Int` in the position of the bound variable, and
+ * once with `Bool` in the `CHOOSE` body.
+ *
+ * Scope safety is defined as the combination of the following properties:
+ *   1. Type consistency: Multiple instances of a variable within the same scope have the same type. They may have
+ *      different types in different scopes. Example: `(\E x \in {1,2,3}: TRUE) /\ \E x \in {"1", "2", "3"}: TRUE`, is
+ *      type- consistent, but `\E x \in {"1", "2", "3"}: x > 0` is not.
+ *   1. Absence of shadowing: Bound variable names are unambiguous w.r.t. the location binding them. Example: `\E x \in
+ *      A: \E x \in B: x > 0` shadows `x` (it is unclear whether `x` in `x > 0` is bound to `A` or `B`).
+ *
+ * Type-correctness is a local property; a violation occurs due to an immediate incompatibility between a parent node
+ * and its direct children in the IR tree. Unfortunately, scope-safety is not; it could be the case that two
+ * expressions, which together violate scope-safety occur in different positions in the IR sub-tree (possibly on
+ * parallel sub-trees s.t. one is not an ancestor of the other).
+ *
+ * Because scope-safety is non-local, builder methods need to keep track of scope ''persistently, and in addition to''
+ * constructing a [[TlaEx]] expression. Instead of a mutable `var` storage, or methods which return tuples (and thus
+ * don't compose), we solve this problem by using [[scalaz.State]]. We define our notion of persistently stored
+ * information in [[TBuilderContext]]; every builder method has the ability to read from, and write to, some
+ * [[TBuilderContext]], to determine whether scope-safety would be violated in the construction of the desired
+ * expression.
+ *
+ * We define the (parameterized) alias [[TBuilderInternalState]]. A [[TBuilderInternalState]][T] value represents the
+ * ''process'' of constructing a value of type `T`, while maintaining an internal, persistent [[TBuilderContext]]. Most
+ * builder methods construct [[TlaEx]] expressions, so we introduce a shorthand type alias [[TBuilderInstruction]],
+ * which is just [[TBuilderInternalState]][`TlaEx`].
+ *
+ * It is important to note that constructing a [[TBuilderInternalState]] will not throw any kinds of exceptions, even if
+ * a scope (or even type) violation would occur, because a [[TBuilderInternalState]] is conceptually a process, not a
+ * value. To actually obtain a value (or possibly an exception), we can invoke one of two methods: [[build]], or
+ * [[BuildViaMethod.build]]. The method (resp. the class) are `implicit`, so they need not be invoked manually. This
+ * lets us use [[TBuilderInternalState]][`T`] anywhere we would otherwise need a value of type `T`. For example, given a
+ * value `bi: TBuilderInternalState`, we can obtain the `TlaEx` (the construction of which is described by the process
+ * `bi`) in any of the following equivalent ways:
+ * {{{
+ *   val tlaEx: TlaEx = bi
+ *   val tlaEx = build(bi)
+ *   val tlaEx = bi.build
+ * }}}
+ * [[liftBuildToSeq]] serves a similar purpose, it implicitly converts a sequence of [[TBuilderInternalState]][`T`] of
+ * `T` values.
+ *
+ * Note to developers: We need to be careful when using methods which accept arguments of `Any` type (e.g. `==`). In
+ * those cases, [[build]], or [[BuildViaMethod.build]] must be explicitly invoked, as matching `Any` will not trigger an
+ * implicit call to [[build]].
+ *
+ * What is left is to determine how to combine this approach with the scope-unsafe-layer builder methods in [[unsafe]],
+ * which already guarantee type-safety. Each builder in [[unsafe]] has a corresponding scope-safe builder in
+ * [[subbuilder]], following the same grouping strategy (by [[TlaOper]] sort).
+ *
+ * For every scope-safe method `method` there is a 2nd-layer method `method(arg1: TlaEx, ..., argN: TlaEx): TlaEx`
+ * defined ins some `unsafeBuilder` used as a basis (a few methods take arguments, which are not `TlaEx`, we omit them
+ * here). Then, the scope-safe `method` has the signature `method(arg1: TBuilderInstruction, ..., argN:
+ * TBuilderInstruction): TBuilderInstruction`. This way, it composes nicely with other scope-safe methods. The general
+ * implementation of a scope-safe method from a scope-unsafe method is fairly simple:
+ * {{{
+ *   for {
+ *     arg1Ex <- arg1
+ *     ...
+ *     argNEx <- argN
+ *   } yield unsafeBuilder.method(arg1Ex, ..., argNEx)
+ * }}}
+ * This way, we get the type-correctness from the 2nd layer for free. [[BuilderUtil]] defines convenience methods for
+ * this generic construction: [[BuilderUtil.binaryFromUnsafe binaryFromUnsafe]], and [[BuilderUtil.ternaryFromUnsafe]]
+ * (the unary case is just a `map`).
+ *
+ * The exceptions to this general rule are the [[subbuilder.LiteralAndNameBuilder.name name]] method, which introduces a
+ * variable with a given name and type, and the various methods, which introduce bound variables (e.g.
+ * [[subbuilder.BoolBuilder.exists exists]], [[subbuilder.FunBuilder.funDef funDef]],
+ * [[subbuilder.BaseBuilder.choose choose]], etc.). These methods manipulate (or read) the internal [[TBuilderContext]],
+ * to ensure scope-safety. The latter utilize the convenience methods
+ * [[BuilderUtil.boundVarIntroductionBinary boundVarIntroductionBinary]],
+ * [[BuilderUtil.boundVarIntroductionTernary boundVarIntroductionTernary]], and
+ * [[BuilderUtil.boundVarIntroductionVariadic boundVarIntroductionVariadic]] to handle bound-variable-introduction,
+ * which internally uses [[BuilderUtil.markAsBound markAsBound]], [[BuilderUtil.getAllBound getAllBound]], and
+ * [[BuilderUtil.getAllUsed getAllUsed]].
+ *
+ * [[ScopedBuilder]] is the amalgamation of all the builder methods defined in [[subbuilder]] (as well as a handful of
+ * methods, which construct [[TlaEx]] expressions unrelated to [[TlaOper]], such as [[ScopedBuilder.decl decl]] or
+ * [[ScopedBuilder.letIn letIn]]). The package [[types]] offers a premade instance of [[ScopedBuilder]] and is
+ * recommended to be used whenever one needs to construct type- and scope-safe TLA+ expressions.
  *
  * @author
  *   Jure Kukovec

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/package.scala
@@ -2,21 +2,65 @@ package at.forsyte.apalache.tla
 
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
+import at.forsyte.apalache.tla.typecomp.SignatureMap
 import scalaz._
 
 import scala.language.implicitConversions
 
 /**
- * The key definitions related to the typed builder. The most important ones for the users of this API are the methods:
+ * This package defines key types and conversions related to [[ScopedBuilder]].
  *
- *   - an implicit conversion [[typecomp#build]] that converts a builder state to its final form, e.g., to `TlaEx`.
- *   - an implicit conversion [[typecomp#liftBuildToSeq]] that applies `build` to a sequence.
+ * <h1> A brief introduction to [[ScopedBuilder]] <h1>
  *
- * To use the above methods in your code, import the implicit conversions as follows:
+ * [[ScopedBuilder]] is a utility class for generating TLA+ IR expressions. It can be conceptually separated into three
+ * distinct layers:
+ *   1. The signature layer
+ *   1. The type-safe, scope-unsafe layer
+ *   1. The type-safe, scope-safe layer
  *
+ * <h2> The signature layer <h2>
+ *
+ * Each TLA+ operator has an associated [[TlaOper]] operator in the IR. The majority (but not all) of the operators have
+ * type signatures, that is, they restrict the types of the arguments, that may be used to construct valid [[OperEx]]
+ * expressions. For instance, [[at.forsyte.apalache.tla.lir.oper.TlaArithOper.plus]] represents the arithmetic operator
+ * `+` and has the signature `(Int, Int) => Int` in the type system, meaning that `e@OperEx(TlaArithOper.plus, x, y)` is
+ * considered valid iff both `x`, `y`, and `e` are all tagged with `Typed(IntT1)`. Similarly,
+ * [[at.forsyte.apalache.tla.lir.oper.TlaOper.chooseBounded]] has the signature `(t, Set(t), Bool) => t`, meaning that
+ * `e@OperEx(TlaOper.chooseBounded, x, S, p)` is considered valid if `x` and `e` are tagged with `Typed(t: TlaType1)`,
+ * for some `t`, `S` is tagged with `Typed(SetT1(t))` (for the same `t`), and `p` is tagged with `Typed(BoolT1)`.
+ *
+ * You can think of a signature `(a1,...,an) => b` as a partial function; given a sequence of argument types `v1, ...
+ * vn`, it returns some type `c` (derived from `b`), if the types `v1, ..., vn` match the pattern `a1, ..., an`. More
+ * precisely, the return value is `s(b)`, if there exists some type substitution `s`, such that `s(ai) = vi` for all i.
+ *
+ * To reason about signatures, we define two types, [[PartialSignature]] and [[Signature]]. They serve the same purpose,
+ * but differ in the way they behave on mis-matches. [[PartialSignature]]s are bare-bones descriptions of the
+ * happy-case; given an input pattern `a1,...,an`, they describe the output `b`. For example, `plus` has the
+ * [[PartialSignature]]
  * {{{
- *  import at.forsyte.apalache.tla.typecomp._
+ *   { case Seq(IntT1, IntT1) => IntT1 }
  * }}}
+ * that is, given an input sequence of exactly two arguments, both of which are `IntT1`, it deduces the result type to
+ * be `IntT1`. Similarly, `chooseBounded` has the signature
+ * {{{
+ *   { case Seq(t, SetT1(tt), BoolT1) if t == tt => t }
+ * }}}
+ * that is, given an input sequence of exactly three arguments, the first two of which are `t` and `Set(t)`, for some
+ * `t`, and the last of which is `BoolT1, , it deduces the result type to be `t`. This means that applying this partial
+ * signature to `Seq(IntT1, SetT1(IntT1), BoolT1)`, would return `IntT1` while applying it to `Seq(StrT1, SetT1(StrT1),
+ * BoolT1)` would return `StrT1`. It is not applicable to `Seq(IntT1, SetT1(StrT1), BoolT1)`.
+ *
+ * [[Signature]]s complete [[PartialSignature]]s, by equipping them with an exception message, should the input sequence
+ * not match the pattern defined by the [[PartialSignature]]. This lifting is done by [[BuilderUtil.completePartial]],
+ * which can be further refined by [[BuilderUtil.checkForArityException]], to output a more precise error message,
+ * outlining whether [[PartialSignature]] application failed because of the non-existence of a type substitution, or
+ * simply because of an invalid arity.
+ *
+ * [[SignatureMap]] represents a map from [[at.forsyte.apalache.tla.lir.oper.ApalacheOper]]s to their signatures (for
+ * those that have one). The module [[signatures]] defines maps for various subtypes of
+ * [[at.forsyte.apalache.tla.lir.oper.ApalacheOper]], grouped by their category. A convenience method
+ * [[BuilderUtil.signatureMapEntry]] is provided, which creates a [[SignatureMap]] entry from a partial signature and
+ * operator. Internally, it invokes [[BuilderUtil.checkForArityException]], by reading the operator's name and arity.
  */
 package object typecomp {
 


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to [./unreleased/][unreleased] for any new functionality

closes #1912

Note: I noticed the `ScopedBuilder.parser` was a `def` instead of a `val` so I just fixed it.

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
