### PR TITLE
Improve the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ assignees: ''
 ## Impact
 
 <!-- Whether this is blocking your work or whether you are able to proceed using -->
-<!-- workarounds or alternative approaces. -->
+<!-- workarounds or alternative approaches. -->
 
 ## Input specification
 
@@ -40,7 +40,7 @@ assignees: ''
 
 ## Log files
 
-<!-- If possible, attach of include the contents `detailed.log` and the tools
+<!-- If possible, attach or include the contents `detailed.log` and the tool's
      output on the command line. -->
 
 ## System information

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,8 +14,8 @@ assignees: ''
 
 ## Description
 
-<!-- A clear and concise description of what the bug is. If you report an
-    exception with a stack trace, no bug explanation is needed. -->
+<!-- A clear and concise description of what the bug is. If you report an -->
+<!-- exception with a stack trace, no bug explanation is needed. -->
 
 ## Impact
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -216,7 +216,7 @@ object Tool extends LazyLogging {
     Console.err.println(
         s"""|Please report an issue at $ISSUES_LINK: $e
             |A bug report template has been generated at [$absPath].
-            |If you choose to use it, please complete the template with a description of the expected behavior.""".stripMargin
+            |If you choose to use it, please complete the template with a description of the expected behavior and impact.""".stripMargin
     )
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -60,9 +60,9 @@ object ReportGenerator {
       |
       |## System information
       |
-      |- Apalache version: `$version`:
-      |- OS: `$os`:
-      |- JDK version: `$jdk`:
+      |- Apalache version: `$version`
+      |- OS: `$os`
+      |- JDK version: `$jdk`
       |""".stripMargin
 
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -41,11 +41,6 @@ object ReportGenerator {
       |<!-- NOTE: Please try to ensure the bug can be produced on the latest release of -->
       |<!-- Apalache. See https://github.com/informalsystems/apalache/releases -->
       |
-      |## Description
-      |
-      |<!-- A clear and concise description of what the bug is. If you report an -->
-      |<!-- exception with a stack trace, no bug explanation is needed. -->
-      |
       |## Impact
       |
       |<!-- Whether this is blocking your work or whether you are able to proceed using -->

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -49,7 +49,7 @@ object ReportGenerator {
       |## Impact
       |
       |<!-- Whether this is blocking your work or whether you are able to proceed using -->
-      |<!-- workarounds or alternative approaces. -->
+      |<!-- workarounds or alternative approaches. -->
       |
       |## Input specification
       |

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -38,6 +38,19 @@ object ReportGenerator {
     s"""<!-- Thank you for filing a report! Please ensure you have filled out all -->
       |<!-- sections, as it help us to address the problem effectively. -->
       |
+      |<!-- NOTE: Please try to ensure the bug can be produced on the latest release of -->
+      |<!-- Apalache. See https://github.com/informalsystems/apalache/releases -->
+      |
+      |## Description
+      |
+      |<!-- A clear and concise description of what the bug is. If you report an -->
+      |<!-- exception with a stack trace, no bug explanation is needed. -->
+      |
+      |## Impact
+      |
+      |<!-- Whether this is blocking your work or whether you are able to proceed using -->
+      |<!-- workarounds or alternative approaces. -->
+      |
       |## Input specification
       |
       |$specTxt
@@ -65,6 +78,14 @@ object ReportGenerator {
       |- Apalache version: `$version`
       |- OS: `$os`
       |- JDK version: `$jdk`
+      |
+      |## Triage checklist (for maintainers)
+      |
+      |<!-- This section is for maintainers -->
+      |
+      |- [ ] Reproduce the bug on the main development branch.
+      |- [ ] Add the issue to the apalache GitHub project.
+      |- [ ] If the bug is high impact, ensure someone available is assigned to fix it.
       |""".stripMargin
 
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -54,9 +54,11 @@ object ReportGenerator {
       |
       |## Log files
       |
+      |<details>
       |```
       |$log
       |```
+      |</details>
       |
       |## System information
       |


### PR DESCRIPTION
- Collapse the log output in our bug report template by [wrapping it in `<details>`](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections).
- Sync the template with the Github issue template in `.github/ISSUE_TEMPLATE/bug_report.md`.
- Fix some typos.