### PR TITLE
Remove dead code

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -121,13 +121,4 @@ class ModelCheckerParams(
   val saveRuns: Boolean =
     tuningOptions.getOrElse("search.simulation.saveRuns", "false").toBoolean
 
-  // does the transition number satisfy the given filter at the given step?
-  def stepMatchesFilter(stepNo: Int, transitionNo: Int): Boolean = {
-    if (transitionFilter.length <= stepNo) {
-      true // no filter applied
-    } else {
-      transitionNo.toString.matches("^%s$".format(transitionFilter(stepNo)))
-    }
-  }
-
 }


### PR DESCRIPTION
Remove `ModelCheckerParams.stepMatchesFilter` as dead code (looks like the functionality moved to `FilteredTransitionExecutor`).