### PR TITLE
Print full ISO 8601 timestamp in detailed.log

### DIFF
--- a/.unreleased/breaking-changes/2064-detailed-log-iso8601.md
+++ b/.unreleased/breaking-changes/2064-detailed-log-iso8601.md
@@ -1,0 +1,1 @@
+Timestamp in `datailed.log` changed to a full ISO 8601 timestamp, see #2064

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/log/LogbackConfigurator.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/log/LogbackConfigurator.scala
@@ -80,7 +80,7 @@ class LogbackConfigurator(runDir: Option[Path], customRunDir: Option[Path]) exte
     val encoder = new LayoutWrappingEncoder[ILoggingEvent]()
     encoder.setContext(loggerContext)
     val layout = new PatternLayout()
-    layout.setPattern("%date [%thread] %-5level %logger{12} - %msg%n")
+    layout.setPattern("%d{\"yyyy-MM-dd'T'HH:mm:ss,SSS\"} [%thread] %-5level %logger{12} - %msg%n")
     layout.setContext(loggerContext)
     layout.start()
     encoder.setLayout(layout)

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/log/LogbackConfigurator.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/log/LogbackConfigurator.scala
@@ -80,7 +80,7 @@ class LogbackConfigurator(runDir: Option[Path], customRunDir: Option[Path]) exte
     val encoder = new LayoutWrappingEncoder[ILoggingEvent]()
     encoder.setContext(loggerContext)
     val layout = new PatternLayout()
-    layout.setPattern("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{12} - %msg%n")
+    layout.setPattern("%date [%thread] %-5level %logger{12} - %msg%n")
     layout.setContext(loggerContext)
     layout.start()
     encoder.setLayout(layout)


### PR DESCRIPTION
We currently only print time in `detailed.log`. This makes it impossible to profile runtime on specs where the computation referred to by a single log line may take >24h.

This PR changes the `detailed.log` format to print a full ISO 8601 timestamp, e.g.

```
2022-08-10T17:29:11,635 [main] INFO  a.f.a.t.b.SeqModelChecker - State 10: Checking 1 state invariants
```

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Closes #2063 