### PR TITLE
Update manual for multi-argument init and temporal

### DIFF
--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -56,14 +56,13 @@ The arguments are as follows:
 
 * General parameters:
     - `--config` specifies the [TLC configuration file](./tlc-config.md)
-    - `--init` specifies the initialization predicates, as a comma separated
-      list, *`Init` by default*
+    - `--init` specifies the initialization predicate, *`Init` by default*
     - `--next` specifies the transition predicate, *`Next` by default*
     - `--cinit` specifies the constant initialization predicate, *optional*
-    - `--inv` specifies the invariant to check, *optional*
+    - `--inv` specifies the invariants to check, as a comma separated list, *optional*
     - `--length` specifies the maximal number of `Next` steps, *10 by default*
     - `--temporal` specifies the temporal properties to check, as a comma
-      separated list, *optional* and empty by default
+      separated list, *optional*
 
 * Advanced parameters:
     - `--algo` lets you to choose the search algorithm: `incremental` is using the incremental SMT solver, `offline` is

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -38,7 +38,9 @@ The model checker can be run as follows:
 
 ```bash
 $ apalache-mc check [--config=filename] [--init=Init] [--cinit=ConstInit] \
-    [--next=Next] [--inv=Inv] [--length=10] [--temporal=TemporalProp] [--algo=(incremental|offline)] \
+    [--next=Next] [--inv=Inv1,...,Invn] [--length=10] \
+    [--temporal=TemporalProp1,...,TemporalPropn] \
+    [--algo=(incremental|offline)] \
     [--discard-disabled] [--no-deadlock] \
     [--tuning-options-file=filename] [--tuning-options=key1=val1:...:keyn=valn] \
     [--smt-encoding=(oopsla19|arrays)] \
@@ -54,12 +56,14 @@ The arguments are as follows:
 
 * General parameters:
     - `--config` specifies the [TLC configuration file](./tlc-config.md)
-    - `--init` specifies the initialization predicate, *`Init` by default*
+    - `--init` specifies the initialization predicates, as a comma separated
+      list, *`Init` by default*
     - `--next` specifies the transition predicate, *`Next` by default*
     - `--cinit` specifies the constant initialization predicate, *optional*
     - `--inv` specifies the invariant to check, *optional*
     - `--length` specifies the maximal number of `Next` steps, *10 by default*
-    - `--temporal` specifies the temporal property to check, *optional*
+    - `--temporal` specifies the temporal properties to check, as a comma
+      separated list, *optional* and empty by default
 
 * Advanced parameters:
     - `--algo` lets you to choose the search algorithm: `incremental` is using the incremental SMT solver, `offline` is


### PR DESCRIPTION
Followup to #2074

This just updates the manual docs to inform users that they can supply a
comm separated list of arguments to the `--init` and `--temporal` flags.

If I'd realized how few additions this needed, I would have just
rolled it into #2074.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality