### PR TITLE
Update/scalatest 3.2.14

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
     val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % Test
     val scalatestplusEasymock = "org.scalatestplus" %% "easymock-4-3" % s"${scalaTestVersion}.0" % Test
     val scalatestplusJunit = "org.scalatestplus" %% "junit-4-13" % s"${scalaTestVersion}.0" % Test
-    val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-15" % s"${scalaTestVersion}.0" % Test
+    val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-17" % s"${scalaTestVersion}.0" % Test
 
     val zioTest = "dev.zio" %% "zio-test" % zioVersion % Test
     val zioTestSbt = "dev.zio" %% "zio-test-sbt" % zioVersion % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
     val scalacheck = "org.scalacheck" %% "scalacheck" % "1.17.0" % Test
     val easymock = "org.easymock" % "easymock" % "5.0.0" % Test
 
-    val scalaTestVersion = "3.2.11"
+    val scalaTestVersion = "3.2.14"
     val scalatest = "org.scalatest" %% "scalatest" % scalaTestVersion % Test
     val scalatestplusEasymock = "org.scalatestplus" %% "easymock-4-3" % s"${scalaTestVersion}.0" % Test
     val scalatestplusJunit = "org.scalatestplus" %% "junit-4-13" % s"${scalaTestVersion}.0" % Test


### PR DESCRIPTION
Replaces #2219

This just adds a trivial tweak to the dependencies to enable the update to go thru.