### PR TITLE
update the alias syntax in the docs

### DIFF
--- a/.unreleased/documentation/2009.md
+++ b/.unreleased/documentation/2009.md
@@ -1,0 +1,1 @@
+update the syntax of type aliases in the documentation

--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -1,12 +1,16 @@
 # How to write type annotations
 
-**Revision:** July 7, 2022
+**Revision:** July 22, 2022
 
 **Important updates:**
 
+ - Version 0.25.10: This HOWTO introduces new syntax for type aliases. See
+   [Type Aliases][] in ADR-002.
+
  - Version 0.25.9: This HOWTO introduces new syntax for record types and
    variants, which is currently under testing. This syntax is activated via the
-   option `--features=rows`. See [Type System 1.2](../adr/002adr-types.md#ts12).
+   option `--features=rows`. See [Type System 1.2](../adr/002adr-types.md#ts12)
+   in ADR-002.
 
  - Version 0.23.1: The example specification uses recursive operators, which
    were removed in version 0.23.1.
@@ -380,7 +384,7 @@ clarify the intended meaning of a simple types in the given context.
 Type aliases are declared with the `@typeAlias` annotation, as follows:
 
 ```tla
-\* @typeAlias: ALIAS = <type>;
+\* @typeAlias: aliasNameInCamelCase = <type>;
 ```
 
 For example, suppose we have annotated some constants as follows:
@@ -398,12 +402,13 @@ that the type `Set(PERSON)` is used frequently. Type aliases let us provide a
 shortcut.
 
 By convention, we introduce all type aliases by annotating an operator called
-`<PREFIX>TypeAliases`, where the `<PREFIX>` is replaced with a unique prefix to 
-prevent name clashes. In the [MissionariesAndCannibals.tla][] example, we have
+`<PREFIX>_typedefs`, where the `<PREFIX>` is replaced with a unique prefix to
+prevent name clashes across different modules. Typically `<PREFIX>` is just the
+module name. For the [MissionariesAndCannibalsTyped.tla][] example, we have:
 
 ```tla
-\* @typeAlias: PERSONS = Set(PERSON);
-MCTypeAliases = TRUE
+\* @typeAlias: persons = Set(PERSON);
+MissionariesAndCannibals_typedefs = TRUE
 ```
 
 Having defined the type alias, we can use it in other definitions anywhere else 
@@ -411,25 +416,25 @@ in the file:
 
 ```tla
 CONSTANTS
-    \* @type: PERSONS;
+    \* @type: $persons;
     Missionaries,
-    \* @type: PERSONS;
+    \* @type: $persons;
     Cannibals 
 
 VARIABLES
     \* @type: Str;
     bank_of_boat,
-    \* @type: Str -> PERSONS;
+    \* @type: Str -> $persons;
     who_is_on_bank 
 ```
 
-Surely, we did not gain much by writing `PERSONS` instead of `Set(PERSON)`.  But
-if your specification has complex types (e.g., records), aliases may help you in
-minimizing the burden of specification maintenance. When you add one more field
-to the record type, it suffices to change the definition of the type alias,
-instead of changing the record type everywhere.
+Surely, we did not gain much by writing `$persons` instead of `Set(PERSON)`.
+But if your specification has complex types (e.g., records), aliases may help
+you in minimizing the burden of specification maintenance. When you add one
+more field to the record type, it suffices to change the definition of the type
+alias, instead of changing the record type everywhere.
 
-For more details on the design and usage, see [ADR002][].
+For more details on the design and usage, see [Type Aliases][] in ADR-002.
 
 ## Recipe 7: Multi-line annotations
 
@@ -522,3 +527,5 @@ This may change later, when the tlaplus [Issue 578][] is resolved.
 [Chapter on variants]: ../lang/variants.md
 [Idiom 3]: ../idiomatic/003record-sets.md
 [LamportMutex.tla]: https://github.com/tlaplus/Examples/blob/master/specifications/lamport_mutex/LamportMutex.tla
+[Type Aliases]: ../adr/002adr-types.md#defTypeAlias
+[MissionariesAndCannibalsTyped.tla]: https://github.com/informalsystems/apalache/blob/main/test/tla/MissionariesAndCannibalsTyped.tla

--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -430,7 +430,7 @@ VARIABLES
 
 Surely, we did not gain much by writing `$persons` instead of `Set(PERSON)`.
 But if your specification has complex types (e.g., records), aliases may help
-you in minimizing the burden of specification maintenance. When you add one
+you in minimizing the burden of specification maintenance. If you add one
 more field to the record type, it suffices to change the definition of the type
 alias, instead of changing the record type everywhere.
 

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -2,7 +2,7 @@
 
 **Difficulty: Blue trail – Easy**
 
-**Revision:** July 8, 2022
+**Revision:** July 22, 2022
 
 In this tutorial, we introduce the Snowcat :snowflake: :cat: type checker.
 We give concrete steps on running the type checker and
@@ -151,11 +151,11 @@ From this we can see that `network` is a function of integers to a function of
 integers to a sequence of messages. So its type should look like:
 
 ```tla
-Int -> (Int -> Seq(MESSAGE))
+Int -> (Int -> Seq(/* message type */))
 ```
 
-But what is a message? To find out, we have to continue our archaeology trip
-and check the definition of `Message` and related operators:
+But what is the message type? To find out, we have to continue our archaeology
+trip and check the definition of `Message` and related operators:
 
 ```tla
 {{#include ../../../test/tla/LamportMutexTyped.tla:Message}}
@@ -176,9 +176,9 @@ Int -> (Int -> Seq({ type: Str, clock: Int }))
 ```
 
 We could write it as above, but that type is a bit hard to read. Hence, we
-split it into two parts: the type alias `MESSAGE` that defines the type of
-messages, and the type of `network` that refers to `MESSAGE`. This can be done
-in the following way:
+split it into two parts: the type alias `message` that defines the type of
+messages, and the type of `network` that refers to the type alias `message`.
+This can be done in the following way:
 
 ```tla
 {{#include ../../../test/tla/LamportMutexTyped.tla:vars2}}

--- a/test/tla/LamportMutexTyped.tla
+++ b/test/tla/LamportMutexTyped.tla
@@ -50,11 +50,11 @@ VARIABLES
   crit,     \* set of processes in critical section
 \* ANCHOR_END: vars1
 \* ANCHOR: vars2
-  \* @typeAlias: MESSAGE = {
+  \* @typeAlias: message = {
   \*     type: Str,
   \*     clock: Int
   \* };
-  \* @type: Int -> (Int -> Seq(MESSAGE));
+  \* @type: Int -> (Int -> Seq($message));
   network   \* messages sent but not yet received
 \* ANCHOR_END: vars2
 

--- a/test/tla/MissionariesAndCannibalsTyped.tla
+++ b/test/tla/MissionariesAndCannibalsTyped.tla
@@ -28,14 +28,15 @@
 EXTENDS Integers, FiniteSets
 
 (***************************************************************************)
-(* The MCTypeAliases operator lets us group all type aliases together.     *)
-(* This makes it easy to rever to the defined aliases and the unique MC    *)
+(* With operator MissionariesAndCannibalsTyped_typedefs, we group all type *)
+(* in one place.                                                           *)
+(* This makes it easy to refer to the defined aliases and the unique       *)
 (* prefix protects against name clashes if this module is extended or      *)
 (* instantiated.                                                           *)
 (***************************************************************************)
 
 \* @typeAlias: persons = Set(PERSON);
-MCTypeAliases == TRUE
+MissionariesAndCannibalsTyped_typedefs == TRUE
 
 (***************************************************************************)
 (* Next comes the declaration of the sets of missionaries and cannibals.   *)


### PR DESCRIPTION
Closes #1978. In this PR, we update the type alias syntax in:

 - [x] ADR-002
 - [x] the types HOWTO
 - [x] the types tutorial
 - [x] a few specifications that are referred in the docs 

 - [x] Entries added to [./unreleased/][unreleased] for any new functionality

[unreleased]: https://github.com/informalsystems/apalache/tree/main/.unreleased
