### PR TITLE
Bump ubuntu version in `deploy` workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We've started encountering the [brownout of `ubuntu-18.04`](https://github.com/actions/runner-images/issues/6002) in our `deploy` Github workflow:
https://github.com/informalsystems/apalache/actions/runs/3249911017

Bump to `ubuntu-latest`.

All other workflows already use `-latest`.