### PR TITLE
 ElemPtr rework, pahse 3: Removing `SmtConstElemPtr`s in CherryPick(Set)

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/ElemPtr.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/ElemPtr.scala
@@ -30,7 +30,8 @@ sealed trait ElemPtr {
 
   /**
    * Collection transformations evaluate membership based on original membership _and_ additional restrictions (e.g.
-   * filter).
+   * filter). `ptr.restrict(x)` returns `ptr2`, such that `ptr2.toSmt` is logically equivalent (but not necessarily
+   * syntactically equal) to `tla.and(ptr.toSmt, x)`, while `ptr.elem = ptr2.elem`.
    */
   def restrict(cond: TBuilderInstruction): SmtExprElemPtr
 }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/ElemPtr.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/ElemPtr.scala
@@ -27,6 +27,12 @@ sealed trait ElemPtr {
    * guarantees of e.g. FixedElemPtr.
    */
   def generalize: SmtExprElemPtr = SmtExprElemPtr(elem, toSmt)
+
+  /**
+   * Collection transformations evaluate membership based on original membership _and_ additional restrictions (e.g.
+   * filter).
+   */
+  def restrict(cond: TBuilderInstruction): SmtExprElemPtr
 }
 
 /**
@@ -38,6 +44,8 @@ sealed trait ElemPtr {
  */
 case class FixedElemPtr(elem: ArenaCell) extends ElemPtr {
   override def toSmt: TBuilderInstruction = tla.bool(true)
+
+  override def restrict(cond: TBuilderInstruction): SmtExprElemPtr = SmtExprElemPtr(elem, cond)
 }
 
 /**
@@ -61,6 +69,9 @@ case class SmtConstElemPtr(elem: ArenaCell) extends ElemPtr {
   val uniqueName = s"_bool_elem$id"
 
   override def toSmt: TBuilderInstruction = tla.name(uniqueName, BoolT1)
+
+  // soon-to-be deleted anyway
+  override def restrict(cond: TBuilderInstruction): SmtExprElemPtr = SmtExprElemPtr(elem, tla.bool(false))
 
 }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
@@ -11,14 +11,19 @@ import at.forsyte.apalache.tla.types.tla
  */
 object PtrUtil {
 
+  /**
+   * Maps each cell, which appears in some set, to all of the pointers pointing to it. Simpler version of
+   * `getCellAndPointingSetMaps`, when pointing sets aren't needed.
+   */
   def getCellMap(ptrs: Seq[ElemPtr]): Map[ArenaCell, Seq[ElemPtr]] =
     ptrs.foldLeft(Map.empty[ArenaCell, Seq[ElemPtr]]) { case (m, ptr) =>
       val elem = ptr.elem
       m + (elem -> (m.getOrElse(elem, Seq.empty) :+ ptr))
     }
 
-  // Maps each cell, which appears in some set, to all of the pointers pointing to it, and
-  // all the sets containing it
+  /**
+   * Maps each cell, which appears in some set, to all of the pointers pointing to it, and all the sets containing it.
+   */
   def getCellAndPointingSetMaps(
       elemsOfSets: Seq[(ArenaCell, Seq[ElemPtr])]): (Map[ArenaCell, Seq[ElemPtr]], Map[ArenaCell, Set[ArenaCell]]) =
     elemsOfSets.foldLeft(Map.empty[ArenaCell, Seq[ElemPtr]], Map.empty[ArenaCell, Set[ArenaCell]]) {
@@ -46,6 +51,11 @@ object PtrUtil {
         if (ptrs.exists { _.isInstanceOf[FixedElemPtr] }) FixedElemPtr(cell)
         else SmtExprElemPtr(cell, tla.or(ptrs.map(_.toSmt): _*))
     }
+  }
+
+  // Sequentially combines getCellMap and mergePtrs
+  def mergePtrsByCellMap(ptrs: Seq[ElemPtr]): Seq[ElemPtr] = getCellMap(ptrs).toSeq.map { case (cell, ps) =>
+    mergePtrs(cell, ps)
   }
 
   def samePointer(original: ElemPtr): ArenaCell => ElemPtr = original match {

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
@@ -11,6 +11,12 @@ import at.forsyte.apalache.tla.types.tla
  */
 object PtrUtil {
 
+  def getCellMap(ptrs: Seq[ElemPtr]): Map[ArenaCell, Seq[ElemPtr]] =
+    ptrs.foldLeft(Map.empty[ArenaCell, Seq[ElemPtr]]) { case (m, ptr) =>
+      val elem = ptr.elem
+      m + (elem -> (m.getOrElse(elem, Seq.empty) :+ ptr))
+    }
+
   // Maps each cell, which appears in some set, to all of the pointers pointing to it, and
   // all the sets containing it
   def getCellAndPointingSetMaps(

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
@@ -118,12 +118,7 @@ class DomainRule(rewriter: SymbStateRewriter, intRangeCache: IntRangeCache) exte
     }
 
     // We merge multiple pointers to the same cell into a single pointer per cell
-    val mergedCellPtrs = PtrUtil
-      .getCellMap(domCellPtrs)
-      .toSeq
-      .map { case (cell, ptrs) =>
-        PtrUtil.mergePtrs(cell, ptrs)
-      }
+    val mergedCellPtrs = PtrUtil.mergePtrsByCellMap(domCellPtrs)
 
     // construct a map from cell ids to lists of pairs
     type KeyToPairs = Map[Int, Set[ArenaCell]]

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/DomainRule.scala
@@ -75,7 +75,7 @@ class DomainRule(rewriter: SymbStateRewriter, intRangeCache: IntRangeCache) exte
     val staticPtrs = arena.getHasPtr(staticDom)
     // the element is in range, if indexBase0 < len
     val actualPtrs = staticPtrs.zipWithIndex.map { case (p, indexBase0) =>
-      p.generalize.restrict(tla.lt(tla.int(indexBase0), len.toBuilder))
+      p.restrict(tla.lt(tla.int(indexBase0), len.toBuilder))
     }
 
     arena = arena.appendHas(dom, actualPtrs: _*)
@@ -118,11 +118,8 @@ class DomainRule(rewriter: SymbStateRewriter, intRangeCache: IntRangeCache) exte
     }
 
     // We merge multiple pointers to the same cell into a single pointer per cell
-    val mergedCellPtrs = domCellPtrs
-      .foldLeft(Map.empty[ArenaCell, Seq[ElemPtr]]) { case (partialCellMap, ptr) =>
-        val elem = ptr.elem
-        partialCellMap + (elem -> (partialCellMap.getOrElse(elem, Seq.empty) :+ ptr))
-      }
+    val mergedCellPtrs = PtrUtil
+      .getCellMap(domCellPtrs)
       .toSeq
       .map { case (cell, ptrs) =>
         PtrUtil.mergePtrs(cell, ptrs)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -38,14 +38,8 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val rightElems = rightPtrs.map(_.elem).toSet
         val common = leftElems.intersect(rightElems)
 
-        // We map each cell, which appears in either the left or the right set, to all (1 or 2) of the pointers
-        // pointing to it.
-        val cellMap = PtrUtil.getCellMap(leftPtrs ++ rightPtrs)
-
         // Fixed pointers dominate, if no pointer is fixed we take the disjunction of the smt constraints
-        val unionElemPtrs: Seq[ElemPtr] = cellMap.toSeq.map { case (cell, ptrs) =>
-          PtrUtil.mergePtrs(cell, ptrs)
-        }
+        val unionElemPtrs: Seq[ElemPtr] = PtrUtil.mergePtrsByCellMap(leftPtrs ++ rightPtrs)
 
         rewriter.solverContext.config.smtEncoding match {
           case SMTEncoding.Arrays =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetCupRule.scala
@@ -40,10 +40,7 @@ class SetCupRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
         // We map each cell, which appears in either the left or the right set, to all (1 or 2) of the pointers
         // pointing to it.
-        val cellMap = (leftPtrs ++ rightPtrs).foldLeft(Map.empty[ArenaCell, Seq[ElemPtr]]) { case (m, ptr) =>
-          val elem = ptr.elem
-          m + (elem -> (m.getOrElse(elem, Seq.empty) :+ ptr))
-        }
+        val cellMap = PtrUtil.getCellMap(leftPtrs ++ rightPtrs)
 
         // Fixed pointers dominate, if no pointer is fixed we take the disjunction of the smt constraints
         val unionElemPtrs: Seq[ElemPtr] = cellMap.toSeq.map { case (cell, ptrs) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetFilterRule.scala
@@ -51,7 +51,7 @@ class SetFilterRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val computedPreds: Seq[TlaEx] = potentialCells.map(eachElem)
         // At this point, we force all pointers to SmtExprElemPtr
         val filteredCellsAndPreds = potentialCells.zip(computedPreds).map { case (ptr, pred) =>
-          (ptr.generalize.restrict(tla.unchecked(pred)), pred)
+          (ptr.restrict(tla.unchecked(pred)), pred)
         }
 
         // get the result type from the type finder

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -597,7 +597,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
       pickSetNonEmpty(cellType, state, oracle, memberSets, elseAssert, noSmt)
   }
 
-  // Alternative method, with no interleaving. Unused at the moment, awaiting performance testing.
+  // Alternative method, with no interleaving. Unused at the moment, awaiting performance testing (#2415)
   private def pickSetNonEmptyPtr(
       cellType: SetT1,
       state: SymbState,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -680,7 +680,8 @@ class CherryPick(rewriter: SymbStateRewriter) {
 
     val maxLen = elemsOfMemberSets.map(_.size).reduce((i, j) => if (i > j) i else j)
     assert(maxLen != 0)
-    // existence is guaranteed by maxLen, but since we use it to pad, we set all pointers to False
+    // Existence is guaranteed by maxLen.
+    // Since maxPadded is used below to pad empty sets' has-pointers, we set all pointers to false.
     val maxPadded = elemsOfMemberSets.find(_.size == maxLen).get.map { p => SmtExprElemPtr(p.elem, tla.bool(false)) }
 
     // pad a non-empty sequence to the given length, keep the empty sequence intact

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -9,6 +9,7 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
 import at.forsyte.apalache.tla.types._
 
+import scala.annotation.unused
 import scala.collection.immutable.SortedMap
 
 /**
@@ -598,6 +599,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
   }
 
   // Alternative method, with no interleaving. Unused at the moment, awaiting performance testing (#2415)
+  @unused
   private def pickSetNonEmptyPtr(
       cellType: SetT1,
       state: SymbState,


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Also contains minor tweaks to `PtrUtil` and an unused method, which handles set-cherrypick in a different way. Currently, due to a lack of understanding of how it impacts performance, the method is not called, but we should revisit it in the future (#2415). 