### PR TITLE
Add tutorial source downloads as ZIP archives

### DIFF
--- a/docs/src/tutorials/entry-tutorial.md
+++ b/docs/src/tutorials/entry-tutorial.md
@@ -39,6 +39,10 @@ of Apalache.
 We assume that you have Apalache installed. If not, check the manual page on
 [Apalache installation][]. The minimal required version is 0.22.0.
 
+We provide all source files referenced in this tutorial as a [ZIP archive][]
+download. We still recommend that you follow along typing the TLA+ examples
+yourself.
+
 ## Running example: Binary search
 
 We are not going to explain the idea of binary search in this tutorial. If you
@@ -1199,5 +1203,4 @@ or drop us a message on [Zulip chat].
 [Test-driven development]: https://en.wikipedia.org/wiki/Test-driven_development
 [TLC]: https://github.com/tlaplus/tlaplus/
 [Zulip chat]: https://informal-systems.zulipchat.com/login/#narrow/stream/265309-apalache
-
-
+[ZIP archive]: https://download-directory.github.io/?url=https://github.com/informalsystems/apalache/tree/main/test/tla/bin-search

--- a/docs/src/tutorials/pluscal-tutorial.md
+++ b/docs/src/tutorials/pluscal-tutorial.md
@@ -17,6 +17,10 @@ specification, check the comments in the original [PlusCal specification][].
 We assume that you have Apalache installed. If not, check the manual page on
 [Apalache installation][]. The minimal required version is 0.22.0.
 
+We provide all source files referenced in this tutorial as a [ZIP archive][]
+download. We still recommend that you follow along typing the TLA+ examples
+yourself.
+
 ## Running example: Bakery
 
 We start with the [PlusCal specification][] of the [Bakery algorithm][]. This
@@ -282,4 +286,4 @@ or drop us a message on [Zulip chat].
 [TLAPS]: https://tla.msr-inria.inria.fr/tlaps/content/Home.html
 [Zulip chat]: https://informal-systems.zulipchat.com/login/#narrow/stream/265309-apalache
 [Bakery algorithm]: https://en.wikipedia.org/wiki/Lamport%27s_bakery_algorithm
-
+[ZIP archive]: https://download-directory.github.io/?url=https://github.com/informalsystems/apalache/tree/main/test/tla/bakery-pluscal


### PR DESCRIPTION
Closes #1996 

For tutorials spanning multiple source files, provide a download link to a ZIP archive containing all the source files.

The ZIP is generated on-demand from checked-in sources via [download-directory/download-directory.github.io](https://github.com/download-directory/download-directory.github.io).