### PR TITLE
Add de/serialization of `SourceOption` values

### DIFF
--- a/.unreleased/features/2134-cfg-dump-on-debug.md
+++ b/.unreleased/features/2134-cfg-dump-on-debug.md
@@ -1,0 +1,2 @@
+The application configuration is now dumped into the `run-dir` when the
+`--debug` flag is supplied (see #2134).

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
@@ -106,8 +106,6 @@ object Config {
    *   Whether or not to write general profiling data into the `runDir`
    * @param features
    *   Control experimental features
-   * @param dumpConfig
-   *   A file into which the loaded configuration can be written
    */
   case class Common(
       command: Option[String] = None,
@@ -118,8 +116,7 @@ object Config {
       configFile: Option[File] = None,
       writeIntermediate: Option[Boolean] = Some(false),
       profiling: Option[Boolean] = Some(false),
-      features: Option[Seq[Feature]] = Some(Seq()),
-      dumpConfig: Option[File] = None)
+      features: Option[Seq[Feature]] = Some(Seq()))
       extends Config[Common] {
 
     def empty: Common = Generic[Common].from(Generic[Common].to(this).map(emptyPoly))

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
@@ -106,6 +106,8 @@ object Config {
    *   Whether or not to write general profiling data into the `runDir`
    * @param features
    *   Control experimental features
+   * @param dumpConfig
+   *   A file into which the loaded configuration can be written
    */
   case class Common(
       command: Option[String] = None,
@@ -116,7 +118,8 @@ object Config {
       configFile: Option[File] = None,
       writeIntermediate: Option[Boolean] = Some(false),
       profiling: Option[Boolean] = Some(false),
-      features: Option[Seq[Feature]] = Some(Seq()))
+      features: Option[Seq[Feature]] = Some(Seq()),
+      dumpConfig: Option[File] = None)
       extends Config[Common] {
 
     def empty: Common = Generic[Common].from(Generic[Common].to(this).map(emptyPoly))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -17,6 +17,7 @@ import scala.util.Random
 import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
+import at.forsyte.apalache.io.ConfigManager
 
 /**
  * Command line access to the APALACHE tools.
@@ -58,6 +59,12 @@ object Tool extends LazyLogging {
     OutputManager.withWriterInRunDir(OutputManager.Names.RunFile)(
         _.println(s"${cmd.env} ${cmd.label} ${cmd.invocation}")
     )
+
+    // Write the application configuration, if debug is enabled
+    if (cfg.common.debug.getOrElse(false)) {
+      OutputManager.withWriterInRunDir("application-configs.cfg")(ConfigManager.save(cfg))
+    }
+
     // force our programmatic logback configuration, as the autoconfiguration works unpredictably
     new LogbackConfigurator(OutputManager.runDirPathOpt, OutputManager.customRunDirPathOpt).configureDefaultContext()
     // TODO: update workers when the multicore branch is integrated

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
@@ -43,9 +43,12 @@ abstract class ApalacheCommand(name: String, description: String)
       useEnv = true)
   var features = opt[Option[Seq[Feature]]](default = None,
       description = {
-        val featureDescriptions: Seq[String] = Feature.all.map(f => s"  ${f.name}: ${f.description}")
+        val featureDescriptions: Seq[String] = Feature.all.map(f => s"  * ${f.name}: ${f.description}")
         ("a comma-separated list of experimental features:" +: featureDescriptions).mkString("\n")
       })
+  var dumpConfig = opt[Option[File]](default = None,
+      description = """|dump the application configuration to the given file, default: none
+                       |(the application configuration is derived by parsing the CLI and reading any configuration files)""".stripMargin)
 
   /**
    * Derives an instance of [[at.forsyte.apalache.infra.passes.options.Config.ApalacheConfig ApalacheConfig]] from the
@@ -73,6 +76,7 @@ abstract class ApalacheCommand(name: String, description: String)
         runDir = runDir,
         writeIntermediate = writeIntermediate,
         features = features,
+        dumpConfig = dumpConfig,
     ))
   }
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
@@ -46,9 +46,6 @@ abstract class ApalacheCommand(name: String, description: String)
         val featureDescriptions: Seq[String] = Feature.all.map(f => s"  * ${f.name}: ${f.description}")
         ("a comma-separated list of experimental features:" +: featureDescriptions).mkString("\n")
       })
-  var dumpConfig = opt[Option[File]](default = None,
-      description = """|dump the application configuration to the given file, default: none
-                       |(the application configuration is derived by parsing the CLI and reading any configuration files)""".stripMargin)
 
   /**
    * Derives an instance of [[at.forsyte.apalache.infra.passes.options.Config.ApalacheConfig ApalacheConfig]] from the
@@ -76,7 +73,6 @@ abstract class ApalacheCommand(name: String, description: String)
         runDir = runDir,
         writeIntermediate = writeIntermediate,
         features = features,
-        dumpConfig = dumpConfig,
     ))
   }
 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3551,6 +3551,69 @@ EXITCODE: ERROR (255)
 $ rm -rf ./.apalache.cfg
 ```
 
+### configuration management: derived configuration can be dumped to a file
+
+First, set some custom config options, to ensure they'll be merged into the derived config:
+
+```sh
+$ printf "checker={length=0,inv=[Inv]}, common.out-dir=./cfg-out" > demo-config.cfg
+```
+
+Then, run a trivial checking command, dumping the derived config to a file:
+
+```sh
+$ apalache-mc check --config-file=demo-config.cfg --dump-config=configdump.cfg --features=rows Counter.tla
+...
+```
+
+Finally, confirm that the dumped config looks as expected, and clean up:
+
+```sh
+$ cat ./configdump.cfg
+checker {
+    algo=incremental
+    discard-disabled=true
+    inv=[
+        Inv
+    ]
+    length=0
+    max-error=1
+    no-deadlocks=false
+    nworkers=1
+    smt-encoding {
+        type=oopsla-19
+    }
+    tuning {
+        "search.outputTraces"="false"
+    }
+}
+common {
+    command=check
+    config-file="demo-config.cfg"
+    debug=false
+    dump-config="configdump.cfg"
+    features=[
+        rows
+    ]
+    out-dir="./cfg-out"
+    profiling=false
+    smtprof=false
+    write-intermediate=false
+}
+input {
+    source {
+        file="Counter.tla"
+        format=tla
+        type=file
+    }
+}
+output {}
+typechecker {
+    inferpoly=true
+}
+$ rm -rf ./configdump.cfg ./demo-config.cfg ./cfg-out
+```
+
 ## module lookup
 
 ### module lookup: looks up dummy module from standard library

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3556,20 +3556,21 @@ $ rm -rf ./.apalache.cfg
 First, set some custom config options, to ensure they'll be merged into the derived config:
 
 ```sh
-$ printf "checker={length=0,inv=[Inv]}, common.out-dir=./cfg-out" > demo-config.cfg
+$ printf "checker={length=0,inv=[Inv]}, common{out-dir=./cfg-out, features=[rows]}" > demo-config.cfg
 ```
 
-Then, run a trivial checking command, dumping the derived config to a file:
+Then, run a trivial checking command with `--debug` so the derived config will
+be saved into to the `--run-dir`:
 
 ```sh
-$ apalache-mc check --config-file=demo-config.cfg --dump-config=configdump.cfg --features=rows Counter.tla
+$ apalache-mc check --config-file=demo-config.cfg --run-dir=configdump-dir --debug Counter.tla
 ...
 ```
 
 Finally, confirm that the dumped config looks as expected, and clean up:
 
 ```sh
-$ cat ./configdump.cfg
+$ cat ./configdump-dir/application-configs.cfg
 checker {
     algo=incremental
     discard-disabled=true
@@ -3590,13 +3591,13 @@ checker {
 common {
     command=check
     config-file="demo-config.cfg"
-    debug=false
-    dump-config="configdump.cfg"
+    debug=true
     features=[
         rows
     ]
     out-dir="./cfg-out"
     profiling=false
+    run-dir=configdump-dir
     smtprof=false
     write-intermediate=false
 }
@@ -3611,7 +3612,7 @@ output {}
 typechecker {
     inferpoly=true
 }
-$ rm -rf ./configdump.cfg ./demo-config.cfg ./cfg-out
+$ rm -rf ./configdump-dir ./demo-config.cfg ./cfg-out
 ```
 
 ## module lookup


### PR DESCRIPTION
Closes #2129

When receiving data from RPC calls, we plan to use our configuration loading
system to read out the application configuration from a JSON payload. This will
need to include the source of the specification, which we represent as a value
of type `SourceOption`. The changes introduced here improve the serialization of
values of this type.

This PR also adds an option `--dump-config=<FILE>` that will write the derived
config of a command into the specified file. This has proved useful for testing,
I think could be useful for other purposes. However, I'm holding off on writing
documentation for it, in case reviewers think the CLI flag shouldn't introduced.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change