### PR TITLE
Make ApalacheConfig take a `SourceOption` for input  instead of a file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,10 @@ lazy val tlair = (project in file("tlair"))
 lazy val infra = (project in file("mod-infra"))
   .dependsOn(tlair)
   .settings(
-      testSettings
+      testSettings,
+      libraryDependencies ++= Seq(
+          Deps.commonsIo
+      ),
   )
 
 lazy val tla_io = (project in file("tla-io"))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -53,13 +53,7 @@ object Tool extends LazyLogging {
     cfg <- cmd.configuration
     _ <- Try(OutputManager.configure(cfg))
   } yield {
-    cfg.common.inputfile.foreach { file =>
-      // The sourceLines file is only relevant if we are loading a TLA file
-      if (file.getName.endsWith(".tla") && file.exists()) {
-        OutputManager.initSourceLines(file)
-      }
-    }
-
+    cfg.input.source.foreach(OutputManager.initSourceLines(_))
     println(s"Output directory: ${OutputManager.runDir.normalize()}")
     OutputManager.withWriterInRunDir(OutputManager.Names.RunFile)(
         _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -5,6 +5,7 @@ import org.backuity.clist.{arg, opt}
 import java.io.File
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.Config
+import at.forsyte.apalache.infra.passes.options.SourceOption
 
 // Holds the minimal necessary info about a specification.
 abstract class AbstractCheckerCmd(val name: String, description: String)
@@ -32,7 +33,7 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
   override def toConfig(): Config.ApalacheConfig = {
     val cfg = super.toConfig()
     cfg.copy(
-        common = cfg.common.copy(inputfile = Some(file)),
+        input = cfg.input.copy(source = Some(SourceOption.FileSource(file))),
         checker = cfg.checker.copy(
             config = config,
             cinit = cinit,

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -13,6 +13,7 @@ import scala.jdk.CollectionConverters._
 import at.forsyte.apalache.infra.passes.options.Config
 import at.forsyte.apalache.infra.passes.options.OptionGroup
 import org.apache.commons.io.FilenameUtils
+import at.forsyte.apalache.infra.passes.options.SourceOption
 
 /**
  * This command initiates the 'check' command line.
@@ -85,19 +86,23 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
         ),
     )
 
-    cfg.common.inputfile.foreach { file =>
-      if (newCfg.checker.config.isEmpty) {
-        // The older versions of apalache were loading a TLC config file of the same basename as the spec.
-        // We have flipped this behavior in version 0.25.0.
-        // Hence, warn the user that their config is not loaded by default.
-        val stem = FilenameUtils.removeExtension(file.getName())
-        val defaultConfig = new File(stem + ".cfg")
-        if (defaultConfig.exists()) {
-          val msg =
-            s"  > TLC config file found in specification directory. To enable it, pass --config=$defaultConfig."
-          logger.info(msg)
+    // The older versions of apalache were loading a TLC config file of
+    // the same basename as the spec by default. We have flipped this
+    // behavior in version 0.25.0. Hence, warn the user that their config
+    // is not loaded by default.
+    cfg.input.source.foreach {
+      // The check is only relevant for TLA files
+      case SourceOption.FileSource(file, SourceOption.Format.Tla) =>
+        if (newCfg.checker.config.isEmpty) {
+          val stem = FilenameUtils.removeExtension(file.getName())
+          val defaultConfig = new File(stem + ".cfg")
+          if (defaultConfig.exists()) {
+            val msg =
+              s"  > TLC config file found in specification directory. To enable it, pass --config=$defaultConfig."
+            logger.info(msg)
+          }
         }
-      }
+      case _ => ()
     }
 
     newCfg

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.Executor
 import at.forsyte.apalache.tla.imp.passes.ParserModule
 import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.infra.passes.options.SourceOption
 
 /**
  * This command initiates the 'parse' command line.
@@ -23,7 +24,8 @@ class ParseCmd
 
   override def toConfig() = {
     val cfg = super.toConfig()
-    cfg.copy(common = cfg.common.copy(inputfile = Some(file)), output = cfg.output.copy(output = output))
+    cfg.copy(input = cfg.input.copy(source = Some(SourceOption.FileSource(file))),
+        output = cfg.output.copy(output = output))
   }
 
   def run() = {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.Config
 import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.infra.passes.options.SourceOption
 
 /**
  * This command initiates the 'test' command line.
@@ -39,9 +40,7 @@ class TestCmd
     val seed = Math.abs(System.currentTimeMillis().toInt)
 
     cfg.copy(
-        common = cfg.common.copy(
-            inputfile = Some(file)
-        ),
+        input = cfg.input.copy(source = Some(SourceOption.FileSource(file))),
         checker = cfg.checker.copy(
             tuning = Some(Map("search.invariantFilter" -> "1->.*", "smt.randomSeed" -> seed.toString)),
             init = Some(before),

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -8,6 +8,7 @@ import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.Config
 import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.infra.passes.options.SourceOption
 
 /**
  * This command initiates the 'typecheck' command line.
@@ -27,7 +28,7 @@ class TypeCheckCmd
   override def toConfig(): Config.ApalacheConfig = {
     val cfg = super.toConfig()
     cfg.copy(
-        common = cfg.common.copy(inputfile = Some(file)),
+        input = cfg.input.copy(source = Some(SourceOption.FileSource(file))),
         output = cfg.output.copy(output = output),
         typechecker = cfg.typechecker.copy(inferpoly = inferPoly),
     )

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -1,13 +1,17 @@
 package at.forsyte.apalache.io
 
+import at.forsyte.apalache.infra.passes.options.Config.ApalacheConfig
+import at.forsyte.apalache.infra.passes.options.SourceOption
 import com.typesafe.scalalogging.LazyLogging
 
-import java.io.{File, FileWriter, PrintWriter}
-import java.nio.file.{Files, Path, Paths}
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import at.forsyte.apalache.infra.passes.options.Config.ApalacheConfig
-
 import scala.io.Source
 
 /**
@@ -37,10 +41,12 @@ object OutputManager extends LazyLogging {
   // lines in the original input. This variable stores them.
   private var sourceLinesOpt: Option[IndexedSeq[String]] = None
 
-  // Should be called only if input is a .tla file
-  def initSourceLines(file: File): Unit =
-    if (sourceLinesOpt.isEmpty) {
-      val src = Source.fromFile(file)
+  // Takes effect only when called on a source that is an existing .tla file or
+  // a string representing a .tla spec
+  def initSourceLines(source: SourceOption): Unit =
+    if (sourceLinesOpt.isEmpty && source.exists) {
+      // We currently just ignore possible auxiliary sources
+      val (src, _) = source.toSources
       try sourceLinesOpt = Some(src.getLines().toIndexedSeq)
       finally src.close()
     }
@@ -121,8 +127,11 @@ object OutputManager extends LazyLogging {
     config = cfg
 
     val fileName =
-      config.common.inputfile
-        .map(_.getName) // Either the name of the file
+      config.input.source
+        .flatMap { // Either the name of the file
+          case SourceOption.FileSource(f, _)      => Some(f.getName())
+          case SourceOption.StringSource(_, _, _) => None
+        }
         .orElse(config.common.command) // Or the name of the command running
         .get // One of those two will always be available
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -45,7 +45,8 @@ object OutputManager extends LazyLogging {
   // a string representing a .tla spec
   def initSourceLines(source: SourceOption): Unit =
     if (sourceLinesOpt.isEmpty && source.exists) {
-      // We currently just ignore possible auxiliary sources
+      // We currently just ignore possible auxiliary sources for  the source lines,
+      // which is why the second value of the uple is ignored here:
       val (src, _) = source.toSources
       try sourceLinesOpt = Some(src.getLines().toIndexedSeq)
       finally src.close()


### PR DESCRIPTION
Closes #2128

## Context

To implement #2013 and friends, we'll need to be able to parse model checking configuration inputs from JSON data. The preceding work on #1174 etc. made it possible to obtain every configuration input required, with the notable exception of spec represented as a string! Currently, the configuration only supports input data via a file name. This won't work for the RPC server, since the client may not have access to the same file system as the server. This PR moves us towards the needed functionality by expanding the `ApalacheConfig` so that it takes a `SourceOption`. Follow up work planned in #2121 will add a converter to enable pure config to de-serialize the desired data.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)