### PR TITLE
Fix unhandled exception on invalid file formats

### DIFF
--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
@@ -310,15 +310,16 @@ object SourceOption {
       FilenameUtils.isExtension(FilenameUtils.removeExtension(fname), "itf")
 
     /** Create a FileSource from a file, deriving the format from the file's extension */
-    def apply(file: java.io.File): FileSource = {
+    def apply(file: java.io.File): Try[FileSource] = {
       val fname = file.getName()
-      val format = FilenameUtils.getExtension(fname) match {
-        case "tla"                               => Format.Tla
-        case "json" if hasItfSubExtension(fname) => Format.Itf
-        case "json"                              => Format.Json
-        case unknown                             => throw new PassOptionException(s"Unsupported file format ${unknown}")
-      }
-      new FileSource(file, format)
+      for {
+        format <- FilenameUtils.getExtension(fname) match {
+          case "tla"                               => Success(Format.Tla)
+          case "json" if hasItfSubExtension(fname) => Success(Format.Itf)
+          case "json"                              => Success(Format.Json)
+          case unknown => Failure(new PassOptionException(s"Unsupported file format ${unknown}"))
+        }
+      } yield new FileSource(file, format)
     }
   }
 

--- a/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestOptions.scala
+++ b/mod-infra/src/test/scala/at/forsyte/apalache/infra/passes/TestOptions.scala
@@ -3,17 +3,18 @@ package at.forsyte.apalache.infra.passes.options
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
+import scala.util.Success
 
 @RunWith(classOf[JUnitRunner])
 class TestOptions extends AnyFunSuite {
   test("Can construct SourceOption.FileSource for ITF files") {
     import SourceOption._
-    assert(FileSource(new java.io.File("foo.itf.json")).format == Format.Itf)
+    assert(FileSource(new java.io.File("foo.itf.json")).map(_.format) == Success(Format.Itf))
   }
 
   test("Non-ITF JSON files are not recognized as ITF format") {
     import SourceOption._
 
-    assert(FileSource(new java.io.File("foo.json")).format == Format.Json)
+    assert(FileSource(new java.io.File("foo.json")).map(_.format) == Success(Format.Json))
   }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/AbstractCheckerCmd.scala
@@ -6,6 +6,7 @@ import java.io.File
 import com.typesafe.scalalogging.LazyLogging
 import at.forsyte.apalache.infra.passes.options.Config
 import at.forsyte.apalache.infra.passes.options.SourceOption
+import scala.util.Try
 
 // Holds the minimal necessary info about a specification.
 abstract class AbstractCheckerCmd(val name: String, description: String)
@@ -30,19 +31,20 @@ abstract class AbstractCheckerCmd(val name: String, description: String)
   var length: Option[Int] =
     opt[Option[Int]](name = "length", default = None, description = "maximal number of Next steps, default: 10")
 
-  override def toConfig(): Config.ApalacheConfig = {
-    val cfg = super.toConfig()
-    cfg.copy(
-        input = cfg.input.copy(source = Some(SourceOption.FileSource(file))),
-        checker = cfg.checker.copy(
-            config = config,
-            cinit = cinit,
-            init = init,
-            next = next,
-            inv = inv,
-            temporalProps = temporal,
-            length = length,
-        ),
-    )
-  }
+  override def toConfig(): Try[Config.ApalacheConfig] = for {
+    cfg <- super.toConfig()
+    fileSource <- SourceOption.FileSource(file)
+  } yield cfg.copy(
+      input = cfg.input.copy(source = Some(fileSource)),
+      checker = cfg.checker.copy(
+          config = config,
+          cinit = cinit,
+          init = init,
+          next = next,
+          inv = inv,
+          temporalProps = temporal,
+          length = length,
+      ),
+  )
+
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ApalacheCommand.scala
@@ -54,7 +54,7 @@ abstract class ApalacheCommand(name: String, description: String)
    * Any configuration values that determine program behavior outside of the class implementing the command line praser
    * instance should be communicated through the derived `ApalacheConfig`.
    */
-  def toConfig(): Config.ApalacheConfig = {
+  def toConfig(): Try[Config.ApalacheConfig] = {
     logger.info("Loading configuration")
 
     // We start with an *empty* base config, so that any values which are *not*
@@ -63,17 +63,17 @@ abstract class ApalacheCommand(name: String, description: String)
     // still letting other config values that are not overriden to propagate
     // through.
     val cfg = Config.ApalacheConfig().empty
-    cfg.copy(common = cfg.common.copy(
-        command = Some(name),
-        configFile = configFile,
-        debug = debug,
-        smtprof = smtprof,
-        profiling = profiling,
-        outDir = outDir,
-        runDir = runDir,
-        writeIntermediate = writeIntermediate,
-        features = features,
-    ))
+    Try(cfg.copy(common = cfg.common.copy(
+            command = Some(name),
+            configFile = configFile,
+            debug = debug,
+            smtprof = smtprof,
+            profiling = profiling,
+            outDir = outDir,
+            runDir = runDir,
+            writeIntermediate = writeIntermediate,
+            features = features,
+        )))
   }
 
   /**
@@ -173,6 +173,6 @@ abstract class ApalacheCommand(name: String, description: String)
 
     // Load configuration and merge in cli config
     // This must be invoked after we parse the CLI args
-    _configure = ConfigManager(this.toConfig())
+    _configure = this.toConfig().flatMap(ConfigManager(_))
   }
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ParseCmd.scala
@@ -21,11 +21,10 @@ class ParseCmd
   var output: Option[File] = opt[Option[File]](name = "output",
       description = "file to which the parsed source is written (.tla or .json), default: None")
 
-  override def toConfig() = {
-    val cfg = super.toConfig()
-    cfg.copy(input = cfg.input.copy(source = Some(SourceOption.FileSource(file))),
-        output = cfg.output.copy(output = output))
-  }
+  override def toConfig() = for {
+    cfg <- super.toConfig()
+    input <- SourceOption.FileSource(file).map(src => cfg.input.copy(source = Some(src)))
+  } yield cfg.copy(input = input, output = cfg.output.copy(output = output))
 
   def run() = {
     val cfg = configuration.get

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
@@ -14,9 +14,10 @@ class ServerCmd
   var port = opt[Option[Int]](description = "the port served by the RPC server, default: 8822 (overrides envvar PORT)",
       useEnv = true)
 
-  override def toConfig(): Config.ApalacheConfig = {
-    val cfg = super.toConfig()
-    cfg.copy(server = Config.Server(port))
+  override def toConfig() = {
+    super.toConfig().map { cfg =>
+      cfg.copy(server = Config.Server(port))
+    }
   }
 
   def run() = {

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/SimulateCmd.scala
@@ -9,11 +9,14 @@ class SimulateCmd extends CheckCmd(name = "simulate", "Symbolically simulate a T
           "do not stop after a first simulation run, but produce up to a given number of runs (unless reached --max-error), default: 100",
         default = 100)
 
-  override def collectTuningOptions(): Map[String, String] = {
-    super.collectTuningOptions() ++ Map(
+  override def toConfig() = {
+    val newTuningOptions = Map(
         "search.simulation" -> "true",
         "search.simulation.maxRun" -> maxRun.toString,
     )
+    for {
+      cfg <- super.toConfig()
+      tuning = cfg.checker.tuning.map(m => m ++ newTuningOptions)
+    } yield cfg.copy(checker = cfg.checker.copy(tuning = tuning))
   }
-
 }

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/TranspileCmd.scala
@@ -3,15 +3,12 @@ package at.forsyte.apalache.tla.tooling.opt
 import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.tla.bmcmt.config.ReTLAToVMTModule
 import at.forsyte.apalache.tla.bmcmt.rules.vmt.TlaExToVMTWriter
-import at.forsyte.apalache.infra.passes.options.Config
 import at.forsyte.apalache.infra.passes.options.OptionGroup
 import at.forsyte.apalache.infra.passes.PassChainExecutor
 
 class TranspileCmd extends AbstractCheckerCmd(name = "transpile", description = "Transpile and quit") {
 
-  override def toConfig(): Config.ApalacheConfig = {
-    val cfg = super.toConfig()
-
+  override def toConfig() = super.toConfig().map { cfg =>
     cfg.copy(typechecker = cfg.typechecker.copy(inferpoly = Some(true)))
   }
 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -177,6 +177,23 @@ Cannot find source file for module
 EXITCODE: ERROR (255)
 ```
 
+## error handling for invalid file formats
+
+Ensure we give a proper user error if invalid file format extension is given in
+input. See https://github.com/informalsystems/apalache/issues/2175 .
+
+```sh
+$ for cmd in check parse typecheck transpile; do apalache-mc $cmd f.badext 2>&1 | grep -o -e "EXITCODE: ERROR (255)" -e "Configuration error: Unsupported file format badext"; done
+Configuration error: Unsupported file format badext
+EXITCODE: ERROR (255)
+Configuration error: Unsupported file format badext
+EXITCODE: ERROR (255)
+Configuration error: Unsupported file format badext
+EXITCODE: ERROR (255)
+Configuration error: Unsupported file format badext
+EXITCODE: ERROR (255)
+```
+
 ## running the parse command
 
 This command parses a TLA+ specification with the SANY parser.


### PR DESCRIPTION
Closes #2175

This fixes the processing of CLI configuration params to avoid unhandled
exceptions. The solution is to be honest about the possible failure of
the the `toConfig` method, which maps CLI param inputs to an
instance of `Options.ApalacheConfig`: Since this conversion can fail, 
we let it return a `Try` and this fix ensures that error is handled 
correctly.

Along the way, it removes the atavistic `collectTuningOptions` method,
which shouldn't be needed with the new config management scheme. This
also enables a slight cleanup on the Tracee command.
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change