### PR TITLE
Organize website decision records

### DIFF
--- a/COORDINATION.md
+++ b/COORDINATION.md
@@ -109,7 +109,7 @@ nothing is a priority".
 
 We use a modified action-priority matrix. Our prioritization process is
 recorded in
-[RFC-21](https://github.com/informalsystems/apalache/blob/main/docs/src/adr/021rfc-prioritization.md)
+[RFC-021](https://github.com/informalsystems/apalache/blob/main/docs/src/adr/021rfc-prioritization.md)
 
 ### Milestones
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -89,6 +89,7 @@
 
 # Design Documents
 
+- [RFC 001: types and type annotations](./adr/001rfc-types.md)
 - [ADR-002: types and type annotations](./adr/002adr-types.md)
 - [ADR-003: transition executor (TRex)](./adr/003adr-trex.md)
 - [ADR-004: code annotations](./adr/004adr-annotations.md)
@@ -97,9 +98,16 @@
 - [ADR-007: restructuring](./adr/007adr-restructuring.md)
 - [ADR-008: exceptions](./adr/008adr-exceptions.md)
 - [ADR-009: outputs](./adr/009adr-outputs.md)
+- [RFC-010: Implementation of Transition Exploration Server](./adr/010rfc-transition-explorer.md)
 - [ADR-011: alternative SMT encoding using arrays](./adr/011adr-smt-arrays.md)
+- [ADR-012: Adopt an ADR Template](./adr/012adr-adopt-adr-template.md)
+- [ADR-013: Configuration Management Component](./adr/013adr-configuration.md)
+- [ADR-014: Precise type inference for records and variants](./adr/014adr-precise-records.md)
 - [ADR-015: ITF: informal trace format](./adr/015adr-trace.md)
 - [ADR-016: ReTLA: Relational TLA](./adr/016adr-retla.md)
 - [PDR-017: Checking temporal properties](./adr/017pdr-temporal.md)
 - [ADR-018: Inlining in Apalache](./adr/018adr-inlining.md)
+- [ADR-019: Harmonize changelog management](./adr/019adr-harmonize-changelog.md)
 - [ADR-020: Improving membership in arenas](./adr/020adr-arenas.md)
+- [RFC-021: Prioritization of Work](./adr/021rfc-prioritization.md)
+- [ADR-022: Unify Configuration Management and "Pass Options"](./adr/022adr-unification-of-configs-and-options.md)

--- a/docs/src/adr/002adr-types.md
+++ b/docs/src/adr/002adr-types.md
@@ -1,8 +1,8 @@
 # ADR-002: types and type annotations
 
-| authors                                | revision | revision date  |
-| -------------------------------------- | --------:| --------------:|
-| Shon Feder, Igor Konnov, Jure Kukovec  |        8 | July 22, 2022 |
+| authors                                | revision  | revision date   |
+| -------------------------------------- | --------: | --------------: |
+| Shon Feder, Igor Konnov, Jure Kukovec  | 8         | July 22, 2022   |
 
 *This is an architectural decision record. For user documentation, check the
 [Snowcat tutorial][] and [Snowcat HOWTO][].*

--- a/docs/src/adr/005adr-json.md
+++ b/docs/src/adr/005adr-json.md
@@ -1,8 +1,8 @@
 # ADR-005: JSON Serialization Format
 
-| author       | revision |
-| ------------ | --------:|
-| Jure Kukovec |        1.1 |
+| author       | revision  |
+| ------------ | --------: |
+| Jure Kukovec | 1.1       |
 
 This ADR documents our decision on serializing the Apalache internal representation (IR) as JSON.
 The purpose of introducing such a serialization is to expose the internal representation in a standardized format, which can be used for persistent storage, or for analysis by third-party tools in the future.

--- a/docs/src/adr/007adr-restructuring.md
+++ b/docs/src/adr/007adr-restructuring.md
@@ -1,8 +1,8 @@
 # ADR-007: Apalache Package Structure Guidelines
 
-| author       | revision |
-| ------------ | --------:|
-| Jure Kukovec |        1 |
+| author       | revision  |
+| ------------ | --------: |
+| Jure Kukovec | 1         |
 
 This ADR documents the design policies guiding the package and dependency structure of Apalache.
 When introducing new classes, use the guidelines defined below to determine which package to place them in.

--- a/docs/src/adr/008adr-exceptions.md
+++ b/docs/src/adr/008adr-exceptions.md
@@ -1,8 +1,8 @@
 # ADR-008: Apalache Exceptions
 
-| author     | revision |
-| ------------ | --------:|
-| Jure Kukovec |    1 |
+| author       | revision  |
+| ------------ | --------: |
+| Jure Kukovec | 1         |
 
 This ADR documents the various exception thrown in Apalache, and the circumstances that trigger them.
 

--- a/docs/src/adr/009adr-outputs.md
+++ b/docs/src/adr/009adr-outputs.md
@@ -1,9 +1,8 @@
----
-authors: Jure Kukovec, Shon Feder
-last revised: 2021-12-14
----
-
 # ADR-009: Apalache Outputs
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Jure Kukovec, Shon Feder               | 2021-12-14      |
 
 This ADR documents the various files produced by Apalache, and where they get written to.
 

--- a/docs/src/adr/009adr-outputs.md
+++ b/docs/src/adr/009adr-outputs.md
@@ -3,7 +3,7 @@ authors: Jure Kukovec, Shon Feder
 last revised: 2021-12-14
 ---
 
-# ADR-008: Apalache Outputs
+# ADR-009: Apalache Outputs
 
 This ADR documents the various files produced by Apalache, and where they get written to.
 

--- a/docs/src/adr/012adr-adopt-adr-template.md
+++ b/docs/src/adr/012adr-adopt-adr-template.md
@@ -1,9 +1,8 @@
----
-authors: Shon Feder
-last revised: 2021-12-05
----
-
 # ADR-012: Adopt an ADR Template
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Shon Feder                             | 2021-12-05      |
 
 **Table of Contents**
 

--- a/docs/src/adr/013adr-configuration.md
+++ b/docs/src/adr/013adr-configuration.md
@@ -3,7 +3,7 @@ authors: Shon Feder
 last revised: 2022-08-15
 ---
 
-# ADR-012: Configuration Management Component
+# ADR-013: Configuration Management Component
 
 **Table of Contents**
 

--- a/docs/src/adr/013adr-configuration.md
+++ b/docs/src/adr/013adr-configuration.md
@@ -1,9 +1,8 @@
----
-authors: Shon Feder
-last revised: 2022-08-15
----
-
 # ADR-013: Configuration Management Component
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Shon Feder                             | 2022-08-15      |
 
 **Table of Contents**
 

--- a/docs/src/adr/014adr-precise-records.md
+++ b/docs/src/adr/014adr-precise-records.md
@@ -1,9 +1,8 @@
----
-authors: Igor Konnov
-last revised: 2021-12-12
----
-
 # ADR-014: Precise type inference for records and variants
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Igor Konnov                            | 2021-12-12      |
 
 **Table of Contents**
 

--- a/docs/src/adr/015adr-trace.md
+++ b/docs/src/adr/015adr-trace.md
@@ -1,14 +1,8 @@
----
-
-**authors:** Igor Konnov
-
-**proposed by:** Vitor Enes, Andrey Kupriyanov
-
-**last revised:** 2022-06-01
-
----
-
 # ADR-015: Informal Trace Format in JSON
+
+| authors                                | proposed by                   | last revised    |
+| -------------------------------------- | ----------------------------  | --------------: |
+| Igor Konnov                            | Vitor Enes, Andrey Kupriyanov | 2022-06-01      |
 
 **Table of Contents**
 

--- a/docs/src/adr/016adr-retla.md
+++ b/docs/src/adr/016adr-retla.md
@@ -1,8 +1,8 @@
 # ADR-16: ReTLA - Relational TLA
 
-| author     | revision |
-| ------------ | --------:|
-| Jure Kukovec |    1 |
+| author       | revision  |
+| ------------ | --------: |
+| Jure Kukovec | 1         |
 
 **Table of Contents**
 

--- a/docs/src/adr/017pdr-temporal.md
+++ b/docs/src/adr/017pdr-temporal.md
@@ -1,9 +1,8 @@
----
-authors: Igor Konnov, Philip Offtermatt
-last revised: 2022-04-01
----
-
 # PDR-017: Checking temporal properties
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Igor Konnov, Philip Offtermatt         | 2022-04-01      |
 
 **This is a preliminary design document. It will be refined and it will mature
   into an ADR later.**

--- a/docs/src/adr/018adr-inlining.md
+++ b/docs/src/adr/018adr-inlining.md
@@ -1,8 +1,8 @@
 # ADR-018: Inlining in Apalache
 
-| author       | revision | last revised |
-| ------------ | --------:| ------------ |
-| Jure Kukovec |        1 | Apr 21, 2022 |
+| author       | revision  | last revised |
+| ------------ | --------: | ------------ |
+| Jure Kukovec | 1         | 2022-04-21   |
 
 **Table of Contents**
 

--- a/docs/src/adr/019adr-harmonize-changelog.md
+++ b/docs/src/adr/019adr-harmonize-changelog.md
@@ -1,9 +1,8 @@
----
-authors: Shon Feder
-last revised: 2022-05-06
----
-
 # ADR-019: Harmonize changelog management
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Shon Feder                             | 2022-05-06      |
 
 **Table of Contents**
 

--- a/docs/src/adr/020adr-arenas.md
+++ b/docs/src/adr/020adr-arenas.md
@@ -1,12 +1,8 @@
----
-
-**authors:** Igor Konnov
-
-**last revised:** 2022-06-01
-
----
-
 # ADR-020: Introduce static membership in arenas
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Igor Konnov                            | 2022-06-01      |
 
 **Table of Contents**
 

--- a/docs/src/adr/021rfc-prioritization.md
+++ b/docs/src/adr/021rfc-prioritization.md
@@ -1,9 +1,8 @@
----
-authors: Shon Feder, Gabriela Moreira
-last revised: 2022-05-24
----
-
 # RFC-021: Prioritization of Work
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Shon Feder, Gabriela Moreira           | 2022-05-24      |
 
 **Table of Contents**
 

--- a/docs/src/adr/021rfc-prioritization.md
+++ b/docs/src/adr/021rfc-prioritization.md
@@ -3,7 +3,7 @@ authors: Shon Feder, Gabriela Moreira
 last revised: 2022-05-24
 ---
 
-# RFC-21: Prioritization of Work
+# RFC-021: Prioritization of Work
 
 **Table of Contents**
 

--- a/docs/src/adr/022adr-unification-of-configs-and-options.md
+++ b/docs/src/adr/022adr-unification-of-configs-and-options.md
@@ -1,9 +1,8 @@
----
-authors: Shon Feder
-last revised: 2022-08-15
----
-
 # ADR-022: Unify Configuration Management and "Pass Options"
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Shon Feder                             | 2022-08-15      |
 
 **Table of Contents**
 

--- a/docs/src/adr/022adr-unification-of-configs-and-options.md
+++ b/docs/src/adr/022adr-unification-of-configs-and-options.md
@@ -3,7 +3,7 @@ authors: Shon Feder
 last revised: 2022-08-15
 ---
 
-# ADR-003: Unify Configuration Management and "Pass Options"
+# ADR-022: Unify Configuration Management and "Pass Options"
 
 **Table of Contents**
 

--- a/docs/src/adr/NNNadr-template.md
+++ b/docs/src/adr/NNNadr-template.md
@@ -1,9 +1,8 @@
----
-authors: Octavia Buttler, Eduardo Galleano
-last revised: YYYY-MM-DD
----
-
 # ADR-{NNN}: {Decision Subject}
+
+| authors                                | last revised    |
+| -------------------------------------- | --------------: |
+| Octavia Buttler, Eduardo Galleano      | YYYY-MM-DD      |
 
 **Table of Contents**
 


### PR DESCRIPTION
Hello :octocat: 

We are missing several ADRs from the website's menu, so I'm linking all of them there. In this process, I fixed some small numbering problems.

I also found a problem in how the ADR template's way of defining authors and revision dates is rendered. It currently looks like this:

![image](https://user-images.githubusercontent.com/18356186/185249801-3bae642c-da46-4a38-8adc-f3bcd338bcee.png)

So I've updated the template and existing entries to use a markdown table which renders like this: 

![image](https://user-images.githubusercontent.com/18356186/185250210-706c2ee5-a2ed-4f3c-be69-fbdd71b1d4a2.png)
