### PR TITLE
Fix unguarded constraining

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunAppRuleWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunAppRuleWithArrays.scala
@@ -43,8 +43,10 @@ class FunAppRuleWithArrays(rewriter: SymbStateRewriter) extends FunAppRule(rewri
         // If argCell is comparable at the Scala level, we generate SMT constraints based on it
         val select = tla.apalacheSelectInFun(elemArg.toNameEx, funCell.toNameEx)
         val eql = tla.eql(elemRes.toNameEx, select)
+        val impl = tla.impl(tla.apalacheSelectInSet(elemArg.toNameEx, domainCell.toNameEx), eql)
         // We need the SMT eql because funCell might be unconstrained, if it originates from a function set
-        rewriter.solverContext.assertGroundExpr(eql)
+        // The constraining only happens if argCell is in the domain
+        rewriter.solverContext.assertGroundExpr(impl)
         return nextState.setRex(elemRes.toNameEx)
       } else {
         // We use an oracle to pick an arg for which the function is applied


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entries added to [./unreleased/][unreleased] for any new functionality~

This PR removes the possibility of applying SMT select to a value outside a function's domain when encoding function application.

[unreleased]: https://github.com/informalsystems/apalache/tree/unstable/.unreleased
