### PR TITLE
Fix markup in bug report template

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/ReportGenerator.scala
@@ -63,6 +63,7 @@ object ReportGenerator {
       |## Log files
       |
       |<details>
+      |
       |```
       |$log
       |```


### PR DESCRIPTION
In our bug report template, Github Markdown fails to recognize the code fence immediately following the `<details>` tag. Insert a newline.

⚠️ Auto-merge is turned on.