### PR TITLE
ITF trace reader

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/tracee/tracee.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/tracee/tracee.scala
@@ -6,5 +6,5 @@ package at.forsyte.apalache.tla
  */
 package object tracee {
   type State = at.forsyte.apalache.io.lir.State
-  type Trace = IndexedSeq[State]
+  type Trace = at.forsyte.apalache.io.lir.Trace
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/itf/ItfToTla.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/itf/ItfToTla.scala
@@ -218,7 +218,7 @@ class ItfToTla[T <: JsonRepresentation](
       stateJson.allFieldsOpt match {
         case None => throw new JsonDeserializationError(s"Malformed JSON: Value at $STATES_FIELD is not an object.")
         case Some(varsInState) =>
-          val undeclared = varsInState -- varSet
+          val undeclared = (varsInState -- varSet) - META_FIELD // #meta is the only extra field allowed in states
           if (undeclared.nonEmpty)
             throw new JsonDeserializationError(
                 s"Undeclared variable(s) present in state: ${undeclared.mkString(", ")}.")

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/itf/ItfToTla.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/itf/ItfToTla.scala
@@ -1,0 +1,249 @@
+package at.forsyte.apalache.io.itf
+
+import at.forsyte.apalache.io.itf.ItfToTla._
+import at.forsyte.apalache.io.json.{JsonDeserializationError, JsonRepresentation, ScalaFactory}
+import at.forsyte.apalache.io.lir.Trace
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
+import at.forsyte.apalache.tla.types.parser.DefaultType1Parser
+import at.forsyte.apalache.tla.types.{tla, ModelValueHandler}
+
+/**
+ * Reads a sequence of States, i.e. mappings from variable names to TlaEx values, from an ITF json.
+ *
+ * @tparam T
+ *   Any class extending JsonRepresentation
+ * @author
+ *   Jure Kukovec
+ */
+class ItfToTla[T <: JsonRepresentation](
+    scalaFactory: ScalaFactory[T]) {
+
+  /**
+   * Checks that the Apalache-specific ITF requirements are met, as defined in ADR15. If yes, returns a mapping from
+   * variables to their types.
+   */
+  private[itf] def validateShapeAndGetTypes(json: T): Map[String, TlaType1] = {
+    val varTypesOpt = for {
+      meta <- json.getFieldOpt(META_FIELD)
+      varTypes <- meta.getFieldOpt(VAR_TYPES_FIELD)
+    } yield varTypes
+    val varTypesJson = varTypesOpt.getOrElse {
+      throw new JsonDeserializationError("ITF JSON does not satisfy Apalache requirements. " +
+        "Toplevel \"#meta\" field must exist and contain \"varTypes\". " +
+        "See ADR15: https://apalache.informal.systems/docs/adr/015adr-trace.html#itf-as-input-to-apalache. ")
+    }
+
+    val diffOpt = for {
+      vars <- json.getFieldOpt(VARS_FIELD)
+      varTypesKeys <- varTypesJson.allFieldsOpt
+    } yield {
+      val varsSet = scalaFactory.asSeq(vars).map { scalaFactory.asStr }.toSet
+      // Symmetric difference
+      (varsSet -- varTypesKeys) ++ (varTypesKeys -- varsSet)
+    }
+
+    val diff = diffOpt.getOrElse {
+      throw new JsonDeserializationError(s"\"$VARS_FIELD\" or \"$VAR_TYPES_FIELD\" contents are malformed.")
+    }
+    if (diff.nonEmpty)
+      throw new JsonDeserializationError(s"\"$VARS_FIELD\" and \"$VAR_TYPES_FIELD\" define different states. " +
+        s"Variable(s) ${diff.toSeq.mkString(", ")} present in exactly one of the two fields.")
+
+    varTypesJson.allFieldsOpt.get.map { k =>
+      k -> DefaultType1Parser.parseType(scalaFactory.asStr(varTypesJson.getFieldOpt(k).get))
+    }.toMap
+  }
+
+  /**
+   * Some values, like the predefined sets (Int, Nat, etc.) are encoded as "UNSERIALIZABLE_FIELD": `<value>` Currently,
+   * per our discussions, we disallow the use of this tag, but the function can be extended in the future.
+   *
+   * E.g. we could return Some(tla.intSet()) on str = "Int".
+   */
+  private[itf] def attemptUnserializable(json: T): Option[TBuilderInstruction] =
+    if (json.allFieldsOpt.contains(Set(UNSERIALIZABLE_FIELD))) {
+      val str = scalaFactory.asStr(json.getFieldOpt(UNSERIALIZABLE_FIELD).get)
+      throw new JsonDeserializationError(s"Unserializable value $str is disallowed.")
+    } else None
+
+  // Note: attemptUnserializable + getOrElse is future-proof, and allows us to eventually case-match
+  // unserializable values.
+
+  private[itf] def typeDrivenBuild(json: T, tt1: TlaType1): TBuilderInstruction =
+    attemptUnserializable(json).getOrElse {
+      tt1 match {
+        case BoolT1 =>
+          tla.bool(scalaFactory.asBool(json))
+        case StrT1 =>
+          val s = scalaFactory.asStr(json)
+          if (ModelValueHandler.isModelValue(s))
+            throw new JsonDeserializationError(
+                s"$s is annotated as a string, but has the value of an uninterpreted literal.")
+          tla.str(s)
+        case ct: ConstT1 =>
+          val raw = scalaFactory.asStr(json)
+          // ConstT1-type literals must adhere to the pattern regex
+          val typeIndexOpt = ModelValueHandler.typeAndIndex(raw)
+          val (constT, idx) = typeIndexOpt.getOrElse {
+            throw new JsonDeserializationError(s"$raw is annotated as an uninterpreted literal, but has string form.")
+          }
+          // The pattern-suffix must also match the declared type
+          if (ct != constT) {
+            throw new JsonDeserializationError(s"$raw is annotated as $ct but has a $constT value.")
+          }
+          tla.const(idx, constT)
+        case IntT1 =>
+          // Big integers are written as strings, not JS integers
+          if (json.allFieldsOpt.contains(Set(BIG_INT_FIELD))) {
+            val biString = scalaFactory.asStr(json.getFieldOpt(BIG_INT_FIELD).get)
+            tla.int(BigInt(biString))
+          } else tla.int(scalaFactory.asInt(json))
+
+        case SeqT1(elemT) =>
+          val elems = scalaFactory.asSeq(json)
+          val args = elems.map { typeDrivenBuild(_, elemT) }
+          // Empty collections have special builder ctors
+          if (args.isEmpty) tla.emptySeq(elemT)
+          else tla.seq(args: _*)
+
+        case RecT1(fieldTypes) =>
+          val keys = fieldTypes.keySet
+          val diffOpt = for {
+            fields <- json.allFieldsOpt
+          } yield (keys -- fields) ++ (fields -- keys) // symmetric difference
+
+          // The above is None, iff json is not an Object with fields
+          val diff = diffOpt.getOrElse {
+            throw new JsonDeserializationError(s"Record object contents are malformed.")
+          }
+
+          // The record type and value must declare the _same_ fields
+          if (diff.nonEmpty)
+            throw new JsonDeserializationError(
+                s"Record object and its type annotation $tt1 define different key sets. " +
+                  s"The keys ${diff.toSeq.mkString(", ")} are present in exactly one of the two.")
+
+          // TODO: We currently don't check the key shape against any sort of pattern.
+          // Technically, "_-?*+" is a valid record field, as far as this code is concerned.
+          // Do we want to restrict the permissible record field names, and if so, to what?
+
+          val recElems = json.allFieldsOpt.get.toSeq.map { k =>
+            k -> typeDrivenBuild(json.getFieldOpt(k).get, fieldTypes(k))
+          }
+
+          // Records must contain at least 1 kv pair
+          if (recElems.isEmpty) throw new JsonDeserializationError(s"Records may not be empty.")
+
+          tla.rec(recElems: _*)
+
+        case TupT1(elems @ _*) =>
+          if (!json.allFieldsOpt.contains(Set(TUP_FIELD)))
+            throw new JsonDeserializationError(s"Tuple-type annotated values must declare a \"$TUP_FIELD\" field.")
+          val tupSeq = scalaFactory.asSeq(json.getFieldOpt(TUP_FIELD).get)
+
+          // The declared tuple length must match the # of elements
+          val valLen = tupSeq.length
+          val typeLen = elems.length
+          if (valLen != typeLen)
+            throw new JsonDeserializationError(
+                s"Tuple value and type have $valLen and $typeLen elements respectively."
+            )
+
+          val args = tupSeq.zip(elems).map { case (elemJson, elemT) =>
+            typeDrivenBuild(elemJson, elemT)
+          }
+          tla.tuple(args: _*)
+
+        case SetT1(elemT) =>
+          if (!json.allFieldsOpt.contains(Set(SET_FIELD)))
+            throw new JsonDeserializationError(s"Set-type annotated values must declare a \"$SET_FIELD\" field.")
+          val setSeq = scalaFactory.asSeq(json.getFieldOpt(SET_FIELD).get)
+          val args = setSeq.map { elemJson =>
+            typeDrivenBuild(elemJson, elemT)
+          }
+          // Empty collections have special builder ctors
+          args match {
+            case Seq() => tla.emptySet(elemT)
+            case seq   => tla.enumSet(seq: _*)
+          }
+
+        case FunT1(argT, resT) =>
+          if (!json.allFieldsOpt.contains(Set(MAP_FIELD)))
+            throw new JsonDeserializationError(s"Function-type annotated values must declare a \"$MAP_FIELD\" field.")
+
+          val funSeq = scalaFactory.asSeq(json.getFieldOpt(MAP_FIELD).get)
+
+          // Since ITF functions are enumerated, we must construct a funAsSet, instead of a funDef.
+
+          val args = funSeq.map { pairArrayJson =>
+            val pairArray = scalaFactory.asSeq(pairArrayJson)
+            if (pairArray.length != 2)
+              throw new JsonDeserializationError(
+                  s"Function entries must be 2-element arrays. Found entry with ${pairArray.length} elements.")
+            val Seq(kJson, vJson) = pairArray
+            val k = typeDrivenBuild(kJson, argT)
+            val v = typeDrivenBuild(vJson, resT)
+            tla.tuple(k, v) // for funAsSet, we need a set of paris
+          }
+          // Empty collections have special builder ctors
+          val set =
+            if (args.isEmpty) tla.emptySet(TupT1(argT, resT))
+            else tla.enumSet(args: _*)
+
+          // TODO: Check if keys are duplicated or let SetAsFun rule catch that? Aternatively,
+          // treat it as double-except semantics
+
+          tla.setAsFun(set)
+
+        case _ =>
+          throw new JsonDeserializationError(s"Type $tt1 does not match any of the permitted ITF value types.")
+
+      }
+    }
+
+  def getTrace(json: T): Trace = {
+    val typesMap = validateShapeAndGetTypes(json)
+    val varSet = typesMap.keySet
+
+    val states =
+      json
+        .getFieldOpt(STATES_FIELD)
+        .map(jsonSeq => IndexedSeq.from(scalaFactory.asSeq(jsonSeq)))
+        .getOrElse {
+          throw new JsonDeserializationError(s"Malformed JSON: missing $STATES_FIELD field.")
+        }
+
+    states.map { stateJson =>
+      stateJson.allFieldsOpt match {
+        case None => throw new JsonDeserializationError(s"Malformed JSON: Value at $STATES_FIELD is not an object.")
+        case Some(varsInState) =>
+          val undeclared = varsInState -- varSet
+          if (undeclared.nonEmpty)
+            throw new JsonDeserializationError(
+                s"Undeclared variable(s) present in state: ${undeclared.mkString(", ")}.")
+          val missing = varSet -- varsInState
+          if (missing.nonEmpty)
+            throw new JsonDeserializationError(s"Variable(s) missing from state: ${missing.mkString(", ")}.")
+      }
+      // assume now the variables in the state are exactly the keys of typesMap
+      typesMap.map { case (varName, varT) =>
+        varName -> typeDrivenBuild(stateJson.getFieldOpt(varName).get, varT).build
+      }
+    }
+  }
+}
+
+object ItfToTla {
+
+  val META_FIELD: String = "#meta"
+  val VAR_TYPES_FIELD: String = "varTypes"
+  val VARS_FIELD: String = "vars"
+  val STATES_FIELD: String = "states"
+
+  val BIG_INT_FIELD: String = "#bigint"
+  val TUP_FIELD: String = "#tup"
+  val SET_FIELD: String = "#set"
+  val MAP_FIELD: String = "#map"
+  val UNSERIALIZABLE_FIELD: String = "#unserializable"
+}

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonRepresentation.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/JsonRepresentation.scala
@@ -11,6 +11,7 @@ trait JsonRepresentation {
 
   def toString: String
   def getFieldOpt(fieldName: String): Option[this.type]
+  def allFieldsOpt: Option[Set[String]]
 
   /** The value used to represent JSON */
   def value: Value

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/UJsonRep.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/UJsonRep.scala
@@ -19,4 +19,11 @@ sealed case class UJsonRep(val value: ujson.Value) extends JsonRepresentation {
     objAsMap <- value.objOpt
     fieldVal <- objAsMap.get(fieldName)
   } yield UJsonRep(fieldVal).asInstanceOf[UJsonRep.this.type]
+
+  override def allFieldsOpt: Option[Set[String]] =
+    value.objOpt.map {
+      // extra toSet because LinkedHashMap.keySet doesn't return the same set type as is required
+      _.keySet.toSet
+    }
+
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/package.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/package.scala
@@ -5,6 +5,7 @@ import at.forsyte.apalache.tla.lir.TlaEx
 package object lir {
   type NotInvariant = TlaEx
   type State = Map[String, TlaEx]
+  type Trace = IndexedSeq[State]
   type Transition = String
   type NextState = (Transition, State)
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/itf/TestItfToTla.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/itf/TestItfToTla.scala
@@ -1,0 +1,330 @@
+package at.forsyte.apalache.io.itf
+
+import at.forsyte.apalache.io.json.JsonDeserializationError
+import at.forsyte.apalache.io.json.impl.{UJsonRep, UJsonScalaFactory}
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.types.tla
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestItfToTla extends AnyFunSuite {
+
+  val itfToTla = new ItfToTla(UJsonScalaFactory)
+
+  import ujson._
+
+  test("validateShapeAndGetTypes") {
+
+    val empty = UJsonRep(Obj())
+    assertThrows[JsonDeserializationError] {
+      itfToTla.validateShapeAndGetTypes(empty)
+    }
+
+    val metaEmpty = UJsonRep(Obj(ItfToTla.META_FIELD -> Obj()))
+    assertThrows[JsonDeserializationError] {
+      itfToTla.validateShapeAndGetTypes(metaEmpty)
+    }
+
+    val noVars = UJsonRep(
+        Obj(
+            ItfToTla.META_FIELD ->
+              Obj(
+                  ItfToTla.VAR_TYPES_FIELD ->
+                    Obj(
+                        "x" -> "Int"
+                    )
+              ),
+            ItfToTla.VARS_FIELD ->
+              Arr(), // empty
+        )
+    )
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.validateShapeAndGetTypes(noVars)
+    }
+
+    val noTypes = UJsonRep(
+        Obj(
+            ItfToTla.META_FIELD ->
+              Obj(
+                  ItfToTla.VAR_TYPES_FIELD -> Obj() // empty
+              ),
+            ItfToTla.VARS_FIELD -> Arr("x"),
+        )
+    )
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.validateShapeAndGetTypes(noTypes)
+    }
+
+    val correct = UJsonRep(
+        Obj(
+            ItfToTla.META_FIELD ->
+              Obj(
+                  ItfToTla.VAR_TYPES_FIELD ->
+                    Obj(
+                        "x" -> "Int",
+                        "y" -> "Str -> Bool",
+                    )
+              ),
+            ItfToTla.VARS_FIELD -> Arr("x", "y"),
+        )
+    )
+
+    assert(
+        itfToTla.validateShapeAndGetTypes(correct) ==
+          Map(
+              "x" -> IntT1,
+              "y" -> FunT1(StrT1, BoolT1),
+          )
+    )
+
+  }
+
+  test("attemptUnserializable") {
+
+    val notUS = UJsonRep(Obj())
+
+    assert(itfToTla.attemptUnserializable(notUS).isEmpty)
+
+    def singleUS(v: String): UJsonRep = UJsonRep(
+        Obj(
+            ItfToTla.UNSERIALIZABLE_FIELD -> v
+        )
+    )
+
+    val bogusUS = singleUS("") // illegal identifier
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.attemptUnserializable(bogusUS)
+    }
+
+    val int = singleUS("Int")
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.attemptUnserializable(int)
+    }
+
+    val nat = singleUS("Nat")
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.attemptUnserializable(nat)
+    }
+  }
+
+  test("typeDrivenBuild") {
+
+    // case BoolT1 =>
+
+    val tru = UJsonRep(Bool(true))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(tru, IntT1)
+    }
+
+    assert(itfToTla.typeDrivenBuild(tru, BoolT1).build == tla.bool(true).build)
+
+    // case StrT1 =>
+
+    val cake = UJsonRep(Str("cake"))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(cake, IntT1)
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(cake, ConstT1("X"))
+    }
+
+    assert(itfToTla.typeDrivenBuild(cake, StrT1).build == tla.str("cake").build)
+
+    // case ct: ConstT1 =>
+
+    val oneOfA = UJsonRep(Str("1_OF_A"))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(oneOfA, StrT1)
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(oneOfA, ConstT1("B"))
+    }
+
+    assert(itfToTla.typeDrivenBuild(oneOfA, ConstT1("A")).build == tla.const("1", ConstT1("A")).build)
+
+    // case IntT1 =>
+
+    val one = UJsonRep(Num(1))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(one, StrT1)
+    }
+
+    assert(itfToTla.typeDrivenBuild(one, IntT1).build == tla.int(1).build)
+
+    val bigOne = UJsonRep(Obj(ItfToTla.BIG_INT_FIELD -> "1"))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(bigOne, StrT1)
+    }
+
+    assert(itfToTla.typeDrivenBuild(bigOne, IntT1).build == tla.int(1).build)
+
+    // case SeqT1(elemT) =>
+
+    val emptySeq = UJsonRep(Arr())
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(emptySeq, FunT1(IntT1, IntT1))
+    }
+
+    assert(itfToTla.typeDrivenBuild(emptySeq, SeqT1(IntT1)).build == tla.emptySeq(IntT1).build)
+    assert(itfToTla.typeDrivenBuild(emptySeq, SeqT1(StrT1)).build == tla.emptySeq(StrT1).build)
+
+    val tt = FunT1(RecT1("x" -> SetT1(BoolT1)), SeqT1(TupT1(ConstT1("X"))))
+    assert(itfToTla.typeDrivenBuild(emptySeq, SeqT1(tt)).build == tla.emptySeq(tt).build)
+
+    val oneTwoThree = UJsonRep(Arr(1, 2, 3))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(oneTwoThree, FunT1(IntT1, IntT1))
+    }
+
+    assert(itfToTla.typeDrivenBuild(oneTwoThree, SeqT1(IntT1)).build == tla
+      .seq(Seq[BigInt](1, 2, 3).map(tla.int): _*)
+      .build)
+
+    // case RecT1(fieldTypes) =>
+
+    val emptyRec = UJsonRep(Obj())
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(emptyRec, RecT1())
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(emptyRec, RecT1("x" -> IntT1))
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(emptyRec, SeqT1(IntT1))
+    }
+
+    val xyRec = UJsonRep(
+        Obj(
+            "x" -> 1,
+            "y" -> "abc",
+        )
+    )
+    val xyRecT = RecT1("x" -> IntT1, "y" -> StrT1)
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(xyRec, IntT1)
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(xyRec, RecT1())
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(xyRec, RecT1("x" -> IntT1, "y" -> StrT1, "z" -> IntT1))
+    }
+
+    assert(itfToTla.typeDrivenBuild(xyRec, xyRecT).build == tla
+      .rec(
+          "x" -> tla.int(1),
+          "y" -> tla.str("abc"),
+      )
+      .build)
+
+    // case TupT1(elems @ _*) =>
+
+    val tupOneA = UJsonRep(
+        Obj(
+            ItfToTla.TUP_FIELD ->
+              Arr(1, "A")
+        )
+    )
+
+    val tupT = TupT1(IntT1, StrT1)
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(one, tupT)
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(tupOneA, SetT1(IntT1))
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(tupOneA, TupT1())
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(tupOneA, TupT1(IntT1, StrT1, BoolT1))
+    }
+
+    assert(itfToTla.typeDrivenBuild(tupOneA, tupT).build == tla.tuple(tla.int(1), tla.str("A")).build)
+
+    // case SetT1(elemT) =>
+
+    val emptySet = UJsonRep(Obj(ItfToTla.SET_FIELD -> Arr()))
+
+    val setT = SetT1(BoolT1)
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(one, setT)
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(emptySet, IntT1)
+    }
+
+    assert(itfToTla.typeDrivenBuild(emptySet, setT).build == tla.emptySet(setT.elem).build)
+
+    val boolSet = UJsonRep(Obj(ItfToTla.SET_FIELD -> Arr(true, false)))
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(boolSet, SetT1(IntT1))
+    }
+
+    assert(itfToTla.typeDrivenBuild(boolSet, setT).build == tla.enumSet(tla.bool(true), tla.bool(false)).build)
+
+    // case FunT1(argT, resT) =>
+
+    val emptyFun = UJsonRep(Obj(ItfToTla.MAP_FIELD -> Arr()))
+
+    val funT = FunT1(IntT1, IntT1)
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(one, funT)
+    }
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(emptyFun, IntT1)
+    }
+
+    assert(itfToTla.typeDrivenBuild(emptyFun, funT).build == tla
+      .setAsFun(tla.emptySet(TupT1(funT.arg, funT.res)))
+      .build)
+
+    val id12 = UJsonRep(
+        Obj(ItfToTla.MAP_FIELD ->
+          Arr(Arr(1, 1), Arr(2, 2)))
+    )
+
+    assertThrows[JsonDeserializationError] {
+      itfToTla.typeDrivenBuild(id12, FunT1(IntT1, StrT1))
+    }
+
+    assert(itfToTla.typeDrivenBuild(id12, funT).build == tla
+      .setAsFun(tla.enumSet(
+              Seq(1, 2).map { i => tla.tuple(tla.int(i), tla.int(i)) }: _*
+          ))
+      .build)
+
+  }
+
+}


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

Closes #2272

Adds support for reading in ITF-format traces (as defined by the latest update to ADR15: #2267). 
Followup: Use the reader to support ITF input to `tracee --trace`.

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
