### PR TITLE
Fix failing nix setup in integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,12 +152,9 @@ jobs:
             ${{ runner.os }}-nix-
             ${{ runner.os }}-
       - name: Install Nix
-        uses: cachix/install-nix-action@v14.1
+        uses: cachix/install-nix-action@v18
         with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: "--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve"
           extra_nix_config: |
-            experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build dev-shell
         run: nix develop -c bash -c exit
@@ -184,12 +181,9 @@ jobs:
             ${{ runner.os }}-nix-
             ${{ runner.os }}-
       - name: Install Nix
-        uses: cachix/install-nix-action@v14
+        uses: cachix/install-nix-action@v18
         with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: "--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve"
           extra_nix_config: |
-            experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build dev-shell
         run: nix develop -c bash -c exit


### PR DESCRIPTION
Our nix installation in the CI was failing, presumably due to updates in the underlying runners that conflicted with the quite outdated version of the github action we were using to install nix. This PR just updates the nix action, which also allows us drop some of the configuration, since flakes is now supported without requiring a special URL.

Closes #2318 

:warning: Auto merge enabled