### PR TITLE
Make example trace output optional via `--save-runs`

### DIFF
--- a/.unreleased/breaking-changes/2047-001-rename-save-runs.md
+++ b/.unreleased/breaking-changes/2047-001-rename-save-runs.md
@@ -1,0 +1,1 @@
+Rename `--save-runs` to `--output-traces`, see #2047

--- a/.unreleased/breaking-changes/2047-002-check-output-traces.md
+++ b/.unreleased/breaking-changes/2047-002-check-output-traces.md
@@ -1,0 +1,1 @@
+Make example trace output optional on `check` via the `--output-traces` flag, see #2047

--- a/.unreleased/breaking-changes/save-runs.md
+++ b/.unreleased/breaking-changes/save-runs.md
@@ -1,0 +1,1 @@
+Made example trace output optional, see #2047

--- a/.unreleased/breaking-changes/save-runs.md
+++ b/.unreleased/breaking-changes/save-runs.md
@@ -1,1 +1,0 @@
-Made example trace output optional, see #2047

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -46,6 +46,7 @@ $ apalache-mc check [--config=filename] [--init=Init] [--cinit=ConstInit] \
     [--write-intermediate=(true|false)] \
     [--config-file=./path/to/file] \
     [--profiling=false] \
+    [--output-traces=false] \
     <myspec>.tla
 ```
 
@@ -90,6 +91,7 @@ The arguments are as follows:
       used in [profiling](profiling.md). The file is only created if `profiling`
       is set to `True`.  Setting `profiling` to `False` is incompatible with the
       `--smtprof` flag. The default is `False`.
+    - `--output-traces`: save an example trace for each symbolic run, default: `false`
 
 Options passed with `--tuning-options` have priority over options passed with `--tuning-options-file`.
 
@@ -108,7 +110,7 @@ The simulator can be run as follows:
 
 ```bash
 $ apalache-mc simulate
-    [all-checker-options] [--max-run=NUM] [--save-runs] <myspec>.tla
+    [all-checker-options] [--max-run=NUM] <myspec>.tla
 ```
 
 The arguments are as follows:
@@ -116,9 +118,6 @@ The arguments are as follows:
 * Special parameters:
 
   - `--max-run=NUM`: but produce up to `NUM` simulation runs (unless `--max-error` errors have been found), default: `100`
-
-  - `--save-runs`: save an example trace for each simulated run, default:
-    `false`
 
 ### 1.3. Supplying JVM arguments
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -57,13 +57,13 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
         default = "")
 
   var saveRuns: Boolean =
-    opt[Boolean](name = "save-runs", description = "save an example trace for each symbolic run, default: false",
+    opt[Boolean](name = "output-traces", description = "save an example trace for each symbolic run, default: false",
         default = false)
 
   def collectTuningOptions(): Map[String, String] = {
     val tuning =
       if (tuningOptionsFile != "") loadProperties(tuningOptionsFile) else Map[String, String]()
-    overrideProperties(tuning, tuningOptions) ++ Map("search.saveRuns" -> saveRuns.toString)
+    overrideProperties(tuning, tuningOptions) ++ Map("search.outputTraces" -> saveRuns.toString)
   }
 
   def run() = {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -63,7 +63,7 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
   def collectTuningOptions(): Map[String, String] = {
     val tuning =
       if (tuningOptionsFile != "") loadProperties(tuningOptionsFile) else Map[String, String]()
-    overrideProperties(tuning, tuningOptions)
+    overrideProperties(tuning, tuningOptions) ++ Map("search.saveRuns" -> saveRuns.toString)
   }
 
   def run() = {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -56,6 +56,10 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
     opt[String](name = "view", description = "the state view to use with --max-error=n, default: transition index",
         default = "")
 
+  var saveRuns: Boolean =
+    opt[Boolean](name = "save-runs", description = "save an example trace for each symbolic run, default: false",
+        default = false)
+
   def collectTuningOptions(): Map[String, String] = {
     val tuning =
       if (tuningOptionsFile != "") loadProperties(tuningOptionsFile) else Map[String, String]()

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
@@ -13,7 +13,6 @@ class SimulateCmd extends CheckCmd(name = "simulate", "Symbolically simulate a T
     super.collectTuningOptions() ++ Map(
         "search.simulation" -> "true",
         "search.simulation.maxRun" -> maxRun.toString,
-        "search.simulation.saveRuns" -> saveRuns.toString,
     )
   }
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
@@ -9,10 +9,6 @@ class SimulateCmd extends CheckCmd(name = "simulate", "Symbolically simulate a T
           "do not stop after a first simulation run, but produce up to a given number of runs (unless reached --max-error), default: 100",
         default = 100)
 
-  var saveRuns: Boolean =
-    opt[Boolean](name = "save-runs", description = "save an example trace for each simulated run, default: false",
-        default = false)
-
   override def collectTuningOptions(): Map[String, String] = {
     super.collectTuningOptions() ++ Map(
         "search.simulation" -> "true",

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3152,15 +3152,7 @@ EXITCODE: OK
 ```sh
 $ find ./test-out-dir/Counter.tla/* -type f -exec basename {} \; | ./sort.sh
 detailed.log
-example0.itf.json
-example0.json
-example0.tla
-example.itf.json
-example.json
-example.tla
 log0.smt
-MCexample0.out
-MCexample.out
 run.txt
 ```
 
@@ -3225,15 +3217,7 @@ $ find ./test-out-dir/Counter.tla/* -type f -exec basename {} \; | ./sort.sh
 12_OutAnalysisPass.json
 12_OutAnalysisPass.tla
 detailed.log
-example0.itf.json
-example0.json
-example0.tla
-example.itf.json
-example.json
-example.tla
 log0.smt
-MCexample0.out
-MCexample.out
 run.txt
 $ rm -rf ./test-out-dir
 ```
@@ -3303,14 +3287,6 @@ $ find ./test-run-dir -type f -exec basename {} \; | ./sort.sh
 12_OutAnalysisPass.json
 12_OutAnalysisPass.tla
 detailed.log
-example0.itf.json
-example0.json
-example0.tla
-example.itf.json
-example.json
-example.tla
-MCexample0.out
-MCexample.out
 run.txt
 $ rm -rf ./test-out-dir ./test-run-dir
 ```
@@ -3346,14 +3322,6 @@ $ apalache-mc check --length=0 Counter.tla | sed 's/[IEW]@.*//'
 EXITCODE: OK
 $ ls ./configured-run-dir | ./sort.sh
 detailed.log
