### PR TITLE
Link to changelog format in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,6 @@
 - [ ] Tests added for any new code
 - [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
 - [ ] Documentation added for any new functionality
-- [ ] Entries added to [./unreleased/][unreleased] for any new functionality
+- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality
 
-[unreleased]: https://github.com/informalsystems/apalache/tree/main/.unreleased
+[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change


### PR DESCRIPTION
I keep forgetting the new changelog format, so this adds a link to the formatting guidelines in [CONTRIBUTING.md](https://github.com/informalsystems/apalache/tree/main/CONTRIBUTING.md#how-to-record-a-change) to our PR template.
The link replaces the previous link to [`./unreleased/`](https://github.com/informalsystems/apalache/tree/main/.unreleased) – the directory is empty after cutting a release and not much help (unless I'm overlooking a use case).