### PR TITLE
Small cleanup on Shai RPCs

### DIFF
--- a/shai/src/main/protobuf/transExplorer.proto
+++ b/shai/src/main/protobuf/transExplorer.proto
@@ -8,9 +8,9 @@ option java_package = "at.forsyte.apalache.shai.v1";
 option java_outer_classname = "TransExplorerProto";
 
 service TransExplorer {
-  rpc OpenConnection (ConnectRequest) returns (Connection);
+  rpc openConnection (ConnectRequest) returns (Connection);
   // TODO rpc Terminate (TerminateRequest) returns (TerminationReply) {}
-  rpc LoadModel(LoadModelRequest) returns (LoadModelResponse);
+  rpc loadModel(LoadModelRequest) returns (LoadModelResponse);
 
   // No-op to check service health
   rpc ping(PingRequest) returns (PongResponse);

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
@@ -22,7 +22,7 @@ object Checker {
       case Error(nerrors, counterexamples) =>
         Obj("checking_result" -> "Error", "counterexamples" -> counterexamples, "nerrors" -> nerrors)
       case Deadlock(counterexample) =>
-        Obj("checking_result" -> "Deadlock", "counterexample" -> counterexample)
+        Obj("checking_result" -> "Deadlock", "counterexamples" -> counterexample.toList)
       case other =>
         Obj("checking_result" -> other.toString())
     }


### PR DESCRIPTION
Two tiny fixes here:

- Use lower-case consistently for gRPC service methods (this doesn't make a difference
for Scala code generation but does for Python)
- Use the same field name and representation for returning counterexamples
coming from deadlock and violation errors 

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change