### PR TITLE
Shai: Return parsing pass error data in RPCs

### DIFF
--- a/.unreleased/breaking-changes/2199-parse-error-output.md
+++ b/.unreleased/breaking-changes/2199-parse-error-output.md
@@ -1,0 +1,6 @@
+The format of parsing error outputs has been changed. Parsing error messages
+that used to be prefixed with `Error by TLA+ parser` are now prefixed with
+`Parsing error` and error messages that used to begin with `Syntax error in
+annotation:` will now also include the `Parsing error` prefix. This is being
+recorded as a breaking change since it could break scripts that rely on parsing
+stdout. (See #2204 and #2242.)

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/imp/SanyParserPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/imp/SanyParserPassImpl.scala
@@ -20,6 +20,7 @@ import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
 import at.forsyte.apalache.tla.imp.SanyException
+import at.forsyte.apalache.io.annotations.AnnotationParserError
 
 /**
  * Parsing TLA+ code with SANY.
@@ -103,11 +104,14 @@ class SanyParserPassImpl @Inject() (
     try {
       parseSource(options.input.source)
     } catch {
-      case err: SanyException =>
-        val msg = err.getMessage()
-        logger.error(s"Parsing error: ${msg}")
-        passFailure(List(msg), ExitCodes.ERROR)
+      case err: SanyException         => reportErr(err.getMessage)
+      case err: AnnotationParserError => reportErr(s"Syntax error in annotation: ${err.getMessage()}")
     }
+  }
+
+  private def reportErr(msg: String): PassResult = {
+    logger.error(s"Parsing error: ${msg}")
+    passFailure(List(msg), ExitCodes.ERROR)
   }
 
   private def parseSource(src: SourceOption): PassResult = for {

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/imp/SanyParserPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/imp/SanyParserPassImpl.scala
@@ -103,7 +103,10 @@ class SanyParserPassImpl @Inject() (
     try {
       parseSource(options.input.source)
     } catch {
-      case err: SanyException => passFailure(List(err.getMessage()), ExitCodes.ERROR)
+      case err: SanyException =>
+        val msg = err.getMessage()
+        logger.error(s"Parsing error: ${msg}")
+        passFailure(List(msg), ExitCodes.ERROR)
     }
   }
 

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerAdapter.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerAdapter.scala
@@ -1,8 +1,6 @@
 package at.forsyte.apalache.tla.passes.typecheck
 
 import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, FailureMessage, NormalErrorMessage}
-import at.forsyte.apalache.io.annotations.AnnotationParserError
-import at.forsyte.apalache.tla.imp.SanyException
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.{OutdatedAnnotationsError, TypingException, UID}
@@ -20,12 +18,6 @@ import com.typesafe.scalalogging.LazyLogging
 class EtcTypeCheckerAdapter @Inject() (sourceStore: SourceStore, changeListener: ChangeListener)
     extends ExceptionAdapter with LazyLogging {
   override def toMessage: PartialFunction[Throwable, ErrorMessage] = super.toMessage.orElse {
-    case err: SanyException =>
-      NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
-
-    case err: AnnotationParserError =>
-      NormalErrorMessage("Syntax error in annotation: " + err.getMessage)
-
     case err: TypingInputException =>
       NormalErrorMessage("Typing input error: " + err.getMessage)
 

--- a/shai/src/main/protobuf/cmdExecutor.proto
+++ b/shai/src/main/protobuf/cmdExecutor.proto
@@ -36,11 +36,22 @@ enum Cmd {
   TYPECHECK = 3;
 }
 
+enum CmdErrorType {
+  PASS_FAILURE = 0;
+  UNEXPECTED = 1;
+}
+
+message CmdError {
+  CmdErrorType errorType = 1;
+  // A JSON encoded string with data useful for understanding the error
+  string data = 2;
+}
+
 message CmdResponse {
   oneof result {
     // A JSON encoded string with data useful on success
     string success = 1;
-    // A JSON encoded string with data useful on error
-    string failure = 2;
+    // Data about the kind of application error resulting from the RPC
+    CmdError failure = 2;
   }
 }

--- a/shai/src/main/protobuf/transExplorer.proto
+++ b/shai/src/main/protobuf/transExplorer.proto
@@ -39,11 +39,21 @@ message LoadModelRequest {
   repeated string aux = 3;
 }
 
+enum TransExplorerErrorType {
+  PASS_FAILURE = 0;
+  UNEXPECTED = 1;
+}
+
+message TransExplorerError {
+  TransExplorerErrorType errorType = 1;
+  string data = 2;
+}
+
 message LoadModelResponse {
   oneof result {
     // A JSON encoded string with the Apalache IR representation of the loaded spec
     string spec = 1;
     // A string describing the error, if parsing fails
-    string err = 2;
+    TransExplorerError err = 2;
   }
 }

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
@@ -9,7 +9,9 @@ import at.forsyte.apalache.infra.passes.options.OptionGroup
 import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor}
 import at.forsyte.apalache.io.ConfigManager
 import at.forsyte.apalache.io.json.impl.TlaToUJson
-import at.forsyte.apalache.shai.v1.cmdExecutor.{Cmd, CmdRequest, CmdResponse, PingRequest, PongResponse, ZioCmdExecutor}
+import at.forsyte.apalache.shai.v1.cmdExecutor.{
+  Cmd, CmdError, CmdErrorType, CmdRequest, CmdResponse, PingRequest, PongResponse, ZioCmdExecutor,
+}
 import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
 import at.forsyte.apalache.tla.passes.imp.ParserModule
 import at.forsyte.apalache.tla.passes.typecheck.TypeCheckerModule
@@ -33,11 +35,14 @@ class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEn
   /** Concurrent tasks performed by the service that produce values of type `T` */
   type Result[T] = ZIO[ZEnv, Status, T]
 
+  /** No-op RPC used to check the connection */
+  def ping(req: PingRequest): Result[PongResponse] = ZIO.succeed(PongResponse())
+
   def run(req: CmdRequest): Result[CmdResponse] = for {
     cmd <- validateCmd(req.cmd)
     resp <- executeCmd(cmd, req.config) match {
+      case Left(err) => ZIO.succeed(CmdResponse.Result.Failure(err))
       case Right(r)  => ZIO.succeed(CmdResponse.Result.Success(r.toString()))
-      case Left(err) => ZIO.succeed(CmdResponse.Result.Failure(err.toString()))
     }
   } yield CmdResponse(resp)
 
@@ -45,32 +50,36 @@ class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEn
   private object Converters {
     import ujson._
 
-    def passErr(err: Pass.PassFailure): ujson.Value = {
-      Obj("error_type" -> "pass_failure", "data" -> err)
+    def passErr(err: Pass.PassFailure): CmdError = {
+      CmdError(errorType = CmdErrorType.PASS_FAILURE, data = ujson.write(err))
     }
 
-    def throwableErr(err: Throwable): ujson.Value =
-      Obj("error_type" -> "unexpected",
-          "data" -> Obj("msg" -> err.getMessage(), "stack_trace" -> err.getStackTrace().map(_.toString()).toList))
+    def throwableErr(err: Throwable): CmdError = {
+      val errData = Obj("msg" -> err.getMessage(), "stack_trace" -> err.getStackTrace().map(_.toString()).toList)
+      CmdError(errorType = CmdErrorType.UNEXPECTED, data = ujson.write(errData))
+    }
 
-    def convErr[O](v: Try[O]): Either[ujson.Value, O] = v.toEither.left.map(throwableErr)
+    // When sequencing the setup and execution of commands, any `Failure(v : Throwable)` can be automatically converted into
+    // into a `CmdError` via `throwableErr`
+    implicit class TryCmdErr[O](v: Try[O]) {
+      def toCmdResult: Either[CmdError, O] = v.toEither.left.map(throwableErr)
+    }
   }
 
-  /** No-op RPC used to check the connection */
-  def ping(req: PingRequest): Result[PongResponse] = ZIO.succeed(PongResponse())
-
   import Converters._
-  private def executeCmd(cmd: Cmd, cfgStr: String): Either[ujson.Value, ujson.Value] = {
+  private def executeCmd(cmd: Cmd, cfgStr: String): Either[CmdError, ujson.Value] = {
 
     for {
-      cfg <- convErr(ConfigManager(cfgStr)).map(cfg => cfg.copy(common = cfg.common.copy(command = Some("server"))))
+      cfg <- ConfigManager(cfgStr).map { cfg =>
+        cfg.copy(common = cfg.common.copy(command = Some("server")))
+      }.toCmdResult
 
       toolModule <- {
         import OptionGroup._
         cmd match {
-          case Cmd.PARSE     => convErr(WithIO(cfg)).map(new ParserModule(_))
-          case Cmd.CHECK     => convErr(WithCheckerPreds(cfg)).map(new CheckerModule(_))
-          case Cmd.TYPECHECK => convErr(WithTypechecker(cfg)).map(new TypeCheckerModule(_))
+          case Cmd.PARSE     => WithIO(cfg).map(new ParserModule(_)).toCmdResult
+          case Cmd.CHECK     => WithCheckerPreds(cfg).map(new CheckerModule(_)).toCmdResult
+          case Cmd.TYPECHECK => WithTypechecker(cfg).map(new TypeCheckerModule(_)).toCmdResult
           case Cmd.Unrecognized(_) =>
             throw new IllegalArgumentException("programmer error: executeCmd applied before validateCmd")
         }

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/TransExplorerService.scala
@@ -13,7 +13,8 @@ package at.forsyte.apalache.shai.v1
  */
 
 import at.forsyte.apalache.shai.v1.transExplorer.{
-  ConnectRequest, Connection, LoadModelRequest, LoadModelResponse, PingRequest, PongResponse, ZioTransExplorer,
+  ConnectRequest, Connection, LoadModelRequest, LoadModelResponse, PingRequest, PongResponse, TransExplorerError,
+  TransExplorerErrorType, ZioTransExplorer,
 }
 import at.forsyte.apalache.infra.passes.options.SourceOption
 import at.forsyte.apalache.io.json.impl.TlaToUJson
@@ -159,31 +160,40 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], logger: Logger)
     }
   } yield LoadModelResponse(result)
 
-  private def parseSpec(spec: String, aux: Seq[String]): Result[Either[String, TlaModule]] = ZIO.effectTotal {
-    try {
-      // TODO: replace hard-coded options with options derived from CLI params
-      val options = {
-        import OptionGroup._
-        WithIO(
-            common = Common(
-                command = "server",
-                outDir = new java.io.File("."),
-                runDir = None,
-                debug = true,
-                smtprof = false,
-                writeIntermediate = false,
-                profiling = false,
-                features = Seq(),
-            ),
-            input = Input(SourceOption.StringSource(spec, aux)),
-            output = Output(Some(new java.io.File("."))),
-        )
+  private def parseSpec(spec: String, aux: Seq[String]): Result[Either[TransExplorerError, TlaModule]] =
+    ZIO.effectTotal {
+      try {
+        // TODO: replace hard-coded options with options derived from CLI params
+        val options = {
+          import OptionGroup._
+          WithIO(
+              common = Common(
+                  command = "server",
+                  outDir = new java.io.File("."),
+                  runDir = None,
+                  debug = true,
+                  smtprof = false,
+                  writeIntermediate = false,
+                  profiling = false,
+                  features = Seq(),
+              ),
+              input = Input(SourceOption.StringSource(spec, aux)),
+              output = Output(Some(new java.io.File("."))),
+          )
+        }
+        PassChainExecutor
+          .run(new ParserModule(options))
+          .left
+          .map { err =>
+            TransExplorerError(errorType = TransExplorerErrorType.PASS_FAILURE, data = ujson.write(err))
+          }
+      } catch {
+        case err: Throwable =>
+          val errData =
+            ujson.Obj("msg" -> err.getMessage(), "stack_trace" -> err.getStackTrace().map(_.toString()).toList)
+          Left(TransExplorerError(errorType = TransExplorerErrorType.UNEXPECTED, data = errData.toString()))
       }
-      PassChainExecutor.run(new ParserModule(options)).left.map(code => s"Parsing failed with error code: ${code}")
-    } catch {
-      case e: Throwable => Left(s"Parsing failed with exception: ${e.getMessage()}")
     }
-  }
 
   private def jsonOfModule(module: TlaModule): String = {
     new TlaToUJson(None).makeRoot(Seq(module)).toString

--- a/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestTransExplorerService.scala
+++ b/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestTransExplorerService.scala
@@ -31,8 +31,8 @@ object TransExplorerServiceSpec extends DefaultRunnableSpec {
           s <- ZIO.service[TransExplorerService]
           conn <- s.openConnection(ConnectRequest())
           resp <- s.loadModel(LoadModelRequest(Some(conn), spec))
-          msg = resp.result.err.get
-        } yield assert(msg)(containsString("Parsing failed with exception: Error by TLA+ parser"))
+          msg = ujson.read(resp.result.err.get.data)("error_data")(0).str
+        } yield assert(msg)(containsString("No module name found in source"))
       },
       testM("loading a valid spec returns parsed model") {
         val spec =

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -332,7 +332,7 @@ Check that we give an informative error if a user tries to invoke `parse` on a
 $ touch foo.itf.json
 $ apalache-mc parse foo.itf.json | sed -e 's/I@.*//' -e 's/E@.*//'
 ...
-Error by TLA+ parser: Parsing the ITF format is not supported
+Parsing error: Parsing the ITF format is not supported
 ...
 EXITCODE: ERROR (255)
 $ rm foo.itf.json

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/config/CheckerExceptionAdapter.scala
@@ -2,11 +2,9 @@ package at.forsyte.apalache.tla.bmcmt.config
 
 import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, FailureMessage, NormalErrorMessage}
 import at.forsyte.apalache.io.ConfigurationError
-import at.forsyte.apalache.io.annotations.AnnotationParserError
 import at.forsyte.apalache.io.json.JsonDeserializationError
 import at.forsyte.apalache.tla.assignments.AssignmentException
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.imp.SanyException
 import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.storage.{ChangeListener, SourceLocator}
 import at.forsyte.apalache.tla.lir.{
@@ -31,12 +29,6 @@ class CheckerExceptionAdapter @Inject() (sourceStore: SourceStore, changeListene
 
   override def toMessage: PartialFunction[Throwable, ErrorMessage] = super.toMessage.orElse {
     // normal errors
-    case err: SanyException =>
-      NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
-
-    case err: AnnotationParserError =>
-      NormalErrorMessage("Syntax error in annotation: " + err.getMessage)
-
     case err: ConfigurationError =>
       NormalErrorMessage("Configuration error (see the manual): " + err.getMessage)
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/ParserExceptionAdapter.scala
@@ -1,11 +1,12 @@
 package at.forsyte.apalache.tla.imp
 
-import at.forsyte.apalache.infra.{ErrorMessage, ExceptionAdapter, NormalErrorMessage}
-import at.forsyte.apalache.io.annotations.AnnotationParserError
+import at.forsyte.apalache.infra.ExceptionAdapter
 import com.typesafe.scalalogging.LazyLogging
 
 import javax.inject.{Inject, Singleton}
 
+// TODO: This can be removed in theory, but our current architecture requires executable passes
+// include a injectable instance of `ExceptionAdapater`
 /**
  * The adapter for all exceptions that can be produced when running the SANY parser and TlaImporter.
  *
@@ -13,12 +14,4 @@ import javax.inject.{Inject, Singleton}
  *   Igor Konnv
  */
 @Singleton
-class ParserExceptionAdapter @Inject() () extends ExceptionAdapter with LazyLogging {
-  override def toMessage: PartialFunction[Throwable, ErrorMessage] = super.toMessage.orElse {
-    case err: SanyException =>
-      NormalErrorMessage("Error by TLA+ parser: " + err.getMessage)
-
-    case err: AnnotationParserError =>
-      NormalErrorMessage("Syntax error in annotation: " + err.getMessage)
-  }
-}
+class ParserExceptionAdapter @Inject() () extends ExceptionAdapter with LazyLogging {}


### PR DESCRIPTION
Closes #2199, #2204

(See #2234 for additional notes on context and the motivation for this approach).

- Catches `SanyException`s from the highest level of the SANY parser
pass and makes these available in the `PassResult`.
- Promotes the general RPC error data into protbuf specs, allowing more
consistentcy and reducing the amount of dynamic JSON.
- Includes some light refactoring as incidental cleanup.
- Updates tests.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)