### PR TITLE
`ScopedBuilder`-based JSON reader

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDeserializationError.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonDeserializationError.scala
@@ -1,4 +1,4 @@
 package at.forsyte.apalache.io.json
 
 /** Thrown, when importing from JSON fails, due to malformed input */
-class JsonDeserializationError(msg: String) extends Exception(msg)
+class JsonDeserializationError(msg: String, cause: Throwable = null) extends Exception(msg, cause)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
@@ -149,7 +149,13 @@ class ScopedBuilder
    * inverse, `unchecked`, needs to be explicit, to stress the fact that it should be used rarely, typically at most
    * once per transformation on the initial input.
    */
-  def unchecked[T](ex: T): TBuilderInternalState[T] = ex.point[TBuilderInternalState]
+  def unchecked(ex: TlaEx): TBuilderInstruction = ex.point[TBuilderInternalState]
+
+  /**
+   * @see
+   *   [[unchecked]]
+   */
+  def uncheckedDecl(decl: TlaOperDecl): TBuilderOperDeclInstruction = decl.point[TBuilderInternalState]
 
   /** Allows the use of type strings in the builder, to simplify writing complex types. */
   def parseType(typeAsString: String): TlaType1 = parser.parseType(typeAsString)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
@@ -149,7 +149,7 @@ class ScopedBuilder
    * inverse, `unchecked`, needs to be explicit, to stress the fact that it should be used rarely, typically at most
    * once per transformation on the initial input.
    */
-  def unchecked(ex: TlaEx): TBuilderInstruction = ex.point[TBuilderInternalState]
+  def unchecked[T](ex: T): TBuilderInternalState[T] = ex.point[TBuilderInternalState]
 
   /** Allows the use of type strings in the builder, to simplify writing complex types. */
   def parseType(typeAsString: String): TlaType1 = parser.parseType(typeAsString)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/BuilderCallByName.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/BuilderCallByName.scala
