### PR TITLE
Add static representation of configuration options

### DIFF
--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
@@ -1,47 +1,99 @@
-package at.forsyte.apalache.infra.passes
+package at.forsyte.apalache.infra.passes.options
 
-/** Collects the passoptions supported for configuring Apalache's various passes */
-object options {
+import at.forsyte.apalache.tla.lir.Feature
+import java.nio.file.Path
 
-  /** Defines the data sources supported in the [[PassOptions]] */
-  sealed abstract class SourceOption
+/**
+ * Collects the passoptions supported for configuring Apalache's various passes
+ *
+ * @author
+ *   Shon Feder
+ */
 
-  object SourceOption {
+/** Defines the data sources supported */
+sealed abstract class SourceOption
 
-    /** Data to be loaded from a file */
-    final case class FileSource(file: java.io.File) extends SourceOption
+object SourceOption {
 
-    /**
-     * Data supplied as a string
-     *
-     * @param content
-     *   the principle data source
-     * @param aux
-     *   auxiliary data sources
-     */
-    final case class StringSource(content: String, aux: Seq[String] = Seq()) extends SourceOption
-  }
+  /** Data to be loaded from a file */
+  final case class FileSource(file: java.io.File) extends SourceOption
 
   /**
-   * Defines the SMT encoding options supported
+   * Data supplied as a string
    *
-   * @author
-   *   Shon Feder
+   * @param content
+   *   the principle data source
+   * @param aux
+   *   auxiliary data sources
    */
-  sealed abstract class SMTEncoding
+  final case class StringSource(content: String, aux: Seq[String] = Seq()) extends SourceOption
+}
 
-  object SMTEncoding {
-    final case object OOPSLA19 extends SMTEncoding {
-      override def toString: String = "oopsla19"
-    }
-    final case object Arrays extends SMTEncoding {
-      override def toString: String = "arrays"
-    }
+/** Defines the SMT encoding options supported */
+sealed abstract class SMTEncoding
 
-    val ofString: String => SMTEncoding = {
-      case "arrays"        => Arrays
-      case "oopsla19"      => OOPSLA19
-      case oddEncodingType => throw new IllegalArgumentException(s"Unexpected SMT encoding type $oddEncodingType")
-    }
+// TODO: Move into at.forsyte.apalache.tla.lir.Feature?
+object SMTEncoding {
+  final case object OOPSLA19 extends SMTEncoding {
+    override def toString: String = "oopsla19"
   }
+  final case object Arrays extends SMTEncoding {
+    override def toString: String = "arrays"
+  }
+
+  val ofString: String => SMTEncoding = {
+    case "arrays"        => Arrays
+    case "oopsla19"      => OOPSLA19
+    case oddEncodingType => throw new IllegalArgumentException(s"Unexpected SMT encoding type $oddEncodingType")
+  }
+}
+
+trait General {
+
+  /** Tuning options control a wide variety of model checker behavior */
+  // TODO: Make tuning params defined statically
+  // TODO: Move these into the `Checker` options?
+  val tuning: Map[String, String]
+  val debug: Boolean
+
+  /** Enables features protected by feature-flags */
+  val features: Seq[Feature]
+}
+
+/** Options used to configure interaction with the SMT solver */
+// TODO: Should this be removed/merged
+trait Smt {
+  val prof: Boolean
+}
+
+// TODO: Move into "IO"
+trait Parser {
+  val source: SourceOption
+}
+
+/** Options used to configure program input and output */
+trait IO {
+  val output: Option[String] = None
+  val outdir: Path
+}
+
+trait Checker {
+  val algo: String = "incremental" // TODO: convert to case class
+  val cinit: String = "" // TODO: conver to optional
+  val config: String = "" // TODO: convert to optional
+  val discardDisabled: Boolean = true
+  val init: String = "" // TODO: convert to optional
+  val inv: List[String] = List()
+  val length: Int = 10
+  val maxError: Int = 1
+  val next: String = "" // TODO: convert to optional
+  val noDeadlocks: Boolean = false
+  val nworkers: Int = 1
+  val smtEncoding: SMTEncoding = SMTEncoding.OOPSLA19
+  val temporal: List[String] = List()
+  val view: String = "" // TODO: convert to optional
+}
+
+trait Typechecker {
+  val inferPoly: Boolean = true
 }


### PR DESCRIPTION
Contributes towards #1174

## Context

This adds traits with values to represent all the options that we are
currently setting in the `at.forsyte.apalache.tla.tooling.opt.Cmd*`
classes. None of those options are actually transferred over here.

The proposed design uses traits to specify all the options, with the idea that
various subprograms can depend on mixins of the traits to statically declare the
configurations they respond to.

## Reviewing

This changeset just prepares the representation of the options, with the aim of
obtaining feedback and clearing the way for the changeogver. The followup PR
will remove the `PassOptions` class, replacing it with objects that implement
the configuration traits needed by the respective subcommands.


<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Rebase once #2023 is merged in