### PR TITLE
Fix computation length output

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -107,7 +107,9 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
     executor.passOptions.set("typechecker.inferPoly", cfg.typechecker.inferpoly.get)
     setCommonOptions()
     executor.run() match {
-      case Right(_)   => Right("Checker reports no error up to computation length " + length)
+      case Right(_) =>
+        Right("Checker reports no error up to computation length " + executor.passOptions.getOrError[Int]("checker",
+            "length"))
       case Left(code) => Left(code, "Checker has found an error")
     }
   }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -394,7 +394,18 @@ EXITCODE: ERROR (12)
 
 ## running the check command
 
-#### check factorization find a counterexample (array-encoding)
+### Prints default computation length of 10 (regression #2087)
+
+```sh
+$ apalache-mc check y2k_instance.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+Checker reports no error up to computation length 10
+...
+EXITCODE: OK
+```
+
+### check factorization find a counterexample (array-encoding)
 
 ```sh
 $ apalache-mc check --length=2 --inv=Inv factorization.tla | sed 's/I@.*//'
@@ -825,6 +836,7 @@ EXITCODE: ERROR (12)
 $ apalache-mc check --length=19 --inv=Safety y2k_instance.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
+Checker reports no error up to computation length 19
 ...
 EXITCODE: OK
 ```


### PR DESCRIPTION
As part of the options rework, we turned all the clist `opt`s into `Option`s (#2065).
As a result, `CheckCmd` didn't access the default value of 10 when printing computation length.

This applies a fix by getting `"checker.length"` from pass options instead.
Also adds 2 integration tests, one with default length and one with explicit `--length`.

Fixes #2087 

