### PR TITLE
Fix typing for quint empty sets

### DIFF
--- a/.unreleased/bug-fixes/quint-empty-sets.md
+++ b/.unreleased/bug-fixes/quint-empty-sets.md
@@ -1,0 +1,1 @@
+Fix the typing of quint empty sets during conversion (see #2466)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -6,6 +6,9 @@ import org.scalatestplus.junit.JUnitRunner
 
 import QuintType._
 import QuintEx._
+import at.forsyte.apalache.tla.lir.Typed
+import at.forsyte.apalache.tla.lir.SetT1
+import at.forsyte.apalache.tla.lir.IntT1
 
 /**
  * Tests the conversion of quint expressions and declarations into TLA expressions
@@ -206,7 +209,13 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin Set operator application for empty sets") {
-    assert(convert(Q.emptyIntSet) == """{}""")
+    val tlaEx = quint.exToTla(Q.emptyIntSet).get
+    // Ensure the constructed empty set has the required type
+    assert(tlaEx.typeTag match {
+      case Typed(SetT1(IntT1)) => true
+      case _                   => false
+    })
+    assert(tlaEx.toString() == """{}""")
   }
   test("can convert builtin exists operator application") {
     assert(convert(Q.app("exists", Q.intSet, Q.intIsGreaterThanZero)) == "∃n ∈ {1, 2, 3}: (n > 0)")


### PR DESCRIPTION
The converter for quint empty types was constructing types wrapped in a
Set. This fixes that error, and expands the test to check for this.

Going forward, I write the quint integration while I expand the
converter to catch this earlier.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change