### PR TITLE
Shai: Remove semaphore

### DIFF
--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.shai.v1
 
 import at.forsyte.apalache.shai.v1.cmdExecutor.ZioCmdExecutor
-import zio.{Semaphore, ZEnv}
+import zio.ZEnv
 import com.typesafe.scalalogging.Logger
 
 /**
@@ -16,8 +16,8 @@ import com.typesafe.scalalogging.Logger
  * [[CmdExecutorService]] is meant to be registered with the [[RpcServer]], and should not need to be used directly.
  */
 
-class CmdExecutorService(parserSemaphore: Semaphore, logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEnv, Any] {
+class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEnv, Any] {
 
   // TODO These will be used when we start adding the RPC calls
-  val _todo = (parserSemaphore, logger)
+  val _todo = logger
 }

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.shai.v1
 
-import zio.{console, Ref, Semaphore, ZEnv, ZIO}
+import zio.{console, Ref, ZEnv, ZIO}
 import java.util.UUID
 import scalapb.zio_grpc.ServerMain
 import scalapb.zio_grpc.ServiceList
@@ -17,20 +17,15 @@ object RpcServer extends ServerMain with LazyLogging {
   override def welcome: ZIO[ZEnv, Throwable, Unit] =
     console.putStrLn("The Apalache server is running. Press Ctrl-C to stop.")
 
-  val parserSemaphore = Semaphore.make(permits = 1)
-
   val createTransExplorerService = for {
     // A thread safe mutable reference to the active connections
     // See https://zio.dev/version-1.x/datatypes/concurrency/ref/
     connections <- Ref.make(Map[UUID, Conn]())
-    semaphore <- parserSemaphore
     // Ensure atomic access to the parser
     // See https://github.com/informalsystems/apalache/issues/1114#issuecomment-1180534894
-  } yield new TransExplorerService(connections, semaphore, logger)
+  } yield new TransExplorerService(connections, logger)
 
-  val createCmdExecutorService = for {
-    semaphore <- parserSemaphore
-  } yield new CmdExecutorService(semaphore, logger)
+  val createCmdExecutorService = ZIO.succeed(new CmdExecutorService(logger))
 
   def services: ServiceList[ZEnv] =
     ServiceList.addM(createTransExplorerService).addM(createCmdExecutorService)

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/TransExplorerService.scala
@@ -23,8 +23,7 @@ import at.forsyte.apalache.tla.imp.passes.ParserModule
 import at.forsyte.apalache.tla.lir.TlaModule
 import io.grpc.Status
 import java.util.UUID
-import zio.{Ref, Semaphore, ZEnv, ZIO}
-import zio.duration._
+import zio.{Ref, ZEnv, ZIO}
 import com.typesafe.scalalogging.Logger
 import at.forsyte.apalache.infra.passes.options.OptionGroup
 
@@ -79,15 +78,10 @@ private case class Conn(
  * @param connections
  *   A thread-safe, mutable reference holding a map registering connections by their unique ID
  *
- * @param parserSemaphore
- *   A semaphore used to ensure atomic access to the SANY parser. This is necessitated by the statefull design of the
- *   SANY parser, which makes it impossible to run two instance of the parser concurrently in the same runtime. See
- *   https://github.com/informalsystems/apalache/issues/1114#issuecomment-1180534894 for details.
- *
  * @param logger
  *   The logger used by the service
  */
-class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: Semaphore, logger: Logger)
+class TransExplorerService(connections: Ref[Map[UUID, Conn]], logger: Logger)
     extends ZioTransExplorer.ZTransExplorer[ZEnv, Any] {
 
   /** Concurrent tasks performed by the service that produce values of type `T` */
@@ -161,39 +155,32 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], parserSemaphore: S
     }
   } yield LoadModelResponse(result)
 
-  private val parserTimeoutDuration: Duration = 2.minute
-
-  private def parseSpec(spec: String, aux: Seq[String]): Result[Either[String, TlaModule]] = for {
-    // Obtain permit on the semaphore protecting access to the parser, ensuring the parser is not
-    // run by more than one thread at a time.
-    result <- parserSemaphore
-      .withPermit(ZIO.effectTotal(try {
-        // TODO: replace hard-coded options with options derived from CLI params
-        val options = {
-          import OptionGroup._
-          WithIO(
-              common = Common(
-                  command = "server",
-                  outDir = new java.io.File("."),
-                  runDir = None,
-                  debug = false,
-                  smtprof = false,
-                  writeIntermediate = false,
-                  profiling = false,
-                  features = Seq(),
-              ),
-              input = Input(SourceOption.StringSource(spec, aux)),
-              output = Output(Some(new java.io.File("."))),
-          )
-        }
-        val parser = Executor(new ParserModule(options))
-        parser.run().left.map(code => s"Parsing failed with error code: ${code}")
-      } catch {
-        case e: Throwable => Left(s"Parsing failed with exception: ${e.getMessage()}")
-      }))
-      .disconnect
-      .timeout(parserTimeoutDuration)
-  } yield result.getOrElse(Left(s"Parsing failed with timeout: exceeded ${parserTimeoutDuration}"))
+  private def parseSpec(spec: String, aux: Seq[String]): Result[Either[String, TlaModule]] = ZIO.effectTotal {
+    try {
+      // TODO: replace hard-coded options with options derived from CLI params
+      val options = {
+        import OptionGroup._
+        WithIO(
+            common = Common(
+                command = "server",
+                outDir = new java.io.File("."),
+                runDir = None,
+                debug = true,
+                smtprof = false,
+                writeIntermediate = false,
+                profiling = false,
+                features = Seq(),
+            ),
+            input = Input(SourceOption.StringSource(spec, aux)),
+            output = Output(Some(new java.io.File("."))),
+        )
+      }
+      val parser = Executor(new ParserModule(options))
+      parser.run().left.map(code => s"Parsing failed with error code: ${code}")
+    } catch {
+      case e: Throwable => Left(s"Parsing failed with exception: ${e.getMessage()}")
+    }
+  }
 
   private def jsonOfModule(module: TlaModule): String = {
     new TlaToUJson(None).makeRoot(Seq(module)).toString


### PR DESCRIPTION
With #2156 in place, we don't need to put a semaphore around invocations
of our pass executions any more, since the synchronization is assured via
the much more focused scope of invocations of SANY.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality