### PR TITLE
improve the warning about large sets

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -35,8 +35,6 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       val tag = ex.typeTag
       if (shallExpand) {
         // Expand the set as well as the underlying set!
-        logger.warn(s"The set S = $ex will be expanded, producing 2^Cardinality(S) constraints.")
-        logger.warn("Expansion may significantly slow down the solver, e.g., when Cardinality(S) >= 10.")
         OperEx(ApalacheOper.expand, OperEx(op, transform(true)(underlyingSet))(tag))(tag)
       } else {
         // Do not expand the set itself, but expand the underlying set!
@@ -47,10 +45,8 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       val tag = ex.typeTag
       if (shallExpand) {
         // Expand everything, including the function set.
-        logger.warn(
-            s"The function set [ S -> T ] = $ex will be expanded, producing Cardinality(T)^Cardinality(S) constraints.")
-        logger.warn(
-            "Expansion may significantly slowdown the solver, e.g., when Cardinality(T)^Cardinality(S) >= 1000.")
+        // Expansion of function sets is not implemented yet, see:
+        // https://github.com/informalsystems/apalache/issues/1452
         OperEx(ApalacheOper.expand, OperEx(op, transform(true)(dom), transform(true)(cdm))(tag))(tag)
       } else {
         // Only expand the domain, but keep the co-domain unexpanded,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -36,7 +36,7 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       if (shallExpand) {
         // Expand the set as well as the underlying set!
         logger.warn(s"The set S = $ex will be expanded, producing 2^Cardinality(S) constraints.")
-        logger.warn("Expansion may significantly slowdown the solver, e.g., when Cardinality(S) >= 10.")
+        logger.warn("Expansion may significantly slow down the solver, e.g., when Cardinality(S) >= 10.")
         OperEx(ApalacheOper.expand, OperEx(op, transform(true)(underlyingSet))(tag))(tag)
       } else {
         // Do not expand the set itself, but expand the underlying set!
@@ -50,7 +50,7 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
         logger.warn(
             s"The function set [ S -> T ] = $ex will be expanded, producing Cardinality(T)^Cardinality(S) constraints.")
         logger.warn(
-            "Expansion may significantly slowdown the solver, e.g., when Cardinality(T) >= 4 or Cardinality(S) >= 5.")
+            "Expansion may significantly slowdown the solver, e.g., when Cardinality(T)^Cardinality(S) >= 1000.")
         OperEx(ApalacheOper.expand, OperEx(op, transform(true)(dom), transform(true)(cdm))(tag))(tag)
       } else {
         // Only expand the domain, but keep the co-domain unexpanded,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -35,7 +35,8 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       val tag = ex.typeTag
       if (shallExpand) {
         // Expand the set as well as the underlying set!
-        logger.warn(s"The set $ex will be expanded. This will blow up the solver.")
+        logger.warn(s"The set S = $ex will be expanded, producing 2^Cardinality(S) constraints.")
+        logger.warn("Expansion may significantly slowdown the solver, e.g., when Cardinality(S) >= 10.")
         OperEx(ApalacheOper.expand, OperEx(op, transform(true)(underlyingSet))(tag))(tag)
       } else {
         // Do not expand the set itself, but expand the underlying set!
@@ -46,7 +47,10 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       val tag = ex.typeTag
       if (shallExpand) {
         // Expand everything, including the function set.
-        logger.warn(s"The set $ex will be expanded. This will blow up the solver.")
+        logger.warn(
+            s"The function set [ S -> T ] = $ex will be expanded, producing Cardinality(T)^Cardinality(S) constraints.")
+        logger.warn(
+            "Expansion may significantly slowdown the solver, e.g., when Cardinality(T) >= 4 or Cardinality(S) >= 5.")
         OperEx(ApalacheOper.expand, OperEx(op, transform(true)(dom), transform(true)(cdm))(tag))(tag)
       } else {
         // Only expand the domain, but keep the co-domain unexpanded,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
@@ -4,6 +4,7 @@ import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.PowSetCtor
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaSetOper}
+import com.typesafe.scalalogging.LazyLogging
 
 /**
  * This rule expands a powerset, that is, SUBSET S for a set S. In the future, it might also expand a set of functions,
@@ -12,7 +13,10 @@ import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaSetOper}
  * @author
  *   Igor Konnov
  */
-class SetExpandRule(rewriter: SymbStateRewriter) extends RewritingRule {
+class SetExpandRule(rewriter: SymbStateRewriter) extends RewritingRule with LazyLogging {
+  // the minimal cardinality of a base set that should trigger a warning
+  private val BASESET_WARNING_THRESHOLD = 10
+
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(ApalacheOper.expand, OperEx(TlaSetOper.powerset, _))  => true
@@ -28,6 +32,13 @@ class SetExpandRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
       case OperEx(ApalacheOper.expand, OperEx(TlaSetOper.powerset, basesetEx)) =>
         val nextState = rewriter.rewriteUntilDone(state.setRex(basesetEx))
+        val baseset = nextState.asCell
+        val baseSize = nextState.arena.getHas(baseset).length
+        if (baseSize >= BASESET_WARNING_THRESHOLD) {
+          val msg =
+            s"The set $baseset is expanded, producing O(2^$baseSize) constraints. This may slow down the solver."
+          logger.warn(msg)
+        }
         new PowSetCtor(rewriter).confringo(nextState, nextState.asCell)
 
       case e @ _ =>


### PR DESCRIPTION
This is a small change in the warning about expanding power sets and function sets. The previous warning is annoying, especially when `SUBSET S` is applied to `S` of cardinality of 1 or 2.