### PR TITLE
Fix support for one-line comments in type annotations

### DIFF
--- a/.unreleased/bug-fixes/2169.md
+++ b/.unreleased/bug-fixes/2169.md
@@ -1,0 +1,2 @@
+Fix missing support for single-line comments inside of type annotations (see
+https://github.com/informalsystems/apalache/issues/2162) 

--- a/test/tla/CommentedTypeAnnotation.tla
+++ b/test/tla/CommentedTypeAnnotation.tla
@@ -1,0 +1,19 @@
+------------------- MODULE CommentedTypeAnnotation -----------------------
+
+(* Used as regression test for https://github.com/informalsystems/apalache/issues/2163 *)
+
+CONSTANT
+  \* @type: Set({
+  \*   // a comment
+  \*   x : Int
+  \*});
+  v,
+  \* @type: {
+  \*   // another comment
+  \*   x : Int,
+  \*   // a third comment
+  \*   y : Seq(Int)
+  \*};
+  y
+
+============================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -273,7 +273,7 @@ because TLA+ Toolbox generates comments that look like malformed annotations.
 ```sh
 $ apalache-mc parse Test1275.tla | sed 's/W@.*//'
 ...
-[Test1275:5:1-5:12]: Syntax error in annotation -- Unexpected character. Missing ')' or ';'?
+[Test1275:5:1-5:12]: Syntax error in annotation -- ';' expected but end of source found
 ...
 EXITCODE: OK
 ...
@@ -3016,7 +3016,7 @@ See https://github.com/informalsystems/apalache/issues/860
 ```sh
 $ apalache-mc typecheck Bug860.tla | sed 's/[IEW]@.*//'
 ...
-Parsing error in the type annotation:  (Int, Int) -> Bool
+Parsing error in the type annotation: (Int, Int) -> Bool
 Typing input error: Parser error in type annotation of Op: '=>' expected but -> found
 ...
 EXITCODE: ERROR (255)
@@ -3032,7 +3032,7 @@ See https://github.com/informalsystems/apalache/issues/832
 ```sh
 $ apalache-mc typecheck Bug832.tla | sed 's/[IEW]@.*//'
 ...
-Parsing error in the type annotation:  () => (Bool, Bool)
+Parsing error in the type annotation: () => (Bool, Bool)
 Typing input error: Parser error in type annotation of Example: '->' expected but ) found
 ...
 EXITCODE: ERROR (255)

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3318,6 +3318,16 @@ $ apalache-mc typecheck PolyTooGeneral.tla | sed 's/[IEW]@.*//'
 EXITCODE: ERROR (120)
 ```
 
+### typecheck annotation with comments
+
+Regression test for https://github.com/informalsystems/apalache/issues/2163
+
+```sh
+$ apalache-mc typecheck CommentedTypeAnnotation.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ## configuring the output manager
 
 ### output manager: set out-dir by CLI flag

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/AnnotationParser.scala
@@ -34,7 +34,7 @@ class AnnotationParser extends Parsers {
       Annotation(name, args: _*)
   }
 
-  def argsInParentheses: Parser[List[AnnotationArg]] = LPAREN() ~ repsep(arg, COMMA()) ~ RPAREN() ^^ {
+  def argsInParentheses: Parser[List[AnnotationArg]] = LPAREN() ~ repsep(arg, argSep) ~ RPAREN() ^^ {
     case _ ~ args ~ _ =>
       args
   }
@@ -45,11 +45,10 @@ class AnnotationParser extends Parsers {
 
   def arg: Parser[AnnotationArg] = stringArg | intArg | boolArg | identArg
 
-  def stringArg: Parser[AnnotationStr] = string ^^ { str =>
-    AnnotationStr(str)
-  }
+  // SEparate arguments
+  private def argSep: Parser[Unit] = (newlines ~ COMMA() ~ newlines) ^^^ ()
 
-  def inlineStringArg: Parser[AnnotationStr] = inlineString ^^ { str =>
+  def stringArg: Parser[AnnotationStr] = string ^^ { str =>
     AnnotationStr(str)
   }
 
@@ -88,6 +87,10 @@ class AnnotationParser extends Parsers {
   private def boolean: Parser[Boolean] = {
     accept("boolean", { case BOOLEAN(b) => b })
   }
+
+  // Zero or more new line tokens
+  private def newlines: Parser[Unit] = opt(rep(NL())) ^^^ ()
+
 }
 
 object AnnotationParser {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/CommentPreprocessor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/CommentPreprocessor.scala
@@ -158,7 +158,10 @@ class CommentPreprocessor {
           annotationBuilder.append(lookaheadChar.get)
 
         case (true, true) =>
-          if (group != "\\*" && group != "(*" && group != "*)" && group != "\n") {
+          // This must NOT ignore new lines, or else we lose the ability to identify
+          // single-line comments in type annotations.
+          // See https://github.com/informalsystems/apalache/issues/2162
+          if (group != "\\*" && group != "(*" && group != "*)") {
             annotationBuilder.append(group)
           } // else: prune the comment characters and line-feed
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/tokens.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/annotations/parser/tokens.scala
@@ -76,3 +76,8 @@ case class LPAREN() extends AnnotationToken {}
  * Right parenthesis ")".
  */
 case class RPAREN() extends AnnotationToken {}
+
+/**
+ * New line "\n" (or "\r\n" on windows)
+ */
+case class NL() extends AnnotationToken {}

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/AnnotationExtractor.scala
@@ -18,7 +18,10 @@ import tla2sany.semantic.{OpDefNode, OpDefOrDeclNode}
 class AnnotationExtractor(annotationStore: AnnotationStore) extends LazyLogging {
   def parseAndSave(uid: UID, node: OpDefOrDeclNode): Unit = {
     val commentText = locateComments(node)
-
+      // Sany for some reason inserts extra line breaks after one-line comments
+      // and removing blank lines in comment scannot break the annotation parsing semantics,
+      // and makes them more regular anyhow.
+      .replace("\n\n", "\n")
     val (freeText, annotationsAsText) = CommentPreprocessor()(commentText)
     val annotations = annotationsAsText.map(AnnotationParser.parse).flatMap {
       case Right(parsed) =>

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestAnnotationParser.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestAnnotationParser.scala
@@ -57,7 +57,7 @@ class TestAnnotationParser extends AnyFunSuite with Checkers {
     val expected =
       Annotation(
           "type",
-          AnnotationStr(" (Int, Int) -> Set(Int) "),
+          AnnotationStr("(Int, Int) -> Set(Int)"),
       )
 
     AnnotationParser
@@ -112,13 +112,17 @@ class TestAnnotationParser extends AnyFunSuite with Checkers {
 
   test("parse variants in type aliases") {
     val extractedText =
-      """MESSAGE =""" + "\n" + """  Req({ ask: Int })      """ + "\n" + """        | Ack({ success: Bool })"""
+      """MESSAGE =
+        #  Req({ ask: Int })
+        #  | Ack({ success: Bool })""".stripMargin('#')
     val text = s"@typeAlias: $extractedText;"
 
+    // Normalize by removing repeated spaces and whitespace
+    val expectedText = """([ \t\f]+)""".r.replaceAllIn(extractedText, " ")
     val expected =
       Annotation(
           "typeAlias",
-          AnnotationStr(""" MESSAGE = Req({ ask: Int }) | Ack({ success: Bool })"""),
+          AnnotationStr(expectedText),
       )
     AnnotationParser
       .parse(text)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/TestCommentPreprocessor.scala
@@ -51,7 +51,7 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers with Matchers {
         | (* \* uuuuvvv*)abc
         |(*
         |  aaaa (* bbbb *) cccc
-        | *)
+        |*)
         |""".stripMargin
     val (output, potentialAnnotations) = CommentPreprocessor()(input)
     val expected =
@@ -61,7 +61,7 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers with Matchers {
         |  abc
         |
         |  aaaa  cccc
-        | 
+        |
         |""".stripMargin
     assert(output == expected)
     assert(potentialAnnotations.isEmpty)
@@ -85,22 +85,22 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers with Matchers {
         | ddd
         | zzz@bbb(1)
         |""".stripMargin
-    assert(potentialAnnotations == List("@annotation(\"a\", 1)", "@semi: foo ;", "@multi: aaa bbb ccc;"))
+    assert(potentialAnnotations == List("@annotation(\"a\", 1)", "@semi: foo ;", "@multi: aaa\n bbb\n ccc;"))
     assert(output == expected)
   }
 
   test("unclosed annotations") {
     val input =
       """\* xx @annotation("a",
-        |(* aaa @semi: bar *)
+        |(* aaa @semi: bar*)
         |""".stripMargin
     val (output, potentialAnnotations) = CommentPreprocessor()(input)
     val expected =
-      """ xx : bar 
+      """ xx : bar
         |""".stripMargin
     assert(output == expected)
     // The extracted annotation is ill-formed. This will be detected by the annotation parser.
-    assert(potentialAnnotations == List("@annotation(\"a\", aaa @semi"))
+    assert(potentialAnnotations == List("@annotation(\"a\",\n aaa @semi"))
   }
 
   test("annotations in strings") {
@@ -113,18 +113,13 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers with Matchers {
         |\* ;
         |""".stripMargin
     val (output, potentialAnnotations) = CommentPreprocessor()(input)
-    val expected =
-      """  (aaa)
-        | 
-        | type annotation 
-        | 
-        |""".stripMargin
-    assert(output == expected)
+    val expected = "(aaa)\n \n type annotation"
+    assert(output.trim == expected.trim)
     assert(potentialAnnotations.size == 4)
     assert(potentialAnnotations.head == "@adventurous(\"@IgnoreMe(false, 42)\", 1)")
     assert(potentialAnnotations(1) == "@beware: of :) ;")
     assert(potentialAnnotations(2) == "@type: Set(Set(a)) ;")
-    assert(potentialAnnotations(3) == "@type: a          => Int ;")
+    assert(potentialAnnotations(3) == "@type: a\n          => Int\n ;")
   }
 
   test("annotation starting with @") {
@@ -163,7 +158,7 @@ class TestCommentPreprocessor extends AnyFunSuite with Checkers with Matchers {
     val input = s"(*\n  $extractedText\n *)"
     val (_, potentialAnnotations) = CommentPreprocessor()(input)
     potentialAnnotations should equal(
-        List("""@typeAlias: MESSAGE = { tag: "req", ask: Int } | { tag: "ack", success: Bool };"""))
+        List("@typeAlias: MESSAGE = { tag: \"req\", ask: Int }\n | { tag: \"ack\", success: Bool };"))
   }
 
   test("no failure on random inputs") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/parser/TestAnnotationLexer.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/annotations/parser/TestAnnotationLexer.scala
@@ -70,7 +70,7 @@ class TestAnnotationLexer extends AnyFunSuite {
 
   test("inline string argument") {
     val text = """@baz: one;"""
-    val expected = List(AT_IDENT("baz"), INLINE_STRING(" one"))
+    val expected = List(AT_IDENT("baz"), INLINE_STRING("one"))
     expectOk(expected, text)
   }
 
@@ -99,9 +99,8 @@ class TestAnnotationLexer extends AnyFunSuite {
 
   test("annotation with ASCII codes") {
     // a sequence of control characters is replaced with a single space
-    val text =
-      " @type: Int \t\f\r\n => Int;".stripMargin
-    val expected = List(AT_IDENT("type"), INLINE_STRING(" Int => Int"))
+    val text = "@type: Int \t\f\t\f => Int;"
+    val expected = List(AT_IDENT("type"), INLINE_STRING("Int => Int"))
     expectOk(expected, text)
   }
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
@@ -344,12 +344,12 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
     val module = loadModule(text)
 
     val expectedSingleLine =
-      """ {
+      """{
         | // comment in single-line annotation
         | f : Int
         | }""".stripMargin
     val expectedMultiLine =
-      """ {
+      """{
         | // comment in multi-line annotation
         | g : Int
         | }""".stripMargin


### PR DESCRIPTION
Fixes #2162

We heard you like comments in your type annotations inside of comments, so we added support for single-line comments, beginning with `//`, that can be used inside of type annotations inside of multi- and single-line TLA+ comments, so you can comment your annotations while annotating inside your comments.

This required tweaking the lexer and preprocessor so that we preserve new lines (and avoid inserting duplicate new lines, added by SANY), and then updating a bunch of finicky tests to accommodate quirks to intermediate strings.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
