### PR TITLE
Avoid setting `-Xmx` if `-XX:MaxRAMPercentage` is supplied

### DIFF
--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -31,8 +31,8 @@ then
     echo "       build jar."
 fi
 
-# Check of the heap size is already set
-if ! [[ "$JVM_ARGS" =~ -Xmx ]]
+# Check if the heap size is already set
+if ! [[ "$JVM_ARGS" =~ -Xmx || "$JVM_ARGS" =~ -XX:MaxRAMPercentage ]]
 then
     # If not, set our default heap size
     JVM_ARGS="${JVM_ARGS} -Xmx4096m"


### PR DESCRIPTION
Instead of explicitly setting JVM max heap memory with `-Xmx`, it can be set via `-XX:MaxRAMPercentage`. The latter [is useful](https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/best-practices/jvm-memory-settings-best-practice) [for containers](https://dzone.com/articles/best-practices-java-memory-arguments-for-container), where the JVM is the only process running and should occupy a sizeable portion of total container memory.

This avoids setting `-Xmx4096m` in `apalache-mc` if `-XX:MaxRAMPercentage` is present in `JVM_ARGS`, as the absolute setting would override the relative `-XX:MaxRAMPercentage`.
