### PR TITLE
Add support for quint's variadic binding operators

### DIFF
--- a/.unreleased/features/quints-variadic-quants.md
+++ b/.unreleased/features/quints-variadic-quants.md
@@ -1,0 +1,2 @@
+Added support for quint's variadic bindings in `forall` and `exists` operators.
+See #2471.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintIR.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintIR.scala
@@ -336,6 +336,12 @@ private[quint] object QuintType {
   @key("tup") case class QuintTupleT(fields: Row) extends QuintType
   object QuintTupleT {
     implicit val rw: RW[QuintTupleT] = macroRW
+
+    // Helper for manually constructing tuple types
+    def ofTypes(types: QuintType*): QuintTupleT = {
+      val fields = types.zipWithIndex.map { case (t, i) => RecordField(i.toString, t) }
+      QuintTupleT(Row.Cell(fields, Row.Nil()))
+    }
   }
 
   @key("rec") case class QuintRecordT(fields: Row) extends QuintType

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -51,7 +51,10 @@ class TestQuintEx extends AnyFunSuite {
     val nIsGreaterThanZero = app("igt", name, _0)
     // A predicate on ints
     val intIsGreaterThanZero = QuintLambda(uid, List("n"), "def", nIsGreaterThanZero)
+    val int2ToBool = QuintLambda(uid, List("n", "acc"), "def", tt)
     val intSet = app("Set", _1, _2, _3)
+    val intPair = app("Tup", _1, _2)
+    val intPairSet = app("Set", intPair, intPair)
     val emptyIntSet = app("Set")
     val setOfIntSets = app("Set", intSet, intSet, intSet)
     // For use in folds
@@ -78,8 +81,11 @@ class TestQuintEx extends AnyFunSuite {
       Q.appBar -> QuintStrT(),
       Q.letBarBeLambdaInAppBar -> QuintStrT(),
       Q.nIsGreaterThanZero -> QuintBoolT(),
+      Q.int2ToBool -> QuintOperT(List(QuintIntT(), QuintIntT()), QuintBoolT()),
       Q.intIsGreaterThanZero -> QuintOperT(List(QuintIntT()), QuintBoolT()),
       Q.intSet -> QuintSetT(QuintIntT()),
+      Q.intPair -> QuintTupleT.ofTypes(QuintIntT(), QuintIntT()),
+      Q.intPairSet -> QuintSetT(QuintTupleT.ofTypes(QuintIntT(), QuintIntT())),
       Q.emptyIntSet -> QuintSetT(QuintIntT()),
       Q.setOfIntSets -> QuintSetT(QuintSetT(QuintIntT())),
       Q.addNameAndAcc -> QuintIntT(),
@@ -217,12 +223,21 @@ class TestQuintEx extends AnyFunSuite {
     })
     assert(tlaEx.toString() == """{}""")
   }
+
   test("can convert builtin exists operator application") {
     assert(convert(Q.app("exists", Q.intSet, Q.intIsGreaterThanZero)) == "∃n ∈ {1, 2, 3}: (n > 0)")
   }
 
+  test("can convert builtin exists operator application using tuple-bound names") {
+    assert(convert(Q.app("exists", Q.intPairSet, Q.int2ToBool)) == "∃(<<n, acc>>) ∈ {Tup(1, 2), Tup(1, 2)}: TRUE")
+  }
+
   test("can convert builtin forall operator application") {
     assert(convert(Q.app("forall", Q.intSet, Q.intIsGreaterThanZero)) == "∀n ∈ {1, 2, 3}: (n > 0)")
+  }
+
+  test("can convert builtin forall operator application using tuple-bound names") {
+    assert(convert(Q.app("forall", Q.intPairSet, Q.int2ToBool)) == "∀(<<n, acc>>) ∈ {Tup(1, 2), Tup(1, 2)}: TRUE")
   }
 
   test("converting binary binding operator with missing lambda fails") {


### PR DESCRIPTION
Closes #2454

Allows converting quint's variadic binding operators with `forall` and `exists`. E.g. `s.forall((x, y, z) = ...)`.

Builds on #2460 

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
