### PR TITLE
Enforce config-style formatting for > 5 args

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -15,3 +15,10 @@ trailingCommas = multiple
 rewrite.rules = [AvoidInfix, SortModifiers, Imports]
 rewrite.imports.sort = original
 project.git = true
+
+# These configs ensure that method applications to more than 5 arguments that span more
+# than 80 characters are formatted in "config style".
+# See: https://scalameta.org/scalafmt/docs/configuration.html#forcing-config-style
+optIn.configStyleArguments = true
+runner.optimizer.forceConfigStyleOnOffset = 80
+runner.optimizer.forceConfigStyleMinArgCount = 5

--- a/build.sbt
+++ b/build.sbt
@@ -197,10 +197,16 @@ lazy val tla_assignments = (project in file("tla-assignments"))
   )
 
 lazy val tla_bmcmt = (project in file("tla-bmcmt"))
-  .dependsOn(tlair,
+  .dependsOn(
+      tlair,
       // property based tests depend on IR generators defined in the tlair tests
       // See https://www.scala-sbt.org/1.x/docs/Multi-Project.html#Per-configuration+classpath+dependencies
-      tlair % "test->test", infra, tla_io, tla_pp, tla_assignments)
+      tlair % "test->test",
+      infra,
+      tla_io,
+      tla_pp,
+      tla_assignments,
+  )
   .settings(
       testSettings,
       testSanyBugSettings,

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/tlc/config/TlcConfig.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/tlc/config/TlcConfig.scala
@@ -207,6 +207,13 @@ case class TlcConfig(
 
 object TlcConfig {
   val empty: TlcConfig =
-    TlcConfig(constAssignments = Map(), constReplacements = Map(), stateConstraints = List.empty,
-        actionConstraints = List.empty, invariants = List.empty, temporalProps = List.empty, behaviorSpec = NullSpec())
+    TlcConfig(
+        constAssignments = Map(),
+        constReplacements = Map(),
+        stateConstraints = List.empty,
+        actionConstraints = List.empty,
+        invariants = List.empty,
+        temporalProps = List.empty,
+        behaviorSpec = NullSpec(),
+    )
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -33,8 +33,15 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
     val cfg = super.toConfig()
     cfg.copy(
         common = cfg.common.copy(inputfile = Some(file)),
-        checker = cfg.checker.copy(config = config, cinit = cinit, init = init, next = next, inv = inv,
-            temporalProps = temporal, length = length),
+        checker = cfg.checker.copy(
+            config = config,
+            cinit = cinit,
+            init = init,
+            next = next,
+            inv = inv,
+            temporalProps = temporal,
+            length = length,
+        ),
     )
   }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Arena.scala
@@ -23,8 +23,15 @@ object Arena {
   val intSetName: String = namePrefix + "4"
 
   def create(solverContext: SolverContext): Arena = {
-    var arena = new Arena(solverContext, 0, new ArenaCell(-1, UnknownT()), HashMap(), new HashMap(), new HashMap(),
-        new HashMap()) /////
+    var arena = new Arena(
+        solverContext,
+        0,
+        new ArenaCell(-1, UnknownT()),
+        HashMap(),
+        new HashMap(),
+        new HashMap(),
+        new HashMap(),
+    ) /////
     // by convention, the first cells have the following semantics:
     //  0 stores FALSE, 1 stores TRUE, 2 stores BOOLEAN, 3 stores Nat, 4 stores Int
     arena = arena
@@ -239,8 +246,15 @@ class Arena private (
   def appendCellNoSmt(cellType: CellT, isUnconstrained: Boolean = false): Arena = {
     val newCell = new ArenaCell(cellCount, cellType, isUnconstrained)
     assert(!cellMap.contains(newCell.toString)) // this might happen, if we messed up arenas
-    new Arena(solverContext, cellCount + 1, newCell, cellMap + (newCell.toString -> newCell), hasEdges, domEdges,
-        cdmEdges)
+    new Arena(
+        solverContext,
+        cellCount + 1,
+        newCell,
+        cellMap + (newCell.toString -> newCell),
+        hasEdges,
+        domEdges,
+        cdmEdges,
+    )
   }
 
   /**
@@ -303,7 +317,15 @@ class Arena private (
           List(elemCell)
       }
 
-    new Arena(solverContext, cellCount, topCell, cellMap, hasEdges + (setCell -> es), domEdges, cdmEdges)
+    new Arena(
+        solverContext,
+        cellCount,
+        topCell,
+        cellMap,
+        hasEdges + (setCell -> es),
+        domEdges,
+        cdmEdges,
+    )
   }
 
   /**
@@ -335,7 +357,15 @@ class Arena private (
     if (domEdges.contains(funCell))
       throw new IllegalStateException("Trying to set function domain, whereas one is already set")
 
-    new Arena(solverContext, cellCount, topCell, cellMap, hasEdges, domEdges + (funCell -> domCell), cdmEdges)
+    new Arena(
+        solverContext,
+        cellCount,
+        topCell,
+        cellMap,
+        hasEdges,
+        domEdges + (funCell -> domCell),
+        cdmEdges,
+    )
   }
 
   /**
@@ -352,7 +382,15 @@ class Arena private (
     if (cdmEdges.contains(funCell))
       throw new IllegalStateException("Trying to set function co-domain, whereas one is already set")
 
-    new Arena(solverContext, cellCount, topCell, cellMap, hasEdges, domEdges, cdmEdges + (funCell -> cdmCell))
+    new Arena(
+        solverContext,
+        cellCount,
+        topCell,
+        cellMap,
+        hasEdges,
+        domEdges,
+        cdmEdges + (funCell -> cdmCell),
+    )
   }
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateRewriterImpl.scala
@@ -485,8 +485,14 @@ class SymbStateRewriterImpl(
    *   the snapshot
    */
   override def snapshot(): SymbStateRewriterSnapshot = {
-    new SymbStateRewriterSnapshot(intValueCache.snapshot(), intRangeCache.snapshot(), modelValueCache.snapshot(),
-        defaultValueCache.snapshot(), recordDomainCache.snapshot(), exprCache.snapshot())
+    new SymbStateRewriterSnapshot(
+        intValueCache.snapshot(),
+        intRangeCache.snapshot(),
+        modelValueCache.snapshot(),
+        defaultValueCache.snapshot(),
+        recordDomainCache.snapshot(),
+        exprCache.snapshot(),
+    )
   }
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/ReTLAToVMTTranspilePassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/ReTLAToVMTTranspilePassImpl.scala
@@ -50,8 +50,14 @@ class ReTLAToVMTTranspilePassImpl @Inject() (
 
     val vmtWriter = new TlaExToVMTWriter(gen)
 
-    vmtWriter.annotateAndWrite(module.varDeclarations, module.constDeclarations, cinitP, initTrans, nextTrans,
-        vcInvs ++ vcActionInvs)
+    vmtWriter.annotateAndWrite(
+        module.varDeclarations,
+        module.constDeclarations,
+        cinitP,
+        initTrans,
+        nextTrans,
+        vcInvs ++ vcActionInvs,
+    )
 
     Right(module)
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/profiler/RuleStatLocator.scala
@@ -37,8 +37,14 @@ class RuleStatLocator {
       val stats = ruleStats.values.toSeq.sortWith(_.nCalls > _.nCalls)
       for (rs <- stats) {
         writer.println("%-20s %9d %9d %9d %9d %9d"
-              .format(rs.ruleName, rs.nCalls, rs.nCellsSelf, rs.nSmtConstsSelf, rs.nSmtAssertsSelf,
-                  rs.smtAssertsSizeAvg))
+              .format(
+                  rs.ruleName,
+                  rs.nCalls,
+                  rs.nCellsSelf,
+                  rs.nSmtConstsSelf,
+                  rs.nSmtAssertsSelf,
+                  rs.smtAssertsSizeAvg,
+              ))
       }
     }
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -313,8 +313,13 @@ class CherryPick(rewriter: SymbStateRewriter) {
     newState = newState.setArena(newState.arena.appendCell(commonRecordT))
     val newRecord = newState.arena.topCell
     // pick the domain using the oracle.
-    newState = pickRecordDomain(commonRecordT, CellTFrom(SetT1(StrT1)), newState, oracle,
-        records.map(r => newState.arena.getDom(r)))
+    newState = pickRecordDomain(
+        commonRecordT,
+        CellTFrom(SetT1(StrT1)),
+        newState,
+        oracle,
+        records.map(r => newState.arena.getDom(r)),
+    )
     val newDom = newState.asCell
     // pick the fields using the oracle
     val fieldCells = commonRecordT.fieldTypes.keySet.toSeq.map(pickAtPos)
@@ -824,7 +829,14 @@ class CherryPick(rewriter: SymbStateRewriter) {
 
         // Propagate the picked function's relation, by relying on the same oracle used to pick the function
         val relationT = SetT1(TupT1(funType.arg, funType.res))
-        nextState = pickSet(relationT, nextState, oracle, funs.map(nextState.arena.getCdm), elseAssert, noSmt = true)
+        nextState = pickSet(
+            relationT,
+            nextState,
+            oracle,
+            funs.map(nextState.arena.getCdm),
+            elseAssert,
+            noSmt = true,
+        )
         val pickedRelation = nextState.asCell
         nextState = nextState.updateArena(_.setCdm(funCell, pickedRelation))
         // For the decoder to work, the relation's arguments may need to be equated to the domain elements

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/CrossTestEncodings.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/CrossTestEncodings.scala
@@ -102,7 +102,13 @@ trait CrossTestEncodings extends AnyFunSuite with Checkers {
       sized { size =>
         if (size <= 1) genPrimitive
         else
-          oneOf(genPrimitive, genSet, genSeq, genFun, /*genOper,*/ genTup, genRec /*, genRowRec, genVariant, genRow*/ )
+          oneOf(
+              genPrimitive,
+              genSet,
+              genSeq,
+              genFun, /*genOper,*/ genTup,
+              genRec, /*, genRowRec, genVariant, genRow*/
+          )
       }
     }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerTrait.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerTrait.scala
@@ -205,7 +205,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.BeforeJoin
@@ -227,7 +233,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.BeforeJoin
@@ -293,7 +305,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.AfterJoin
@@ -315,7 +333,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = false
     params.invariantMode = InvariantMode.AfterJoin
@@ -337,7 +361,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.BeforeJoin
@@ -359,7 +389,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.BeforeJoin
@@ -381,7 +417,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.AfterJoin
@@ -403,7 +445,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
       .typed(types, "b")
     val notInv = not(inv).typed(types, "b")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None, CheckerInputVC(List(), List((inv, notInv))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List((inv, notInv))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     params.discardDisabled = true
     params.invariantMode = InvariantMode.AfterJoin
@@ -430,8 +478,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val notInvDecl = TlaOperDecl("TraceInv", List(OperParam("hist", 0)), notInv)(Untyped)
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None,
-          CheckerInputVC(List(), List(), List((invDecl, notInvDecl))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List(), List((invDecl, notInvDecl))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
@@ -456,8 +509,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val notInv = not(inv).typed(types, "b")
     val notInvDecl = TlaOperDecl("TraceInv", List(OperParam("hist", 0)), notInv)(Untyped)
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None,
-          CheckerInputVC(List(), List(), List((invDecl, notInvDecl))))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List(), List(), List((invDecl, notInvDecl))),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 10, Map())
     // initialize the model checker
     val ctx = new IncrementalExecutionContext(rewriter)
@@ -775,8 +833,13 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val view = tuple(le(name("x") ? "i", int(0)) ? "b", ge(name("x") ? "i", int(0)) ? "b")
       .typed(types, "bb")
     val checkerInput =
-      new CheckerInput(mkModuleWithX(), initTrans, nextTrans, None,
-          CheckerInputVC(List((inv, notInv)), List.empty, List.empty, Some(view)))
+      new CheckerInput(
+          mkModuleWithX(),
+          initTrans,
+          nextTrans,
+          None,
+          CheckerInputVC(List((inv, notInv)), List.empty, List.empty, Some(view)),
+      )
     val params = new ModelCheckerParams(checkerInput, stepsBound = 2, Map())
     // we expect 4 errors, but an upper bound may be larger
     params.nMaxErrors = 10

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -11,10 +11,19 @@ import at.forsyte.apalache.tla.lir.convenience.tla._
  */
 trait TestSymbStateRewriterAssignment extends RewriterBase {
   private val types =
-    Map("b" -> BoolT1, "B" -> SetT1(BoolT1), "i" -> IntT1, "I" -> SetT1(IntT1), "II" -> SetT1(SetT1(IntT1)),
-        "b_to_i" -> FunT1(BoolT1, IntT1), "b_TO_i" -> SetT1(FunT1(BoolT1, IntT1)), "i_to_b" -> FunT1(IntT1, BoolT1),
-        "i_to_i" -> FunT1(IntT1, IntT1), "i_TO_i" -> SetT1(FunT1(IntT1, IntT1)),
-        "ibI" -> TupT1(IntT1, BoolT1, SetT1(IntT1)))
+    Map(
+        "b" -> BoolT1,
+        "B" -> SetT1(BoolT1),
+        "i" -> IntT1,
+        "I" -> SetT1(IntT1),
+        "II" -> SetT1(SetT1(IntT1)),
+        "b_to_i" -> FunT1(BoolT1, IntT1),
+        "b_TO_i" -> SetT1(FunT1(BoolT1, IntT1)),
+        "i_to_b" -> FunT1(IntT1, BoolT1),
+        "i_to_i" -> FunT1(IntT1, IntT1),
+        "i_TO_i" -> SetT1(FunT1(IntT1, IntT1)),
+        "ibI" -> TupT1(IntT1, BoolT1, SetT1(IntT1)),
+    )
   private val set12: TlaEx = enumSet(int(1), int(2)).typed(SetT1(IntT1))
   private val x_prime: TlaEx = prime(name("x") ? "i").typed(types, "i")
   private val y_prime: TlaEx = prime(name("y") ? "i").typed(types, "i")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -8,12 +8,25 @@ import at.forsyte.apalache.tla.lir.TypedPredefs._
 
 trait TestSymbStateRewriterFun extends RewriterBase with TestingPredefs {
   private val types =
-    Map("b" -> BoolT1, "B" -> SetT1(BoolT1), "i" -> IntT1, "I" -> SetT1(IntT1), "(i)" -> TupT1(IntT1),
-        "i_to_i" -> FunT1(IntT1, IntT1), "i_to_I" -> FunT1(IntT1, SetT1(IntT1)), "r" -> RecT1("a" -> IntT1),
-        "s" -> StrT1, "S" -> SetT1(StrT1), "(s)" -> TupT1(StrT1), "i_to_s" -> FunT1(IntT1, StrT1),
-        "s_to_i" -> FunT1(StrT1, IntT1), "i_to_r" -> FunT1(IntT1, RecT1("a" -> IntT1)),
-        "b_to_b" -> FunT1(BoolT1, BoolT1), "b_TO_b" -> SetT1(FunT1(BoolT1, BoolT1)),
-        "i_to_b_to_b" -> FunT1(IntT1, FunT1(BoolT1, BoolT1)))
+    Map(
+        "b" -> BoolT1,
+        "B" -> SetT1(BoolT1),
+        "i" -> IntT1,
+        "I" -> SetT1(IntT1),
+        "(i)" -> TupT1(IntT1),
+        "i_to_i" -> FunT1(IntT1, IntT1),
+        "i_to_I" -> FunT1(IntT1, SetT1(IntT1)),
+        "r" -> RecT1("a" -> IntT1),
+        "s" -> StrT1,
+        "S" -> SetT1(StrT1),
+        "(s)" -> TupT1(StrT1),
+        "i_to_s" -> FunT1(IntT1, StrT1),
+        "s_to_i" -> FunT1(StrT1, IntT1),
+        "i_to_r" -> FunT1(IntT1, RecT1("a" -> IntT1)),
+        "b_to_b" -> FunT1(BoolT1, BoolT1),
+        "b_TO_b" -> SetT1(FunT1(BoolT1, BoolT1)),
+        "i_to_b_to_b" -> FunT1(IntT1, FunT1(BoolT1, BoolT1)),
+    )
 
   test("""[x \in {1,2,3,4} |-> x / 3: ]""") { rewriterType: SMTEncoding =>
     val set = enumSet(1.to(4).map(int): _*)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
@@ -12,8 +12,14 @@ import org.scalatest.funsuite.AnyFunSuite
 @RunWith(classOf[JUnitRunner])
 class TestExpansionMarker extends AnyFunSuite with BeforeAndAfterEach {
   private var marker = new ExpansionMarker(TrackerWithListeners())
-  val types = Map("S" -> SetT1(IntT1), "PS" -> SetT1(SetT1(IntT1)), "i" -> IntT1, "b" -> BoolT1,
-      "f" -> FunT1(IntT1, IntT1), "FS" -> SetT1(FunT1(IntT1, IntT1)))
+  val types = Map(
+      "S" -> SetT1(IntT1),
+      "PS" -> SetT1(SetT1(IntT1)),
+      "i" -> IntT1,
+      "b" -> BoolT1,
+      "f" -> FunT1(IntT1, IntT1),
+      "FS" -> SetT1(FunT1(IntT1, IntT1)),
+  )
 
   override def beforeEach(): Unit = {
     marker = new ExpansionMarker(TrackerWithListeners())

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
@@ -30,7 +30,14 @@ class AnnotationExtractor(annotationStore: AnnotationStore) extends LazyLogging 
         // that look like malformed annotations, e.g., CONSTANT definitions @modelParameterConstants:0Foo
         val loc = node.getLocation
         val msg = "[%s:%d:%d-%d:%d]: Syntax error in annotation -- %s"
-          .format(loc.source(), loc.beginLine(), loc.beginColumn(), loc.endLine(), loc.endColumn(), message)
+          .format(
+              loc.source(),
+              loc.beginLine(),
+              loc.beginColumn(),
+              loc.endLine(),
+              loc.endColumn(),
+              message,
+          )
         logger.warn(msg)
         None
     }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -492,8 +492,13 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
 
   test("a multi-line function") {
     val writer = new PrettyWriter(printWriter, layout30)
-    val expr = funDef(plus(name("verylong1"), name("verylong2")), name("verylong1"), name("verylong3"),
-        name("verylong2"), name("verylong4"))
+    val expr = funDef(
+        plus(name("verylong1"), name("verylong2")),
+        name("verylong1"),
+        name("verylong3"),
+        name("verylong2"),
+        name("verylong4"),
+    )
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -517,8 +522,13 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
 
   test("a multi-line map") {
     val writer = new PrettyWriter(printWriter, layout30)
-    val expr = map(plus(name("verylong1"), name("verylong2")), name("verylong1"), name("verylong3"), name("verylong2"),
-        name("verylong4"))
+    val expr = map(
+        plus(name("verylong1"), name("verylong2")),
+        name("verylong1"),
+        name("verylong3"),
+        name("verylong2"),
+        name("verylong4"),
+    )
     writer.write(expr)
     printWriter.flush()
     val expected =
@@ -718,7 +728,13 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
 
   test("a multi-line CASE with OTHER") {
     val writer = new PrettyWriter(printWriter, layout40)
-    val expr = caseOther(name("otherAction"), name("guard1"), name("action1"), name("guard2"), name("action2"))
+    val expr = caseOther(
+        name("otherAction"),
+        name("guard1"),
+        name("action1"),
+        name("guard2"),
+        name("action2"),
+    )
     writer.write(expr)
     printWriter.flush()
     val expected =

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
@@ -604,8 +604,13 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         OperEx(
             VariantOper.variant,
             ValEx(TlaStr("T1a")),
-            OperEx(TlaFunOper.rec, ValEx(TlaStr("val")), ValEx(TlaInt(3)), ValEx(TlaStr("found")),
-                ValEx(TlaBool(false))),
+            OperEx(
+                TlaFunOper.rec,
+                ValEx(TlaStr("val")),
+                ValEx(TlaInt(3)),
+                ValEx(TlaStr("found")),
+                ValEx(TlaBool(false)),
+            ),
         ),
     )
 
@@ -652,8 +657,13 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
             VariantOper.variantGetOrElse,
             ValEx(TlaStr("T1a")),
             NameEx("var"),
-            OperEx(TlaFunOper.rec, ValEx(TlaStr("val")), ValEx(TlaInt(0)), ValEx(TlaStr("found")),
-                ValEx(TlaBool(false))),
+            OperEx(
+                TlaFunOper.rec,
+                ValEx(TlaStr("val")),
+                ValEx(TlaInt(0)),
+                ValEx(TlaStr("found")),
+                ValEx(TlaBool(false)),
+            ),
         ),
         OperParam("var"),
     )

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Keramelizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Keramelizer.scala
@@ -26,7 +26,14 @@ class Keramelizer(gen: UniqueNameGenerator, tracker: TransformationTracker)
    * Partial transformers, applied left-to-right.
    */
   override val partialTransformers =
-    List(transformAssignments, transformLogic, transformSets, transformTuples, transformRecords, transformControl)
+    List(
+        transformAssignments,
+        transformLogic,
+        transformSets,
+        transformTuples,
+        transformRecords,
+        transformControl,
+    )
 
   override def apply(expr: TlaEx): TlaEx = {
     LanguageWatchdog(FlatLanguagePred()).check(expr)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/NormalizedNames.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/NormalizedNames.scala
@@ -34,8 +34,15 @@ object NormalizedNames {
    */
   def isVC(decl: TlaDecl): Boolean = {
     decl.isInstanceOf[TlaOperDecl] &&
-    List(VC_INV_PREFIX, VC_NOT_INV_PREFIX, VC_ACTION_INV_PREFIX, VC_NOT_ACTION_INV_PREFIX, VC_TRACE_INV_PREFIX,
-        VC_NOT_TRACE_INV_PREFIX, VC_VIEW).exists(decl.name.startsWith)
+    List(
+        VC_INV_PREFIX,
+        VC_NOT_INV_PREFIX,
+        VC_ACTION_INV_PREFIX,
+        VC_NOT_ACTION_INV_PREFIX,
+        VC_TRACE_INV_PREFIX,
+        VC_NOT_TRACE_INV_PREFIX,
+        VC_VIEW,
+    ).exists(decl.name.startsWith)
   }
 
   /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/ConfigurationPassImpl.scala
@@ -152,9 +152,14 @@ class ConfigurationPassImpl @Inject() (
       case NullSpec() => ("Init", "Next")
     }
 
-    derivedPreds.configure(init = init, next = next, invariants = options.predicates.invariants,
-        temporalProps = options.predicates.temporalProps, view = options.predicates.view,
-        cinit = options.predicates.cinit)
+    derivedPreds.configure(
+        init = init,
+        next = next,
+        invariants = options.predicates.invariants,
+        temporalProps = options.predicates.temporalProps,
+        view = options.predicates.view,
+        cinit = options.predicates.cinit,
+    )
 
     if (derivedPreds.invariants.nonEmpty) {
       logger.info(s"""  > $basename: found INVARIANTS: ${derivedPreds.invariants.mkString(", ")}""")

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestDesugarer.scala
@@ -354,8 +354,13 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
     // input: [f EXCEPT ![i][j] = e1, ![k][l] = e2]
     val input =
       tla
-        .except(tla.name("f") ? "f2", tla.tuple(tla.name("i") ? "i", tla.name("j") ? "i") ? "i2", tla.name("e1") ? "i",
-            tla.tuple(tla.name("k") ? "i", tla.name("l") ? "i") ? "i2", tla.name("e2") ? "i")
+        .except(
+            tla.name("f") ? "f2",
+            tla.tuple(tla.name("i") ? "i", tla.name("j") ? "i") ? "i2",
+            tla.name("e1") ? "i",
+            tla.tuple(tla.name("k") ? "i", tla.name("l") ? "i") ? "i2",
+            tla.name("e2") ? "i",
+        )
         .typed(exceptTypes, "f2")
     val output = desugarer.transform(input)
     // output: a series of definitions
@@ -704,8 +709,13 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
     // input: [ x \in X, y \in Y |-> x + y ]
     val map =
       tla
-        .funDef(tla.plus(tla.name("x") ? "i", tla.name("y") ? "i") ? "i", tla.name("x") ? "i", tla.name("X") ? "I",
-            tla.name("y") ? "i", tla.name("Y") ? "I")
+        .funDef(
+            tla.plus(tla.name("x") ? "i", tla.name("y") ? "i") ? "i",
+            tla.name("x") ? "i",
+            tla.name("X") ? "I",
+            tla.name("y") ? "i",
+            tla.name("Y") ? "I",
+        )
         .typed(tupleTypes, "ii_to_i")
     val sugarFree = desugarer.transform(map)
     // output: [ x_y \in X \X Y |-> x_y[1] + x_y[2] ]
@@ -726,8 +736,13 @@ class TestDesugarer extends AnyFunSuite with BeforeAndAfterEach {
     // input: f[x \in S, y \in T] == x + y
     val input =
       tla
-        .recFunDef(tla.plus(tla.name("x") ? "i", tla.name("y") ? "i") ? "i", tla.name("x") ? "i", tla.name("S") ? "I",
-            tla.name("y") ? "i", tla.name("T") ? "I")
+        .recFunDef(
+            tla.plus(tla.name("x") ? "i", tla.name("y") ? "i") ? "i",
+            tla.name("x") ? "i",
+            tla.name("S") ? "I",
+            tla.name("y") ? "i",
+            tla.name("T") ? "I",
+        )
         .typed(tupleTypes, "ii_to_i")
     val output = desugarer.transform(input)
     // output: f[x_y \in S \X T] == x_y[1] + x_y[2]

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestKeramelizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestKeramelizer.scala
@@ -120,8 +120,15 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
   }
 
   test("""[a: A, b: B] ~~> {[a |-> t_1, b |-> t_2]: t_1 \in A, t_2 \in B}""") {
-    val types = Map("a" -> BoolT1, "b" -> StrT1, "A" -> SetT1(BoolT1), "B" -> SetT1(StrT1), "s" -> StrT1,
-        "r" -> RecT1("a" -> BoolT1, "b" -> StrT1), "R" -> SetT1(RecT1("a" -> BoolT1, "b" -> StrT1)))
+    val types = Map(
+        "a" -> BoolT1,
+        "b" -> StrT1,
+        "A" -> SetT1(BoolT1),
+        "B" -> SetT1(StrT1),
+        "s" -> StrT1,
+        "r" -> RecT1("a" -> BoolT1, "b" -> StrT1),
+        "R" -> SetT1(RecT1("a" -> BoolT1, "b" -> StrT1)),
+    )
     val input =
       tla
         .recSet(tla.name("a") ? "s", tla.name("A") ? "A", tla.name("b") ? "s", tla.name("B") ? "B")
@@ -130,14 +137,26 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
     val rec = tla.enumFun(tla.name("a") ? "s", tla.name("t_1") ? "a", tla.name("b") ? "s", tla.name("t_2") ? "b")
     val expected =
       tla
-        .map(rec ? "r", tla.name("t_1") ? "a", tla.name("A") ? "A", tla.name("t_2") ? "b", tla.name("B") ? "B")
+        .map(
+            rec ? "r",
+            tla.name("t_1") ? "a",
+            tla.name("A") ? "A",
+            tla.name("t_2") ? "b",
+            tla.name("B") ? "B",
+        )
         .typed(types, "R")
     assert(expected == output)
   }
 
   test("""A \X B ~~> {<<t_1, t_2>>: t_1 \in A, t_2 \in B}""") {
-    val types = Map("a" -> BoolT1, "b" -> StrT1, "A" -> SetT1(BoolT1), "B" -> SetT1(StrT1),
-        "t" -> SetT1(TupT1(BoolT1, StrT1)), "T" -> SetT1(TupT1(BoolT1, StrT1)))
+    val types = Map(
+        "a" -> BoolT1,
+        "b" -> StrT1,
+        "A" -> SetT1(BoolT1),
+        "B" -> SetT1(StrT1),
+        "t" -> SetT1(TupT1(BoolT1, StrT1)),
+        "T" -> SetT1(TupT1(BoolT1, StrT1)),
+    )
     val input =
       tla
         .times(tla.name("A") ? "A", tla.name("B") ? "B")
@@ -146,7 +165,13 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
     val tup = tla.tuple(tla.name("t_1") ? "a", tla.name("t_2") ? "b")
     val expected =
       tla
-        .map(tup ? "t", tla.name("t_1") ? "a", tla.name("A") ? "A", tla.name("t_2") ? "b", tla.name("B") ? "B")
+        .map(
+            tup ? "t",
+            tla.name("t_1") ? "a",
+            tla.name("A") ? "A",
+            tla.name("t_2") ? "b",
+            tla.name("B") ? "B",
+        )
         .typed(types, "T")
     assert(expected == output)
   }
@@ -159,8 +184,13 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
         OTHER  -> e_def
      */
     val input = tla
-      .caseOther(tla.name("e_def") ? "i", tla.name("p_1") ? "b", tla.name("e_1") ? "i", tla.name("p_2") ? "b",
-          tla.name("e_2") ? "i")
+      .caseOther(
+          tla.name("e_def") ? "i",
+          tla.name("p_1") ? "b",
+          tla.name("e_1") ? "i",
+          tla.name("p_2") ? "b",
+          tla.name("e_2") ? "i",
+      )
       .typed(types, "i")
     val output = keramelizer.apply(input)
 
@@ -207,8 +237,13 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
         OTHER  -> e_def
      */
     val input = tla
-      .caseOther(tla.name("e_def") ? "b", tla.name("p_1") ? "b", tla.name("e_1") ? "b", tla.name("p_2") ? "b",
-          tla.name("e_2") ? "b")
+      .caseOther(
+          tla.name("e_def") ? "b",
+          tla.name("p_1") ? "b",
+          tla.name("e_1") ? "b",
+          tla.name("p_2") ? "b",
+          tla.name("e_2") ? "b",
+      )
       .typed(types, "b")
     val output = keramelizer.apply(input)
     /*
@@ -284,8 +319,13 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
   }
 
   test("""x' \in [S -> T] ~~> \E t_1 \in [S -> T]: x' = t_1""") {
-    val types = Map("b" -> BoolT1, "S" -> SetT1(IntT1), "T" -> SetT1(StrT1), "f" -> FunT1(IntT1, StrT1),
-        "Sf" -> SetT1(FunT1(IntT1, StrT1)))
+    val types = Map(
+        "b" -> BoolT1,
+        "S" -> SetT1(IntT1),
+        "T" -> SetT1(StrT1),
+        "f" -> FunT1(IntT1, StrT1),
+        "Sf" -> SetT1(FunT1(IntT1, StrT1)),
+    )
     val funSet = tla.funSet(tla.name("S") ? "S", tla.name("T") ? "T") ? "Sf"
     val input = tla
       .in(tla.prime(tla.name("x") ? "f") ? "f", funSet)
@@ -320,8 +360,13 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
   }
 
   test("""A \subseteq POWSET POWSET B ~~> \A S \in A: \A T \in S: \A t \in T: t \in B""") {
-    val types = Map("BOOL" -> BoolT1, "POWPOWSET" -> SetT1(SetT1(SetT1(IntT1))), "POWSET" -> SetT1(SetT1(IntT1)),
-        "SET" -> SetT1(IntT1), "INT" -> IntT1)
+    val types = Map(
+        "BOOL" -> BoolT1,
+        "POWPOWSET" -> SetT1(SetT1(SetT1(IntT1))),
+        "POWSET" -> SetT1(SetT1(IntT1)),
+        "SET" -> SetT1(IntT1),
+        "INT" -> IntT1,
+    )
     def A = tla.name("A") ? "POWPOWSET"
     def B = tla.name("B") ? "SET"
     def powB = tla.powSet(B) ? "POWSET"
@@ -389,8 +434,13 @@ class TestKeramelizer extends AnyFunSuite with Checkers with BeforeAndAfterEach 
 
   test("""rewrite f \in [S -> SUBSET T]  ~~>  DOMAIN f = S /\ \A x \in S: \A y \in f[x]: y \in T""".stripMargin) {
     val types =
-      Map("b" -> BoolT1, "s" -> SetT1(IntT1), "p" -> SetT1(SetT1(IntT1)), "f" -> FunT1(IntT1, SetT1(IntT1)),
-          "fs" -> SetT1(FunT1(IntT1, SetT1(IntT1))))
+      Map(
+          "b" -> BoolT1,
+          "s" -> SetT1(IntT1),
+          "p" -> SetT1(SetT1(IntT1)),
+          "f" -> FunT1(IntT1, SetT1(IntT1)),
+          "fs" -> SetT1(FunT1(IntT1, SetT1(IntT1))),
+      )
     val input =
       tla
         .in(tla.name("f") ? "f", tla.funSet(tla.name("S") ? "s", tla.powSet(tla.name("T") ? "s") ? "p") ? "fs")

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSourceLocator.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSourceLocator.scala
@@ -25,9 +25,17 @@ class TestSourceLocator extends AnyFunSuite {
   private val parser = DefaultType1Parser
 
   val types =
-    Map("i" -> parser("Int"), "b" -> parser("Bool"), "iiTOi" -> parser("(Int, Int) => Int"),
-        "iTOi" -> parser("Int => Int"), "X" -> parser("Int => Int"), "D2" -> parser("(Int => Int, Int) => Int"),
-        "TOi" -> parser("() => Int"), "rx" -> parser("[x: Int]"), "ii" -> parser("<<Int, Int>>"))
+    Map(
+        "i" -> parser("Int"),
+        "b" -> parser("Bool"),
+        "iiTOi" -> parser("(Int, Int) => Int"),
+        "iTOi" -> parser("Int => Int"),
+        "X" -> parser("Int => Int"),
+        "D2" -> parser("(Int => Int, Int) => Int"),
+        "TOi" -> parser("() => Int"),
+        "rx" -> parser("[x: Int]"),
+        "ii" -> parser("<<Int, Int>>"),
+    )
 
   // plus(a, b) == a + b
   val decl1: TlaOperDecl =

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTypeSubstitutor.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTypeSubstitutor.scala
@@ -19,9 +19,15 @@ class TestTypeSubstitutor extends AnyFunSuite with BeforeAndAfterEach {
   private val parser = DefaultType1Parser
 
   private val types =
-    Map("b" -> parser("Bool"), "F" -> parser("a => <<a, a>>"), "a" -> parser("a"), "ii" -> parser("Int -> Int"),
-        "Fii" -> parser("(Int -> Int) => <<Int -> Int, Int -> Int>>"), "aa" -> parser("<<a, a>>"),
-        "ii2" -> parser("<<Int -> Int, Int -> Int>>"))
+    Map(
+        "b" -> parser("Bool"),
+        "F" -> parser("a => <<a, a>>"),
+        "a" -> parser("a"),
+        "ii" -> parser("Int -> Int"),
+        "Fii" -> parser("(Int -> Int) => <<Int -> Int, Int -> Int>>"),
+        "aa" -> parser("<<a, a>>"),
+        "ii2" -> parser("<<Int -> Int, Int -> Int>>"),
+    )
 
   override def beforeEach(): Unit = {}
 

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -539,7 +539,13 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
   test("function update [ f EXCEPT ![e1] = e2, ![e3] = e4 ]") {
     // a function or a sequence
     val ex =
-      tla.except(tla.name("f"), tla.tuple(tla.name("e1")), tla.name("e2"), tla.tuple(tla.name("e3")), tla.name("e4"))
+      tla.except(
+          tla.name("f"),
+          tla.tuple(tla.name("e1")),
+          tla.name("e2"),
+          tla.tuple(tla.name("e3")),
+          tla.name("e4"),
+      )
 
     val types1 = Seq(parser("(a, b) => (a -> b)"), parser("(Int, a) => Seq(a)"))
     val types2 = Seq(parser("(c, d) => (c -> d)"), parser("(Int, c) => Seq(c)"))
@@ -584,7 +590,13 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
 
   test("tuple update [ f EXCEPT ![3] = e2, ![5] = e4]") {
     // a function or a record
-    val ex = tla.except(tla.name("f"), tla.tuple(tla.int(3)), tla.name("e2"), tla.tuple(tla.int(5)), tla.name("e4"))
+    val ex = tla.except(
+        tla.name("f"),
+        tla.tuple(tla.int(3)),
+        tla.name("e2"),
+        tla.tuple(tla.int(5)),
+        tla.name("e4"),
+    )
 
     val types1 = Seq(parser("(Int, a) => (Int -> a)"), parser("(Int, a) => Seq(a)"), parser("(Int, a) => <| 3: a |>"))
     val tower1 = mkUniqApp(types1, mkUniqConst(IntT1), mkUniqName("e2"))
@@ -791,7 +803,13 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
   test("Labels") {
     val typ = parser("(Str, Str, Str, a) => a")
     val expected =
-      mkUniqApp(Seq(typ), mkUniqConst(StrT1), mkUniqConst(StrT1), mkUniqConst(StrT1), mkUniqName("x"))
+      mkUniqApp(
+          Seq(typ),
+          mkUniqConst(StrT1),
+          mkUniqConst(StrT1),
+          mkUniqConst(StrT1),
+          mkUniqName("x"),
+      )
     val ex = tla.label(tla.name("x"), "lab", "a", "b")
     assert(expected == mkToEtcExpr()(ex))
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/TlaType1.scala
@@ -190,8 +190,34 @@ case class VarT1(no: Int) extends TlaType1 {
 
 object VarT1 {
   // human-friendly names of the first 26 variables
-  protected val QNAMES: Vector[String] = Vector("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n",
-      "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z")
+  protected val QNAMES: Vector[String] = Vector(
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+      "q",
+      "r",
+      "s",
+      "t",
+      "u",
+      "v",
+      "w",
+      "x",
+      "y",
+      "z",
+  )
 
   /**
    * Construct a variable from the human-readable form like `b` or `a100`. We use this method to write human-readable

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/IrGenerators.scala
@@ -67,40 +67,92 @@ trait IrGenerators extends TlaType1Gen {
   /**
    * Propositional operators and quantifiers, excluding unbounded quantifiers (`TlaBoolOper._`)
    */
-  val logicOperators = List(TlaBoolOper.and, TlaBoolOper.or, TlaBoolOper.not, TlaBoolOper.equiv, TlaBoolOper.implies,
-      TlaBoolOper.exists, TlaBoolOper.forall)
+  val logicOperators = List(
+      TlaBoolOper.and,
+      TlaBoolOper.or,
+      TlaBoolOper.not,
+      TlaBoolOper.equiv,
+      TlaBoolOper.implies,
+      TlaBoolOper.exists,
+      TlaBoolOper.forall,
+  )
 
   /**
    * Arithmetic operators (`TlaArithOper._`)
    */
-  val arithOperators = List(TlaArithOper.div, TlaArithOper.dotdot, TlaArithOper.exp, TlaArithOper.ge, TlaArithOper.gt,
-      TlaArithOper.le, TlaArithOper.lt, TlaArithOper.minus, TlaArithOper.mod, TlaArithOper.mult, TlaArithOper.plus,
-      TlaArithOper.uminus)
+  val arithOperators = List(
+      TlaArithOper.div,
+      TlaArithOper.dotdot,
+      TlaArithOper.exp,
+      TlaArithOper.ge,
+      TlaArithOper.gt,
+      TlaArithOper.le,
+      TlaArithOper.lt,
+      TlaArithOper.minus,
+      TlaArithOper.mod,
+      TlaArithOper.mult,
+      TlaArithOper.plus,
+      TlaArithOper.uminus,
+  )
 
   /**
    * Set operators (`TlaSetOper._`)
    */
-  val setOperators = List(TlaSetOper.cap, TlaSetOper.cup, TlaSetOper.enumSet, TlaSetOper.filter, TlaSetOper.funSet,
-      TlaSetOper.in, TlaSetOper.notin, TlaSetOper.map, TlaSetOper.powerset, TlaSetOper.recSet, TlaSetOper.seqSet,
-      TlaSetOper.setminus, TlaSetOper.subseteq, TlaSetOper.times, TlaSetOper.union)
+  val setOperators = List(
+      TlaSetOper.cap,
+      TlaSetOper.cup,
+      TlaSetOper.enumSet,
+      TlaSetOper.filter,
+      TlaSetOper.funSet,
+      TlaSetOper.in,
+      TlaSetOper.notin,
+      TlaSetOper.map,
+      TlaSetOper.powerset,
+      TlaSetOper.recSet,
+      TlaSetOper.seqSet,
+      TlaSetOper.setminus,
+      TlaSetOper.subseteq,
+      TlaSetOper.times,
+      TlaSetOper.union,
+  )
 
   /**
    * Function operators (`TlaFunOper._`)
    */
-  val functionOperators = List(TlaFunOper.rec, TlaFunOper.tuple, TlaFunOper.app, TlaFunOper.domain, TlaFunOper.funDef,
-      TlaFunOper.recFunDef, TlaFunOper.recFunRef, TlaFunOper.except)
+  val functionOperators = List(
+      TlaFunOper.rec,
+      TlaFunOper.tuple,
+      TlaFunOper.app,
+      TlaFunOper.domain,
+      TlaFunOper.funDef,
+      TlaFunOper.recFunDef,
+      TlaFunOper.recFunRef,
+      TlaFunOper.except,
+  )
 
   /**
    * Action operators (`TlaActionOper._`)
    */
-  val actionOperators = List(TlaActionOper.prime, TlaActionOper.enabled, TlaActionOper.stutter, TlaActionOper.nostutter,
-      TlaActionOper.unchanged, TlaActionOper.composition)
+  val actionOperators = List(
+      TlaActionOper.prime,
+      TlaActionOper.enabled,
+      TlaActionOper.stutter,
+      TlaActionOper.nostutter,
+      TlaActionOper.unchanged,
+      TlaActionOper.composition,
+  )
 
   /**
    * Temporal operators, excluding `\AA` and `\EE`, as those are not useful to us (`TlaTempOper._`)
    */
-  val temporalOperators = List(TlaTempOper.box, TlaTempOper.diamond, TlaTempOper.leadsTo, TlaTempOper.guarantees,
-      TlaTempOper.strongFairness, TlaTempOper.weakFairness)
+  val temporalOperators = List(
+      TlaTempOper.box,
+      TlaTempOper.diamond,
+      TlaTempOper.leadsTo,
+      TlaTempOper.guarantees,
+      TlaTempOper.strongFairness,
+      TlaTempOper.weakFairness,
+  )
 
   /**
    * Generates a type tag, either typed or untyped.
@@ -153,7 +205,14 @@ trait IrGenerators extends TlaType1Gen {
    *   a generator of `ValEx(_)`.
    */
   def genValEx: Gen[ValEx] =
-    oneOf(genInt, genBool, genStr, const(ValEx(TlaBoolSet)), const(ValEx(TlaIntSet)), const(ValEx(TlaNatSet)))
+    oneOf(
+        genInt,
+        genBool,
+        genStr,
+        const(ValEx(TlaBoolSet)),
+        const(ValEx(TlaIntSet)),
+        const(ValEx(TlaNatSet)),
+    )
 
   /**
    * Generate a name expression.
@@ -241,8 +300,13 @@ trait IrGenerators extends TlaType1Gen {
             if (ctx.nonEmpty) {
               // a value, a name,
               // an application of a user-defined operator in the context, an application of a built-in operator
-              oneOf(genValEx, genNameEx(ctx), genOperApply(genTlaEx(builtInOpers))(ctx),
-                  genLetInEx(genTlaEx(builtInOpers))(ctx), const(OperEx(oper, args: _*).withTag(tt)))
+              oneOf(
+                  genValEx,
+                  genNameEx(ctx),
+                  genOperApply(genTlaEx(builtInOpers))(ctx),
+                  genLetInEx(genTlaEx(builtInOpers))(ctx),
+                  const(OperEx(oper, args: _*).withTag(tt)),
+              )
             } else {
               // as above but no user-defined operators
               oneOf(genValEx, genLetInEx(genTlaEx(builtInOpers))(ctx), const(OperEx(oper, args: _*).withTag(tt)))

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestModule.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestModule.scala
@@ -40,23 +40,33 @@ class TestModule extends AnyFunSuite {
      * \in Data
      */
     new TlaOperDecl("ABInit", List(),
-        OperEx(TlaBoolOper.and, OperEx(TlaOper.eq, NameEx("msgQ"), emptySeq),
-            OperEx(TlaOper.eq, NameEx("ackQ"), emptySeq), OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet),
-            OperEx(TlaOper.eq, NameEx("sAck"), NameEx("sBit")), OperEx(TlaOper.eq, NameEx("rBit"), NameEx("sBit")),
-            OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet), OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet)))
+        OperEx(
+            TlaBoolOper.and,
+            OperEx(TlaOper.eq, NameEx("msgQ"), emptySeq),
+            OperEx(TlaOper.eq, NameEx("ackQ"), emptySeq),
+            OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet),
+            OperEx(TlaOper.eq, NameEx("sAck"), NameEx("sBit")),
+            OperEx(TlaOper.eq, NameEx("rBit"), NameEx("sBit")),
+            OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet),
+            OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet),
+        ))
 
     /**
      * ABTypeInv == /\ msgQ \in Seq( {0,1} \times Data ) /\ ackQ \in Seq( {0,1} ) /\ sBit \in {0,1} /\ sAck \in {0,1} /\
      * rBit \in {0,1} /\ sent \in Data /\ rcvd \in Data
      */
     new TlaOperDecl("ABTypeInv", List(),
-        OperEx(TlaBoolOper.and,
+        OperEx(
+            TlaBoolOper.and,
             OperEx(TlaSetOper.in, NameEx("msgQ"),
                 OperEx(TlaSetOper.seqSet, OperEx(TlaSetOper.times, ZeroOneSet, NameEx("Data")))),
             OperEx(TlaSetOper.in, NameEx("ackQ"), OperEx(TlaSetOper.seqSet, ZeroOneSet)),
-            OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet), OperEx(TlaSetOper.in, NameEx("sAck"), ZeroOneSet),
-            OperEx(TlaSetOper.in, NameEx("rBit"), ZeroOneSet), OperEx(TlaSetOper.in, NameEx("sent"), NameEx("Data")),
-            OperEx(TlaSetOper.in, NameEx("rcvd"), NameEx("Data"))))
+            OperEx(TlaSetOper.in, NameEx("sBit"), ZeroOneSet),
+            OperEx(TlaSetOper.in, NameEx("sAck"), ZeroOneSet),
+            OperEx(TlaSetOper.in, NameEx("rBit"), ZeroOneSet),
+            OperEx(TlaSetOper.in, NameEx("sent"), NameEx("Data")),
+            OperEx(TlaSetOper.in, NameEx("rcvd"), NameEx("Data")),
+        ))
 
     /**
      * ---------------------------------------------------------------------------------------------------------------
@@ -89,8 +99,15 @@ class TestModule extends AnyFunSuite {
             OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("msgQ")),
                 OperEx(TlaSeqOper.append, NameEx("msgQ"), OperEx(TlaFunOper.tuple, NameEx("sBit"), NameEx("sent")))),
             OperEx(TlaActionOper.unchanged,
-                OperEx(TlaFunOper.tuple, NameEx("ackQ"), NameEx("sBit"), NameEx("sAck"), NameEx("rBit"), NameEx("sent"),
-                    NameEx("rcvd")))))
+                OperEx(
+                    TlaFunOper.tuple,
+                    NameEx("ackQ"),
+                    NameEx("sBit"),
+                    NameEx("sAck"),
+                    NameEx("rBit"),
+                    NameEx("sent"),
+                    NameEx("rcvd"),
+                ))))
 
     /**
      * RcvMsg == /\ msgQ # <<>> /\ msgQ' = Tail( msgQ ) /\ rBit' = Head( msgQ ) [ 1 ] /\ rcvd' = Head( msgQ ) [ 2 ] /\
@@ -117,20 +134,36 @@ class TestModule extends AnyFunSuite {
             OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("ackQ")),
                 OperEx(TlaSeqOper.append, NameEx("ackQ"), NameEx("rBit"))),
             OperEx(TlaActionOper.unchanged,
-                OperEx(TlaFunOper.tuple, NameEx("msgQ"), NameEx("sBit"), NameEx("sAck"), NameEx("rBit"), NameEx("sent"),
-                    NameEx("rcvd")))))
+                OperEx(
+                    TlaFunOper.tuple,
+                    NameEx("msgQ"),
+                    NameEx("sBit"),
+                    NameEx("sAck"),
+                    NameEx("rBit"),
+                    NameEx("sent"),
+                    NameEx("rcvd"),
+                ))))
 
     /**
      * RcvAck == /\ ackQ # <<>> /\ ackQ' = Tail( ackQ ) /\ sAck' = Head( ackQ ) /\ UNCHANGED << msgQ, sBit, rBit, sent,
      * rcvd >>
      */
     new TlaOperDecl("RcvAck", List(),
-        OperEx(TlaBoolOper.and, OperEx(TlaOper.ne, NameEx("ackQ"), emptySeq),
+        OperEx(
+            TlaBoolOper.and,
+            OperEx(TlaOper.ne, NameEx("ackQ"), emptySeq),
             OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("ackQ")), OperEx(TlaSeqOper.tail, NameEx("ackQ"))),
             OperEx(TlaOper.eq, OperEx(TlaActionOper.prime, NameEx("sAck")), OperEx(TlaSeqOper.head, NameEx("ackQ"))),
             OperEx(TlaActionOper.unchanged,
-                OperEx(TlaFunOper.tuple, NameEx("msgQ"), NameEx("sBit"), NameEx("rBit"), NameEx("sent"),
-                    NameEx("rcvd")))))
+                OperEx(
+                    TlaFunOper.tuple,
+                    NameEx("msgQ"),
+                    NameEx("sBit"),
+                    NameEx("rBit"),
+                    NameEx("sent"),
+                    NameEx("rcvd"),
+                )),
+        ))
 
     /**
      * Lose( q ) == /\ q # <<>> /\ \exists i \in 1 .. Len( q ) : q' = [ j \in 1 .. ( Len( q ) - 1 ) |-> IF j < i THEN q[
@@ -166,10 +199,17 @@ class TestModule extends AnyFunSuite {
      * ABNext == \/ \exists d \in Data : SndNewValue(d) \/ ReSndMsg \/ RcvMsg \/ SndAck \/ RcvAck \/ LoseMsg \/ LoseAck
      */
     new TlaOperDecl("ABNext", List(),
-        OperEx(TlaBoolOper.or,
+        OperEx(
+            TlaBoolOper.or,
             OperEx(TlaBoolOper.exists, NameEx("d"), NameEx("Data"),
-                OperEx(TlaOper.apply, NameEx("SndNewValue"), NameEx("d"))), NameEx("ReSndMsg"), NameEx("RcvMsg"),
-            NameEx("SndAck"), NameEx("RcvAck"), NameEx("LoseMsg"), NameEx("LoseAck")))
+                OperEx(TlaOper.apply, NameEx("SndNewValue"), NameEx("d"))),
+            NameEx("ReSndMsg"),
+            NameEx("RcvMsg"),
+            NameEx("SndAck"),
+            NameEx("RcvAck"),
+            NameEx("LoseMsg"),
+            NameEx("LoseAck"),
+        ))
 
     /**
      * ---------------------------------------------------------------------------------------------------------------
@@ -180,17 +220,28 @@ class TestModule extends AnyFunSuite {
      */
     new TlaOperDecl("abvars", // NOTE: Is this really an operator? Seems contrived.
         List(),
-        OperEx(TlaFunOper.tuple, NameEx("msgQ"), NameEx("ackQ"), NameEx("sBit"), NameEx("sAck"), NameEx("rBit"),
-            NameEx("sent"), NameEx("rcvd")))
+        OperEx(
+            TlaFunOper.tuple,
+            NameEx("msgQ"),
+            NameEx("ackQ"),
+            NameEx("sBit"),
+            NameEx("sAck"),
+            NameEx("rBit"),
+            NameEx("sent"),
+            NameEx("rcvd"),
+        ))
 
     /**
      * ABFairness == /\ WF_abvars( ReSndMsg ) /\ WF_abvars( SndAck ) /\ SF_abvars( RcvMsg ) /\ SF_abvars( RcvAck )
      */
     new TlaOperDecl("AbFairness", List(),
-        OperEx(TlaBoolOper.and, OperEx(TlaTempOper.weakFairness, NameEx("abvars"), NameEx("ReSndMsg")),
+        OperEx(
+            TlaBoolOper.and,
+            OperEx(TlaTempOper.weakFairness, NameEx("abvars"), NameEx("ReSndMsg")),
             OperEx(TlaTempOper.weakFairness, NameEx("abvars"), NameEx("SndAck")),
             OperEx(TlaTempOper.strongFairness, NameEx("abvars"), NameEx("RcvMsg")),
-            OperEx(TlaTempOper.strongFairness, NameEx("abvars"), NameEx("RcvAck"))))
+            OperEx(TlaTempOper.strongFairness, NameEx("abvars"), NameEx("RcvAck")),
+        ))
 
     /**
      * ---------------------------------------------------------------------------------------------------------------

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TlaType1Gen.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TlaType1Gen.scala
@@ -133,7 +133,18 @@ trait TlaType1Gen {
       } else {
         // We may produce deeper trees.
         // NOTE: we do not generate sparse tuples, as they cannot appear in user's annotations.
-        oneOf(genPrimitive, genSet, genSeq, genFun, genOper, genTup, genRec, genRowRec, genVariant, genRow)
+        oneOf(
+            genPrimitive,
+            genSet,
+            genSeq,
+            genFun,
+            genOper,
+            genTup,
+            genRec,
+            genRowRec,
+            genVariant,
+            genRow,
+        )
       }
     }
   }


### PR DESCRIPTION
Some times we need to construct a case class or apply a method with very
many arguments. In this cases, it is generally easier to read the
applications and grock the inputs if we use "config-style", which puts
each parameter on its own line.

This will help with readability of the configuration construction from the CLI
parsing in #2065
 
-------

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
