### PR TITLE
Fix untyped implementation for VariantFilter

### DIFF
--- a/src/tla/Variants.tla
+++ b/src/tla/Variants.tla
@@ -48,7 +48,7 @@ Variant(__tagName, __value) ==
  *)
 VariantFilter(__tagName, __S) ==
     \* default untyped implementation
-    { __d \in { __e \in __S: __e.tag = __tagName }: __d.value }
+    { __d.value : __d \in { __e \in __S: __e.tag = __tagName } }
 
 (**
  * Get the tag name that is associated with a variant.


### PR DESCRIPTION
Hello :octocat: 

I was just running TLC for a spec with variants and `VariantFilter` definition is broken, so this fixes it.

I don't think we are testing this untyped version, so I didn't change any tests. Let me know if I should.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [X] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
