### PR TITLE
Add sbt-unicode dependency and build scaladoc in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,17 @@ jobs:
       - name: Check formatting
         run: make fmt-check
 
+  scaladoc-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Check scaladoc
+        run: sbt unidoc
+
   compiler-warnings:
     env:
       APALACHE_FATAL_WARNINGS: true

--- a/build.sbt
+++ b/build.sbt
@@ -244,7 +244,7 @@ lazy val apalacheCurrentPackage = taskKey[File]("Set the current executable apal
 
 // Define the main entrypoint and uber jar package
 lazy val root = (project in file("."))
-  .enablePlugins(UniversalPlugin, sbtdocker.DockerPlugin, ChangelingPlugin)
+  .enablePlugins(UniversalPlugin, sbtdocker.DockerPlugin, ChangelingPlugin, ScalaUnidocPlugin)
   .dependsOn(distribution)
   .aggregate(
       // propagate commands to these sub-projects
@@ -261,6 +261,9 @@ lazy val root = (project in file("."))
   )
   .settings(
       testSettings,
+      // TODO: uncomment to enable building unidoc for for all test and src code
+      // Generate scaladoc for both test and src code
+      // ScalaUnidoc / unidoc / unidocConfigurationFilter := inConfigurations(Compile, Test),
       // Package definition
       Compile / packageBin / mappings ++= Seq(
           // Include theese assets in the compiled package at the specified locations

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/Executor.scala
@@ -7,8 +7,8 @@ import com.google.inject.Guice
  * This Executor abstracts the dependency injection and execution logic required for executing a PassChainExecutor
  *
  * @param toolModule
- *   The [[ToolModule]] that specifies the sequence of passes
- * @throws [[AdaptedException]]
+ *   The [[infra.passes.ToolModule]] that specifies the sequence of passes
+ * @throws AdaptedException
  *   if any exceptions are caught by the configured [[ExceptionAdapter]]
  * @author
  *   Shon Feder

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/exceptions.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/exceptions.scala
@@ -16,7 +16,7 @@ class PassExecException(message: String) extends Exception(message)
 class PassOptionException(message: String) extends Exception(message)
 
 /**
- * An error that has been adapted by the [[ExceptionAdaptor]]
+ * An error that has been adapted by a [[ExceptionAdapter]]
  * @param err
  *   the [[ErrorMessage]] into which the originating error was adapted
  */

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -25,8 +25,8 @@ object Tool extends LazyLogging {
   lazy val ISSUES_LINK: String = "[https://github.com/informalsystems/apalache/issues]"
 
   /**
-   * Run the tool in the standalone mode with the provided arguments. This method calls [[System.exit]] with the
-   * computed exit code. To call the tool without System.exit, use [[run]].
+   * Run the tool in the standalone mode with the provided arguments. This method calls [[java.lang.System.exit]] with
+   * the computed exit code. To call the tool without System.exit, use [[run]].
    *
    * @param args
    *   the command line arguments

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/PassExecutorCmd.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.infra.Executor
 
 /**
- * Interface for the subcommands that run an [[Executor]]
+ * Interface for the subcommands that run an `Executor`
  *
  * @author
  *   Shon Feder
@@ -15,14 +15,14 @@ abstract class PassExecutorCmd(name: String, description: String)
   /**
    * The executor used to sequence a chain of passes
    *
-   * Executors are created using [[at.forsyte.apalache.infra.passes.ToolModule]]. E.g.,
+   * Executors are created using `at.forsyte.apalache.infra.passes.ToolModule`. E.g.,
    *
    * {{{
    * val executor = Executor(new TypeCheckerModule)
    * }}}
    *
    * The [[run]] methods of a subcommand implementing this trait will generally end with an invication of
-   * [[executor.run]], such as
+   * `executor.run`, such as
    *
    * {{{
    * executor.run() match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,8 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 // https://scalapb.github.io/zio-grpc/docs/installation
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
+// https://github.com/sbt/sbt-unidoc
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 // See https://github.com/scalapb/zio-grpc/blob/master/examples/routeguide/project/plugins.sbt
 val zioGrpcVersion = "0.5.1"

--- a/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/TransExplorerService.scala
@@ -38,26 +38,26 @@ private case class Conn(
   }
 }
 
+// TODO: Link the TransitionExecutor once tla.bmcmt.trex is imported
 /**
- * The service enabling interaction with the symbolic model checker, via the
- * [[at.forsyte.apalache.tla.bmcmt.trex.TransitionExecutor]]
+ * The service enabling interaction with the symbolic model checker, via the `TransitionExecutor`
  *
  * ==Overview==
  * The public methods of this class are handlers for the protobuf messages defined in `transExplorer.proto`. These
  * handlers implement RPC calls enabling interaction with the Apalache model checker.
  *
- * On a successful remote procedure call, a handler returns a value of type [[Result[T]]], were [[T]] is the type of the
+ * On a successful remote procedure call, a handler returns a value of type `[[Result]][T]`, were `T` is the type of the
  * protobuf message specified as the response for the given RPC.
  *
- * The type [[Result[T]]] is an alias for [[ZIO[ZEnv, Status, T]]], which is fallible promise to return a value of type
- * [[T]] computed in the environment [[ZEnv]].
+ * The type `[[Result]][T]` is an alias for `ZIO[ZEnv, Status, T]`, which is fallible promise to return a value of type
+ * `T` computed in the environment `ZEnv`.
  *
  * ==Error handling==
  *
  * There are two kinds of errors that may be signled by the PRC handlers:
  *
  *   - '''Protocol-level errors''', which indicate a failure to communicate successfully with the RPC system. These are
- *     indicated by [[Status]] error codes.
+ *     indicated by the `Status` error codes.
  *   - '''Application-level errors''', which indicate some erroneous outcome in the execution of an RPC that was
  *     successfully communicated and executed. These are indicated by `err` results in the protobuf message sent back in
  *     response.
@@ -85,7 +85,7 @@ private case class Conn(
 class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: Semaphore)
     extends ZioTransExplorer.ZTransExplorer[ZEnv, Any] {
 
-  /** Concurrent tasks performed by the service that produce values of type [[T]] */
+  /** Concurrent tasks performed by the service that produce values of type `T` */
   type Result[T] = ZIO[ZEnv, Status, T]
 
   // The type of the `conn` field carried by all requests (exception for the `ConnectRequest`)
@@ -98,10 +98,10 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: S
   /**
    * Creates and registers a new connection
    *
-   * This method handles the [[OpenConnection]] RPC defined by `transExplorer.proto`
+   * This method handles the `openConnection` RPC defined by `transExplorer.proto`
    *
-   * Every session that interacts with the server must begin by obtaining a [[Connection]], and every subsequent request
-   * must include a `conn` field holding the [[Connection]].
+   * Every session that interacts with the server must begin by obtaining a [[transExplorer.Connection]], and every
+   * subsequent request must include a `conn` field holding the [[transExplorer.Connection]].
    *
    * @param req
    *   the request (isomorphic to the Unit)
@@ -114,7 +114,7 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: S
   /**
    * Parses a spec into a model
    *
-   * This method handles the [[LoadModelRequest]] RPC defined by `transExplorer.proto`
+   * This method handles the [[transExplorer.LoadModelRequest]] RPC defined by `transExplorer.proto`
    *
    * @param req
    *   the request to load a model, including the root module spec and any auxiliary modules

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
@@ -137,7 +137,7 @@ class Arena private (
    *   the name returned by ArenaCell.toString
    * @return
    *   the cell, if it exists
-   * @throws NoSuchElementException
+   * @throws java.util.NoSuchElementException
    *   when no cell is found
    */
   def findCellByName(name: String): ArenaCell = {
@@ -153,7 +153,7 @@ class Arena private (
    *   the found cell
    * @throws InvalidTlaExException
    *   if the name does not follow the convention
-   * @throws NoSuchElementException
+   * @throws java.util.NoSuchElementException
    *   when no cell is found
    */
   def findCellByNameEx(nameEx: TlaEx): ArenaCell = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/DumpFilesModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/DumpFilesModelCheckerListener.scala
@@ -11,10 +11,10 @@ import com.typesafe.scalalogging.LazyLogging
  * Observer to [[SeqModelChecker]] that dumps example and counterexample traces to files.
  *
  * The traces are written to files
- *   - `${prefix}${index}.{tla,json,.itf.json}` contains the current (counter)example
- *   - `${prefix}.{tla,json,.itf.json}` contains the latest (counter)example
+ *   - `\${prefix}\${index}.{tla,json,.itf.json}` contains the current (counter)example
+ *   - `\${prefix}.{tla,json,.itf.json}` contains the latest (counter)example
  *
- * where $prefix and $index are
+ * where \$prefix and \$index are
  *   - "violation" and `errorIndex` for counterexamples, and
  *   - "example" and `exampleIndex` for examples.
  */

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/MessageStorage.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/MessageStorage.scala
@@ -24,7 +24,7 @@ trait MessageStorage {
    *   an id of the object, e.g., ArenaCell.id
    * @return
    *   a text message, if exists
-   * @throws NoSuchElementException
+   * @throws java.util.NoSuchElementException
    *   if there is no message associated with the given id
    */
   def findMessage(id: Int): String

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelCheckerListener.scala
@@ -19,10 +19,11 @@ trait ModelCheckerListener {
    *   The invariant violation to record in the counterexample. Pass
    *   - for invariant violations: the negated invariant,
    *   - for deadlocks: `ValEx(TlaBool(true))`,
-   *   - for trace invariants: the applied, negated trace invariant (see [[SeqModelChecker.applyTraceInv]]).
+   *   - for trace invariants: the applied, negated trace invariant
    * @param errorIndex
    *   Number of found error (likely [[search.SearchState.nFoundErrors]]).
    */
+  // For more on possible trace invariant violations, see the private method `SeqModelChecker.applyTraceInv`
   def onCounterexample(
       rootModule: TlaModule,
       trace: DecodedExecution,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -595,7 +595,7 @@ class SymbStateRewriterImpl(
    *   an id of the object, e.g., ArenaCell.id
    * @return
    *   a text message, if exists
-   * @throws NoSuchElementException
+   * @throws java.util.NoSuchElementException
    *   if there is no message associated with the given id
    */
   override def findMessage(id: Int): String = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithPacker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/IntArithPacker.scala
@@ -16,7 +16,7 @@ trait IntArithPacker {
   private lazy val substRule = new SubstRule
 
   /**
-   * Rewrite [[state]]'s expression into an expression that is purely arithmetic, referring to arena cells for
+   * Rewrite `state`'s expression into an expression that is purely arithmetic, referring to arena cells for
    * non-arithmetic subexpressions.
    *
    * @param rewriter

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -18,7 +18,7 @@ object ModelCheckerParams {
  * A collection of model checker parameters that come from the user configuration.
  *
  * @param stepsBound
- *   Step bound for bounded model-checking, excluding the initial transition introduced by [[PrimingPass]]. E.g.,
+ *   Step bound for bounded model-checking, excluding the initial transition introduced by `PrimingPass`. E.g.,
  *   `stepsBound=1` includes one actual application of the transition operator (e.g., `Next`)
  *
  * @author

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/IncrementalExecutionContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/IncrementalExecutionContext.scala
@@ -34,7 +34,7 @@ class IncrementalExecutionContext(val rewriter: SymbStateRewriter)
    *
    * @param snapshot
    *   a snapshot
-   * @throws IllegalStateException
+   * @throws java.lang.IllegalStateException
    *   when recovery is impossible
    */
   override def recover(snapshot: IncrementalExecutionContextSnapshot): Unit = {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/OfflineExecutionContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/OfflineExecutionContext.scala
@@ -38,7 +38,7 @@ class OfflineExecutionContext(var rewriter: SymbStateRewriter, renaming: Increme
    *
    * @param snapshot
    *   a snapshot
-   * @throws IllegalStateException
+   * @throws java.lang.IllegalStateException
    *   when recovery is impossible
    */
   override def recover(snapshot: OfflineExecutionContextSnapshot): Unit = {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -27,7 +27,7 @@ private object Converters {
 /**
  * The configuration values that can be overriden based on CLI arguments
  *
- * For documentation on the use and meaning of these fields, see [[at.forsyte.apalache.tla.tooling.opt.General]].
+ * For documentation on the use and meaning of these fields, see `at.forsyte.apalache.tla.tooling.opt.General`.
  */
 trait CliConfig {
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -68,7 +68,7 @@ object OutputManager extends LazyLogging {
   /**
    * Accessor for the configured output directory.
    *
-   * @throws IllegalStateException
+   * @throws java.lang.IllegalStateException
    *   if called before OutputManager is configured: this is considered an implementator error
    */
   def outDir: Path = {
@@ -78,7 +78,7 @@ object OutputManager extends LazyLogging {
   /**
    * Accessor for the configured run directory.
    *
-   * @throws IllegalStateException
+   * @throws java.lang.IllegalStateException
    *   if called before OutputManager is configured: this is considered an implementator error
    */
   def runDir: Path = {

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -12,7 +12,7 @@ import at.forsyte.apalache.tla.lir.values._
  * After Apalache's type-checking, we can rewrite some expressions to simpler forms. For example, the (after
  * type-checking) vacuously true `x \in BOOLEAN` is rewritten to `TRUE` (as `x` must be a `BoolT1`).
  *
- * We currently perform the following simplifications (for type-defining sets TDS, see [[isTypeDefining]]):
+ * We currently perform the following simplifications:
  *   - `n \in Nat` ~> `x >= 0`
  *   - `b \in BOOLEAN`, `i \in Int`, `r \in Real` ~> `TRUE`
  *   - `seq \in Seq(TDS)` ~> `TRUE`
@@ -24,6 +24,7 @@ import at.forsyte.apalache.tla.lir.values._
  * @author
  *   Thomas Pani
  */
+// For type-defining sets TDS, see the private method `isTypeDefining`
 class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTransformer(tracker) {
   private val boolTag = Typed(BoolT1)
   private val intTag = Typed(IntT1)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlaConstInliner.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/TlaConstInliner.scala
@@ -8,7 +8,7 @@ import at.forsyte.apalache.tla.lir.transformations.{TlaExTransformation, Transfo
  * Replaces primitive-valued constants initialized in ConstInit with the values they hold.
  *
  * @param tracker
- *   a [[TransformationTracker]]
+ *   a `TransformationTracker`
  * @param constants
  *   the module constant's names
  */
@@ -42,12 +42,12 @@ class TlaConstInliner(tracker: TransformationTracker, constants: Set[String]) {
   }
 
   /**
-   * Returns a [[TlaExTransformation]] that replaces constant references with constant values from `constValMap`.
+   * Returns a `TlaExTransformation` that replaces constant references with constant values from `constValMap`.
    *
    * @param constValMap
-   *   a [[Map]] from constant names to TLA+ values (e.g., constructed by [[buildConstMap]])
+   *   a [[valMap]] from constant names to TLA+ values (e.g., constructed by [[buildConstMap]])
    * @return
-   *   the inlining [[TlaExTransformation]]
+   *   the inlining `TlaExTransformation`
    */
   def replaceConstWithValue(constValMap: valMap): TlaExTransformation = tracker.trackEx {
     case ex @ NameEx(c) if constants.contains(c) =>
@@ -77,7 +77,7 @@ object TlaConstInliner {
    * Replaces primitive-valued constants initialized in ConstInit with the values they hold.
    *
    * @param tracker
-   *   a [[TransformationTracker]]
+   *   a `TlaExTransformation`
    * @param constants
    *   the module constant's names
    */

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/temporal/TableauEncoder.scala
@@ -432,8 +432,6 @@ class TableauEncoder(
 
   /**
    * Encodes each of a sequence of temporal formulas.
-   * @see
-   *   [[encodeFormula]]
    */
   def temporalsToInvariants(modWithPreds: ModWithPreds, formulas: TlaOperDecl*): TlaModule = {
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeAliasSubstitution.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/TypeAliasSubstitution.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.typecheck.TypingInputException
 
 /**
  * A substitution from constant names to types. It is very similar to Substitution. However, [[TypeAliasSubstitution]]
- * is meant to replace constant types, e.g., ENTRY or $entryInCamlCase, with a concrete type, whereas [[Substitution]]
+ * is meant to replace constant types, e.g., ENTRY or \$entryInCamlCase, with a concrete type, whereas [[Substitution]]
  * replaces variables. We use [[TypeAliasSubstitution]] to rewrite type aliases.
  *
  * @param context

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/TemporalBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/TemporalBuilder.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.typecomp.BuilderUtil._
 import at.forsyte.apalache.tla.typecomp.unsafe.UnsafeTemporalBuilder
 
 /**
- * Scope-safe builder for [[at.forsyte.apalache.tla.lir.oper.TlaTempOper]] expressions.
+ * Scope-safe builder for `at.forsyte.apalache.tla.lir.oper.TlaTempOper` expressions.
  *
  * @author
  *   Jure Kukovec

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeTemporalBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeTemporalBuilder.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.tla.lir.oper.TlaTempOper
 import at.forsyte.apalache.tla.lir.{NameEx, TlaEx}
 
 /**
- * Scope-unsafe builder for [[TlaTempOper]] expressions.
+ * Scope-unsafe builder for `TlaTempOper` expressions.
  *
  * @author
  *   Jure Kukovec

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Builder.scala
@@ -613,7 +613,7 @@ class Builder {
   }
 
   /**
-   * Apply the operator [[ApalacheOper.mkSeq]].
+   * Apply the operator [[oper.ApalacheOper.mkSeq]].
    *
    * @param lenEx
    *   non-negative length of the sequence

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
@@ -136,7 +136,7 @@ object ConstT1 {
   }
 
   /**
-   * Does this type represent a reference to an alias, e.g., `$aliasReference`. This case is only of relevance to the
+   * Does this type represent a reference to an alias, e.g., `\$aliasReference`. This case is only of relevance to the
    * type parser and the type checker.
    *
    * @param name
@@ -152,7 +152,7 @@ object ConstT1 {
    * Extract alias name from the reference syntax.
    *
    * @param reference
-   *   a reference such as $aliasRef
+   *   a reference such as \$aliasRef
    * @return
    *   the name without the dollar sign
    */

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeramelizerInputLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeramelizerInputLanguagePred.scala
@@ -7,12 +7,12 @@ import at.forsyte.apalache.tla.lir.transformations.{PredResult, PredResultFail, 
 import scala.collection.immutable.HashSet
 
 /**
- * Test whether expressions fit into the input fragment of [[Keramelizer]], i.e., whether an expression
+ * Test whether expressions fit into the input fragment of `Keramelizer`, i.e., whether an expression
  *   - is flattened (see [[FlatLanguagePred]]),
  *   - operators `exists`, `forall`, `chooseBounded`, `filter`, `apply` take a [[NameEx]] as first argument, and
  *   - `Seq(_)` is prohibited.
  *
- * To get a better idea of the accepted fragment, check [[TestKeramelizerInputLanguagePred]].
+ * To get a better idea of the accepted fragment, check `TestKeramelizerInputLanguagePred`.
  */
 class KeramelizerInputLanguagePred extends ContextualLanguagePred {
   override def isExprOk(expr: TlaEx): PredResult = {


### PR DESCRIPTION
Closes #1911

## Overview

We want to begin running the scaladoc build in our CI and enable devs to easily
build and view the scaladoc rendering of our API docs. This change gets us part
way there. Further work to streamline building and viewing the docs will follow,
along with developer documentation.

## Changes

- Adds the `sbt-unidoc` plugin to generate a single site from all our docs
- Fixes a number of scaladoc errors
- Runs unidoc in our CI builds

## Reviewing

Probably easiest to go by commit, as most of the scaladoc error fixes can
probably be skimmed. If anyone can advise on how to get some of the stubborn
references working correctly, I'd appreciate the tips.

To build the docs locally to see what they look like, you can run

``` sh
sbt unidoc
```

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)