### PR TITLE
 ElemPtr rework, pahse 3: Removing SmtConstElemPtrs in `gen-` methods and function-cherrypick

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/TupleOrSeqCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/TupleOrSeqCtorRule.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.arena.SmtConstElemPtr
+import at.forsyte.apalache.tla.bmcmt.arena.FixedElemPtr
 import at.forsyte.apalache.tla.bmcmt.rules.aux.ProtoSeqOps
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
@@ -53,7 +53,7 @@ class TupleOrSeqCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
     val tuple = arena.topCell
 
     // connect the cells to the tuple (or a sequence): the order of edges is important!
-    arena = arena.appendHasNoSmt(tuple, cells.map(SmtConstElemPtr): _*)
+    arena = arena.appendHasNoSmt(tuple, cells.map(FixedElemPtr): _*)
     state.setArena(arena).setRex(tuple.toNameEx)
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.arena.{PureArenaAdapter, SmtConstElemPtr}
+import at.forsyte.apalache.tla.bmcmt.arena.{FixedElemPtr, PureArenaAdapter}
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir._
 
@@ -44,7 +44,7 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
         val tuple = newArena.topCell
         newArena = argTypes.foldLeft(newArena) { (arena, argT) =>
           val (nextArena, valueCell) = makeUpValue(arena, argT)
-          nextArena.appendHasNoSmt(tuple, SmtConstElemPtr(valueCell)) // made-up cell = ConstElemPtr
+          nextArena.appendHasNoSmt(tuple, FixedElemPtr(valueCell))
         }
         (newArena, tuple)
 
@@ -53,7 +53,7 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
         val recCell = newArena.topCell
         newArena = recT.fieldTypes.values.foldLeft(newArena) { (arena, v) =>
           val (nextArena, valueCell) = makeUpValue(arena, v)
-          nextArena.appendHasNoSmt(recCell, SmtConstElemPtr(valueCell)) // made-up cell = ConstElemPtr
+          nextArena.appendHasNoSmt(recCell, FixedElemPtr(valueCell))
         }
         // create the domain and attach it to the record
         val pairOfSets = (recT.fieldTypes.keySet, SortedSet[String]())
@@ -67,7 +67,7 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
         val recCell = newArena.topCell
         newArena = fieldTypes.values.foldLeft(newArena) { (arena, v) =>
           val (nextArena, valueCell) = makeUpValue(arena, v)
-          nextArena.appendHasNoSmt(recCell, SmtConstElemPtr(valueCell)) // made-up cell = ConstElemPtr
+          nextArena.appendHasNoSmt(recCell, FixedElemPtr(valueCell))
         }
         (newArena, recCell)
 
@@ -104,7 +104,7 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
         nextArena = nextArena.appendCell(variantT)
         val variantCell = nextArena.topCell
         for (fieldCell <- (variantValues + (RecordAndVariantOps.variantTagField -> tagAsCell)).valuesIterator) {
-          nextArena = nextArena.appendHasNoSmt(variantCell, SmtConstElemPtr(fieldCell)) // made-up cell = ConstElemPtr
+          nextArena = nextArena.appendHasNoSmt(variantCell, FixedElemPtr(fieldCell))
         }
 
         (nextArena, variantCell)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ProtoSeqOps.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ProtoSeqOps.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
-import at.forsyte.apalache.tla.bmcmt.arena.{FixedElemPtr, PureArenaAdapter, SmtConstElemPtr}
+import at.forsyte.apalache.tla.bmcmt.arena.{FixedElemPtr, PureArenaAdapter}
 import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, UnknownT}
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir._
@@ -59,10 +59,7 @@ class ProtoSeqOps(rewriter: SymbStateRewriter) {
 
     // attach the cells to the proto sequence, do not track this in SMT
     nextState = nextState
-      .updateArena(_.appendHasNoSmt(protoSeq,
-              ArraySeq.unsafeWrapArray(cellsAsArray).map {
-                SmtConstElemPtr // @Igor: Should we use Expr pointers here?
-              }: _*))
+      .updateArena(_.appendHasNoSmt(protoSeq, ArraySeq.unsafeWrapArray(cellsAsArray).map { FixedElemPtr }: _*))
     nextState.setRex(protoSeq.toBuilder)
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ValueGenerator.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.arena.SmtConstElemPtr
+import at.forsyte.apalache.tla.bmcmt.arena.FixedElemPtr
 import at.forsyte.apalache.tla.bmcmt.rules.aux.AuxOps.constrainRelationArgs
 import at.forsyte.apalache.tla.bmcmt.types.{CellT, CellTFrom}
 import at.forsyte.apalache.tla.lir.TypedPredefs._
@@ -87,7 +87,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
           nextState = gen(nextState, elemType)
           nextState.asCell
         }
