### PR TITLE
Test roundtrip JSON serialization and deserialization

### DIFF
--- a/test/tla/MegaSpec1.tla
+++ b/test/tla/MegaSpec1.tla
@@ -6,8 +6,8 @@
 
 EXTENDS Integers, Sequences, FiniteSets, Reals, Apalache
 CONSTANTS
- \* @typeAlias: ELEM = Int;
- \* @type: ELEM;
+ \* @typeAlias: elem = Int;
+ \* @type: $elem;
  N
 
 ASSUME(N > 42)

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -323,7 +323,7 @@ $ cat output.json | head
 $ rm output.json
 ```
 
-### parse on an ITF file fail with an error
+### parse on an ITF file fails with an error
 
 Check that we give an informative error if a user tries to invoke `parse` on a
 `itf.json` file.
@@ -336,6 +336,22 @@ Parsing error: Parsing the ITF format is not supported
 ...
 EXITCODE: ERROR (255)
 $ rm foo.itf.json
+```
+
+### parsing and emitting JSON IR
+
+#### can check the spec from JSON produced by parsing the MegaSpec1.tla to JSON
+
+A round-trip test for our JSON serialization and deserialization.
+
+```sh
+$ apalache-mc typecheck --output=megaspec1.json MegaSpec1.tla
+...
+EXITCODE: OK
+$ apalache-mc check --length=0 --cinit=CInit megaspec1.json
+...
+EXITCODE: OK
+$ rm megaspec1.json
 ```
 
 ### typecheck --output=output.tla Annotations succeeds


### PR DESCRIPTION
Closes #2253

This just adds a simple round-trip test of our ability to parse a spec into type-preserving JSON representation of the IR and then check the the spec using that generated JSON as input.