### PR TITLE
Format and fix tuning docs

### DIFF
--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -48,10 +48,9 @@ default mode is `before`.
 
 `search.transitionFilter=<regex>`. Restrict the choice of
 symbolic transitions at every step with a regular expression. The regular
-expression should recognize words over of the form 's->t', where `s` is a
-regular expression over step numbers and `t` is a regular expression over
-transition numbers. For instance,
-`search.transitionFilter=(0->0|1->5|2->(2|3)|[3-9]->.*|[1-9][0-9]+->.*)`
+expression should recognize words over of the form `s->t`, where `s` is a
+step number and `t` is a transition number.\
+For instance, `search.transitionFilter=(0->0|1->5|2->(2|3)|[3-9]->.*|[1-9][0-9]+->.*)`
 requires to start with the 0th transition, continue with the 5th transition,
 then execute either the 2nd or the 3rd transition and after that execute
 arbitrary transitions until the `length.` Note that there is no direct

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -63,7 +63,7 @@ etc.
 
 ### Invariant filter
 
-`search.invariantFilter=regex`.
+`search.invariantFilter=<regex>`.
 Check the invariant only at the steps that satisfy the regular expression.
 For instance, `search.invariantFilter=10|15|20` tells the model checker to
 check the invariant only *after* exactly 10, 15, or 20 step were made. Step 0

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -19,66 +19,70 @@ The following options are supported:
 
 ## Randomization
 
