### PR TITLE
Convert Quint integer operators

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -156,6 +156,19 @@ class Quint(moduleData: QuintOutput) {
         case "and"     => variadicApp(args => tla.and(args: _*))
         case "or"      => variadicApp(args => tla.or(args: _*))
 
+        // Integers
+        case "iadd"    => binaryApp(opName, tla.plus)
+        case "isub"    => binaryApp(opName, tla.minus)
+        case "imul"    => binaryApp(opName, tla.mult)
+        case "idiv"    => binaryApp(opName, tla.div)
+        case "imod"    => binaryApp(opName, tla.mod)
+        case "ipow"    => binaryApp(opName, tla.exp)
+        case "ilt"     => binaryApp(opName, tla.lt)
+        case "igt"     => binaryApp(opName, tla.gt)
+        case "ilte"    => binaryApp(opName, tla.le)
+        case "igte"    => binaryApp(opName, tla.ge)
+        case "iuminus" => unaryApp(opName, tla.uminus)
+
         // Actions
         case "assign"    => binaryApp(opName, (lhs, rhs) => tla.assign(tla.prime(lhs), rhs))
         case "actionAll" => variadicApp(args => tla.and(args: _*))

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintIR.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintIR.scala
@@ -30,7 +30,7 @@ private[quint] class QuintIRParseError(errMsg: String)
 /** The JSON output produced by quint parse */
 private[quint] case class QuintOutput(
     stage: String,
-    modules: List[QuintModule],
+    modules: Seq[QuintModule],
     // Maps source IDs to types, see the `WithId` trait
     types: Map[Int, QuintTypeScheme])
 
@@ -46,7 +46,7 @@ private[quint] object QuintOutput {
 private[quint] case class QuintModule(
     id: Int,
     name: String,
-    defs: List[QuintDef])
+    defs: Seq[QuintDef])
 private[quint] object QuintModule {
   implicit val rw: RW[QuintModule] = macroRW
 }
@@ -110,7 +110,7 @@ private[quint] object QuintEx {
       /** The name of the operator being applied */
       opcode: String,
       /** A list of arguments to the operator */
-      args: List[QuintEx])
+      args: Seq[QuintEx])
       extends QuintEx {}
   object QuintApp {
     implicit val rw: RW[QuintApp] = macroRW
@@ -119,7 +119,7 @@ private[quint] object QuintEx {
   @key("lambda") case class QuintLambda(
       id: Int,
       /** Identifiers for the formal parameters */
-      params: List[String],
+      params: Seq[String],
       /** The qualifier for the defined operator */
       // TODO should this eventually be a sumtype?
       qualifier: String,
@@ -302,7 +302,7 @@ private[quint] object QuintType {
     implicit val rw: RW[QuintFunT] = macroRW
   }
 
-  @key("oper") case class QuintOperT(args: List[QuintType], res: QuintType) extends QuintType
+  @key("oper") case class QuintOperT(args: Seq[QuintType], res: QuintType) extends QuintType
   object QuintOperT {
     implicit val rw: RW[QuintOperT] = macroRW
   }
@@ -317,7 +317,7 @@ private[quint] object QuintType {
   object Row {
     implicit val rw: RW[Row] = RW.merge(Cell.rw, Var.rw, Nil.rw)
 
-    @key("row") case class Cell(fields: List[RecordField], other: Row) extends Row
+    @key("row") case class Cell(fields: Seq[RecordField], other: Row) extends Row
     object Cell {
       implicit val rw: RW[Cell] = macroRW
     }
@@ -348,7 +348,7 @@ private[quint] object QuintType {
     implicit val rw: RW[UnionRecord] = macroRW
   }
 
-  @key("union") case class QuintUnionT(tag: String, records: List[UnionRecord]) extends QuintType
+  @key("union") case class QuintUnionT(tag: String, records: Seq[UnionRecord]) extends QuintType
   object QuintUnionT {
     implicit val rw: RW[QuintUnionT] = macroRW
   }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -127,4 +127,49 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin or operator application") {
     assert(convert(Q.app("or", Q.tt, Q.tt)) == "TRUE ∨ TRUE")
   }
+
+  // Integers
+  test("can convert builtin iadd operator application") {
+    assert(convert(Q.app("iadd", Q._42, Q._42)) == "42 + 42")
+  }
+
+  test("can convert builtin isub operator application") {
+    assert(convert(Q.app("isub", Q._42, Q._42)) == "42 - 42")
+  }
+
+  test("can convert builtin imul operator application") {
+    assert(convert(Q.app("imul", Q._42, Q._42)) == "42 * 42")
+  }
+
+  test("can convert builtin idiv operator application") {
+    assert(convert(Q.app("idiv", Q._42, Q._42)) == "42 // 42")
+  }
+
+  test("can convert builtin imod operator application") {
+    assert(convert(Q.app("imod", Q._42, Q._42)) == "42 % 42")
+  }
+
+  test("can convert builtin ipow operator application") {
+    assert(convert(Q.app("ipow", Q._42, Q._42)) == "42 ^ 42")
+  }
+
+  test("can convert builtin ilt operator application") {
+    assert(convert(Q.app("ilt", Q._42, Q._42)) == "42 < 42")
+  }
+
+  test("can convert builtin igt operator application") {
+    assert(convert(Q.app("igt", Q._42, Q._42)) == "42 > 42")
+  }
+
+  test("can convert builtin ilte operator application") {
+    assert(convert(Q.app("ilte", Q._42, Q._42)) == "42 ≤ 42")
+  }
+
+  test("can convert builtin igte operator application") {
+    assert(convert(Q.app("igte", Q._42, Q._42)) == "42 ≥ 42")
+  }
+
+  test("can convert builtin iuminus operator application") {
+    assert(convert(Q.app("iuminus", Q._42)) == "-42")
+  }
 }


### PR DESCRIPTION
Closes #2442

Along the way to adding conversion of builtin quint integer operators I hit upon
a simplification in the test setup, which also motivated addressing the
improvement to the IR interface which @thpani suggested in
https://github.com/informalsystems/apalache/pull/2425#discussion_r1112670162 --
so the IR now accepts a `Seq` anywhere it previously required an `Int`.

## Reviewing

The new additions are contained in 7b1111d, the other two commits are just refactoring and cleaup.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change