### PR TITLE
Adds pointer caching

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
@@ -18,6 +18,9 @@ object PtrUtil {
 
   object Heuristics {
 
+    // for debugging; using this is equivalent to disabling caching
+    def alwaysFalse: CachingHeuristic = _ => false
+
     def notAName: CachingHeuristic = {
       case _: NameEx => false
       case _         => true

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PtrUtil.scala
@@ -1,6 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt.arena
 
 import at.forsyte.apalache.tla.bmcmt.ArenaCell
+import at.forsyte.apalache.tla.lir.oper.TlaBoolOper
+import at.forsyte.apalache.tla.lir.{NameEx, OperEx, TlaEx}
+import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
 import at.forsyte.apalache.tla.types.tla
 
 /**
@@ -10,6 +13,35 @@ import at.forsyte.apalache.tla.types.tla
  *   Jure Kukovec
  */
 object PtrUtil {
+
+  type CachingHeuristic = TlaEx => Boolean
+
+  object Heuristics {
+
+    def notAName: CachingHeuristic = {
+      case _: NameEx => false
+      case _         => true
+    }
+
+    def notConjunctionOfNames: CachingHeuristic = {
+      case _: NameEx                          => false
+      case OperEx(TlaBoolOper.and, args @ _*) => args.exists(notConjunctionOfNames)
+      case _                                  => true
+    }
+
+  }
+
+  // When creating SmtExprElemPtr from other ElemPtrs, their `smtExpr` expressions have varying complexity
+  // Should these expressions grow too complex, we replace the pointer with an equivalent one, where the complex expression
+  // is substituted with a single boolean variable, and push an assertion to the solver. This allows us to
+  // use the newly introduced variable in future edges, without copying the entire complex expression.
+  def cacheIfExprTooComplex(
+      heuristic: CachingHeuristic
+    )(ptr: ElemPtr): Option[TBuilderInstruction => (ElemPtr, TBuilderInstruction)] = ptr match {
+    case SmtExprElemPtr(elem, smtEx) if heuristic(smtEx) =>
+      Some({ predName => (SmtExprElemPtr(elem, predName), tla.eql(predName, smtEx)) })
+    case _ => None
+  }
 
   /**
    * Maps each cell, which appears in some set, to all of the pointers pointing to it. Simpler version of

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PureArenaAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PureArenaAdapter.scala
@@ -175,7 +175,7 @@ case class PureArenaAdapter(arena: PureArena, context: SolverContext) {
         case Some(cacheGen) =>
           val aWithCacheCell = a.appendCell(BoolT1)
           val (cachedPtr, constraints) = cacheGen(aWithCacheCell.topCell.toBuilder)
-          context.assertGroundExpr(constraints)
+          aWithCacheCell.context.assertGroundExpr(constraints)
           (aWithCacheCell, cachedPtr)
         case _ => (a, ptr)
       }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PureArenaAdapter.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/arena/PureArenaAdapter.scala
@@ -163,15 +163,25 @@ case class PureArenaAdapter(arena: PureArena, context: SolverContext) {
    *
    * @param parentCell
    *   the cell that points to the children cells
-   * @param childrenCells
+   * @param childrenPtrs
    *   the cells that are pointed by the parent cell
    * @return
    *   the updated arena
    */
-  def appendHas(parentCell: ArenaCell, childrenCells: ElemPtr*): PureArenaAdapter =
-    childrenCells.foldLeft(this) { (a, c) =>
-      a.appendOneHasEdge(addInPred = true, parentCell, c)
+  def appendHas(parentCell: ArenaCell, childrenPtrs: ElemPtr*): PureArenaAdapter = {
+    childrenPtrs.foldLeft(this) { (a, ptr) =>
+      // Cache any pointers, the expressions of which are too complex
+      val (newArena, newPtr) = PtrUtil.cacheIfExprTooComplex(PtrUtil.Heuristics.notConjunctionOfNames)(ptr) match {
+        case Some(cacheGen) =>
+          val aWithCacheCell = a.appendCell(BoolT1)
+          val (cachedPtr, constraints) = cacheGen(aWithCacheCell.topCell.toBuilder)
+          context.assertGroundExpr(constraints)
+          (aWithCacheCell, cachedPtr)
+        case _ => (a, ptr)
+      }
+      newArena.appendOneHasEdge(addInPred = true, parentCell, newPtr)
     }
+  }
 
   /**
    * Append 'has' edges that connect the first cell to the other cells, in the given order. The previously added edges

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -651,7 +651,7 @@ class CherryPick(rewriter: SymbStateRewriter) {
       val toPickFrom = paddedOfMemberSets.map { _(i).elem }
       nextState = pickByOracle(nextState, oracle, toPickFrom, elseAssert)
       val picked = nextState.asCell
-      val membershipEx = tla.storeInSet(picked.toBuilder, resultCell.toBuilder)
+      val membershipEx = tla.selectInSet(picked.toBuilder, resultCell.toBuilder)
 
       // this property is enforced by the oracle magic: chosen = 1 => z_i = c_i /\ chosen = 2 => z_i = d_i
 
@@ -660,7 +660,8 @@ class CherryPick(rewriter: SymbStateRewriter) {
       // (chosen = 1 /\ in(z_i, R) <=> in(c_i, S_1)) \/ (chosen = 2 /\ in(z_i, R) <=> in(d_i, S_2)) \/ (chosen = N <=> elseAssert)
       def nthIn(elemAndSet: (ArenaCell, ArenaCell), no: Int): (TBuilderInstruction, TBuilderInstruction) = {
         if (elemsOfMemberSets(no).nonEmpty) {
-          val inSet = tla.ite(tla.selectInSet(elemAndSet._1.toBuilder, elemAndSet._2.toBuilder), membershipEx,
+          val inSet = tla.ite(tla.selectInSet(elemAndSet._1.toBuilder, elemAndSet._2.toBuilder),
+              tla.storeInSet(picked.toBuilder, resultCell.toBuilder),
               tla.storeNotInSet(picked.toBuilder, resultCell.toBuilder))
           val unchangedSet = rewriter.solverContext.config.smtEncoding match {
             case SMTEncoding.Arrays =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -230,7 +230,6 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext with LazyL
     inCache.get((setId, elemId)) match {
       case None =>
         addInToCache(name, setId, elemId)
-
       case Some((const, _)) =>
         const
     }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -201,7 +201,7 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext with LazyL
     _metrics = _metrics.addNCells(1)
   }
 
-  def addInToCache(name: String, setId: Int, elemId: Int): ExprSort = {
+  private def addInToCache(name: String, setId: Int, elemId: Int): ExprSort = {
     smtListener.onIntroSmtConst(name)
     log(s";; declare edge predicate $name: Bool")
     log(s"(declare-const $name Bool)")


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

In addition to adding automatic caching to `ElemPtr`s in `PtrUtil`, this PR also changes the way `Z3SolverContext` handles `in`-relation cells. Previously, attempting to assert and expression containing an `in_X_Y` pointer name would throw, unless `declareInPredIfNeeded` was called at some point in the past. This seems completely pointless and unnecessary, so `getInPred` now just calls `declareInPredIfNeeded` if it doesn't already have the expression cached, instead of throwing.
