### PR TITLE
Introduce --features=imprecise.records and test type annotations

### DIFF
--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
@@ -38,8 +38,8 @@ abstract class ApalacheCommand(name: String, description: String) extends Comman
       useEnv = true)
   var features = opt[Option[Seq[Feature]]](default = None,
       description = {
-        val featureDescriptions = Feature.all.map(f => s"  ${f.name}: ${f.description}")
-        ("a comma-separated list of experimental features:" :: featureDescriptions).mkString("\n")
+        val featureDescriptions: Seq[String] = Feature.all.map(f => s"  ${f.name}: ${f.description}")
+        ("a comma-separated list of experimental features:" +: featureDescriptions).mkString("\n")
       })
 
   /**

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
@@ -4,13 +4,13 @@ import at.forsyte.apalache.infra.ExitCodes
 import at.forsyte.apalache.infra.passes.Pass.PassResult
 import at.forsyte.apalache.infra.passes.PassOptions
 import at.forsyte.apalache.io.annotations.store.AnnotationStore
-import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.io.lir.TlaWriterFactory
+import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.imp.utils
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
-import at.forsyte.apalache.tla.lir.{Feature, ModuleProperty, RowsFeature, TlaModule, TypeTag, UID, Untyped}
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.typecheck.TypeCheckerTool
-import at.forsyte.apalache.tla.imp.utils
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 
@@ -25,8 +25,9 @@ class EtcTypeCheckerPassImpl @Inject() (
 
   protected def inferPoly: Boolean = options.getOrElse[Boolean]("typecheck", "inferPoly", true)
 
+  // use rows by default, unless the user passed --features=imprecise.records
   protected def useRows: Boolean =
-    options.getOrElse[Seq[Feature]]("general", "features", Seq()).contains(RowsFeature())
+    !options.getOrElse[Seq[Feature]]("general", "features", Seq()).contains(ImpreciseRecordsFeature())
 
   override def name: String = "TypeCheckerSnowcat"
 

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprRows.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExprRows.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
-import at.forsyte.apalache.io.annotations.store.{createAnnotationStore, AnnotationStore}
 import at.forsyte.apalache.io.typecheck.parser.{DefaultType1Parser, Type1Parser}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir._
@@ -18,15 +17,12 @@ import org.scalatestplus.junit.JUnitRunner
  */
 @RunWith(classOf[JUnitRunner])
 class TestToEtcExprRows extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBase {
-  private var parser: Type1Parser = _
-  private var annotationStore: AnnotationStore = _
+  private val parser: Type1Parser = DefaultType1Parser
   private var gen: ToEtcExpr = _
 
   override protected def beforeEach(): Unit = {
-    parser = DefaultType1Parser
-    annotationStore = createAnnotationStore()
     // a new instance of the translator, as it gives unique names to the variables
-    gen = new ToEtcExpr(annotationStore, TypeAliasSubstitution.empty, new TypeVarPool(), useRows = true)
+    gen = new ToEtcExpr(Map(), TypeAliasSubstitution.empty, new TypeVarPool(), useRows = true)
   }
 
   test("record set constructor") {

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExprBase.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExprBase.scala
@@ -1,11 +1,18 @@
 package at.forsyte.apalache.tla.typecheck.etc
 
-import at.forsyte.apalache.tla.lir.{OperT1, SetT1, TlaType1, TupT1, VarT1}
+import at.forsyte.apalache.tla.lir.{OperT1, SetT1, TlaType1, TupT1, UID, VarT1}
 
 /**
  * The base class to be used by TestToEtcExprFoo classes.
  */
 protected trait ToEtcExprBase extends EtcBuilder {
+  protected def mkToEtcExpr(
+      annotations: Map[UID, TlaType1] = Map.empty,
+      aliases: TypeAliasSubstitution = TypeAliasSubstitution.empty,
+      useRows: Boolean = false): ToEtcExpr = {
+    new ToEtcExpr(annotations, aliases, new TypeVarPool(), useRows)
+  }
+
   protected def mkAppByType(operTypes: Seq[TlaType1], args: TlaType1*): EtcApp = {
     mkUniqApp(operTypes, args.map(a => mkUniqConst(a)): _*)
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Feature.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/Feature.scala
@@ -11,12 +11,29 @@ sealed trait Feature {
 /**
  * Enable rows, new records, and variants, as described in <a
  * href="https://github.com/informalsystems/apalache/blob/main/docs/src/adr/014adr-precise-records.md">ADR-014</a>.
+ *
+ * [[RowsFeature]] is mutually exclusive to [[ImpreciseRecordsFeature]]. We enable [[RowsFeature]] by default and keep
+ * it only for backwards compatibility.
  */
 case class RowsFeature(
     name: String = "rows",
-    description: String = "enable row typing as explained in ADR-014")
+    description: String = "enable row typing as explained in ADR-014 (default in versions after 0.29.0)")
     extends Feature {
-  override val toString = name
+  override val toString: String = name
+}
+
+/**
+ * Enable imprecise record types, see <a
+ * href="https://apalache.informal.systems/docs/adr/002adr-types.html#15-discussion">the discussion in ADR-002</a>.
+ *
+ * [[ImpreciseRecordsFeature]] is mutually exclusive with [[RowsFeature]]. It is present only for backwards
+ * compatibility.
+ */
+case class ImpreciseRecordsFeature(
+    name: String = "imprecise.records",
+    description: String = "enable imprecise typing for records (default in versions prior to 0.29.0)")
+    extends Feature {
+  override val toString: String = name
 }
 
 object Feature {
@@ -26,7 +43,7 @@ object Feature {
    *
    * This provides the source of truth for all valid feature names and descriptions.
    */
-  val all = List(RowsFeature())
+  val all: Seq[Feature] = List(RowsFeature(), ImpreciseRecordsFeature())
 
   val fromString: String => Option[Feature] = str => all.find(_.name == str)
 }


### PR DESCRIPTION
Closes #1926. Closes #1943.

- [x] Following #1943, This PR introduces a new feature flag `imprecise.records`, which is the opposite of `rows`.
- [x] As requested in #1926, we have to warn the users when they are using the old type annotations with `rows` and when they are using new type annotations with `imprecise.records`. This check is now done in `TypeCheckerTool`.
- [x] To make the check in `TypeCheckerTool`, I had to refactor `ToEtcExpr`. It does not receive `AnnotationStore` anymore, but just a map from identifiers to types. This nicely isolates annotation processing and additional checks in `TypeCheckerTool`.
- [x] The feature `rows` is the default now, that is, it is only kept for transitional compatibility with the documentation.
- [x] The feature `imprecise.records` is not the default anymore, it has to be explicitly enabled.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality. Postponed for another PR.
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