-        .map { SmtConstElemPtr }
+        .map { FixedElemPtr }
     nextState = nextState.updateArena(a => a.appendHasNoSmt(recCell, elemCells: _*))
     nextState.setRex(recCell.toNameEx.withTag(Typed(recordType)))
   }
@@ -104,7 +104,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
           nextState = gen(nextState, elemType)
           nextState.asCell
         }
-        .map { SmtConstElemPtr }
+        .map { FixedElemPtr }
     nextState = nextState.updateArena(a => a.appendHasNoSmt(recCell, elemCells: _*))
     nextState.setRex(recCell.toNameEx.withTag(Typed(CellTFrom(recordT))))
   }
@@ -130,7 +130,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
     val variantCell = nextState.arena.topCell
     // add the fields in the order of their names
     for (fieldCell <- variantFields.valuesIterator) {
-      nextState = nextState.updateArena(_.appendHasNoSmt(variantCell, SmtConstElemPtr(fieldCell)))
+      nextState = nextState.updateArena(_.appendHasNoSmt(variantCell, FixedElemPtr(fieldCell)))
     }
 
     nextState.setRex(variantCell.toNameEx)
@@ -146,7 +146,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
           nextState = gen(nextState, elemType)
           nextState.asCell
         }
-        .map { SmtConstElemPtr }
+        .map { FixedElemPtr }
     nextState = nextState.updateArena(a => a.appendHasNoSmt(tupleCell, elemCells: _*))
     nextState.setRex(tupleCell.toNameEx.withTag(Typed(tupleType)))
   }
@@ -161,7 +161,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
     val setType = CellT.fromType1(SetT1(elemType))
     nextState = nextState.updateArena(a => a.appendCellOld(setType))
     val setCell = nextState.arena.topCell
-    nextState = nextState.updateArena(a => a.appendHas(setCell, elems.map { SmtConstElemPtr }: _*))
+    nextState = nextState.updateArena(a => a.appendHas(setCell, elems.map { FixedElemPtr }: _*))
     // In the arrays encoding, set membership constraints are not generated in appendHas, so we add them below
     if (rewriter.solverContext.config.smtEncoding == SMTEncoding.Arrays) {
       for (elem <- elems) {
@@ -216,7 +216,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
         // create a relation cell
         nextState = nextState.updateArena(_.appendCellNoSmt(CellTFrom(SetT1(TupT1(funType.arg, funType.res)))))
         val relationCell = nextState.arena.topCell
-        nextState = nextState.updateArena(_.appendHasNoSmt(relationCell, pairs.map { SmtConstElemPtr }: _*))
+        nextState = nextState.updateArena(_.appendHasNoSmt(relationCell, pairs.map { FixedElemPtr }: _*))
         nextState = nextState.updateArena(_.setCdm(funCell, relationCell))
 
         val domainCells = pairs.map(pair => nextState.arena.getHas(pair)(0))
@@ -224,7 +224,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
 
         nextState = nextState.updateArena(_.appendCell(SetT1(funType.arg)))
         val domainCell = nextState.arena.topCell
-        nextState = nextState.updateArena(_.appendHas(domainCell, domainCells.map { SmtConstElemPtr }: _*))
+        nextState = nextState.updateArena(_.appendHas(domainCell, domainCells.map { FixedElemPtr }: _*))
         // In the arrays encoding, set membership constraints are not generated in appendHas, so we add them below
         for (domainElem <- domainCells) {
           // TODO: when #1916 is closed, remove tlaLegacy and use tla directly
@@ -256,7 +256,7 @@ class ValueGenerator(rewriter: SymbStateRewriter, bound: Int) {
         val relationCell = nextState.arena.topCell
         // we just add the pairs, but do not restrict their membership, as the generator is free to produce a set
         // that is an arbitrary subset of the pairs
-        nextState = nextState.updateArena(_.appendHas(relationCell, pairs.map { SmtConstElemPtr }: _*))
+        nextState = nextState.updateArena(_.appendHas(relationCell, pairs.map { FixedElemPtr }: _*))
 
         nextState = nextState.updateArena(_.setCdm(funCell, relationCell))
         // Require that if two arguments belong to the domain, they are distinct.


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Miscellaneous instances of `SmtConstElemPtr` replaced with the other kinds. For the most part, any value produced by `gen-` methods should just use fixed pointers, no point in having overapproximation in generated values.

After both this and #2416 get merged we can remove that pointer sort entirely.