### PR TITLE
Allow SanyImporter.loadFromSource to return a try

### DIFF
--- a/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestTransExplorerService.scala
+++ b/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestTransExplorerService.scala
@@ -31,8 +31,8 @@ object TransExplorerServiceSpec extends DefaultRunnableSpec {
           s <- ZIO.service[TransExplorerService]
           conn <- s.openConnection(ConnectRequest())
           resp <- s.loadModel(LoadModelRequest(Some(conn), spec))
-          msg = resp.result.err.get
-        } yield assert(msg)(containsString("Parsing failed with exception: Error by TLA+ parser"))
+          msg = ujson.read(resp.result.err.get)("data")("error_data")(0).str
+        } yield assert(msg)(containsString("No module name found in source"))
       },
       testM("loading a valid spec returns parsed model") {
         val spec =

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
@@ -125,7 +125,7 @@ class TestVCGenerator extends AnyFunSuite {
   private def loadFromText(moduleName: String, text: String): TlaModule = {
     val locationStore = new SourceStore
     val (_, modules) =
-      new SanyImporter(locationStore, createAnnotationStore()).loadFromSource(Source.fromString(text))
+      new SanyImporter(locationStore, createAnnotationStore()).loadFromSource(Source.fromString(text)).get
     modules(moduleName)
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -122,7 +122,7 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
    * @return
    *   the pair (the root module name, a map of modules)
    */
-  def loadFromSource(source: Source, aux: Seq[Source] = Seq()): (String, Map[String, TlaModule]) = {
+  def loadFromSource(source: Source, aux: Seq[Source] = Seq()): Try[(String, Map[String, TlaModule])] = {
     val tempDir = sanyTempDir()
     val nameAndModule = for {
       (rootName, rootFile) <- saveTlaFile(tempDir, source)
@@ -133,7 +133,7 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
     } yield result
     tempDir.delete()
     // Raise any errors previously captures in the `Try`
-    nameAndModule.get
+    nameAndModule
   }
 
   // Create a unique temp directory for use by the SANY importer

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -79,12 +79,12 @@ class SanyParserPassImpl @Inject() (
     Right(modules.get(rootName).get)
   }
 
-  private def loadFromTlaString(content: String, aux: Seq[String]): PassResult = {
-    val (rootName, modules) =
+  private def loadFromTlaString(content: String, aux: Seq[String]): PassResult = for {
+    (rootName, modules) <-
       new SanyImporter(sourceStore, annotationStore)
         .loadFromSource(Source.fromString(content), aux.map(Source.fromString(_)))
-    Right(modules.get(rootName).get)
-  }
+
+  } yield modules.get(rootName).get
 
   private def saveLoadedModule(module: TlaModule): Either[PassFailure, Unit] = {
     // save the output

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -1,24 +1,31 @@
 package at.forsyte.apalache.tla.imp.passes
 
 import at.forsyte.apalache.infra.ExitCodes
-import at.forsyte.apalache.infra.passes.Pass.{PassFailure, PassResult}
+import at.forsyte.apalache.infra.passes.Pass.PassFailure
+import at.forsyte.apalache.infra.passes.Pass.PassResult
+import at.forsyte.apalache.infra.passes.options.OptionGroup
+import at.forsyte.apalache.infra.passes.options.SourceOption
 import at.forsyte.apalache.io.annotations.store._
-import at.forsyte.apalache.io.json.impl.{DefaultTagReader, UJsonRep, UJsonToTla}
-import at.forsyte.apalache.tla.imp.src.SourceStore
-import at.forsyte.apalache.tla.lir.{CyclicDependencyError, TlaModule}
-import at.forsyte.apalache.tla.lir.transformations.standard.DeclarationSorter
+import at.forsyte.apalache.io.json.impl.DefaultTagReader
+import at.forsyte.apalache.io.json.impl.UJsonRep
+import at.forsyte.apalache.io.json.impl.UJsonToTla
 import at.forsyte.apalache.io.lir.TlaWriterFactory
-import at.forsyte.apalache.tla.imp.{utils, SanyImporter, SanyImporterException}
+import at.forsyte.apalache.tla.imp.SanyImporter
+import at.forsyte.apalache.tla.imp.SanyImporterException
+import at.forsyte.apalache.tla.imp.src.SourceStore
+import at.forsyte.apalache.tla.imp.utils
+import at.forsyte.apalache.tla.lir.CyclicDependencyError
+import at.forsyte.apalache.tla.lir.TlaModule
+import at.forsyte.apalache.tla.lir.transformations.standard.DeclarationSorter
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
 
 import java.io.File
-import at.forsyte.apalache.infra.passes.options.SourceOption
 import scala.io.Source
-import at.forsyte.apalache.infra.passes.options.OptionGroup
-import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
+import at.forsyte.apalache.tla.imp.SanyException
 
 /**
  * Parsing TLA+ code with SANY.

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/passes/SanyParserPassImpl.scala
@@ -42,6 +42,14 @@ class SanyParserPassImpl @Inject() (
 
   override def name: String = "SanyParser"
 
+  // Enable implicit conversions of appropriate `Try` values into `PassResult`s
+  implicit val resultOfTry: Try[TlaModule] => PassResult = {
+    case Success(tlaModule) => Right(tlaModule)
+    // `SanyException`s are `NormalErrors`
+    case Failure(err: SanyException) => passFailure(List(err.getMessage()), ExitCodes.ERROR)
+    case Failure(err)                => throw err // For other exceptions, just throw them again
+  }
+
   private def loadFromJsonSource(source: SourceOption): PassResult = {
     import SourceOption._
     val readable: ujson.Readable = source match {

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -29,7 +29,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |================================
       """.stripMargin
 
-    val (rootName, _) = sanyImporter.loadFromSource(Source.fromString(text))
+    val (rootName, _) = sanyImporter.loadFromSource(Source.fromString(text)).get
     assert("justASimpleTest" == rootName)
   }
 
@@ -62,7 +62,7 @@ class TestSanyImporter extends SanyImporterTestBase {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     val mod = expectSingleModule("onevar", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -85,6 +85,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("oneconst", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -104,6 +105,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -129,6 +131,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -154,6 +157,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -179,6 +183,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -205,6 +210,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -229,6 +235,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -256,6 +263,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("constop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -278,6 +286,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("builtinop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -305,6 +314,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("localop", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -329,6 +339,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("localop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -358,6 +369,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("localop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -373,6 +385,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("emptyset", rootName, modules)
     assert(1 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -396,6 +409,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("builtinop", rootName, modules)
     assert(2 == mod.declarations.size)
     expectSourceInfoInDefs(mod)
@@ -491,6 +505,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     expectSingleModule("builtins", rootName, modules)
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -787,6 +802,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     expectSingleModule("comprehensions", rootName, modules)
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -842,6 +858,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("composite", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -942,6 +959,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("except", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1013,6 +1031,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("labels", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1063,6 +1082,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("args", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1099,6 +1119,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("updates", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1167,6 +1188,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("selects", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1209,6 +1231,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("funCtor", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1279,6 +1302,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("weird", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1308,6 +1332,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("level1Operators", rootName, modules)
 
     def expectDecl(n: String, p: List[OperParam], b: TlaEx) =
@@ -1353,6 +1378,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("level2Operators", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1389,6 +1415,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = expectSingleModule("level2builtin", rootName, modules)
     expectSourceInfoInDefs(mod)
 
@@ -1437,6 +1464,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     val mod = modules(rootName)
     expectSourceInfoInDefs(mod)
 
@@ -1486,6 +1514,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1540,7 +1569,7 @@ class TestSanyImporter extends SanyImporterTestBase {
         |""".stripMargin
 
     assertThrows[SanyImporterException] {
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     }
   }
 
@@ -1555,6 +1584,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1603,6 +1633,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1661,6 +1692,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(2 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1753,6 +1785,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1819,6 +1852,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -1864,6 +1898,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size) // Naturals, Sequences, and our module
     // the root module and naturals
     val root = modules(rootName)
@@ -1886,6 +1921,7 @@ class TestSanyImporter extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(rootText), List(Source.fromString(auxText)))
+      .get
     // We've loaded two modules
     assert(2 == modules.size)
     // the root module and naturals

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterAnnotations.scala
@@ -33,7 +33,7 @@ class TestSanyImporterAnnotations extends AnyFunSuite with BeforeAndAfter {
 
   private def loadModule(text: String): TlaModule = {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     modules(rootName)
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterInstances.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterInstances.scala
@@ -45,6 +45,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(2 == modules.size) // inst + Naturals
     // the root module and A
     val root = modules(rootName)
@@ -125,6 +126,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -159,6 +161,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     expectSourceInfoInDefs(modules(rootName))
   }
@@ -177,6 +180,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -222,6 +226,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -257,6 +262,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -295,6 +301,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     val root = modules(rootName)
     val base = root.declarations
@@ -328,6 +335,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -365,6 +373,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(1 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -391,6 +400,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     // the root module and naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -418,6 +428,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     // the root module and naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -445,6 +456,7 @@ class TestSanyImporterInstances extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     // the root module and naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporterStandardModules.scala
@@ -32,6 +32,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(2 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -67,6 +68,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(2 == modules.size)
     // the root module and naturals
     val root = modules(rootName)
@@ -164,6 +166,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(3 == modules.size) // Integers extends Naturals
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -248,6 +251,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(4 == modules.size) // Reals include Integers that include Naturals
     val root = modules(rootName)
     // the definitions of the standard operators are filtered out
@@ -332,6 +336,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(3 == modules.size) // Naturals, Sequences, and our module
     // the root module and naturals
     val root = modules(rootName)
@@ -377,6 +382,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(5 == modules.size) // Naturals, Sequences, FiniteSets, and our module
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -423,6 +429,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (rootName, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     // the root module and integers
     val root = modules(rootName)
     expectSourceInfoInDefs(root)
@@ -471,7 +478,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
         |================================
       """.stripMargin
 
-    val (_, modules) = sanyImporter.loadFromSource(Source.fromString(text))
+    val (_, modules) = sanyImporter.loadFromSource(Source.fromString(text)).get
     assert(6 == modules.size) // Naturals, Sequences, TLC, FiniteSets, Bags, and our module
 
     val root = modules("localSum")
@@ -502,6 +509,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (_, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
     assert(7 == modules.size) // root, Apalache, Integers, FiniteSets, and whatever they import
 
     val root = modules("root")
@@ -590,6 +598,7 @@ class TestSanyImporterStandardModules extends SanyImporterTestBase {
 
     val (_, modules) = sanyImporter
       .loadFromSource(Source.fromString(text))
+      .get
 
     val root = modules("root")
     expectSourceInfoInDefs(root)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstAndDefRewriter.scala
@@ -36,7 +36,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     val root = modules(rootName)
     // we don't want to run a type checker, so we just hack the type of the declaration n
     val newDeclarations =
@@ -71,7 +71,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     val root = modules(rootName)
     assertThrows[OverridingError](new ConstAndDefRewriter(new IdleTracker())(root))
   }
@@ -86,7 +86,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     val root = modules(rootName)
     assertThrows[OverridingError](new ConstAndDefRewriter(new IdleTracker())(root))
   }
@@ -100,7 +100,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     val root = modules(rootName)
     val rewritten = new ConstAndDefRewriter(new IdleTracker())(root)
     assert(rewritten.constDeclarations.isEmpty)
@@ -119,7 +119,7 @@ class TestConstAndDefRewriter extends AnyFunSuite with BeforeAndAfterEach {
       """.stripMargin
 
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(text))
+      sanyImporter.loadFromSource(Source.fromString(text)).get
     val root = modules(rootName)
     assertThrows[OverridingError](new ConstAndDefRewriter(new IdleTracker())(root))
   }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestTlcConfigImporter.scala
@@ -34,7 +34,7 @@ class TestTlcConfigImporter extends AnyFunSuite with BeforeAndAfterEach {
   def configureAndCompare(tla: String, tlc: String, expected: String): Assertion = {
     val config = TlcConfigParserApalache(tlc)
     val (rootName, modules) =
-      sanyImporter.loadFromSource(Source.fromString(tla))
+      sanyImporter.loadFromSource(Source.fromString(tla)).get
 
     val mod = modules(rootName)
     // run the type checker

--- a/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
+++ b/tla-types/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestTypeCheckerTool.scala
@@ -60,7 +60,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   test("the tool runs and reports no type errors") {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(loadSpecFromResource(megaSpec))
+      sanyImporter.loadFromSource(loadSpecFromResource(megaSpec)).get
 
     val mod = modules(rootName)
 
@@ -82,7 +82,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   test("the tool runs and tags all expressions") {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(loadSpecFromResource(megaSpec))
+      sanyImporter.loadFromSource(loadSpecFromResource(megaSpec)).get
 
     val mod = modules(rootName)
 
@@ -128,7 +128,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   private def typecheckSpecAndEncoding(specName: String): Unit = {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(loadSpecFromResource(specName))
+      sanyImporter.loadFromSource(loadSpecFromResource(specName)).get
 
     val mod = modules(rootName)
 
@@ -167,7 +167,7 @@ class TestTypeCheckerTool extends AnyFunSuite with BeforeAndAfterEach with EasyM
 
   private def typecheckSpec(specName: String): Unit = {
     val (rootName, modules) =
-      sanyImporter.loadFromSource(loadSpecFromResource(specName))
+      sanyImporter.loadFromSource(loadSpecFromResource(specName)).get
 
     val mod = modules(rootName)
 


### PR DESCRIPTION
Contributes to #2199

## Context

Our current practice in the parsing pass is to signal all errors via exceptions
that bubble up to the top, but the rest of the passes are able to return their
errors via the `PassResult`. Much (if not most) of the SANY code is already
hadnling errors through `Try`s or `Either`s, but we've thus far been casting
those into exceptions at the final mile.

This PR starts the process of converting the exception-based error handling into
ADT-based error handling in the parser pass ([as recommended in the Scala
docs](https://docs.scala-lang.org/overviews/scala-book/functional-error-handling.html)).

## Reviewing

Reviewing by commit should be helpful.

This initial, small PR is meant to illustrate how these conversions from
exceptional errors to `Try`/`Either` errors will look, and followups towards
#2199 will likely proceed in the same way but in larger batches. So please
consider the general shape of the change proposed here to see whether it make
sense, or whether you think an alternative approach would be preferable.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)