### PR TITLE
Make the server port configurable

### DIFF
--- a/.unreleased/features/server-configure-port.md
+++ b/.unreleased/features/server-configure-port.md
@@ -1,0 +1,2 @@
+Server port is now configurable via the `--port` CLI argument or `server.port`
+configuration key (see #2264).

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
@@ -2,14 +2,30 @@ package at.forsyte.apalache.tla.tooling.opt
 
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.shai
+import org.backuity.clist._
+
+import at.forsyte.apalache.infra.passes.options.Config
+import at.forsyte.apalache.infra.passes.options.OptionGroup
 
 class ServerCmd
     extends ApalacheCommand(name = "server", description = "Run in server mode (in early development)")
     with LazyLogging {
 
+  var port = opt[Option[Int]](description = "the port served by the RPC server, default: 8822 (overrides envvar PORT)",
+      useEnv = true)
+
+  override def toConfig(): Config.ApalacheConfig = {
+    val cfg = super.toConfig()
+    cfg.copy(server = Config.Server(port))
+  }
+
   def run() = {
-    logger.info("Starting server...")
-    shai.v1.RpcServer.main(Array())
+    val cfg = configuration.get
+    val options = OptionGroup.WithServer(cfg).get
+
+    logger.info(s"Starting server on port ${options.server.port}...")
+    val server = shai.v1.RpcServer(options.server.port)
+    server.main(Array())
     Right("Server terminated")
   }
 }

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -11,11 +11,9 @@ import com.typesafe.scalalogging.LazyLogging
  *
  * We extend LazyLogging to give the server process access to the same logger configured for the rest of Apalache.
  */
-object RpcServer extends ServerMain with LazyLogging {
-  override def port: Int = 8822
-
+class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
   override def welcome: ZIO[ZEnv, Throwable, Unit] =
-    console.putStrLn("The Apalache server is running. Press Ctrl-C to stop.")
+    console.putStrLn(s"The Apalache server is running on port ${port}. Press Ctrl-C to stop.")
 
   val createTransExplorerService = for {
     // A thread safe mutable reference to the active connections
@@ -29,4 +27,10 @@ object RpcServer extends ServerMain with LazyLogging {
 
   def services: ServiceList[ZEnv] =
     ServiceList.addM(createTransExplorerService).addM(createCmdExecutorService)
+}
+
+object RpcServer {
+  val DEFAULT_PORT = 8822
+
+  def apply(port: Int = DEFAULT_PORT) = new RpcServer(port)
 }

--- a/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestCmdExecutorService.scala
+++ b/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestCmdExecutorService.scala
@@ -127,5 +127,5 @@ object TestCmdExecutorService extends DefaultRunnableSpec {
     // all tests as if they were against the same service this accurately
     // reflects our usage, since only one server instance will ever be running
     // in an Apalache process at a time
-    .provideSomeLayerShared[ZEnv](RpcServer.createCmdExecutorService.toLayer)
+    .provideSomeLayerShared[ZEnv](RpcServer().createCmdExecutorService.toLayer)
 }

--- a/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestTransExplorerService.scala
+++ b/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestTransExplorerService.scala
@@ -116,5 +116,5 @@ object TransExplorerServiceSpec extends DefaultRunnableSpec {
     // all tests as if they were against the same service this accurately
     // reflects our usage, since only one server instance will ever be running
     // in an Apalache process at a time
-    .provideSomeLayerShared[ZEnv](RpcServer.createTransExplorerService.toLayer)
+    .provideSomeLayerShared[ZEnv](RpcServer().createTransExplorerService.toLayer)
 }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3777,5 +3777,13 @@ up and output its welcome message, before killing it:
 ```sh
 $ apalache-mc server & pid=$! && sleep 3 && kill $pid
 ...
-The Apalache server is running. Press Ctrl-C to stop.
+The Apalache server is running on port 8822. Press Ctrl-C to stop.
+```
+
+### server mode: server can be started at different port
+
+```sh
+$ apalache-mc server --port=8888 & pid=$! && sleep 3 && kill $pid
+...
+The Apalache server is running on port 8888. Press Ctrl-C to stop.
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3693,6 +3693,9 @@ input {
     }
 }
 output {}
+server {
+    port=8822
+}
 tracee {}
 typechecker {
     inferpoly=true


### PR DESCRIPTION
- Adds `server` section to our configuration enabling configuration of
  server settings via config file.
- Adds a corresponding `Server` `OptionGroup` to validate config values.
- Adds a `port` CLI argument, to allow supplying the port at time of
  command invocation.
- Adds an `RpcServer` class so that the port can be configured when
  the class is instantiated.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change