### PR TITLE
Update of set filter rule with SMT arrays 

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
@@ -76,9 +76,7 @@ class SetFilterRule(rewriter: SymbStateRewriter) extends RewritingRule {
           // since newSetCell is assumed to be unconstrained we simple use SMT select here
           val inNewSet = tla.apalacheSelectInSet(cell.toNameEx, newSetCell.toNameEx)
           val notInNewSet = tla.not(tla.apalacheSelectInSet(cell.toNameEx, newSetCell.toNameEx))
-          val inOldSet = tla.apalacheSelectInSet(cell.toNameEx, setCell.toNameEx)
-          val inOldSetAndPred = tla.and(pred, inOldSet)
-          val ite = tla.ite(inOldSetAndPred, inNewSet, notInNewSet)
+          val ite = tla.ite(pred, inNewSet, notInNewSet)
           rewriter.solverContext.assertGroundExpr(ite)
         }
 
@@ -89,6 +87,8 @@ class SetFilterRule(rewriter: SymbStateRewriter) extends RewritingRule {
             rewriter.solverContext.assertGroundExpr(tla.apalacheUnconstrainArray(newSetCell.toNameEx))
             for ((cell, pred) <- filteredCellsAndPreds)
               addCellConsForUnconstrainedNewSetCell(cell, pred)
+            // using SMT map with conjunction ensures that elements of newSetCell are added only if they are present in
+            // setCell, so we don't need membership constraints in addCellConsForUnconstrainedNewSetCell
             val smtMap = tla.apalacheSmtMap(TlaBoolOper.and, setCell.toNameEx, newSetCell.toNameEx)
             rewriter.solverContext.assertGroundExpr(smtMap)
 


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

This PR removes a redundant membership check in the set filter rule, as suggested by @konnov a while back.

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