-example0.itf.json
-example0.json
-example0.tla
-example.itf.json
-example.json
-example.tla
-MCexample0.out
-MCexample.out
 run.txt
 $ rm -rf ./configured-run-dir ./.apalache.cfg
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1631,11 +1631,43 @@ EXITCODE: OK
 ### simulate y2k with --save-runs succeeds
 
 ```sh
-$ apalache-mc simulate --length=10 --max-run=5 --save-runs --inv=Safety y2k_instance.tla | sed 's/I@.*//'
+$ apalache-mc simulate --out-dir=./test-out-dir --length=10 --max-run=5 --save-runs --inv=Safety y2k_instance.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
 EXITCODE: OK
+```
+
+```sh
+$ find ./test-out-dir/y2k_instance.tla/* -type f -exec basename {} \; | ./sort.sh
+detailed.log
+example1.itf.json
+example1.json
+example1.tla
+example2.itf.json
+example2.json
+example2.tla
+example3.itf.json
+example3.json
+example3.tla
+example4.itf.json
+example4.json
+example4.tla
+example5.itf.json
+example5.json
+example5.tla
+example.itf.json
+example.json
+example.tla
+log0.smt
+MCexample1.out
+MCexample2.out
+MCexample3.out
+MCexample4.out
+MCexample5.out
+MCexample.out
+run.txt
+$ rm -rf ./test-out-dir
 ```
 
 ## configure the check command
@@ -2131,6 +2163,32 @@ EXITCODE: OK
 $ head -n 1 ./profile-run-dir/profile.csv
 # weight,nCells,nConsts,nSmtExprs,location
 $ rm -rf ./profile-run-dir
+```
+
+### check y2k with --save-runs succeeds
+
+```sh
+$ apalache-mc check --out-dir=./test-out-dir --length=10 --save-runs --inv=Safety y2k_instance.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+EXITCODE: OK
+```
+
+```sh
+$ find ./test-out-dir/y2k_instance.tla/* -type f -exec basename {} \; | ./sort.sh
+detailed.log
+example0.itf.json
+example0.json
+example0.tla
+example.itf.json
+example.json
+example.tla
+log0.smt
+MCexample0.out
+MCexample.out
+run.txt
+$ rm -rf ./test-out-dir
 ```
 
 ### check ModelVal.tla succeeds

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1628,10 +1628,10 @@ $ apalache-mc check --discard-disabled=0 --tuning-options=search.invariant.mode=
 EXITCODE: OK
 ```
 
-### simulate y2k with --save-runs succeeds
+### simulate y2k with --output-traces succeeds
 
 ```sh
-$ apalache-mc simulate --out-dir=./test-out-dir --length=10 --max-run=5 --save-runs --inv=Safety y2k_instance.tla | sed 's/I@.*//'
+$ apalache-mc simulate --out-dir=./test-out-dir --length=10 --max-run=5 --output-traces --inv=Safety y2k_instance.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -2165,10 +2165,10 @@ $ head -n 1 ./profile-run-dir/profile.csv
 $ rm -rf ./profile-run-dir
 ```
 
-### check y2k with --save-runs succeeds
+### check y2k with --output-traces succeeds
 
 ```sh