@@ -8,6 +8,8 @@ import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
 import at.forsyte.apalache.tla.types.tla
 
 /**
+ * Invokes the `ScopedBuilder` from an operator application by-name (as is read from JSON files)
+ *
  * @author
  *   Jure Kukovec
  */

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/BuilderCallByName.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/BuilderCallByName.scala
@@ -1,0 +1,432 @@
+package at.forsyte.apalache.tla.typecomp.json
+
+import at.forsyte.apalache.io.json.JsonDeserializationError
+import at.forsyte.apalache.tla.lir.{TlaEx, TlaType1, ValEx, VariantT1}
+import at.forsyte.apalache.tla.lir.oper._
+import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
+import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
+import at.forsyte.apalache.tla.types.tla
+
+/**
+ * @author
+ *   Jure Kukovec
+ */
+object BuilderCallByName {
+  private def validateExpectedArity[T](oper: TlaOper, args: Seq[T]): Unit = {
+    val n = args.length
+    if (!oper.isCorrectArity(n)) throw new JsonDeserializationError(s"${oper.name} does not permit $n arguments.")
+  }
+
+  private val nameMap = Map(
+      TlaOper.eq.name -> TlaOper.eq,
+      TlaOper.ne.name -> TlaOper.ne,
+      TlaOper.apply.name -> TlaOper.apply,
+      TlaOper.chooseBounded.name -> TlaOper.chooseBounded,
+      TlaOper.chooseUnbounded.name -> TlaOper.chooseUnbounded,
+      TlaBoolOper.and.name -> TlaBoolOper.and,
+      TlaBoolOper.or.name -> TlaBoolOper.or,
+      TlaBoolOper.not.name -> TlaBoolOper.not,
+      TlaBoolOper.implies.name -> TlaBoolOper.implies,
+      TlaBoolOper.equiv.name -> TlaBoolOper.equiv,
+      TlaBoolOper.forall.name -> TlaBoolOper.forall,
+      TlaBoolOper.exists.name -> TlaBoolOper.exists,
+      TlaBoolOper.forallUnbounded.name -> TlaBoolOper.forallUnbounded,
+      TlaBoolOper.existsUnbounded.name -> TlaBoolOper.existsUnbounded,
+      TlaActionOper.prime.name -> TlaActionOper.prime,
+      TlaActionOper.stutter.name -> TlaActionOper.stutter,
+      TlaActionOper.nostutter.name -> TlaActionOper.nostutter,
+      TlaActionOper.enabled.name -> TlaActionOper.enabled,
+      TlaActionOper.unchanged.name -> TlaActionOper.unchanged,
+      TlaActionOper.composition.name -> TlaActionOper.composition,
+      TlaControlOper.caseNoOther.name -> TlaControlOper.caseNoOther,
+      TlaControlOper.caseWithOther.name -> TlaControlOper.caseWithOther,
+      TlaControlOper.ifThenElse.name -> TlaControlOper.ifThenElse,
+      TlaTempOper.AA.name -> TlaTempOper.AA,
+      TlaTempOper.box.name -> TlaTempOper.box,
+      TlaTempOper.diamond.name -> TlaTempOper.diamond,
+      TlaTempOper.EE.name -> TlaTempOper.EE,
+      TlaTempOper.guarantees.name -> TlaTempOper.guarantees,
+      TlaTempOper.leadsTo.name -> TlaTempOper.leadsTo,
+      TlaTempOper.strongFairness.name -> TlaTempOper.strongFairness,
+      TlaTempOper.weakFairness.name -> TlaTempOper.weakFairness,
+      TlaArithOper.plus.name -> TlaArithOper.plus,
+      TlaArithOper.uminus.name -> TlaArithOper.uminus,
+      TlaArithOper.minus.name -> TlaArithOper.minus,
+      TlaArithOper.mult.name -> TlaArithOper.mult,
+      TlaArithOper.div.name -> TlaArithOper.div,
+      TlaArithOper.mod.name -> TlaArithOper.mod,
+      TlaArithOper.realDiv.name -> TlaArithOper.realDiv,
+      TlaArithOper.exp.name -> TlaArithOper.exp,
+      TlaArithOper.dotdot.name -> TlaArithOper.dotdot,
+      TlaArithOper.lt.name -> TlaArithOper.lt,
+      TlaArithOper.gt.name -> TlaArithOper.gt,
+      TlaArithOper.le.name -> TlaArithOper.le,
+      TlaArithOper.ge.name -> TlaArithOper.ge,
+      TlaFiniteSetOper.cardinality.name -> TlaFiniteSetOper.cardinality,
+      TlaFiniteSetOper.isFiniteSet.name -> TlaFiniteSetOper.isFiniteSet,
+      TlaFunOper.app.name -> TlaFunOper.app,
+      TlaFunOper.domain.name -> TlaFunOper.domain,
+      TlaFunOper.rec.name -> TlaFunOper.rec,
+      TlaFunOper.except.name -> TlaFunOper.except,
+      TlaFunOper.funDef.name -> TlaFunOper.funDef,
+      TlaFunOper.tuple.name -> TlaFunOper.tuple,
+      TlaSeqOper.append.name -> TlaSeqOper.append,
+      TlaSeqOper.concat.name -> TlaSeqOper.concat,
+      TlaSeqOper.head.name -> TlaSeqOper.head,
+      TlaSeqOper.tail.name -> TlaSeqOper.tail,
+      TlaSeqOper.len.name -> TlaSeqOper.len,
+      TlaSeqOper.subseq.name -> TlaSeqOper.subseq,
+      TlaSetOper.enumSet.name -> TlaSetOper.enumSet,
+      TlaSetOper.in.name -> TlaSetOper.in,
+      TlaSetOper.notin.name -> TlaSetOper.notin,
+      TlaSetOper.cap.name -> TlaSetOper.cap,
+      TlaSetOper.cup.name -> TlaSetOper.cup,
+      TlaSetOper.filter.name -> TlaSetOper.filter,
+      TlaSetOper.funSet.name -> TlaSetOper.funSet,
+      TlaSetOper.map.name -> TlaSetOper.map,
+      TlaSetOper.powerset.name -> TlaSetOper.powerset,
+      TlaSetOper.recSet.name -> TlaSetOper.recSet,
+      TlaSetOper.seqSet.name -> TlaSetOper.seqSet,
+      TlaSetOper.setminus.name -> TlaSetOper.setminus,
+      TlaSetOper.subseteq.name -> TlaSetOper.subseteq,
+      TlaSetOper.times.name -> TlaSetOper.times,
+      TlaSetOper.union.name -> TlaSetOper.union,
+      TlaFunOper.recFunRef.name -> TlaFunOper.recFunRef,
+      TlaFunOper.recFunDef.name -> TlaFunOper.recFunDef,
+      ApalacheOper.assign.name -> ApalacheOper.assign,
+      ApalacheOper.gen.name -> ApalacheOper.gen,
+      ApalacheOper.skolem.name -> ApalacheOper.skolem,
+      ApalacheOper.expand.name -> ApalacheOper.expand,
+      ApalacheOper.constCard.name -> ApalacheOper.constCard,
+      ApalacheInternalOper.distinct.name -> ApalacheInternalOper.distinct,
+      ApalacheOper.mkSeq.name -> ApalacheOper.mkSeq,
+      ApalacheOper.foldSet.name -> ApalacheOper.foldSet,
+      ApalacheOper.foldSeq.name -> ApalacheOper.foldSeq,
+      ApalacheInternalOper.selectInSet.name -> ApalacheInternalOper.selectInSet,
+      ApalacheInternalOper.selectInFun.name -> ApalacheInternalOper.selectInFun,
+      ApalacheInternalOper.storeInSet.name -> ApalacheInternalOper.storeInSet,
+      ApalacheInternalOper.storeNotInSet.name -> ApalacheInternalOper.storeNotInSet,
+      ApalacheInternalOper.storeNotInFun.name -> ApalacheInternalOper.storeNotInFun,
+      ApalacheInternalOper.smtMap(TlaBoolOper.and).name -> ApalacheInternalOper.smtMap(TlaBoolOper.and),
+      ApalacheInternalOper.smtMap(TlaBoolOper.or).name -> ApalacheInternalOper.smtMap(TlaBoolOper.or),
+      ApalacheInternalOper.unconstrainArray.name -> ApalacheInternalOper.unconstrainArray,
+      ApalacheOper.setAsFun.name -> ApalacheOper.setAsFun,
+      ApalacheOper.guess.name -> ApalacheOper.guess,
+      VariantOper.variant.name -> VariantOper.variant,
+      VariantOper.variantTag.name -> VariantOper.variantTag,
+      VariantOper.variantGetUnsafe.name -> VariantOper.variantGetUnsafe,
+      VariantOper.variantGetOrElse.name -> VariantOper.variantGetOrElse,
+      VariantOper.variantFilter.name -> VariantOper.variantFilter,
+  )
+
+  def apply(operString: String, tt1: TlaType1, args: Seq[TBuilderInstruction]): TBuilderInstruction = {
+    val oper = nameMap(operString)
+    validateExpectedArity(oper, args)
+    oper match {
+      case TlaOper.eq =>
+        val Seq(x, y) = args
+        tla.eql(x, y)
+      case TlaOper.ne =>
+        val Seq(x, y) = args
+        tla.neql(x, y)
+      case TlaOper.apply =>
+        val h +: t = args
+        tla.appOp(h, t: _*)
+      case TlaOper.chooseBounded =>
+        val Seq(x, set, p) = args
+        tla.choose(x, set, p)
+      case TlaOper.chooseUnbounded =>
+        val Seq(x, p) = args
+        tla.choose(x, p)
+      case TlaBoolOper.and =>
+        tla.and(args: _*)
+      case TlaBoolOper.or =>
+        tla.or(args: _*)
+      case TlaBoolOper.not =>
+        val Seq(p) = args
+        tla.not(p)
+      case TlaBoolOper.implies =>
+        val Seq(p, q) = args
+        tla.impl(p, q)
+      case TlaBoolOper.equiv =>
+        val Seq(p, q) = args
+        tla.equiv(p, q)
+      case TlaBoolOper.forall =>
+        val Seq(x, set, p) = args
+        tla.forall(x, set, p)
+      case TlaBoolOper.exists =>
+        val Seq(x, set, p) = args
+        tla.exists(x, set, p)
+      case TlaBoolOper.forallUnbounded =>
+        val Seq(x, p) = args
+        tla.forall(x, p)
+      case TlaBoolOper.existsUnbounded =>
+        val Seq(x, p) = args
+        tla.exists(x, p)
+      case TlaActionOper.prime =>
+        val Seq(ex) = args
+        tla.prime(ex)
+      case TlaActionOper.stutter =>
+        val Seq(a, e) = args
+        tla.stutt(a, e)
+      case TlaActionOper.nostutter =>
+        val Seq(a, e) = args
+        tla.nostutt(a, e)
+      case TlaActionOper.enabled =>
+        val Seq(ex) = args
+        tla.enabled(ex)
+      case TlaActionOper.unchanged =>
+        val Seq(ex) = args
+        tla.unchanged(ex)
+      case TlaActionOper.composition =>
+        val Seq(a, b) = args
+        tla.comp(a, b)
+      case TlaControlOper.caseNoOther =>
+        tla.caseSplitMixed(args: _*)
+      case TlaControlOper.caseWithOther =>
+        val h +: t = args
+        tla.caseOtherMixed(h, t: _*)
+      case TlaControlOper.ifThenElse =>
+        val Seq(i, t, e) = args
+        tla.ite(i, t, e)
+      case TlaTempOper.AA =>
+        val Seq(x, p) = args
+        tla.AA(x, p)
+      case TlaTempOper.box =>
+        val Seq(p) = args
+        tla.box(p)
+      case TlaTempOper.diamond =>
+        val Seq(p) = args
+        tla.diamond(p)
+      case TlaTempOper.EE =>
+        val Seq(x, p) = args
+        tla.EE(x, p)
+      case TlaTempOper.guarantees =>
+        val Seq(p, q) = args
+        tla.guarantees(p, q)
+      case TlaTempOper.leadsTo =>
+        val Seq(p, q) = args
+        tla.leadsTo(p, q)
+      case TlaTempOper.strongFairness =>
+        val Seq(x, a) = args
+        tla.SF(x, a)
+      case TlaTempOper.weakFairness =>
+        val Seq(x, a) = args
+        tla.WF(x, a)
+      case TlaArithOper.plus =>
+        val Seq(x, y) = args
+        tla.plus(x, y)
+      case TlaArithOper.uminus =>
+        val Seq(x) = args
+        tla.uminus(x)
+      case TlaArithOper.minus =>
+        val Seq(x, y) = args
+        tla.minus(x, y)
+      case TlaArithOper.mult =>
+        val Seq(x, y) = args
+        tla.mult(x, y)
+      case TlaArithOper.div =>
+        val Seq(x, y) = args
+        tla.div(x, y)
+      case TlaArithOper.mod =>
+        val Seq(x, y) = args
+        tla.mod(x, y)
+      case o @ TlaArithOper.realDiv =>
+        throw new JsonDeserializationError(s"${o.name} is not supported.")
+      case TlaArithOper.exp =>
+        val Seq(x, y) = args
+        tla.exp(x, y)
+      case TlaArithOper.dotdot =>
+        val Seq(x, y) = args
+        tla.dotdot(x, y)
+      case TlaArithOper.lt =>
+        val Seq(x, y) = args
+        tla.lt(x, y)
+      case TlaArithOper.gt =>
+        val Seq(x, y) = args
+        tla.gt(x, y)
+      case TlaArithOper.le =>
+        val Seq(x, y) = args
+        tla.le(x, y)
+      case TlaArithOper.ge =>
+        val Seq(x, y) = args
+        tla.ge(x, y)
+      case TlaFiniteSetOper.cardinality =>
+        val Seq(set) = args
+        tla.cardinality(set)
+      case TlaFiniteSetOper.isFiniteSet =>
+        val Seq(set) = args
+        tla.isFiniteSet(set)
+      case TlaFunOper.app =>
+        val Seq(f, x) = args
+        tla.app(f, x)
+      case TlaFunOper.domain =>
+        val Seq(f) = args
+        tla.dom(f)
+      case TlaFunOper.rec =>
+        tla.recMixed(args: _*)
+      case TlaFunOper.except =>
+        val h +: t = args
+        val tPairs = t.grouped(2).toSeq.map { case Seq(a, b) => (a, b) }
+        tla.exceptMany(h, tPairs: _*)
+      case TlaFunOper.funDef =>
+        val h +: t = args
+        tla.funDefMixed(h, t: _*)
+      case TlaFunOper.tuple =>
+        tla.tuple(args: _*)
+      case TlaSeqOper.append =>
+        val Seq(s, e) = args
+        tla.append(s, e)
+      case TlaSeqOper.concat =>
+        val Seq(s, t) = args
+        tla.concat(s, t)
+      case TlaSeqOper.head =>
+        val Seq(s) = args
+        tla.head(s)
+      case TlaSeqOper.tail =>
+        val Seq(s) = args
+        tla.tail(s)
+      case TlaSeqOper.len =>
+        val Seq(s) = args
+        tla.len(s)
+      case TlaSeqOper.subseq =>
+        val Seq(s, i, j) = args
+        tla.subseq(s, i, j)
+      case TlaSetOper.enumSet =>
+        if (args.isEmpty) tla.emptySet(tt1)
+        else tla.enumSet(args: _*)
+      case TlaSetOper.in =>
+        val Seq(x, s) = args
+        tla.in(x, s)
+      case TlaSetOper.notin =>
+        val Seq(x, s) = args
+        tla.notin(x, s)
+      case TlaSetOper.cap =>
+        val Seq(s, t) = args
+        tla.cap(s, t)
+      case TlaSetOper.cup =>
+        val Seq(s, t) = args
+        tla.cup(s, t)
+      case TlaSetOper.filter =>
+        val Seq(x, set, p) = args
+        tla.filter(x, set, p)
+      case TlaSetOper.funSet =>
+        val Seq(s, t) = args
+        tla.funSet(s, t)
+      case TlaSetOper.map =>
+        val h +: t = args
+        tla.mapMixed(h, t: _*)
+      case TlaSetOper.powerset =>
+        val Seq(s) = args
+        tla.powSet(s)
+      case TlaSetOper.recSet =>
+        tla.recSetMixed(args: _*)
+      case TlaSetOper.seqSet =>
+        val Seq(s) = args
+        tla.seqSet(s)
+      case TlaSetOper.setminus =>
+        val Seq(s, t) = args
+        tla.setminus(s, t)
+      case TlaSetOper.subseteq =>
+        val Seq(s, t) = args
+        tla.subseteq(s, t)
+      case TlaSetOper.times =>
+        tla.times(args: _*)
+      case TlaSetOper.union =>
+        val Seq(s) = args
+        tla.union(s)
+      case o @ (TlaFunOper.recFunRef | TlaFunOper.recFunDef) =>
+        throw new JsonDeserializationError(s"${o.name} is not supported.")
+      case ApalacheOper.assign =>
+        val Seq(x, e) = args
+        tla.assign(x, e)
+      case ApalacheOper.gen =>
+        val Seq(nEx): Seq[TlaEx] = args
+        nEx match {
+          case ValEx(TlaInt(n)) =>
+            tla.gen(n, tt1)
+          // should never happen, for case-completeness
+          case _ => throw new JsonDeserializationError(s"${oper.name} requires an integer argument.")
+        }
+      case ApalacheOper.skolem =>
+        val Seq(ex) = args
+        tla.skolem(ex)
+      case ApalacheOper.expand =>
+        val Seq(ex) = args
+        tla.expand(ex)
+      case ApalacheOper.constCard =>
+        val Seq(ex) = args
+        tla.constCard(ex)
+      case ApalacheInternalOper.distinct =>
+        tla.distinct(args: _*)
+      case ApalacheOper.mkSeq =>
+        val Seq(n, f) = args
+        val nEx: TlaEx = n
+        nEx match {
+          case ValEx(TlaInt(n)) =>
+            tla.mkSeq(n, f)
+          // should never happen, for case-completeness
+          case _ => throw new JsonDeserializationError(s"${oper.name} requires an integer argument.")
+        }
+      case ApalacheOper.foldSet =>
+        val Seq(f, v, s) = args
+        tla.foldSet(f, v, s)
+      case ApalacheOper.foldSeq =>
+        val Seq(f, v, s) = args
+        tla.foldSeq(f, v, s)
+      case ApalacheInternalOper.selectInSet =>
+        val Seq(x, s) = args
+        tla.selectInSet(x, s)
+      case ApalacheInternalOper.selectInFun =>
+        val Seq(x, f) = args
+        tla.selectInFun(x, f)
+      case ApalacheInternalOper.storeInSet =>
+        args match {
+          case Seq(x, s)    => tla.storeInSet(x, s)
+          case Seq(x, f, y) => tla.storeInSet(x, f, y)
+          // should never happen, for case-completeness
+          case _ => throw new JsonDeserializationError(s"${oper.name} requires 2 or 3 arguments.")
+        }
+      case ApalacheInternalOper.storeNotInSet =>
+        val Seq(x, s) = args
+        tla.storeNotInSet(x, s)
+      case ApalacheInternalOper.storeNotInFun =>
+        val Seq(x, f) = args
+        tla.storeNotInFun(x, f)
+      case ApalacheInternalOper.smtMap(oper) =>
+        val Seq(s, t) = args
+        tla.smtMap(oper, s, t)
+      case ApalacheInternalOper.unconstrainArray =>
+        val Seq(s) = args
+        tla.unconstrainArray(s)
+      case ApalacheOper.setAsFun =>
+        val Seq(s) = args
+        tla.setAsFun(s)
+      case ApalacheOper.guess =>
+        val Seq(s) = args
+        tla.guess(s)
+      case VariantOper.variant =>
+        require(tt1.isInstanceOf[VariantT1])
+        val Seq(t, v) = args
+        tla.variant(getStrValue(t), v, tt1.asInstanceOf[VariantT1])
+      case VariantOper.variantTag =>
+        val Seq(v) = args
+        tla.variantTag(v)
+      case VariantOper.variantGetUnsafe =>
+        val Seq(t, v) = args
+        tla.variantGetUnsafe(getStrValue(t), v)
+      case VariantOper.variantGetOrElse =>
+        val Seq(t, v, d) = args
+        tla.variantGetOrElse(getStrValue(t), v, d)
+      case VariantOper.variantFilter =>
+        val Seq(t, v) = args
+        tla.variantFilter(getStrValue(t), v)
+    }
+  }
+
+  private def getStrValue(ex: TlaEx): String = ex match {
+    case ValEx(TlaStr(s)) => s
+    case _                => throw new JsonDeserializationError(s"$ex must be a string.")
+  }
+
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/JsonToTlaViaBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/JsonToTlaViaBuilder.scala
@@ -235,7 +235,7 @@ class JsonToTlaViaBuilder[T <: JsonRepresentation](
         val declsObjSeq = scalaFactory.asSeq(declsField)
         val decls = declsObjSeq.map(asTlaDecl)
         assert(decls.forall { _.isInstanceOf[TlaOperDecl] })
-        // narrowng cast + unchecked lift to satisfy the TBIS[TlaOperDecl] signature
+        // narrowing cast + unchecked lift to satisfy the TBIS[TlaOperDecl] signature
         val operDecls: Seq[TBuilderOperDeclInstruction] =
           decls.map { d => tla.uncheckedDecl(d.asInstanceOf[TlaOperDecl]) }
         tla.letIn(body, operDecls: _*)

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/JsonToTlaViaBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/JsonToTlaViaBuilder.scala
@@ -1,0 +1,274 @@
+package at.forsyte.apalache.tla.typecomp.json
+
+import at.forsyte.apalache.io.json._
+import at.forsyte.apalache.io.lir.TypeTagReader
+import at.forsyte.apalache.tla.imp.src.{SourceLocation, SourceStore}
+import at.forsyte.apalache.tla.types.tla
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.lir.TypedPredefs._
+import at.forsyte.apalache.tla.lir.src.{SourceLocation, SourcePosition, SourceRegion}
+import at.forsyte.apalache.tla.lir._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+ * A JsonDecoder, which uses the ScopedBuilder to construct TLA IR
+ *
+ * TODO: Once package refactoring is done, this should replace io.json.JsonToTla. Currently impossible due to dependency
+ * issues.
+ *
+ * @author
+ *   Jure Kukovec
+ */
+class JsonToTlaViaBuilder[T <: JsonRepresentation](
+    scalaFactory: ScalaFactory[T],
+    sourceStoreOpt: Option[SourceStore] = None,
+  )(implicit typeTagReader: TypeTagReader)
+    extends JsonDecoder[T] {
+  private def missingField(fieldName: String): JsonDeserializationError =
+    new JsonDeserializationError(s"JSON has no field named [$fieldName].")
+
+  private def getOrThrow(json: T, fieldName: String): T =
+    json.getFieldOpt(fieldName).getOrElse { throw missingField(fieldName) }
+
+  private def rethrowAsJsonDeserializationException[T](method: => T): T =
+    try {
+      method
+    } catch {
+      // rethrow as deserialization error
+      case e: TBuilderTypeException =>
+        throw new JsonDeserializationError(s"JSON contains ill-typed expressions: ${e.getMessage}")
+      case e: TBuilderScopeException =>
+        throw new JsonDeserializationError(s"JSON contains ill-scoped expressions: ${e.getMessage}")
+    }
+
+  private def validateTag[T](tagged: TypeTagged[T], tag: TypeTag): Unit =
+    if (tagged.typeTag != tag)
+      throw new JsonDeserializationError(s"$tagged is tagged with $tag, but should have ${tagged.typeTag}.")
+
+  private def asFParam(json: T): OperParam = {
+    val kindField = getOrThrow(json, TlaToJson.kindFieldName)
+    val kind = scalaFactory.asStr(kindField)
+
+    kind match {
+      case "OperParam" =>
+        val nameField = getOrThrow(json, "name")
+        val name = scalaFactory.asStr(nameField)
+        val arityField = getOrThrow(json, "arity")
+        val arity = scalaFactory.asInt(arityField)
+        OperParam(name, arity)
+      case _ => throw new JsonDeserializationError(s"$kind is not a valid OperParam kind")
+    }
+  }
+
+  private def asTlaValEx(json: T): TBuilderInstruction = {
+    val kindField = getOrThrow(json, TlaToJson.kindFieldName)
+    val kind = scalaFactory.asStr(kindField)
+
+    kind match {
+      case "TlaStr" =>
+        val valField = getOrThrow(json, "value")
+        val valStr = scalaFactory.asStr(valField)
+        tla.str(valStr)
+      case "TlaDecimal" =>
+        throw new JsonDeserializationError("TlaDecimal is not supported.")
+      case "TlaInt" =>
+        val valField = getOrThrow(json, "value")
+        val bi = valField
+          .getFieldOpt("bigInt")
+          .map { biField =>
+            BigInt(scalaFactory.asStr(biField))
+          }
+          .getOrElse {
+            BigInt(scalaFactory.asInt(valField))
+          }
+        tla.int(bi)
+      case "TlaBool" =>
+        val valField = getOrThrow(json, "value")
+        val valBool = scalaFactory.asBool(valField)
+        tla.bool(valBool)
+      case "TlaBoolSet" => tla.booleanSet()
+      case "TlaIntSet"  => tla.intSet()
+      case "TlaStrSet"  => tla.stringSet()
+      case "TlaNatSet"  => tla.natSet()
+      case _            => throw new JsonDeserializationError(s"$kind is not a valid TlaValue kind")
+    }
+  }
+
+  private def getSourceLocationOpt(json: T): Option[SourceLocation] = for {
+    sourceObj <- json.getFieldOpt(TlaToJson.sourceFieldName)
+    fileName <- sourceObj.getFieldOpt("filename").map(scalaFactory.asStr)
+    fromObj <- sourceObj.getFieldOpt("from")
+    toObj <- sourceObj.getFieldOpt("to")
+    fromLine <- fromObj.getFieldOpt("line").map(scalaFactory.asInt)
+    fromCol <- fromObj.getFieldOpt("column").map(scalaFactory.asInt)
+    toLine <- toObj.getFieldOpt("line").map(scalaFactory.asInt)
+    toCol <- toObj.getFieldOpt("column").map(scalaFactory.asInt)
+  } yield SourceLocation(
+      fileName,
+      SourceRegion(
+          SourcePosition(fromLine, fromCol),
+          SourcePosition(toLine, toCol),
+      ),
+  )
+
+  private def setLoc(identifiable: Identifiable, locationOpt: Option[SourceLocation]): Unit =
+    sourceStoreOpt.foreach { store =>
+      locationOpt.foreach { loc =>
+        store.add(identifiable.ID, loc)
+      }
+    }
+
+  override def asTlaModule(moduleJson: T): TlaModule = rethrowAsJsonDeserializationException {
+    val kindField = getOrThrow(moduleJson, TlaToJson.kindFieldName)
+    val kind = scalaFactory.asStr(kindField)
+    if (kind != "TlaModule")
+      throw new JsonDeserializationError(s"JSON kind is $kind, expected TlaModule")
+
+    val nameField = getOrThrow(moduleJson, "name")
+    val name = scalaFactory.asStr(nameField)
+    val declField = getOrThrow(moduleJson, "declarations")
+    val declObjSeq = scalaFactory.asSeq(declField)
+    val decls = declObjSeq.map(asTlaDecl)
+
+    TlaModule(name, decls)
+  }
+
+  override def asTlaDecl(declJson: T): TlaDecl = rethrowAsJsonDeserializationException {
+    val typeField = getOrThrow(declJson, TlaToJson.typeFieldName)
+    val tag = scalaFactory.asStr(typeField)
+    val typeTag = typeTagReader(tag)
+    val kindField = getOrThrow(declJson, TlaToJson.kindFieldName)
+    val kind = scalaFactory.asStr(kindField)
+    val decl = kind match {
+      case "TlaTheoremDecl" =>
+        val nameField = getOrThrow(declJson, "name")
+        val name = scalaFactory.asStr(nameField)
+        val bodyField = getOrThrow(declJson, "body")
+        val body: TlaEx = asTlaExInternal(bodyField)
+        validateTag(body, typeTag)
+        TlaTheoremDecl(name, body)(typeTag)
+      case "TlaVarDecl" =>
+        val nameField = getOrThrow(declJson, "name")
+        val name = scalaFactory.asStr(nameField)
+        TlaVarDecl(name)(typeTag)
+      case "TlaConstDecl" =>
+        val nameField = getOrThrow(declJson, "name")
+        val name = scalaFactory.asStr(nameField)
+        TlaConstDecl(name)(typeTag)
+      case "TlaOperDecl" =>
+        val nameField = getOrThrow(declJson, "name")
+        val name = scalaFactory.asStr(nameField)
+        val recField = getOrThrow(declJson, "isRecursive")
+        val isRecursive = scalaFactory.asBool(recField)
+        val bodyField = getOrThrow(declJson, "body")
+        val body = asTlaExInternal(bodyField)
+        val paramsField = getOrThrow(declJson, "formalParams")
+        val paramsObjList = scalaFactory.asSeq(paramsField).toList
+        val fParams = paramsObjList.map(asFParam)
+        val paramTypes = typeTag match {
+          case Typed(OperT1(args, _)) =>
+            val l1 = args.length
+            val l2 = fParams.length
+            if (l1 != l2)
+              throw new JsonDeserializationError(s"$nameField has arity $l1, but the type has arity $l2.")
+            args
+          case t => throw new JsonDeserializationError(s"$nameField should have an operator type, found $t.")
+        }
+
+        val opDecl: TlaOperDecl = tla.decl(name, body, fParams.zip(paramTypes): _*)
+
+        validateTag(opDecl, typeTag)
+
+        opDecl.isRecursive = isRecursive
+        opDecl
+
+      case "TlaAssumeDecl" =>
+        val bodyField = getOrThrow(declJson, "body")
+        val body = asTlaExInternal(bodyField)
+        TlaAssumeDecl(body)(typeTag)
+      case _ => throw new JsonDeserializationError(s"$kind is not a valid TlaDecl kind")
+    }
+    setLoc(decl, getSourceLocationOpt(declJson))
+    decl
+  }
+
+  override def asTlaEx(exJson: T): TBuilderResult = rethrowAsJsonDeserializationException {
+    asTlaExInternal(exJson)
+  }
+
+  // It's more efficient to operate over TBuilderInstruction for as long as possible, and only build in the end step
+  private def asTlaExInternal(exJson: T): TBuilderInstruction = {
+    val kindField = getOrThrow(exJson, TlaToJson.kindFieldName)
+    val kind = scalaFactory.asStr(kindField)
+    if (kind == "NullEx")
+      throw new JsonDeserializationError("NullEx is not supported.")
+
+    val typeField = getOrThrow(exJson, TlaToJson.typeFieldName)
+    val tag = scalaFactory.asStr(typeField)
+    val typeTag = typeTagReader(tag)
+    val exCmp = kind match {
+      case "NameEx" =>
+        val nameField = getOrThrow(exJson, "name")
+        val name = scalaFactory.asStr(nameField)
+        val tt1 = typeTag match {
+          case Typed(tt: TlaType1) => tt
+          case t                   => throw new JsonDeserializationError(s"Expected TlaType1, found $t.")
+        }
+        tla.name(name, tt1)
+      case "ValEx" =>
+        val valueField = getOrThrow(exJson, "value")
+        asTlaValEx(valueField)
+
+      case "OperEx" =>
+        val operField = getOrThrow(exJson, "oper")
+        val operString = scalaFactory.asStr(operField)
+        val argsField = getOrThrow(exJson, "args")
+        val argsObjSeq = scalaFactory.asSeq(argsField)
+        val args = argsObjSeq.map(asTlaExInternal)
+        BuilderCallByName(operString, typeTag.asTlaType1(), args)
+
+      case "LetInEx" =>
+        val bodyField = getOrThrow(exJson, "body")
+        val body = asTlaExInternal(bodyField)
+        val declsField = getOrThrow(exJson, "decls")
+        val declsObjSeq = scalaFactory.asSeq(declsField)
+        val decls = declsObjSeq.map(asTlaDecl)
+        assert(decls.forall { _.isInstanceOf[TlaOperDecl] })
+        // narrowng cast + unchecked lift to satisfy the TBIS[TlaOperDecl] signature
+        val operDecls: Seq[TBuilderOperDeclInstruction] =
+          decls.map { d => tla.unchecked(d.asInstanceOf[TlaOperDecl]) }
+        tla.letIn(body, operDecls: _*)
+      case _ => throw new JsonDeserializationError(s"$kind is not a valid TlaEx kind")
+    }
+
+    exCmp.map { ex =>
+      validateTag(ex, typeTag)
+      setLoc(ex, getSourceLocationOpt(exJson))
+      ex
+    }
+
+  }
+
+  override def fromRoot(rootJson: T): Seq[TlaModule] = rethrowAsJsonDeserializationException {
+    val versionField = getOrThrow(rootJson, TlaToJson.versionFieldName)
+    val version = scalaFactory.asStr(versionField)
+    val current = JsonVersion.current
+    if (version != current) {
+      throw new JsonDeserializationError(s"JSON version is $version, expected $current.")
+    } else {
+      val modulesField = getOrThrow(rootJson, "modules")
+      scalaFactory.asSeq(modulesField).map(asTlaModule)
+    }
+  }
+
+  override def fromSingleModule(json: T): Try[TlaModule] = rethrowAsJsonDeserializationException {
+    for {
+      modules <- Try(fromRoot(json))
+      module <- modules match {
+        case m +: Nil => Success(m)
+        case _        => Failure(new JsonDeserializationError(s"JSON included more than one module"))
+      }
+    } yield module
+  }
+}

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/JsonToTlaViaBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/JsonToTlaViaBuilder.scala
@@ -237,7 +237,7 @@ class JsonToTlaViaBuilder[T <: JsonRepresentation](
         assert(decls.forall { _.isInstanceOf[TlaOperDecl] })
         // narrowng cast + unchecked lift to satisfy the TBIS[TlaOperDecl] signature
         val operDecls: Seq[TBuilderOperDeclInstruction] =
-          decls.map { d => tla.unchecked(d.asInstanceOf[TlaOperDecl]) }
+          decls.map { d => tla.uncheckedDecl(d.asInstanceOf[TlaOperDecl]) }
         tla.letIn(body, operDecls: _*)
       case _ => throw new JsonDeserializationError(s"$kind is not a valid TlaEx kind")
     }

--- a/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/UJsonToTlaViaBuilder.scala
+++ b/tla-types/src/main/scala/at/forsyte/apalache/tla/typecomp/json/UJsonToTlaViaBuilder.scala
@@ -1,0 +1,12 @@
+package at.forsyte.apalache.tla.typecomp.json
+
+import at.forsyte.apalache.io.json.impl.{UJsonRep, UJsonScalaFactory}
+import at.forsyte.apalache.io.lir.TypeTagReader
+import at.forsyte.apalache.tla.imp.src.SourceStore
+
+/**
+ * @author
+ *   Jure Kukovec
+ */
+class UJsonToTlaViaBuilder(sourceStoreOpt: Option[SourceStore] = None)(implicit typeTagReader: TypeTagReader)
+    extends JsonToTlaViaBuilder[UJsonRep](UJsonScalaFactory, sourceStoreOpt)(typeTagReader)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
@@ -7,7 +7,6 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
 import at.forsyte.apalache.tla.types.tla
-import at.forsyte.apalache.tla.types._
 import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.typecomp.json.UJsonToTlaViaBuilder
 import org.junit.runner.RunWith

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
@@ -82,14 +82,12 @@ class TestUJsonToTlaViaBuilder extends AnyFunSuite with Checkers {
   }
 
   test("Predef sets (see #1281)") {
-    val sets: Seq[ValEx] = Seq(
-        TlaIntSet,
-        TlaNatSet,
-        TlaBoolSet,
-        TlaStrSet,
-    ).map { v =>
-      ValEx(v).withTag(Untyped)
-    }
+    val sets: Seq[TlaEx] = Seq(
+        tla.intSet(),
+        tla.natSet(),
+        tla.booleanSet(),
+        tla.stringSet(),
+    )
 
     sets.foreach { s =>
       assert(dec.asTlaEx(enc(s)) == s)

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
@@ -1,0 +1,118 @@
+package at.forsyte.apalache.tla.typecomp
+
+import at.forsyte.apalache.io.json.JsonDeserializationError
+import at.forsyte.apalache.io.json.impl.{DefaultTagReader, TlaToUJson}
+import at.forsyte.apalache.io.lir.TlaType1PrinterPredefs
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.oper.TlaArithOper
+import at.forsyte.apalache.tla.types.tla
+import at.forsyte.apalache.tla.types._
+import at.forsyte.apalache.tla.lir.values._
+import at.forsyte.apalache.tla.typecomp.json.UJsonToTlaViaBuilder
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+import org.scalatestplus.scalacheck.Checkers
+
+/**
+ * TODO: Implement generators for well-typed IR, then rewrite as PBT
+ */
+@RunWith(classOf[JUnitRunner])
+class TestUJsonToTlaViaBuilder extends AnyFunSuite with Checkers {
+  implicit val reader = DefaultTagReader
+  implicit val printer = TlaType1PrinterPredefs.printer
+
+  val dec = new UJsonToTlaViaBuilder(sourceStoreOpt = None)
+  val enc = new TlaToUJson(locatorOpt = None)
+
+  test("dec(enc(x)) =?= x") {
+    val exs: Seq[TlaEx] = Seq(
+        tla.and(tla.name("x", BoolT1), tla.bool(true)),
+        tla.ite(tla.name("p", BoolT1), tla.name("A", ConstT1("X")), tla.name("B", ConstT1("X"))),
+        tla.letIn(
+            tla.appOp(tla.name("A", OperT1(Seq(IntT1), IntT1)), tla.int(1)),
+            tla.decl(
+                "A",
+                tla.plus(tla.name("p", IntT1), tla.int(1)),
+                tla.param("p", IntT1),
+            ),
+        ),
+    )
+
+    exs.foreach { ex =>
+      val encEx = enc(ex)
+      val decEx = dec.asTlaEx(encEx)
+      assert(decEx == ex)
+    }
+
+    // Typed builder should fail on these, and the exceptions should be rethrown as deserialization exceptions
+    val badExs: Seq[TlaEx] = Seq(
+        NameEx("a")(Untyped),
+        OperEx(TlaArithOper.plus, tla.int(1), tla.name("x", BoolT1))(Typed(IntT1)),
+    )
+
+    badExs.foreach { ex =>
+      val encEx = enc(ex)
+      assertThrows[JsonDeserializationError] {
+        dec.asTlaEx(encEx)
+      }
+    }
+
+    val decls: Seq[TlaDecl] = Seq(
+        tla.decl("X", tla.eql(tla.name("a", IntT1), tla.int(1)), tla.param("a", IntT1)),
+        TlaAssumeDecl(tla.eql(tla.int(1), tla.int(0))),
+        TlaConstDecl("c"),
+        TlaVarDecl("v"),
+    )
+
+    decls.foreach { decl =>
+      assert(dec.asTlaDecl(enc(decl)) == decl)
+    }
+
+    val modules: Seq[TlaModule] = Seq(
+        TlaModule("Empty", Seq.empty),
+        TlaModule("Module", decls),
+    )
+
+    modules.foreach { m =>
+      assert(dec.asTlaModule(enc(m)) == m)
+    }
+
+    assert(dec.fromRoot(enc.makeRoot(modules)) == modules)
+  }
+
+  test("Predef sets (see #1281)") {
+    val sets: Seq[ValEx] = Seq(
+        TlaIntSet,
+        TlaNatSet,
+        TlaBoolSet,
+        TlaStrSet,
+    ).map { v =>
+      ValEx(v).withTag(Untyped)
+    }
+
+    sets.foreach { s =>
+      assert(dec.asTlaEx(enc(s)) == s)
+    }
+
+  }
+
+  // TODO: Uncomment once generated IRs are well-typed
+//  test("Deserializing a serialized IR produces an equivalent IR") {
+//    val gens: IrGenerators = new IrGenerators {
+//      override val maxArgs: Int = 3
+//    }
+//    val operators =
+//      gens.simpleOperators ++ gens.logicOperators ++ gens.arithOperators ++ gens.setOperators ++ gens.functionOperators ++ gens.actionOperators ++ gens.temporalOperators
+//    val genDecl = gens.genTlaDeclButNotVar(gens.genTlaEx(operators)) _
+//    val prop = forAll(gens.genTlaModuleWith(genDecl)) { module =>
+//      val moduleJson = enc(module)
+//      val moduleFromJson = dec.asTlaModule(moduleJson)
+//
+//      module =? moduleFromJson
+//    }
+//    check(prop, minSuccessful(500), sizeRange(7))
+//  }
+
+}

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecomp/TestUJsonToTlaViaBuilder.scala
@@ -7,7 +7,6 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.oper.TlaArithOper
 import at.forsyte.apalache.tla.types.tla
-import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.typecomp.json.UJsonToTlaViaBuilder
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Due to the `tla-io` package being a dependency for `tla-types`, these classes must temporarily be placed in `tla-types` (or higher). Once package refactoring is addressed, these classes should replace the ones in `io.json`, which currently use the old builder.
Additionally, the deserialization tests _should_ use generators, but we currently lack ways to generate type-correct TLAIR, which would mean that deserializing serialized auto-generated expressions would throw, more often than not.


closes #2201 