### PR TITLE
Raise an error on invalid keys in configuration

### DIFF
--- a/.unreleased/breaking-changes/2125-err-on-invalid-config-keys.md
+++ b/.unreleased/breaking-changes/2125-err-on-invalid-config-keys.md
@@ -1,0 +1,2 @@
+Invalid configuration keys found in configuration sources (e.g., `apalache.cfg`
+files) will now produce a configuration error on load (see #2125). 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3539,6 +3539,18 @@ Configuration error: at 'common.features.0'
 $ rm -rf ./.apalache.cfg
 ```
 
+### configuration management: unsupported keys produce an error on load
+
+```sh
+$ echo "invalid.key: foo" > .apalache.cfg
+$ apalache-mc check --length=0 Counter.tla | grep -o -e "Configuration error:.*" -e ".apalache.cfg:.*" -e "EXITCODE:.*"
+...
+Configuration error: at 'invalid':
+.apalache.cfg: 1) Unknown key.
+EXITCODE: ERROR (255)
+$ rm -rf ./.apalache.cfg
+```
+
 ## module lookup
 
 ### module lookup: looks up dummy module from standard library

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ConfigManager.scala
@@ -2,6 +2,7 @@ package at.forsyte.apalache.io
 
 import pureconfig._
 import pureconfig.generic.auto._
+import pureconfig.generic.ProductHint
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import at.forsyte.apalache.tla.lir.Feature
@@ -27,6 +28,9 @@ private object Converters {
   implicit val featureReader = ConfigReader.fromString[Feature](optF(Feature.fromString))
   implicit val featureWriter = ConfigWriter.toString[Feature](_.toString)
 
+  // Do not allow unknown keys
+  // See https://pureconfig.github.io/docs/overriding-behavior-for-case-classes.html#unknown-keys
+  implicit val hint = ProductHint[ApalacheConfig](allowUnknownKeys = false)
 }
 
 /**


### PR DESCRIPTION
Previously, unexpected keys in a configuration source were silently
ignored. This led to invalid configuration values (e.g., due to
configuration format updates or due to typos) being silently ignored.

This addition ensures we raise an error on unexpected keys in
configuration sources.

This was spun out of ongoing work on #2121.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change