### PR TITLE
Fix source position handling

### DIFF
--- a/.unreleased/bug-fixes/2430-long-lines.md
+++ b/.unreleased/bug-fixes/2430-long-lines.md
@@ -1,0 +1,1 @@
+Fix parsing of lines longer than 999 characters, see #2430

--- a/test/tla/Bug2429.tla
+++ b/test/tla/Bug2429.tla
@@ -1,0 +1,30 @@
+-------------------------------- MODULE Bug2429 --------------------------------
+VARIABLES
+\* @type: Int;
+x
+
+My_very_and_unnecessarily_long_operator_name_0 == x' = 0
+My_very_and_unnecessarily_long_operator_name_1 == x' = 1
+My_very_and_unnecessarily_long_operator_name_2 == x' = 2
+My_very_and_unnecessarily_long_operator_name_3 == x' = 3
+My_very_and_unnecessarily_long_operator_name_4 == x' = 4
+My_very_and_unnecessarily_long_operator_name_5 == x' = 5
+My_very_and_unnecessarily_long_operator_name_6 == x' = 6
+My_very_and_unnecessarily_long_operator_name_7 == x' = 7
+My_very_and_unnecessarily_long_operator_name_8 == x' = 8
+My_very_and_unnecessarily_long_operator_name_9 == x' = 9
+My_very_and_unnecessarily_long_operator_name_10 == x' = 10
+My_very_and_unnecessarily_long_operator_name_11 == x' = 11
+My_very_and_unnecessarily_long_operator_name_12 == x' = 12
+My_very_and_unnecessarily_long_operator_name_13 == x' = 13
+My_very_and_unnecessarily_long_operator_name_14 == x' = 14
+My_very_and_unnecessarily_long_operator_name_15 == x' = 15
+My_very_and_unnecessarily_long_operator_name_16 == x' = 16
+My_very_and_unnecessarily_long_operator_name_17 == x' = 17
+My_very_and_unnecessarily_long_operator_name_18 == x' = 18
+My_very_and_unnecessarily_long_operator_name_19 == x' = 19
+
+Next == My_very_and_unnecessarily_long_operator_name_0 \/ My_very_and_unnecessarily_long_operator_name_1 \/ My_very_and_unnecessarily_long_operator_name_2 \/ My_very_and_unnecessarily_long_operator_name_3 \/ My_very_and_unnecessarily_long_operator_name_4 \/ My_very_and_unnecessarily_long_operator_name_5 \/ My_very_and_unnecessarily_long_operator_name_6 \/ My_very_and_unnecessarily_long_operator_name_7 \/ My_very_and_unnecessarily_long_operator_name_8 \/ My_very_and_unnecessarily_long_operator_name_9 \/ My_very_and_unnecessarily_long_operator_name_10 \/ My_very_and_unnecessarily_long_operator_name_11 \/ My_very_and_unnecessarily_long_operator_name_12 \/ My_very_and_unnecessarily_long_operator_name_13 \/ My_very_and_unnecessarily_long_operator_name_14 \/ My_very_and_unnecessarily_long_operator_name_15 \/ My_very_and_unnecessarily_long_operator_name_16 \/ My_very_and_unnecessarily_long_operator_name_17 \/ My_very_and_unnecessarily_long_operator_name_18 \/ My_very_and_unnecessarily_long_operator_name_19
+Init == x = 0
+
+=============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -296,6 +296,17 @@ EXITCODE: OK
 ...
 ```
 
+### parse Bug2429 succeeds
+
+Long lines caused an issue with Apalache's source position handling (see #2429).
+
+```sh
+$ apalache-mc parse Bug2429.tla | sed 's/W@.*//'
+...
+EXITCODE: OK
+...
+```
+
 ### parse --output=annotations.tla Annotations succeeds
 
 And also check that it actually parses into TLA (see #1079)

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSourceLocator.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSourceLocator.scala
@@ -117,8 +117,8 @@ class TestSourceLocator extends AnyFunSuite {
     new SourceLocation(
         "filename",
         new SourceRegion(
-            new SourcePosition(uid.id.toInt),
-            new SourcePosition(uid.id.toInt),
+            new SourcePosition(uid.id.toInt / 1000, uid.id.toInt % 1000),
+            new SourcePosition(uid.id.toInt / 1000, uid.id.toInt % 1000),
         ),
     )
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/RegionTree.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/RegionTree.scala
@@ -11,7 +11,7 @@ package at.forsyte.apalache.tla.lir.src
 class RegionTree {
   private class Node(val index: Int, val region: SourceRegion, val children: Seq[Node])
 
-  private val rootRegion = SourceRegion(SourcePosition(0), SourcePosition(Int.MaxValue))
+  private val rootRegion = SourceRegion(SourcePosition(0, 0), SourcePosition(Int.MaxValue, Int.MaxValue))
   private var root: Node = new Node(0, rootRegion, Seq())
   private var regions: Seq[SourceRegion] = Seq(rootRegion)
 

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourcePosition.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourcePosition.scala
@@ -1,5 +1,7 @@
 package at.forsyte.apalache.tla.lir.src
 
+import scala.math.Ordering._
+
 /**
  * Represent a position in a text file as a `(line, column)` tuple.
  */
@@ -17,10 +19,8 @@ class SourcePosition(val line: Int, val column: Int) extends Ordered[SourcePosit
     line * 31 + column
   }
 
-  override def compare(that: SourcePosition): Int = this.line - that.line match {
-    case 0    => this.column - that.column
-    case diff => diff
-  }
+  override def compare(that: SourcePosition): Int =
+    Tuple2[Int, Int].compare((this.line, this.column), (that.line, that.column))
 }
 
 object SourcePosition {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourcePosition.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourcePosition.scala
@@ -1,53 +1,30 @@
 package at.forsyte.apalache.tla.lir.src
 
 /**
- * An object of this class represents a position in a text file. Instead of the standard representation of a position as
- * a (line, column), we keep it as line * MAX_WIDTH + column, where MAX_WIDTH is the length of the longest possible
- * line. Whenever a longer column value is given, it is truncated.
+ * Represent a position in a text file as a `(line, column)` tuple.
  */
-class SourcePosition(val offset: Int) {
-
-  /**
-   * Get the line number of the position, starting with 1.
-   * @return
-   *   the line number
-   */
-  def line: Int = 1 + offset / SourcePosition.MAX_WIDTH
-
-  /** Get the column, starting with 1 and up to SourcePosition.MAX_WIDTH */
-  def column: Int = 1 + offset % SourcePosition.MAX_WIDTH
-
+class SourcePosition(val line: Int, val column: Int) extends Ordered[SourcePosition] {
   override def toString: String = s"${line}:${column}"
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[SourcePosition]
 
   override def equals(other: Any): Boolean = other match {
-    case that: SourcePosition =>
-      (that.canEqual(this)) &&
-      offset == that.offset
-    case _ => false
+    case that: SourcePosition => that.canEqual(this) && this.line == that.line && this.column == that.column
+    case _                    => false
   }
 
   override def hashCode(): Int = {
-    val state = Seq(offset)
-    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+    line * 31 + column
+  }
+
+  override def compare(that: SourcePosition): Int = this.line - that.line match {
+    case 0    => this.column - that.column
+    case diff => diff
   }
 }
 
 object SourcePosition {
-
-  /**
-   * The maximal length of a text line. We can safely assume that human-produced code does not have lines longer than
-   * that. If you generate you code, think of introducing line breaks.
-   */
-  val MAX_WIDTH = 1000
-
-  def apply(offset: Int): SourcePosition = {
-    new SourcePosition(offset)
-  }
-
   def apply(line: Int, column: Int): SourcePosition = {
-    val truncatedColumn = if (column <= MAX_WIDTH + 1) column - 1 else MAX_WIDTH
-    new SourcePosition((line - 1) * MAX_WIDTH + truncatedColumn)
+    new SourcePosition(line, column)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourceRegion.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/src/SourceRegion.scala
@@ -1,20 +1,18 @@
 package at.forsyte.apalache.tla.lir.src
 
 /**
- * This class captures a region in a text file. Instead of the standard representation of a position as a (line,
- * column), we keep it as line * MAX_WIDTH + column, where MAX_WIDTH is the length of the longest possible line.
- * Whenever a longer column value is given, it is truncated.
+ * This class captures a region in a text file.
  *
  * @param start
  *   the starting position
  * @param end
  *   the ending position, inclusive
  * @author
- *   Igor Konnov
+ *   Igor Konnov, Thomas Pani
  */
 class SourceRegion(val start: SourcePosition, val end: SourcePosition) {
   def isInside(larger: SourceRegion): Boolean = {
-    start.offset >= larger.start.offset && end.offset <= larger.end.offset
+    start >= larger.start && end <= larger.end
   }
 
   def contains(smaller: SourceRegion): Boolean = {
@@ -22,8 +20,8 @@ class SourceRegion(val start: SourcePosition, val end: SourcePosition) {
   }
 
   def isIntersecting(another: SourceRegion): Boolean = {
-    val maxStart = Math.max(start.offset, another.start.offset)
-    val minEnd = Math.min(end.offset, another.end.offset)
+    val maxStart = Seq(start, another.start).max
+    val minEnd = Seq(end, another.end).min
     maxStart <= minEnd
   }
 
@@ -33,9 +31,9 @@ class SourceRegion(val start: SourcePosition, val end: SourcePosition) {
 
   override def equals(other: Any): Boolean = other match {
     case that: SourceRegion =>
-      (that.canEqual(this)) &&
-      start == that.start &&
-      end == that.end
+      that.canEqual(this) &&
+      start.equals(that.start) &&
+      end.equals(that.end)
     case _ => false
   }
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourcePosition.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourcePosition.scala
@@ -1,0 +1,52 @@
+package at.forsyte.apalache.tla.lir
+
+import at.forsyte.apalache.tla.lir.src.SourcePosition
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestSourcePosition extends AnyFunSuite {
+  val pos0 = SourcePosition(0, 0)
+  val pos1 = SourcePosition(15, 20)
+  val pos2 = SourcePosition(15, 20)
+  val pos3 = SourcePosition(15, 55)
+  val pos4 = SourcePosition(19, 5)
+  val pos5 = SourcePosition(19, 20)
+  val pos6 = SourcePosition(5454, 4646)
+
+  test("toString") {
+    assert(pos0.toString == "0:0")
+    assert(pos1.toString == "15:20")
+    assert(pos2.toString == "15:20")
+    assert(pos3.toString == "15:55")
+    assert(pos4.toString == "19:5")
+    assert(pos5.toString == "19:20")
+    assert(pos6.toString == "5454:4646")
+  }
+
+  test("equals") {
+    // equal line and column
+    assert(pos1 == pos2)
+    assert(pos2 == pos1)
+
+    // different line and column
+    assert(pos0 != pos1)
+    assert(pos0 != pos2)
+    assert(pos0 != pos3)
+    assert(pos0 != pos4)
+    assert(pos0 != pos5)
+    assert(pos0 != pos6)
+
+    // different line, same column
+    assert(pos1 != pos5)
+
+    // same line, different column
+    assert(pos2 != pos3)
+  }
+
+  test("equals have same hashCode") {
+    assert(pos1.hashCode() == pos2.hashCode())
+    assert(pos6.hashCode() == SourcePosition(5454, 4646).hashCode())
+  }
+}

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourcePosition.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourcePosition.scala
@@ -49,4 +49,11 @@ class TestSourcePosition extends AnyFunSuite {
     assert(pos1.hashCode() == pos2.hashCode())
     assert(pos6.hashCode() == SourcePosition(5454, 4646).hashCode())
   }
+
+  test("compare") {
+    Seq(pos1, pos2, pos3, pos4, pos5, pos6).foreach(p => assert(p > pos0))
+    assert(pos1.compare(pos2) == 0)
+    Seq(pos0, pos1, pos2, pos3, pos4, pos5).foreach(p => assert(p < pos6))
+    assert(pos2.compare(pos3) < 0)
+  }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceRegion.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceRegion.scala
@@ -48,6 +48,13 @@ class TestSourceRegion extends AnyFunSuite {
     assert(r24.hashCode() == SourceRegion(pos2, pos4).hashCode())
   }
 
+  test("compare") {
+    Seq(pos1, pos2, pos3, pos4, pos5, pos6).foreach(p => assert(p > pos0))
+    assert(pos1.compare(pos2) == 0)
+    Seq(pos0, pos1, pos2, pos3, pos4, pos5).foreach(p => assert(p < pos6))
+    assert(pos2.compare(pos3) < 0)
+  }
+
   test("isInside") {
     assert(r15.isInside(root))
     assert(r16.isInside(root))

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceRegion.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestSourceRegion.scala
@@ -1,0 +1,108 @@
+package at.forsyte.apalache.tla.lir
+
+import at.forsyte.apalache.tla.lir.src.{SourcePosition, SourceRegion}
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestSourceRegion extends AnyFunSuite {
+  val pos0 = SourcePosition(0, 0)
+  val pos1 = SourcePosition(15, 20)
+  val pos2 = SourcePosition(15, 20)
+  val pos3 = SourcePosition(15, 55)
+  val pos4 = SourcePosition(19, 5)
+  val pos5 = SourcePosition(19, 20)
+  val pos6 = SourcePosition(5454, 4646)
+
+  val root = SourceRegion(pos0, pos6)
+  val r15 = SourceRegion(pos1, pos5)
+  val r16 = SourceRegion(pos1, pos6)
+  val r24 = SourceRegion(pos2, pos4)
+  val r04 = SourceRegion(pos0, pos4)
+  val r01 = SourceRegion(pos0, pos1)
+  val r56 = SourceRegion(pos5, pos6)
+
+  test("toString") {
+    assert(root.toString == "0:0-5454:4646")
+    assert(r15.toString == "15:20-19:20")
+    assert(r24.toString == "15:20-19:5")
+    assert(r04.toString == "0:0-19:5")
+  }
+
+  test("equals") {
+    assert(root == SourceRegion(0, 0, 5454, 4646))
+    assert(root == SourceRegion(pos0, pos6))
+
+    assert(root != r15)
+    assert(root != r24)
+    assert(root != r04)
+    assert(r15 != r24)
+    assert(r15 != r04)
+    assert(r24 != r04)
+  }
+
+  test("equals have same hashCode") {
+    assert(root.hashCode() == SourceRegion(0, 0, 5454, 4646).hashCode())
+    assert(root.hashCode() == SourceRegion(pos0, pos6).hashCode())
+    assert(r24.hashCode() == SourceRegion(pos2, pos4).hashCode())
+  }
+
+  test("isInside") {
+    assert(r15.isInside(root))
+    assert(r16.isInside(root))
+    assert(r24.isInside(root))
+    assert(r04.isInside(root))
+
+    assert(!root.isInside(r15))
+    assert(!root.isInside(r16))
+    assert(!root.isInside(r24))
+    assert(!root.isInside(r04))
+
+    assert(r15.isInside(r16))
+    assert(r24.isInside(r16))
+  }
+
+  test("contains") {
+    assert(root.contains(r15))
+    assert(root.contains(r16))
+    assert(root.contains(r24))
+    assert(root.contains(r04))
+
+    assert(!r15.contains(root))
+    assert(!r16.contains(root))
+    assert(!r24.contains(root))
+    assert(!r04.contains(root))
+
+    assert(!r15.contains(r16))
+    assert(!r24.contains(r16))
+  }
+
+  test("isIntersecting") {
+    // inclusion
+    assert(root.isIntersecting(r15))
+    assert(root.isIntersecting(r16))
+    assert(root.isIntersecting(r24))
+    assert(root.isIntersecting(r04))
+
+    // membership
+    assert(r15.isIntersecting(root))
+    assert(r16.isIntersecting(root))
+    assert(r24.isIntersecting(root))
+    assert(r04.isIntersecting(root))
+
+    // non-trivial intersection
+    assert(r15.isIntersecting(r16))
+    assert(r15.isIntersecting(r24))
+    assert(r15.isIntersecting(r04))
+
+    // shared boundary
+    assert(r01.isIntersecting(r15))
+    assert(r01.isIntersecting(r16))
+    assert(r15.isIntersecting(r01))
+    assert(r16.isIntersecting(r01))
+
+    // disjoint
+    assert(!r01.isIntersecting(r56))
+  }
+}


### PR DESCRIPTION
Our handling of source positions currently mangles lines and columns into a single integer,
reserving the 3 least-significant digits for the column number.

This causes issues when parsing a file containing lines longer than 999 characters long.

This PR changes `SourcePosition` to represent the line and column numbers as separate integer fields.
We also add comprehensive unit tests for the `SourcePosition` and `SourceRegion` classes.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Fixes #2429