-$ apalache-mc check --out-dir=./test-out-dir --length=10 --save-runs --inv=Safety y2k_instance.tla | sed 's/I@.*//'
+$ apalache-mc check --out-dir=./test-out-dir --length=10 --output-traces --inv=Safety y2k_instance.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/DumpFilesModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/DumpFilesModelCheckerListener.scala
@@ -50,6 +50,6 @@ object DumpFilesModelCheckerListener extends ModelCheckerListener with LazyLoggi
     // for automation scripts, produce ${prefix}${index}.{tla,json,...}
     val filenames = dump(index.toString)
 
-    logger.error(s"Check the trace in: ${filenames.mkString(", ")}")
+    logger.info(s"Check the trace in: ${filenames.mkString(", ")}")
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -82,7 +82,7 @@ class SeqModelChecker[ExecutorContextT](
 
     if (searchState.nFoundErrors > 0) {
       logger.info("Found %d error(s)".format(searchState.nFoundErrors))
-    } else if (!params.isRandomSimulation) {
+    } else if (!params.isRandomSimulation && params.saveRuns) {
       // Output an example in the end of the search.
       outputExampleRun()
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -90,12 +90,18 @@ class SeqModelChecker[ExecutorContextT](
     searchState.finalResult
   }
 
-  // output an example of a run, if the context is satisfiable
-  def outputExampleRun(): Unit = {
+  /**
+   * Output an example of the current symbolic run, if the context is satisfiable.
+   */
+  private def outputExampleRun(): Unit = {
+    logger.info("Constructing an example run")
     trex.sat(params.smtTimeoutSec) match {
       case Some(true) =>
         listeners.foreach(_.onExample(checkerInput.rootModule, trex.decodedExecution(), searchState.nRunsLeft))
-      case _ => ()
+      case Some(false) =>
+        logger.warn("All executions are shorter than the provided bound")
+      case None =>
+        logger.error("SMT timeout while constructing an example run")
     }
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -82,7 +82,7 @@ class SeqModelChecker[ExecutorContextT](
 
     if (searchState.nFoundErrors > 0) {
       logger.info("Found %d error(s)".format(searchState.nFoundErrors))
-    } else {
+    } else if (!params.isRandomSimulation) {
       // Output an example in the end of the search.
       outputExampleRun()
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -67,7 +67,7 @@ class SeqModelChecker[ExecutorContextT](
         makeStep(isNext = true, checkerInput.nextTransitions)
       }
 
-      if (params.saveRuns) {
+      if (params.isRandomSimulation && params.saveRuns) {
         outputExampleRun()
       }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -120,6 +120,6 @@ class ModelCheckerParams(
    * Whether to save an example trace for each symbolic run.
    */
   val saveRuns: Boolean =
-    tuningOptions.getOrElse("search.saveRuns", "false").toBoolean
+    tuningOptions.getOrElse("search.outputTraces", "false").toBoolean
 
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -117,9 +117,9 @@ class ModelCheckerParams(
     tuningOptions.getOrElse("search.simulation.maxRun", "100").toInt
 
   /**
-   * Whether to save all visited simulation runs.
+   * Whether to save an example trace for each symbolic run.
    */
   val saveRuns: Boolean =
-    tuningOptions.getOrElse("search.simulation.saveRuns", "false").toBoolean
+    tuningOptions.getOrElse("search.saveRuns", "false").toBoolean
 
 }


### PR DESCRIPTION
We introduced example trace output in #1838. As described in #2039 and #2019, this creates a unexpected performance bottleneck if the SMT call for constructing the trace takes a long time.

Oddly enough, writing the trace was made optional for `simulate` via the `--save-runs` flag   (defaulting to `false`) in #1838, but always enabled for `check`.

With this PR, we lift `--save-runs` to `check`, making example trace output optional also for `check`.

We also make some UX improvements that
* fix the case where the last symbolic run of `simulate` was output twice,
* add log output around the example trace output, and
* adjust example output log levels from `ERROR` to `INFO`.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Fixes #2039