### PR TITLE
Return failure data from pass chain executions

### DIFF
--- a/.unreleased/features/2186-rpc-data.md
+++ b/.unreleased/features/2186-rpc-data.md
@@ -1,0 +1,2 @@
+Return JSON with success or failure data from RPC calls to the CmdExecutor
+service (see #2186).

--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,9 @@ lazy val infra = (project in file("mod-infra"))
   .settings(
       testSettings,
       libraryDependencies ++= Seq(
-          Deps.commonsIo
+          Deps.commonsIo,
+          Deps.ujson,
+          Deps.upickle,
       ),
   )
 

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/Pass.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/Pass.scala
@@ -77,7 +77,7 @@ trait Pass {
   /**
    * Construct a failing pass result
    *
-   * To be called to construct a failing [[PassResult]] in the event that a pass fails.
+   * To be called to construct a failing `PassResult` in the event that a pass fails.
    *
    * @param errorData
    *   Data providing insights into the reasons for the failure.

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/Pass.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/Pass.scala
@@ -72,5 +72,6 @@ trait Pass {
 }
 
 object Pass {
-  type PassResult = Either[TExitCode, TlaModule]
+  type PassFailure = (Throwable, TExitCode)
+  type PassResult = Either[PassFailure, TlaModule]
 }

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/PassChainExecutor.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/PassChainExecutor.scala
@@ -1,6 +1,5 @@
 package at.forsyte.apalache.infra.passes
 
-import at.forsyte.apalache.infra.ExitCodes.TExitCode
 import at.forsyte.apalache.infra.passes.Pass.PassResult
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.tla.lir.{MissingTransformationError, TlaModule, TlaModuleProperties}
@@ -22,7 +21,7 @@ import at.forsyte.apalache.infra.AdaptedException
  */
 object PassChainExecutor extends LazyLogging {
 
-  type PassResultModule = Either[TExitCode, TlaModule with TlaModuleProperties]
+  type PassResultModule = Either[Pass.PassFailure, TlaModule with TlaModuleProperties]
 
   def run[O <: OptionGroup](toolModule: ToolModule[O]): PassResult = {
 

--- a/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestPassChainExecutor.scala
+++ b/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestPassChainExecutor.scala
@@ -17,7 +17,7 @@ class TestPassChainExecutor extends AnyFunSuite {
       if (result) {
         Right(TlaModule("TestModule", Seq()))
       } else {
-        Left(ExitCodes.ERROR)
+        passFailure(None, ExitCodes.ERROR)
       }
     }
     override def dependencies = deps

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -124,8 +124,8 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
     PassChainExecutor.run(new CheckerModule(options)) match {
-      case Right(_)   => Right(s"Checker reports no error up to computation length ${options.checker.length}")
-      case Left(code) => Left(code, "Checker has found an error")
+      case Right(_)      => Right(s"Checker reports no error up to computation length ${options.checker.length}")
+      case Left(failure) => Left(failure.exitCode, "Checker has found an error")
     }
   }
 

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -36,7 +36,7 @@ class ParseCmd
 
     PassChainExecutor.run(new ParserModule(options)) match {
       case Right(m) => Right(s"Parsed successfully\nRoot module: ${m.name} with ${m.declarations.length} declarations.")
-      case Left(code) => Left(code, "Parser has failed")
+      case Left(failure) => Left(failure.exitCode, "Parser has failed")
     }
   }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TestCmd.scala
@@ -73,8 +73,8 @@ class TestCmd
     logger.info("Tuning: " + tuning.toList.map { case (k, v) => s"$k=$v" }.mkString(":"))
 
     PassChainExecutor.run(new CheckerModule(options)) match {
-      case Right(_)   => Right("No example found")
-      case Left(code) => Left(code, "Found a violation of the postcondition. Check violation.tla.")
+      case Right(_)      => Right("No example found")
+      case Left(failure) => Left(failure.exitCode, "Found a violation of the postcondition. Check violation.tla.")
     }
 
   }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
@@ -26,8 +26,8 @@ class TranspileCmd extends AbstractCheckerCmd(name = "transpile", description = 
       .getOrElse(TlaExToVMTWriter.outFileName)
 
     PassChainExecutor.run(new ReTLAToVMTModule(options)) match {
-      case Right(_)   => Right(s"VMT constraints successfully generated at\n$outFilePath")
-      case Left(code) => Left(code, "Failed to generate constraints")
+      case Right(_)      => Right(s"VMT constraints successfully generated at\n$outFilePath")
+      case Left(failure) => Left(failure.exitCode, "Failed to generate constraints")
     }
   }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TypeCheckCmd.scala
@@ -40,8 +40,8 @@ class TypeCheckCmd
     logger.info("Type checking " + file)
 
     PassChainExecutor.run(new TypeCheckerModule(options)) match {
-      case Right(_)   => Right("Type checker [OK]")
-      case Left(code) => Left(code, "Type checker [FAILED]")
+      case Right(_)      => Right("Type checker [OK]")
+      case Left(failure) => Left(failure.exitCode, "Type checker [FAILED]")
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,7 @@ object Dependencies {
     val shapeless = "com.chuusai" %% "shapeless" % "2.3.10"
     val tla2tools = "org.lamport" % "tla2tools" % "1.7.0-SNAPSHOT"
     val ujson = "com.lihaoyi" %% "ujson" % "2.0.0"
+    val upickle = "com.lihaoyi" %% "upickle" % "2.0.0"
     val z3 = "tools.aqua" % "z3-turnkey" % "4.11.2"
     val zio = "dev.zio" %% "zio" % zioVersion
     // Keep up to sync with version in plugins.sbt

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
@@ -1,23 +1,20 @@
 package at.forsyte.apalache.shai.v1
 
+import scala.util.Try
+
 import com.typesafe.scalalogging.Logger
 import io.grpc.Status
-import zio.ZIO
 import zio.ZEnv
+import zio.ZIO
 
-import at.forsyte.apalache.infra.passes.PassChainExecutor
 import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor}
 import at.forsyte.apalache.io.ConfigManager
 import at.forsyte.apalache.io.json.impl.TlaToUJson
-import at.forsyte.apalache.io.lir.TlaType1PrinterPredefs.printer // Required as implicit parameter to JsonTlaWRiter
-import at.forsyte.apalache.shai.v1.cmdExecutor.Cmd
-import at.forsyte.apalache.shai.v1.cmdExecutor.{CmdRequest, CmdResponse, ZioCmdExecutor}
+import at.forsyte.apalache.shai.v1.cmdExecutor.{Cmd, CmdRequest, CmdResponse, ZioCmdExecutor}
 import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
 import at.forsyte.apalache.tla.imp.passes.ParserModule
-import at.forsyte.apalache.tla.lir.TlaModule
 import at.forsyte.apalache.tla.typecheck.passes.TypeCheckerModule
-import at.forsyte.apalache.infra.passes.Pass
-import scala.util.Try
 
 /**
  * Provides the [[CmdExecutorService]]
@@ -46,19 +43,23 @@ class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEn
     }
   } yield CmdResponse(resp)
 
-  private def executeCmd(cmd: Cmd, cfgStr: String): Either[ujson.Value, ujson.Value] = {
-    // Convert a Try into an `Either` with `Left` the message from a possible `Failure`.
+  // Convert pass error results into the JSON representation
+  private object Converters {
     import ujson._
-
-    def throwableErr(err: Throwable): ujson.Value =
-      Obj("error_type" -> "unexpected",
-          "data" -> Obj("msg" -> err.getMessage(), "stack_trace" -> err.getStackTrace().map(_.toString()).toList))
 
     def passErr(err: Pass.PassFailure): ujson.Value = {
       Obj("error_type" -> "pass_failure", "data" -> err)
     }
 
+    def throwableErr(err: Throwable): ujson.Value =
+      Obj("error_type" -> "unexpected",
+          "data" -> Obj("msg" -> err.getMessage(), "stack_trace" -> err.getStackTrace().map(_.toString()).toList))
+
     def convErr[O](v: Try[O]): Either[ujson.Value, O] = v.toEither.left.map(throwableErr)
+  }
+
+  import Converters._
+  private def executeCmd(cmd: Cmd, cfgStr: String): Either[ujson.Value, ujson.Value] = {
 
     for {
       cfg <- convErr(ConfigManager(cfgStr)).map(cfg => cfg.copy(common = cfg.common.copy(command = Some("server"))))
@@ -79,7 +80,7 @@ class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEn
         catch {
           case err: Throwable => Left(throwableErr(err))
         }
-    } yield jsonOfModule(tlaModule)
+    } yield TlaToUJson(tlaModule)
   }
 
   // Allows us to handle invalid protobuf messages on the ZIO level, before
@@ -89,16 +90,5 @@ class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEn
       val msg = s"Invalid protobuf value for Cmd enum: ${cmd}"
       ZIO.fail(Status.INVALID_ARGUMENT.withDescription(msg))
     case cmd => ZIO.succeed(cmd)
-  }
-
-  // private def parseConfig(data: String): Either[String, Config.ApalacheConfig] = {
-  //   ConfigManager(data) match {
-  //     case Success(cfg) => Right(cfg.copy(common = cfg.common.copy(command = Some("server"))))
-  //     case Failure(err) => Left(s"Invalid configuration data given to command: ${err.getMessage()}")
-  //   }
-  // }
-
-  private def jsonOfModule(module: TlaModule): ujson.Value = {
-    new TlaToUJson(None).makeRoot(Seq(module)).value
   }
 }

--- a/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestCmdExecutorService.scala
+++ b/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestCmdExecutorService.scala
@@ -89,8 +89,8 @@ object TestCmdExecutorService extends DefaultRunnableSpec {
         } yield {
           assert(json("error_type").str)(equalTo("pass_failure"))
           assert(json("data")("pass_name").str)(equalTo("BoundedChecker"))
-          assert(json("data")("data")("checking_result").str)(equalTo("violation"))
-          assert(json("data")("data")("data")("counterexamples").arr)(isNonEmpty)
+          assert(json("data")("error_data")("checking_result").str)(equalTo("violation"))
+          assert(json("data")("error_data")("counterexamples").arr)(isNonEmpty)
         }
       },
       testM("typechecking well-typed spec succeeds") {
@@ -107,7 +107,7 @@ object TestCmdExecutorService extends DefaultRunnableSpec {
         } yield {
           assert(json("error_type").str)(equalTo("pass_failure"))
           assert(json("data")("pass_name").str)(equalTo("TypeCheckerSnowcat"))
-          assert(json("data")("data").arr)(isNonEmpty)
+          assert(json("data")("error_data").arr)(isNonEmpty)
         }
       },
   )

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
@@ -19,7 +19,7 @@ object Checker {
     override val isOk: Boolean = true
   }
 
-  case class Error(nerrors: Int) extends CheckerResult {
+  case class Error(nerrors: Int, counterexamples: Seq[CounterExample]) extends CheckerResult {
     override def toString: String = s"Error"
 
     override val isOk: Boolean = false

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
@@ -19,14 +19,15 @@ object Checker {
     import ujson._
 
     implicit val ujsonView: CheckerResult => ujson.Value = { result =>
-      val (errType, errData) = result match {
+      val (passResultKind, errData) = result match {
         case Error(nerrors, counterexamples) =>
-          ("violation", Obj("counterexamples" -> counterexamples, "nerrors" -> nerrors))
+          ("Error", Obj("counterexamples" -> counterexamples, "nerrors" -> nerrors))
         case Deadlock(counterexample) =>
-          ("deadlock", Obj("counterexample" -> counterexample))
+          ("Deadlock", Obj("counterexample" -> counterexample))
         case other => (other.toString(), Obj())
       }
-      Obj("error_type" -> errType, "error_data" -> errData)
+      Obj("checking_result" -> passResultKind, "data" -> errData)
+
     }
 
     implicit val upickleWriter: Writer[CheckerResult] = writer[ujson.Value].comap(ujsonView)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
@@ -18,16 +18,13 @@ object Checker {
     import upickle.default.{writer, Writer}
     import ujson._
 
-    implicit val ujsonView: CheckerResult => ujson.Value = { result =>
-      val (passResultKind, errData) = result match {
-        case Error(nerrors, counterexamples) =>
-          ("Error", Obj("counterexamples" -> counterexamples, "nerrors" -> nerrors))
-        case Deadlock(counterexample) =>
-          ("Deadlock", Obj("counterexample" -> counterexample))
-        case other => (other.toString(), Obj())
-      }
-      Obj("checking_result" -> passResultKind, "data" -> errData)
-
+    implicit val ujsonView: CheckerResult => ujson.Value = {
+      case Error(nerrors, counterexamples) =>
+        Obj("checking_result" -> "Error", "counterexamples" -> counterexamples, "nerrors" -> nerrors)
+      case Deadlock(counterexample) =>
+        Obj("checking_result" -> "Deadlock", "counterexample" -> counterexample)
+      case other =>
+        Obj("checking_result" -> other.toString())
     }
 
     implicit val upickleWriter: Writer[CheckerResult] = writer[ujson.Value].comap(ujsonView)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/CollectCounterexamplesModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/CollectCounterexamplesModelCheckerListener.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.trex.DecodedExecution
-import at.forsyte.apalache.tla.lir.{TlaEx, TlaModule}
+import at.forsyte.apalache.tla.lir.TlaModule
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.mutable.ListBuffer
@@ -12,18 +12,16 @@ import scala.collection.mutable.ListBuffer
 class CollectCounterexamplesModelCheckerListener extends ModelCheckerListener with LazyLogging {
 
   override def onCounterexample(
-      rootModule: TlaModule,
-      trace: DecodedExecution,
-      invViolated: TlaEx,
+      counterexample: Counterexample,
       errorIndex: Int): Unit = {
-    _counterExamples += trace
+    _counterExamples += counterexample
   }
 
   override def onExample(rootModule: TlaModule, trace: DecodedExecution, exampleIndex: Int): Unit = {
     // ignore the examples
   }
 
-  private val _counterExamples = ListBuffer.empty[DecodedExecution]
+  private val _counterExamples = ListBuffer.empty[Counterexample]
 
-  def counterExamples: Seq[DecodedExecution] = _counterExamples.toSeq
+  def counterExamples: Seq[Counterexample] = _counterExamples.toSeq
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Counterexample.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Counterexample.scala
@@ -1,0 +1,47 @@
+package at.forsyte.apalache.tla.bmcmt
+
+import at.forsyte.apalache.tla.lir.TlaEx
+import at.forsyte.apalache.tla.lir.TlaModule
+import at.forsyte.apalache.io.lir.ItfCounterexampleWriter
+import at.forsyte.apalache.tla.bmcmt.trex.DecodedExecution
+
+/**
+ * Representation of a counterexample found while model checking
+ *
+ * @param rootModule
+ *   The checked TLA+ module.
+ * @param states
+ *   The states leading up to the invariant violation.
+ * @param invViolated
+ *   The invariant violation to record in the counterexample. Pass
+ *   - for invariant violations: the negated invariant,
+ *   - for deadlocks: `ValEx(TlaBool(true))`,
+ *   - for trace invariants: the applied, negated trace invariant
+ *
+ * @author
+ *   Shon Feder
+ */
+case class Counterexample(module: TlaModule, states: Counterexample.States, invViolated: TlaEx)
+
+object Counterexample {
+  type States = List[(String, Map[String, TlaEx])]
+
+  import upickle.default.{writer, Writer}
+
+  // Defines an implicit view for converting to UJSON
+  implicit val ujsonView: Counterexample => ujson.Value = { case Counterexample(module, states, _) =>
+    ItfCounterexampleWriter.mkJson(module, states)
+  }
+
+  // Defines an implicit converter for writing with upickle
+  implicit val upickleWriter: Writer[Counterexample] =
+    writer[ujson.Value].comap(ujsonView)
+
+  /** Produce a `Counterexample` given a [[DecodeExecution]] trace */
+  def apply(module: TlaModule, trace: DecodedExecution, invViolated: TlaEx): Counterexample = {
+    // TODO(shonfeder): This conversion seems kind of sensless: we just swap the tuple and convert the transition index to
+    // a string. Lots depends on this particular format, but it seems like a pretty pointless intermediary structure?
+    val states = trace.path.map(p => (p._2.toString, p._1))
+    Counterexample(module, states, invViolated)
+  }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Counterexample.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Counterexample.scala
@@ -37,7 +37,7 @@ object Counterexample {
   implicit val upickleWriter: Writer[Counterexample] =
     writer[ujson.Value].comap(ujsonView)
 
-  /** Produce a `Counterexample` given a [[DecodeExecution]] trace */
+  /** Produce a `Counterexample` from a `trace` (rather than `states`) */
   def apply(module: TlaModule, trace: DecodedExecution, invViolated: TlaEx): Counterexample = {
     // TODO(shonfeder): This conversion seems kind of sensless: we just swap the tuple and convert the transition index to
     // a string. Lots depends on this particular format, but it seems like a pretty pointless intermediary structure?

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Counterexample.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Counterexample.scala
@@ -37,9 +37,9 @@ object Counterexample {
   implicit val upickleWriter: Writer[Counterexample] =
     writer[ujson.Value].comap(ujsonView)
 
-  /** Produce a `Counterexample` from a `trace` (rather than `states`) */
+  /** Produce a `Counterexample` from a `trace` (rather than from `states`) */
   def apply(module: TlaModule, trace: DecodedExecution, invViolated: TlaEx): Counterexample = {
-    // TODO(shonfeder): This conversion seems kind of sensless: we just swap the tuple and convert the transition index to
+    // TODO(shonfeder): This conversion seems kind of senseless: we just swap the tuple and convert the transition index to
     // a string. Lots depends on this particular format, but it seems like a pretty pointless intermediary structure?
     val states = trace.path.map(p => (p._2.toString, p._1))
     Counterexample(module, states, invViolated)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/DumpFilesModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/DumpFilesModelCheckerListener.scala
@@ -34,8 +34,9 @@ object DumpFilesModelCheckerListener extends ModelCheckerListener with LazyLoggi
       index: Int,
       prefix: String): Unit = {
     def dump(suffix: String): List[String] = {
-      // TODO Should this take a Counterexample?
-      // Would require fixing package dependencies.
+      // TODO(shonfeder): Should the CounterexampleWriter take a Counterexample?
+      // Would require fixing inter-package dependencies, since it would require
+      // exposing the Counterexample class to the tla-io project.
       CounterexampleWriter.writeAllFormats(
           prefix,
           suffix,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelCheckerListener.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/ModelCheckerListener.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.trex.DecodedExecution
-import at.forsyte.apalache.tla.lir.{TlaEx, TlaModule}
+import at.forsyte.apalache.tla.lir.TlaModule
 
 /**
  * Observe [[SeqModelChecker]]. State changes in model checker state are reported via callbacks.
@@ -11,23 +11,14 @@ trait ModelCheckerListener {
   /**
    * Call when the model checker encounters a counterexample.
    *
-   * @param rootModule
-   *   The checked TLA+ module.
-   * @param trace
-   *   The counterexample trace.
-   * @param invViolated
-   *   The invariant violation to record in the counterexample. Pass
-   *   - for invariant violations: the negated invariant,
-   *   - for deadlocks: `ValEx(TlaBool(true))`,
-   *   - for trace invariants: the applied, negated trace invariant
+   * @param counterexample
+   *   The counterexample to record
    * @param errorIndex
    *   Number of found error (likely [[search.SearchState.nFoundErrors]]).
    */
   // For more on possible trace invariant violations, see the private method `SeqModelChecker.applyTraceInv`
   def onCounterexample(
-      rootModule: TlaModule,
-      trace: DecodedExecution,
-      invViolated: TlaEx,
+      counterexample: Counterexample,
       errorIndex: Int): Unit
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -89,14 +89,18 @@ class BoundedCheckerPassImpl @Inject() (
       case Algorithm.Offline     => runOfflineChecker(params, input, tuning, solverConfig)
     }
 
-    if (result) Right(module) else Left(ExitCodes.ERROR_COUNTEREXAMPLE)
+    if (result.isOk) {
+      Right(module)
+    } else {
+      passFailure(result, ExitCodes.ERROR_COUNTEREXAMPLE)
+    }
   }
 
   private def runIncrementalChecker(
       params: ModelCheckerParams,
       input: CheckerInput,
       tuning: Map[String, String],
-      solverConfig: SolverConfig): Boolean = {
+      solverConfig: SolverConfig): Checker.CheckerResult = {
     val solverContext: RecordingSolverContext = RecordingSolverContext.createZ3(None, solverConfig)
 
     val metricProfilerListener =
@@ -131,14 +135,14 @@ class BoundedCheckerPassImpl @Inject() (
     val outcome = checker.run()
     rewriter.dispose()
     logger.info(s"The outcome is: " + outcome)
-    outcome.isOk
+    outcome
   }
 
   private def runOfflineChecker(
       params: ModelCheckerParams,
       input: CheckerInput,
       tuning: Map[String, String],
-      solverConfig: SolverConfig): Boolean = {
+      solverConfig: SolverConfig): Checker.CheckerResult = {
     val solverContext: RecordingSolverContext = RecordingSolverContext.createZ3(None, solverConfig)
 
     if (solverConfig.profile) {
@@ -166,7 +170,7 @@ class BoundedCheckerPassImpl @Inject() (
     val outcome = checker.run()
     rewriter.dispose()
     logger.info(s"The outcome is: " + outcome)
-    outcome.isOk
+    outcome
   }
 
   /*

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/CrossTestEncodings.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/CrossTestEncodings.scala
@@ -198,15 +198,15 @@ trait CrossTestEncodings extends AnyFunSuite with Checkers {
     val checker = new SeqModelChecker(checkerParams, checkerInput, trex, Seq(listener))
 
     // check the outcome
-    val outcome = checker.run()
-    if (outcome != Error(1)) {
-      Left(outcome)
-    } else {
-      // extract witness expression from the counterexample
-      assert(listener.counterExamples.length == 1) // () --(init transition)--> initial state
-      val cex = listener.counterExamples.head.path
-      val (binding, _) = cex.last // initial state binding
-      Right(binding)
+    checker.run() match {
+      case Error(1, _) =>
+        // extract witness expression from the counterexample
+        assert(listener.counterExamples.length == 1) // () --(init transition)--> initial state
+        val cex = listener.counterExamples.head.states
+        val (_, binding) = cex.last // initial state binding
+        Right(binding)
+
+      case outcome => Left(outcome)
     }
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCollectCounterexamplesSeqModelCheckerListener.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCollectCounterexamplesSeqModelCheckerListener.scala
@@ -69,8 +69,8 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
     assert(listener.counterExamples.length == 1)
     val cex = listener.counterExamples.head.states
     assert(cex.length == 2) // () --(init transition)--> initial state
-    assert(cex.forall(_._2 == 0)) // state number
-    assert(cex.head._1.isEmpty) // empty binding on 0th state
+    assert(cex.forall(_._1 == "0")) // state number
+    assert(cex.head._2.isEmpty) // empty binding on 0th state
     val (_, binding) = cex.last
     assert(binding.contains("x"))
     val valOfX = binding("x")
@@ -94,8 +94,8 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
     assert(listener.counterExamples.length == 1)
     val cex = listener.counterExamples.head.states
     assert(cex.length == 3) // () --(init transition)--> initial state
-    assert(cex.forall(_._2 == 0)) // state number
-    assert(cex.head._1.isEmpty) // empty binding on 0th state
+    assert(cex.forall(_._1 == "0")) // state number
+    assert(cex.head._2.isEmpty) // empty binding on 0th state
     val (_, binding) = cex.last
     assert(binding.contains("x"))
     val valOfX = binding("x")

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCollectCounterexamplesSeqModelCheckerListener.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCollectCounterexamplesSeqModelCheckerListener.scala
@@ -48,6 +48,11 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
     (listener, checker)
   }
 
+  private def assertResultHasNErrors(n: Int, result: Checker.CheckerResult) = assert(result match {
+    case Error(m, _) if m == n => true
+    case _                     => false
+  })
+
   test("finds cex for invariant violation at initial state") {
     // construct TLA+ module
     val initTrans = List(mkAssign("x", 2))
@@ -58,16 +63,15 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
 
     // check the outcome
     val (listener, checker) = getChecker(module, initTrans, nextTrans, inv, 1)
-    val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, checker.run())
 
     // check the counterexample
     assert(listener.counterExamples.length == 1)
-    val cex = listener.counterExamples.head.path
+    val cex = listener.counterExamples.head.states
     assert(cex.length == 2) // () --(init transition)--> initial state
     assert(cex.forall(_._2 == 0)) // state number
     assert(cex.head._1.isEmpty) // empty binding on 0th state
-    val (binding, _) = cex.last
+    val (_, binding) = cex.last
     assert(binding.contains("x"))
     val valOfX = binding("x")
     assert(valOfX.isInstanceOf[ValEx])
@@ -84,16 +88,15 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
 
     // check the outcome
     val (listener, checker) = getChecker(module, initTrans, nextTrans, inv, 1)
-    val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, checker.run())
 
     // check the counterexample
     assert(listener.counterExamples.length == 1)
-    val cex = listener.counterExamples.head.path
+    val cex = listener.counterExamples.head.states
     assert(cex.length == 3) // () --(init transition)--> initial state
     assert(cex.forall(_._2 == 0)) // state number
     assert(cex.head._1.isEmpty) // empty binding on 0th state
-    val (binding, _) = cex.last
+    val (_, binding) = cex.last
     assert(binding.contains("x"))
     val valOfX = binding("x")
     assert(valOfX.isInstanceOf[ValEx])
@@ -110,8 +113,7 @@ class TestCollectCounterexamplesModelCheckerListener extends AnyFunSuite {
 
     // check the outcome
     val (listener, checker) = getChecker(module, initTrans, nextTrans, inv, 3)
-    val outcome = checker.run()
-    assert(Error(3) == outcome)
+    assertResultHasNErrors(3, checker.run())
 
     // check the counterexample
     assert(listener.counterExamples.length == 3)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerTrait.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSeqModelCheckerTrait.scala
@@ -34,6 +34,11 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     TlaModule("root", List(TlaVarDecl("x")(intTag), TlaVarDecl("y")(intTag)))
   }
 
+  private def assertResultHasNErrors(n: Int, result: Checker.CheckerResult) = assert(result match {
+    case Error(m, _) if m == n => true
+    case _                     => false
+  })
+
   test("Init + Inv => OK") { rewriter: SymbStateRewriter =>
     // x' <- 2
     val initTrans = List(mkAssign("x", 2))
@@ -65,7 +70,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("ConstInit + Init => OK") { rewriter: SymbStateRewriter =>
@@ -105,7 +110,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assert(outcome match { case Error(1, _) => true; case _ => false })
   }
 
   test("Init, deadlock") { rewriter: SymbStateRewriter =>
@@ -119,7 +124,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Deadlock() == outcome)
+    assert(outcome match { case Deadlock(_) => true; case _ => false })
   }
 
   test("Init, 2 options, OK") { rewriter: SymbStateRewriter =>
@@ -170,7 +175,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + Inv (before + all-enabled) => ERR") { rewriter: SymbStateRewriter =>
@@ -192,7 +197,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + ActionInv (before + all-enabled) => ERR") { rewriter: SymbStateRewriter =>
@@ -220,7 +225,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + ActionInv (before + all-enabled) => OK") { rewriter: SymbStateRewriter =>
@@ -270,7 +275,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + Inv (after + no-all-enabled) => ERR") { rewriter: SymbStateRewriter =>
@@ -292,7 +297,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + ActionInv (after + all-enabled) => ERR") { rewriter: SymbStateRewriter =>
@@ -320,7 +325,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + ActionInv (after + all-enabled) => OK") { rewriter: SymbStateRewriter =>
@@ -376,7 +381,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + ActionInv (before) => OK") { rewriter: SymbStateRewriter =>
@@ -432,7 +437,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 10 + ActionInv (after) => OK") { rewriter: SymbStateRewriter =>
@@ -522,7 +527,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next x 2 (LET-IN) + Inv => ERR") { rewriter: SymbStateRewriter =>
@@ -549,7 +554,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("determinstic Init + 2 steps (regression)") { rewriter: SymbStateRewriter =>
@@ -591,7 +596,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Deadlock() == outcome)
+    assert(outcome match { case Deadlock(_) => true; case _ => false })
   }
 
   test("Init + Next, 10 steps, OK") { rewriter: SymbStateRewriter =>
@@ -623,7 +628,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Deadlock() == outcome)
+    assert(outcome match { case Deadlock(_) => true; case _ => false })
   }
 
   test("Init + Next + Inv x 10 => OK") { rewriter: SymbStateRewriter =>
@@ -667,7 +672,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next + Inv x 2 => OK, edge case") { rewriter: SymbStateRewriter =>
@@ -755,7 +760,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("cInit + Init + Next, 10 steps") { rewriter: SymbStateRewriter =>
@@ -789,7 +794,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    assert(Error(1) == outcome)
+    assertResultHasNErrors(1, outcome)
   }
 
   test("Init + Next, 10 steps and filter") { rewriter: SymbStateRewriter =>
@@ -850,13 +855,7 @@ trait TestSeqModelCheckerTrait extends FixtureAnyFunSuite {
     val trex = new TransitionExecutorImpl(params.consts, params.vars, ctx)
     val checker = new SeqModelChecker(params, checkerInput, trex)
     val outcome = checker.run()
-    outcome match {
-      case Error(nerrors) =>
-        assert(4 == nerrors)
-
-      case _ =>
-        fail("Expected 4 errors")
-    }
+    assertResultHasNErrors(4, outcome)
   }
 
   private def mkAssign(varName: String, value: Int): TlaEx = {

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDecoder.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDecoder.scala
@@ -13,5 +13,17 @@ trait JsonDecoder[T <: JsonRepresentation] {
   def asTlaModule(moduleJson: T): TlaModule
   def asTlaDecl(declJson: T): TlaDecl
   def asTlaEx(exJson: T): TlaEx
-  def fromRoot(rootJson: T): Try[TlaModule]
+  def fromRoot(rootJson: T): Seq[TlaModule]
+
+  /**
+   * Parse a json representation which holds only a single TLA module. This is our typical, and currently only supported
+   * use case.
+   *
+   * @param json
+   *   A JSON encoding of a TLA Module
+   * @return
+   *   `Success(m)` if the `json` can be parsed, correctly and it described a single module. Otherwise `Failure(t)`
+   *   where `t` is a `Throwable` describing the error.
+   */
+  def fromSingleModule(json: T): Try[TlaModule]
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDecoder.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDecoder.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.io.json
 
 import at.forsyte.apalache.tla.lir.{TlaDecl, TlaEx, TlaModule}
+import scala.util.Try
 
 /**
  * A JsonDecoder defines a conversion from a json (as represented by T) to a TLA+ expression/declaration/module
@@ -12,5 +13,5 @@ trait JsonDecoder[T <: JsonRepresentation] {
   def asTlaModule(moduleJson: T): TlaModule
   def asTlaDecl(declJson: T): TlaDecl
   def asTlaEx(exJson: T): TlaEx
-  def fromRoot(rootJson: T): Iterable[TlaModule]
+  def fromRoot(rootJson: T): Try[TlaModule]
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonRepresentation.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonRepresentation.scala
@@ -6,7 +6,7 @@ package at.forsyte.apalache.io.json
  */
 trait JsonRepresentation {
 
-  /** The type of tused to represent JSON */
+  /** The type used to represent JSON */
   type Value
 
   def toString: String

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonToTla.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonToTla.scala
@@ -221,7 +221,7 @@ class JsonToTla[T <: JsonRepresentation](
     modules <- Try(fromRoot(json))
     module <- modules match {
       case m +: Nil => Success(m)
-      case _        => Failure(new JsonDeserializationError(s"JSON inlucded more than one module"))
+      case _        => Failure(new JsonDeserializationError(s"JSON included more than one module"))
     }
   } yield module
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/TlaToUJson.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/TlaToUJson.scala
@@ -3,6 +3,8 @@ package at.forsyte.apalache.io.json.impl
 import at.forsyte.apalache.io.json.TlaToJson
 import at.forsyte.apalache.io.lir.TypeTagPrinter
 import at.forsyte.apalache.tla.lir.storage.SourceLocator
+import at.forsyte.apalache.tla.lir.TlaModule
+import at.forsyte.apalache.io.lir.TlaType1PrinterPredefs.printer // Required as implicit parameter to JsonTlaWRiter
 
 /**
  * A json encoder, using the UJson representation
@@ -11,3 +13,9 @@ class TlaToUJson(
     locatorOpt: Option[SourceLocator] = None
   )(implicit typeTagPrinter: TypeTagPrinter)
     extends TlaToJson[UJsonRep](UJsonFactory, locatorOpt)(typeTagPrinter)
+
+object TlaToUJson {
+  def apply(module: TlaModule): ujson.Value = (new TlaToUJson()).makeRoot(Seq(module)).value
+
+  implicit val ujsonView: TlaModule => ujson.Value = TlaToUJson(_)
+}

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/ItfCounterexampleWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/ItfCounterexampleWriter.scala
@@ -19,6 +19,12 @@ import scala.collection.mutable
  *   Igor Konnov
  */
 class ItfCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter {
+  override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): Unit = {
+    writer.write(ujson.write(ItfCounterexampleWriter.mkJson(rootModule, states), indent = 2))
+  }
+}
+
+object ItfCounterexampleWriter {
 
   /**
    * The minimal value that can be reliably represented with Double in JavaScript.
@@ -73,10 +79,6 @@ class ItfCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
     rootMap.put("vars", varsToJson(rootModule))
     rootMap.put("states", ujson.Arr(mappedStates.zipWithIndex.map((stateToJson _).tupled): _*))
     ujson.Obj(rootMap)
-  }
-
-  override def write(rootModule: TlaModule, notInvariant: NotInvariant, states: List[NextState]): Unit = {
-    writer.write(ujson.write(mkJson(rootModule, states), indent = 2))
   }
 
   private def varsToJson(root: TlaModule): ujson.Value = {

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -45,7 +45,7 @@ class SanyParserPassImpl @Inject() (
 
     val result = for {
       moduleJson <- Try(UJsonRep(ujson.read(readable)))
-      module <- new UJsonToTla(Some(sourceStore))(DefaultTagReader).fromRoot(moduleJson)
+      module <- new UJsonToTla(Some(sourceStore))(DefaultTagReader).fromSingleModule(moduleJson)
     } yield module
 
     result match {

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -53,7 +53,7 @@ class SanyParserPassImpl @Inject() (
       case Failure(err) =>
         logger.error(s"  > Error parsing file ${source}")
         logger.error("  > " + err.getMessage)
-        Left((err, ExitCodes.ERROR_SPEC_PARSE))
+        passFailure(err.getMessage(), ExitCodes.ERROR_SPEC_PARSE)
     }
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
@@ -63,7 +63,8 @@ class TestUJsonToTla extends AnyFunSuite with Checkers {
       assert(dec.asTlaModule(enc(m)) == m)
     }
 
-    assert(dec.fromRoot(enc.makeRoot(modules)) == modules)
+    // TODO Should a "root" be able to be a list of modules?
+    assert(dec.fromRoot(enc.makeRoot(modules)).isFailure)
   }
 
   test("Predef sets (see #1281)") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTla.scala
@@ -63,8 +63,7 @@ class TestUJsonToTla extends AnyFunSuite with Checkers {
       assert(dec.asTlaModule(enc(m)) == m)
     }
 
-    // TODO Should a "root" be able to be a list of modules?
-    assert(dec.fromRoot(enc.makeRoot(modules)).isFailure)
+    assert(dec.fromRoot(enc.makeRoot(modules)) == modules)
   }
 
   test("Predef sets (see #1281)") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestItfCounterexampleWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestItfCounterexampleWriter.scala
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 
-import java.io.{PrintWriter, StringWriter}
 import scala.collection.immutable.SortedMap
 
 @RunWith(classOf[JUnitRunner])
@@ -25,8 +24,7 @@ class TestItfCounterexampleWriter extends AnyFunSuite {
    *   the expected output as a string
    */
   def compareJson(rootModule: TlaModule, states: List[NextState], expected: String): Unit = {
-    val writer = new ItfCounterexampleWriter(new PrintWriter(new StringWriter()))
-    val actualJson = writer.mkJson(rootModule, states)
+    val actualJson = ItfCounterexampleWriter.mkJson(rootModule, states)
     // erase the date from the description as it is time dependent
     actualJson("#meta")("description") = "Created by Apalache"
     val expectedJson = ujson.read(expected)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/exceptions.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/exceptions.scala
@@ -42,6 +42,10 @@ class IrrecoverablePreprocessingError(message: String) extends Exception(message
  */
 class TlaInputError(message: String, val sourceId: Option[UID] = None) extends Exception(message)
 
+// TODO Docs and formatting of error message
+class UnsupportedExpressionErrors(failIds: Seq[(UID, String)])
+    extends Exception(s"Unsopported expressions found $failIds")
+
 /**
  * An exception that should be thrown when a TLC configuration is wrong/not-found
  * @param message

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/exceptions.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/exceptions.scala
@@ -42,10 +42,6 @@ class IrrecoverablePreprocessingError(message: String) extends Exception(message
  */
 class TlaInputError(message: String, val sourceId: Option[UID] = None) extends Exception(message)
 
-// TODO Docs and formatting of error message
-class UnsupportedExpressionErrors(failIds: Seq[(UID, String)])
-    extends Exception(s"Unsopported expressions found $failIds")
-
 /**
  * An exception that should be thrown when a TLC configuration is wrong/not-found
  * @param message

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassPartial.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassPartial.scala
@@ -15,7 +15,6 @@ import at.forsyte.apalache.tla.lir.transformations.standard.{
 import at.forsyte.apalache.infra.passes.DerivedPredicates
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.OptionGroup
-import at.forsyte.apalache.tla.pp.UnsupportedExpressionErrors
 
 abstract class PreproPassPartial(
     val options: OptionGroup.HasChecker,
@@ -72,8 +71,8 @@ abstract class PreproPassPartial(
           val message = "%s: unsupported expression: %s".format(findLoc(id), errorMessage)
           logger.error(message)
         }
-        val errs = new UnsupportedExpressionErrors(failedIds)
-        Left((errs, ExitCodes.FAILURE_SPEC_EVAL))
+        val errData = failedIds.map { case (uid, s) => (uid.toString(), s) }
+        passFailure(errData, ExitCodes.FAILURE_SPEC_EVAL)
     }
 
   protected def executeWithParams(

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassPartial.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/passes/PreproPassPartial.scala
@@ -15,6 +15,7 @@ import at.forsyte.apalache.tla.lir.transformations.standard.{
 import at.forsyte.apalache.infra.passes.DerivedPredicates
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.tla.pp.UnsupportedExpressionErrors
 
 abstract class PreproPassPartial(
     val options: OptionGroup.HasChecker,
@@ -71,7 +72,8 @@ abstract class PreproPassPartial(
           val message = "%s: unsupported expression: %s".format(findLoc(id), errorMessage)
           logger.error(message)
         }
-        Left(ExitCodes.FAILURE_SPEC_EVAL)
+        val errs = new UnsupportedExpressionErrors(failedIds)
+        Left((errs, ExitCodes.FAILURE_SPEC_EVAL))
     }
 
   protected def executeWithParams(

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/SourceAwareTypeCheckerListener.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/SourceAwareTypeCheckerListener.scala
@@ -4,14 +4,7 @@ import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.UID
 
-/**
- * <p>Type checker calls the listener on important events:</p>
- *
- * <ol> <li>the type of a new expression has been computed, or </li> <li>a type error has been found.</li> </ol>
- *
- * @author
- *   Igor Konnov
- */
+/** A [[TypeCheckerListener]] that has a source store and and a change listener */
 abstract class SourceAwareTypeCheckerListener(sourceStore: SourceStore, changeListener: ChangeListener)
     extends TypeCheckerListener {
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/SourceAwareTypeCheckerListener.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/SourceAwareTypeCheckerListener.scala
@@ -1,0 +1,26 @@
+package at.forsyte.apalache.tla.typecheck
+
+import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
+import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.lir.UID
+
+/**
+ * <p>Type checker calls the listener on important events:</p>
+ *
+ * <ol> <li>the type of a new expression has been computed, or </li> <li>a type error has been found.</li> </ol>
+ *
+ * @author
+ *   Igor Konnov
+ */
+abstract class SourceAwareTypeCheckerListener(sourceStore: SourceStore, changeListener: ChangeListener)
+    extends TypeCheckerListener {
+
+  protected def findLoc(id: UID): String = {
+    val sourceLocator: SourceLocator = SourceLocator(sourceStore.makeSourceMap, changeListener)
+
+    sourceLocator.sourceOf(id) match {
+      case Some(loc) => loc.toString
+      case None      => "unknown location"
+    }
+  }
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/TypeCheckerTool.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/TypeCheckerTool.scala
@@ -5,9 +5,7 @@ import at.forsyte.apalache.io.annotations.{Annotation, AnnotationStr, StandardAn
 import at.forsyte.apalache.io.typecheck.parser.{DefaultType1Parser, Type1ParseError}
 import at.forsyte.apalache.tla.lir
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.transformations.TransformationTracker
 import at.forsyte.apalache.tla.typecheck.etc._
-import at.forsyte.apalache.tla.typecheck.integration.{RecordingTypeCheckerListener, TypeRewriter}
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -56,36 +54,6 @@ class TypeCheckerTool(annotationStore: AnnotationStore, inferPoly: Boolean, useR
     // run the type checker
     val result = typeChecker.compute(listener, TypeContext.empty, rootExpr)
     result.isDefined
-  }
-
-  /**
-   * Check the types in a module and, if the module is well-typed, produce a new module that attaches a type tag to
-   * every expression and declaration in the module.
-   *
-   * @param tracker
-   *   a transformation tracker that is applied when expressions and declarations are tagged
-   * @param listener
-   *   a listener to type checking events
-   * @param defaultTag
-   *   a function that returns a default type for UID, when type is missing
-   * @param module
-   *   a module to type check
-   * @return
-   *   Some(newModule) if module is well-typed; None, otherwise
-   */
-  def checkAndTag(
-      tracker: TransformationTracker,
-      listener: TypeCheckerListener,
-      defaultTag: UID => TypeTag,
-      module: TlaModule): Option[TlaModule] = {
-    val recorder = new RecordingTypeCheckerListener()
-    if (!check(new MultiTypeCheckerListener(listener, recorder), module)) {
-      None
-    } else {
-      val transformer = new TypeRewriter(tracker, defaultTag)(recorder.toMap)
-      val taggedDecls = module.declarations.map(transformer(_))
-      Some(TlaModule(module.name, taggedDecls))
-    }
   }
 
   // Parse type aliases from the annotations.

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/RecordingTypeCheckerListener.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/RecordingTypeCheckerListener.scala
@@ -23,9 +23,9 @@ class RecordingTypeCheckerListener(sourceStore: SourceStore, changeListener: Cha
     uidToType.toMap
   }
 
-  private def errors: mutable.Queue[(String, String)] = mutable.Queue()
+  private val _errors: mutable.ListBuffer[(String, String)] = mutable.ListBuffer.empty
 
-  def getErrors(): List[(String, String)] = errors.toList
+  def getErrors(): List[(String, String)] = _errors.toList
 
   override def onTypeFound(sourceRef: ExactRef, monotype: TlaType1): Unit = {
     uidToType += sourceRef.tlaId -> monotype
@@ -40,6 +40,6 @@ class RecordingTypeCheckerListener(sourceStore: SourceStore, changeListener: Cha
    *   the error description
    */
   override def onTypeError(sourceRef: EtcRef, message: String): Unit = {
-    errors.addOne((findLoc(sourceRef.tlaId), message))
+    _errors += (findLoc(sourceRef.tlaId) -> message)
   }
 }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
@@ -64,8 +64,7 @@ class EtcTypeCheckerPassImpl @Inject() (
       Right(newModule)
     } else {
       logger.info(" > Snowcat asks you to fix the types. Meow.")
-      val errs = recordingListener.getErrors()
-      Left((new TypeErrors(errs), ExitCodes.ERROR_TYPECHECK))
+      passFailure(recordingListener.getErrors(), ExitCodes.ERROR_TYPECHECK)
     }
   }
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/EtcTypeCheckerPassImpl.scala
@@ -13,6 +13,9 @@ import at.forsyte.apalache.tla.typecheck.TypeCheckerTool
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.tla.typecheck.integration.RecordingTypeCheckerListener
+import at.forsyte.apalache.tla.typecheck.MultiTypeCheckerListener
+import at.forsyte.apalache.tla.typecheck.integration.TypeRewriter
 
 class EtcTypeCheckerPassImpl @Inject() (
     val options: OptionGroup.HasTypechecker,
@@ -47,21 +50,22 @@ class EtcTypeCheckerPassImpl @Inject() (
       Untyped
     }
 
-    val listener = new LoggingTypeCheckerListener(sourceStore, changeListener, inferPoly)
-    val taggedModule = tool.checkAndTag(tracker, listener, defaultTag, tlaModule)
-
-    taggedModule match {
-      case Some(newModule) =>
-        logger.info(" > Your types are purrfect!")
-        logger.info(if (isTypeCoverageComplete) " > All expressions are typed" else " > Some expressions are untyped")
-        writeOut(writerFactory, newModule)
-
-        utils.writeToOutput(newModule, options, writerFactory, logger, sourceStore)
-
-        Right(newModule)
-      case None =>
-        logger.info(" > Snowcat asks you to fix the types. Meow.")
-        Left(ExitCodes.ERROR_TYPECHECK)
+    val loggingListener = new LoggingTypeCheckerListener(sourceStore, changeListener, inferPoly)
+    val recordingListener = new RecordingTypeCheckerListener(sourceStore, changeListener)
+    val listener = new MultiTypeCheckerListener(loggingListener, recordingListener)
+    if (tool.check(listener, tlaModule)) {
+      val transformer = new TypeRewriter(tracker, defaultTag)(recordingListener.toMap)
+      val taggedDecls = tlaModule.declarations.map(transformer(_))
+      val newModule = TlaModule(tlaModule.name, taggedDecls)
+      logger.info(" > Your types are purrfect!")
+      logger.info(if (isTypeCoverageComplete) " > All expressions are typed" else " > Some expressions are untyped")
+      writeOut(writerFactory, newModule)
+      utils.writeToOutput(newModule, options, writerFactory, logger, sourceStore)
+      Right(newModule)
+    } else {
+      logger.info(" > Snowcat asks you to fix the types. Meow.")
+      val errs = recordingListener.getErrors()
+      Left((new TypeErrors(errs), ExitCodes.ERROR_TYPECHECK))
     }
   }
 

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/LoggingTypeCheckerListener.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecheck/passes/LoggingTypeCheckerListener.scala
@@ -1,17 +1,17 @@
 package at.forsyte.apalache.tla.typecheck.passes
 
 import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
-import at.forsyte.apalache.tla.lir.{TlaType1, UID}
+import at.forsyte.apalache.tla.lir.storage.ChangeListener
+import at.forsyte.apalache.tla.lir.TlaType1
 import at.forsyte.apalache.tla.typecheck.etc.{EtcRef, ExactRef}
-import at.forsyte.apalache.tla.typecheck.{TypeCheckerListener, TypingInputException}
+import at.forsyte.apalache.tla.typecheck.{SourceAwareTypeCheckerListener, TypingInputException}
 import com.typesafe.scalalogging.LazyLogging
 
 class LoggingTypeCheckerListener(
     sourceStore: SourceStore,
     changeListener: ChangeListener,
     isPolymorphismEnabled: Boolean)
-    extends TypeCheckerListener with LazyLogging {
+    extends SourceAwareTypeCheckerListener(sourceStore, changeListener) with LazyLogging {
 
   /**
    * This method is called when the type checker finds the type of an expression.
@@ -40,14 +40,5 @@ class LoggingTypeCheckerListener(
    */
   override def onTypeError(sourceRef: EtcRef, message: String): Unit = {
     logger.error("[%s]: %s".format(findLoc(sourceRef.tlaId), message))
-  }
-
-  private def findLoc(id: UID): String = {
-    val sourceLocator: SourceLocator = SourceLocator(sourceStore.makeSourceMap, changeListener)
-
-    sourceLocator.sourceOf(id) match {
-      case Some(loc) => loc.toString
-      case None      => "unknown location"
-    }
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/exceptions.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/exceptions.scala
@@ -78,12 +78,6 @@ class CyclicDependencyError(message: String) extends LirError(message)
 class TypingException(message: String, val causeExprId: UID) extends Exception(message)
 
 /**
- * This exception is used to report all recoverable type checking error encountered
- */
-// TODO format message
-class TypeErrors(errors: List[(String, String)]) extends Exception(s"Type checking errors: ${errors}")
-
-/**
  * This exception is thrown when an outdated type annotation (pre 0.12.0) is met.
  *
  * @param message

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/exceptions.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/exceptions.scala
@@ -78,6 +78,12 @@ class CyclicDependencyError(message: String) extends LirError(message)
 class TypingException(message: String, val causeExprId: UID) extends Exception(message)
 
 /**
+ * This exception is used to report all recoverable type checking error encountered
+ */
+// TODO format message
+class TypeErrors(errors: List[(String, String)]) extends Exception(s"Type checking errors: ${errors}")
+
+/**
  * This exception is thrown when an outdated type annotation (pre 0.12.0) is met.
  *
  * @param message


### PR DESCRIPTION
Closes #2185, #2170

This PR enriches the `PassResult` so that it can it can include data about the reasons for pass failures. The approach here is currently going for the shortest path to getting the needed JSON-encodable data for RPC calls. 

Further work could be useful to impose a more rigorous interface. In particular, it could be helpful to reorganize the package dependencies so that the failure data returned by different passes could be enumerated in a case class, allowing static specification of the supported data structures. This is apposed to he approach taken here, which just converts the pass data into ujson. The latter approach is expedient given the current motivating need, but won't be nice to work with if we decide we want to use this data  for purposes other than returning RPC results.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
