### PR TITLE
Fix snippet in `docs/apalache/parameters.md`

### DIFF
--- a/docs/src/apalache/parameters.md
+++ b/docs/src/apalache/parameters.md
@@ -12,7 +12,7 @@ expression of TLA+. For instance, below is the example
 which instantiates `y2k.tla`:
 
 ```tla
-{{#include ../../../test/tla/y2k_instance.tla::11}}
+{{#include ../../../test/tla/y2k_instance.tla::15}}
 ```
 
 The downside of this approach is that you have to declare the variables of the


### PR DESCRIPTION
The module actually goes until line 15: https://github.com/informalsystems/apalache/blob/0795560e3382fc22b5b5ecabc02346bd5b2849d8/test/tla/y2k_instance.tla#L1-L15

Btw, at a quick glance it doesn't appear that the contributing guidelines mention anything about PRs for docs.