-`smt.randomSeed=<int>` passes the random seed to `z3` (via `z3`'s parameters `sat.random_seed` and `smt.random_seed`).
+`smt.randomSeed=<int>` passes the random seed to `z3` (via `z3`'s parameters
+`sat.random_seed` and `smt.random_seed`).
 
 ##  Timeouts
 
-`search.smt.timeout=<seconds>` defines the timeout to the SMT
-solver in seconds. The default value is `0`, which stands for the unbounded
-timeout.  For instance, the timeout is used in the following cases: checking
-if a transition is enabled, checking an invariant, checking for deadlocks.
-If the solver times out, it reports 'UNKNOWN', and the model checker reports
-a runtime error.
+`search.smt.timeout=<seconds>` defines the timeout to the SMT solver in seconds.
+The default value is `0`, which stands for the unbounded timeout.  For instance,
+the timeout is used in the following cases: checking if a transition is enabled,
+checking an invariant, checking for deadlocks. If the solver times out, it
+reports 'UNKNOWN', and the model checker reports a runtime error.
 
 ## Invariant mode
 
-`search.invariant.mode=(before|after)` defines the moment
-when the invariant is checked. In the `after` mode, all transitions are first
-translated, one of them is picked non-deterministically and then the
-invariant is checked. Although this mode reduces the number of SMT queries,
-it usually requires more memory than the `before` mode. In the `before` mode,
-the invariant is checked for every enabled transition independently. The
-`before` mode may drastically reduce memory consumption, but it may take
-longer than the `after` mode, provided that Apalache has enough memory. The
-default mode is `before`.
+`search.invariant.mode=(before|after)` defines the moment when the invariant is
+checked. In the `after` mode, all transitions are first translated, one of them
+is picked non-deterministically and then the invariant is checked. Although this
+mode reduces the number of SMT queries, it usually requires more memory than the
+`before` mode. In the `before` mode, the invariant is checked for every enabled
+transition independently. The `before` mode may drastically reduce memory
+consumption, but it may take longer than the `after` mode, provided that
+Apalache has enough memory. The default mode is `before`.
 
 ## Guided search
 
 ### Transition filter
 
-`search.transitionFilter=<regex>`. Restrict the choice of
-symbolic transitions at every step with a regular expression. The regular
-expression should recognize words over of the form `s->t`, where `s` is a
-step number and `t` is a transition number.\
-For instance, `search.transitionFilter=(0->0|1->5|2->(2|3)|[3-9]->.*|[1-9][0-9]+->.*)`
+`search.transitionFilter=<regex>`. Restrict the choice of symbolic transitions
+at every step with a regular expression. The regular expression should recognize
+words over of the form `s->t`, where `s` is a step number and `t` is a
+transition number.
+
+For instance,
+`search.transitionFilter=(0->0|1->5|2->(2|3)|[3-9]->.*|[1-9][0-9]+->.*)`
 requires to start with the 0th transition, continue with the 5th transition,
 then execute either the 2nd or the 3rd transition and after that execute
-arbitrary transitions until the `length.` Note that there is no direct
-correspondence between the transition numbers and the actions in the TLA+
-spec. To find the numbers, run Apalache with `--write-intermediate=true` and
-check the transition numbers in
-`_apalache-out/<MySpec>.tla/*/intermediate/XX_OutTransitionFinderPass.tla`: the 0th
-transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`,
-etc.
+arbitrary transitions until the `length.`
+
+Note that there is no direct correspondence between the transition numbers and
+the actions in the TLA+ spec. To find the numbers, run Apalache with
+`--write-intermediate=true` and check the transition numbers in
+`_apalache-out/<MySpec>.tla/*/intermediate/XX_OutTransitionFinderPass.tla`: the
+0th transition is called `Next_si_0000`, 1st transition is called
+`Next_si_0001`, etc.
 
 ### Invariant filter
 
-`search.invariantFilter=<regex>`.
-Check the invariant only at the steps that satisfy the regular expression.
+`search.invariantFilter=<regex>`. Check the invariant only at the steps that
+satisfy the regular expression.
+
 For instance, `search.invariantFilter=10|15|20` tells the model checker to
 check the invariant only *after* exactly 10, 15, or 20 step were made. Step 0
 corresponds to the initialization with ``Init``, step 1 is the first step
-with ``Next``, etc. This option is useful for checking consensus algorithms,
-where the decision cannot be revoked. So instead of checking the invariant
-after each step, we can do that after the algorithm has made a good number of
-steps.
+with ``Next``, etc.
+
+This option is useful for checking consensus algorithms, where the decision
+cannot be revoked. So instead of checking the invariant after each step, we can
+do that after the algorithm has made a good number of steps.
 
 ## Translation to SMT
 
 ### Short circuiting
 
-`rewriter.shortCircuit=(false|true)`. When
-`rewriter.shortCircuit=true`, `A \/ B` and `A /\ B` are translated to SMT
-as if-then-else expressions, e.g., `(ite A true B)`. Otherwise,
-disjunctions and conjunctions are directly translated to `(or ...)` and
-`(and ...)` respectively. By default, `rewriter.shortCircuit=false`.
+`rewriter.shortCircuit=(false|true)`. When `rewriter.shortCircuit=true`, `A \/
+B` and `A /\ B` are translated to SMT as if-then-else expressions, e.g., `(ite A
+true B)`. Otherwise, disjunctions and conjunctions are directly translated to
+`(or ...)` and `(and ...)` respectively. By default,
+`rewriter.shortCircuit=false`.

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -17,56 +17,67 @@ passing the option `--tuning-options` that has the following format:
 
 The following options are supported:
 
-1. __Randomization__: `smt.randomSeed=<int>` passes the random seed to `z3` (via
-   `z3`'s parameters `sat.random_seed` and `smt.random_seed`).
+## Randomization
 
-1. __Timeouts__: `search.smt.timeout=<seconds>` defines the timeout to the SMT
-   solver in seconds. The default value is `0`, which stands for the unbounded
-   timeout.  For instance, the timeout is used in the following cases: checking
-   if a transition is enabled, checking an invariant, checking for deadlocks.
-   If the solver times out, it reports 'UNKNOWN', and the model checker reports
-   a runtime error.
+`smt.randomSeed=<int>` passes the random seed to `z3` (via `z3`'s parameters `sat.random_seed` and `smt.random_seed`).
 
-1. __Invariant mode__: `search.invariant.mode=(before|after)` defines the moment
-   when the invariant is checked. In the `after` mode, all transitions are first
-   translated, one of them is picked non-deterministically and then the
-   invariant is checked. Although this mode reduces the number of SMT queries,
-   it usually requires more memory than the `before` mode. In the `before` mode,
-   the invariant is checked for every enabled transition independently. The
-   `before` mode may drastically reduce memory consumption, but it may take
-   longer than the `after` mode, provided that Apalache has enough memory. The
-   default mode is `before`.
+##  Timeouts
 
-1. __Guided search__: `search.transitionFilter=<regex>`. Restrict the choice of
-   symbolic transitions at every step with a regular expression. The regular
-   expression should recognize words over of the form 's->t', where `s` is a
-   regular expression over step numbers and `t` is a regular expression over
-   transition numbers. For instance,
-   `search.transitionFilter=(0->0|1->5|2->(2|3)|[3-9]->.*|[1-9][0-9]+->.*)`
-   requires to start with the 0th transition, continue with the 5th transition,
-   then execute either the 2nd or the 3rd transition and after that execute
-   arbitrary transitions until the `length.` Note that there is no direct
-   correspondence between the transition numbers and the actions in the TLA+
-   spec. To find the numbers, run Apalache with `--write-intermediate=true` and
-   check the transition numbers in
-   `_apalache-out/<MySpec>.tla/*/intermediate/XX_OutTransitionFinderPass.tla`: the 0th
-   transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`,
-   etc.
+`search.smt.timeout=<seconds>` defines the timeout to the SMT
+solver in seconds. The default value is `0`, which stands for the unbounded
+timeout.  For instance, the timeout is used in the following cases: checking
+if a transition is enabled, checking an invariant, checking for deadlocks.
+If the solver times out, it reports 'UNKNOWN', and the model checker reports
+a runtime error.
 
-1. __Invariant checking at certain steps__: `search.invariantFilter=regex`.
-   Check the invariant only at the steps that satisfy the regular expression.
-   For instance, `search.invariantFilter=10|15|20` tells the model checker to
-   check the invariant only *after* exactly 10, 15, or 20 step were made. Step 0
-   corresponds to the initialization with ``Init``, step 1 is the first step
-   with ``Next``, etc. This option is useful for checking consensus algorithms,
-   where the decision cannot be revoked. So instead of checking the invariant
-   after each step, we can do that after the algorithm has made a good number of
-   steps.
+## Invariant mode
 
-1. __Translation to SMT__:
+`search.invariant.mode=(before|after)` defines the moment
+when the invariant is checked. In the `after` mode, all transitions are first
+translated, one of them is picked non-deterministically and then the
+invariant is checked. Although this mode reduces the number of SMT queries,
+it usually requires more memory than the `before` mode. In the `before` mode,
+the invariant is checked for every enabled transition independently. The
+`before` mode may drastically reduce memory consumption, but it may take
+longer than the `after` mode, provided that Apalache has enough memory. The
+default mode is `before`.
 
-    1. __Short circuiting__: `rewriter.shortCircuit=(false|true)`. When
-     `rewriter.shortCircuit=true`, `A \/ B` and `A /\ B` are translated to SMT
-     as if-then-else expressions, e.g., `(ite A true B)`. Otherwise,
-     disjunctions and conjunctions are directly translated to `(or ...)` and
-     `(and ...)` respectively. By default, `rewriter.shortCircuit=false`.
+## Guided search
+
+`search.transitionFilter=<regex>`. Restrict the choice of
+symbolic transitions at every step with a regular expression. The regular
+expression should recognize words over of the form 's->t', where `s` is a
+regular expression over step numbers and `t` is a regular expression over
+transition numbers. For instance,
+`search.transitionFilter=(0->0|1->5|2->(2|3)|[3-9]->.*|[1-9][0-9]+->.*)`
+requires to start with the 0th transition, continue with the 5th transition,
+then execute either the 2nd or the 3rd transition and after that execute
+arbitrary transitions until the `length.` Note that there is no direct
+correspondence between the transition numbers and the actions in the TLA+
+spec. To find the numbers, run Apalache with `--write-intermediate=true` and
+check the transition numbers in
+`_apalache-out/<MySpec>.tla/*/intermediate/XX_OutTransitionFinderPass.tla`: the 0th
+transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`,
+etc.
+
+## Invariant checking at certain steps
+
+`search.invariantFilter=regex`.
+Check the invariant only at the steps that satisfy the regular expression.
+For instance, `search.invariantFilter=10|15|20` tells the model checker to
+check the invariant only *after* exactly 10, 15, or 20 step were made. Step 0
+corresponds to the initialization with ``Init``, step 1 is the first step
+with ``Next``, etc. This option is useful for checking consensus algorithms,
+where the decision cannot be revoked. So instead of checking the invariant
+after each step, we can do that after the algorithm has made a good number of
+steps.
+
+## Translation to SMT
+
+### Short circuiting
+
+`rewriter.shortCircuit=(false|true)`. When
+`rewriter.shortCircuit=true`, `A \/ B` and `A /\ B` are translated to SMT
+as if-then-else expressions, e.g., `(ite A true B)`. Otherwise,
+disjunctions and conjunctions are directly translated to `(or ...)` and
+`(and ...)` respectively. By default, `rewriter.shortCircuit=false`.

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -44,6 +44,8 @@ default mode is `before`.
 
 ## Guided search
 
+### Transition filter
+
 `search.transitionFilter=<regex>`. Restrict the choice of
 symbolic transitions at every step with a regular expression. The regular
 expression should recognize words over of the form 's->t', where `s` is a
@@ -60,7 +62,7 @@ check the transition numbers in
 transition is called `Next_si_0000`, 1st transition is called `Next_si_0001`,
 etc.
 
-## Invariant checking at certain steps
+### Invariant filter
 
 `search.invariantFilter=regex`.
 Check the invariant only at the steps that satisfy the regular expression.


### PR DESCRIPTION
Format and clarify tuning manual page.

**Reviewing**: The first and last commit are purely mechanical and don't change the prose. The remaining changes are relatively small and should be self-explanatory.

This is in preparation of #2031, where I need to explain the extended invariant filter.