### PR TITLE
Extend SourceOption.FileSource for itf.json

### DIFF
--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
@@ -261,6 +261,7 @@ object SourceOption {
   object Format {
     case object Tla extends Format
     case object Json extends Format
+    case object Itf extends Format
   }
 
   /** Data to be loaded from a file */
@@ -274,12 +275,17 @@ object SourceOption {
 
   object FileSource {
 
+    private def hasItfSubExtension(fname: String): Boolean =
+      FilenameUtils.isExtension(FilenameUtils.removeExtension(fname), "itf")
+
     /** Create a FileSource from a file, deriving the format from the file's extension */
     def apply(file: java.io.File): FileSource = {
-      val format = FilenameUtils.getExtension(file.getName()) match {
-        case "json"  => Format.Json
-        case "tla"   => Format.Tla
-        case unknown => throw new PassOptionException(s"Unsupported file format ${unknown}")
+      val fname = file.getName()
+      val format = FilenameUtils.getExtension(fname) match {
+        case "tla"                               => Format.Tla
+        case "json" if hasItfSubExtension(fname) => Format.Itf
+        case "json"                              => Format.Json
+        case unknown                             => throw new PassOptionException(s"Unsupported file format ${unknown}")
       }
       new FileSource(file, format)
     }

--- a/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestOptions.scala
+++ b/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestOptions.scala
@@ -1,0 +1,19 @@
+package at.forsyte.apalache.infra.passes.options
+
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestOptions extends AnyFunSuite {
+  test("Can construct SourceOption.FileSource for ITF files") {
+    import SourceOption._
+    assert(FileSource(new java.io.File("foo.itf.json")).format == Format.Itf)
+  }
+
+  test("Non-ITF JSON files are not recognized as ITF format") {
+    import SourceOption._
+
+    assert(FileSource(new java.io.File("foo.json")).format == Format.Json)
+  }
+}

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/imp/SanyParserPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/imp/SanyParserPassImpl.scala
@@ -94,6 +94,7 @@ class SanyParserPassImpl @Inject() (
     val src = options.input.source
     for {
       rootModule <- src.format match {
+        case Format.Itf  => throw new SanyImporterException("Parsing the ITF format is not supported")
         case Format.Json => loadFromJsonSource(src)
         case Format.Tla =>
           src match {

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -323,6 +323,21 @@ $ cat output.json | head
 $ rm output.json
 ```
 
+### parse on an ITF file fail with an error
+
+Check that we give an informative error if a user tries to invoke `parse` on a
+`itf.json` file.
+
+```sh
+$ touch foo.itf.json
+$ apalache-mc parse foo.itf.json | sed -e 's/I@.*//' -e 's/E@.*//'
+...
+Error by TLA+ parser: Parsing the ITF format is not supported
+...
+EXITCODE: ERROR (255)
+$ rm foo.itf.json
+```
+
 ### typecheck --output=output.tla Annotations succeeds
 
 Check that it actually parses into TLA (see #1284)


### PR DESCRIPTION
Closes #2222

After noodling around to confirm that detecting ".itf.json" would be reasy
enough, it seemed to make sense to offer the solution as a PR.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change