### PR TITLE
Resolve possible XML dependency conflict

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,3 +33,9 @@ lazy val root = (project in file("."))
 
 lazy val changelingPlugin =
   ProjectRef(file("sbt-changeling"), "sbt_changeling")
+
+// Required due to dependency conflict in SBT
+// See https://github.com/sbt/sbt/issues/6997
+ThisBuild / libraryDependencySchemes ++= Seq(
+    "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
Without this configuration, devs may hit an error like

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.scala-lang.modules:scala-xml_2.12:2.1.0 (early-semver) is selected over {1.3.0, 1.0.6, 1.2.0}
[error] 	    +- org.scoverage:scalac-scoverage-reporter_2.12:2.0.2 (depends on 2.1.0)
[error] 	    +- com.github.sbt:sbt-native-packager:1.9.11 (sbtVersion=1.0, scalaVersion=2.12) (depends on 2.1.0)
[error] 	    +- org.scala-sbt:testing_2.12:1.6.2                   (depends on 1.3.0)
[error] 	    +- org.scala-sbt:sbinary_2.12:0.5.1                   (depends on 1.0.6)
[error] 	    +- org.scala-sbt:main_2.12:1.6.2                      (depends on 1.3.0)
[error] 	    +- org.scala-sbt:librarymanagement-core_2.12:1.6.1    (depends on 1.2.0)
[error] 	    +- org.scala-lang:scala-compiler:2.12.16              (depends on 1.0.6)
[error] 	    +- io.get-coursier:lm-coursier-shaded_2.12:2.0.10     (depends on 1.3.0)
[error]
[error]
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```

See https://github.com/sbt/sbt/issues/6997

-------
    
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality