### PR TITLE
Convert quint Map operators (TLA functions)

### DIFF
--- a/.unreleased/bug-fixes/quint-indexing.md
+++ b/.unreleased/bug-fixes/quint-indexing.md
@@ -1,0 +1,1 @@
+Fix conversion of quint list indexing operator. See #2495.

--- a/.unreleased/features/quint-ops.md
+++ b/.unreleased/features/quint-ops.md
@@ -1,0 +1,3 @@
+Add conversion of quint operators `range`, `foldr`, `assert`, `select`, and
+operators over maps (TLA+ functions). See #2439, #2489, #2492, #2493.
+

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -394,7 +394,9 @@ class Quint(moduleData: QuintOutput) {
         case "setOfMaps" => binaryApp(opName, tla.funSet)
         case "set"       => ternaryApp(opName, tla.except)
         case "mapBy"     => binaryBindingApp(opName, (name, set, expr) => tla.funDef(expr, (name, set)))
-        case "setBy"     => null
+        case "setBy"     =>
+          // f.setBy(x, op) ~~> [f EXCEPT ![k] |-> op(f[k])]
+          ternaryApp(opName, (f, x, op) => tla.except(f, x, tla.appOp(op, tla.app(f, x))))
         case "put" =>
           quintArgs =>
             ternaryApp(opName,

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -384,14 +384,13 @@ class Quint(moduleData: QuintOutput) {
         case "tuples" => variadicApp(tla.times)
 
         // Maps (functions)
-        // case "Map"       => null // Rewire with "Apalache!SetAsFun"
-        // case "Map"       => variadicApp(args => tla.appOp("Apalache!SetAsFun", tla.enumSet(args: _*)))
+        case "Map"       => variadicApp(args => tla.setAsFun(args: _))
         case "get"       => binaryApp(opName, tla.app)
         case "keys"      => unaryApp(opName, tla.dom)
-        case "mapBy"     => null
         case "setToMap"  => unaryApp(opName, tla.setAsFun)
         case "setOfMaps" => binaryApp(opName, tla.funSet)
         case "set"       => ternaryApp(opName, tla.except)
+        case "mapBy"     => null
         case "setBy"     => null
         case "put" =>
           quintArgs =>

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -383,6 +383,18 @@ class Quint(moduleData: QuintOutput) {
         case "item"   => binaryApp(opName, tla.app)
         case "tuples" => variadicApp(tla.times)
 
+        // Maps (functions)
+        // case "Map"       => null // Rewire with "Apalache!SetAsFun"
+        // case "Map"       => variadicApp(args => tla.appOp("Apalache!SetAsFun", tla.enumSet(args: _*)))
+        case "get"       => binaryApp(opName, tla.app)
+        case "keys"      => unaryApp(opName, tla.dom)
+        case "mapBy"     => null
+        case "setToMap"  => unaryApp(opName, tla.setAsFun)
+        case "setOfMaps" => binaryApp(opName, tla.funSet)
+        case "set"       => ternaryApp(opName, tla.except)
+        case "setBy"     => null
+        case "put"       => null
+
         // Actions
         case "assign"    => binaryApp(opName, (lhs, rhs) => tla.assign(tla.prime(lhs), rhs))
         case "actionAll" => variadicApp(args => tla.and(args: _*))

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -75,7 +75,7 @@ class TestQuintEx extends AnyFunSuite {
     val intTup2 = app("Tup", _3, _42)
     val intMap = app("Map", intTup1, intTup2) // Map(0 -> 1, 3 -> 42)
     // For use in folds
-    val addNameAndAcc = app("isum", name, acc)
+    val addNameAndAcc = app("iadd", name, acc)
     val accumulatingOpp = QuintLambda(uid, List(accParam, nParam), "def", addNameAndAcc)
     val chooseSomeFromIntSet = app("chooseSome", intSet)
     // Requires ID registered with type
@@ -155,7 +155,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert multi argument lambda") {
-    assert(convert(Q.accumulatingOpp) == """LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0""")
+    assert(convert(Q.accumulatingOpp) == """LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0""")
   }
 
   test("can convert operator application") {
@@ -319,7 +319,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin fold operator application") {
-    val expected = "Apalache!ApaFoldSet(LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0, 1, {1, 2, 3})"
+    val expected = "Apalache!ApaFoldSet(LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0, 1, {1, 2, 3})"
     assert(convert(Q.app("fold", Q.intSet, Q._1, Q.accumulatingOpp)) == expected)
   }
 
@@ -381,7 +381,7 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin foldl operator application") {
     val expected =
-      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0, 0, <<1, 2, 3>>)"
+      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0, 0, <<1, 2, 3>>)"
     assert(convert(Q.app("foldl", Q.intList, Q._0, Q.accumulatingOpp)) == expected)
   }
 
@@ -422,7 +422,7 @@ class TestQuintEx extends AnyFunSuite {
       val reverseDecl =
         s"__QUINT_LAMBDA3(__quint_var0) ≜ LET ${slenDecl} IN Sequences!SubSeq(Apalache!MkSeq(ApalacheInternal!__ApalacheSeqCapacity(__quint_var0), ${get_ith}), 1, __QUINT_LAMBDA1())"
       val map =
-        "LET __QUINT_LAMBDA4(__quint_var3, __quint_var2) ≜ LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0(__quint_var2, __quint_var3) IN __QUINT_LAMBDA4"
+        "LET __QUINT_LAMBDA4(__quint_var3, __quint_var2) ≜ LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0(__quint_var2, __quint_var3) IN __QUINT_LAMBDA4"
       val reversedSeq = "__QUINT_LAMBDA3(<<1, 2, 3>>)"
       s"LET ${reverseDecl} IN Apalache!ApaFoldSeqLeft(${map}, 0, ${reversedSeq})"
     }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -71,6 +71,9 @@ class TestQuintEx extends AnyFunSuite {
     val intPairSet = app("Set", intPair, intPair)
     val emptyIntSet = app("Set")
     val setOfIntSets = app("Set", intSet, intSet, intSet)
+    val intTup1 = app("Tup", _0, _1)
+    val intTup2 = app("Tup", _3, _42)
+    val intMap = app("Map", intTup1, intTup2) // Map(0 -> 1, 3 -> 42)
     // For use in folds
     val addNameAndAcc = app("isum", name, acc)
     val accumulatingOpp = QuintLambda(uid, List(accParam, nParam), "def", addNameAndAcc)
@@ -443,5 +446,10 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin assert operator") {
     assert(convert(Q.app("assert", Q.nIsGreaterThanZero)) == "n > 0")
+  }
+
+  ignore("can convert builtin put operator application") {
+    // TODO(#2480): extend when we have support for `Map()`
+    assert(convert(Q.app("put", Q.intMap, Q._3, Q._42)) == "")
   }
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -10,6 +10,11 @@ import at.forsyte.apalache.tla.lir.Typed
 import at.forsyte.apalache.tla.lir.SetT1
 import at.forsyte.apalache.tla.lir.IntT1
 
+// You can run all these tests in watch mode in the
+// sbt console with
+//
+//      sbt:apalache> ~tla_io/testOnly *TestQuint*
+
 /**
  * Tests the conversion of quint expressions and declarations into TLA expressions
  */

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -82,6 +82,7 @@ class TestQuintEx extends AnyFunSuite {
     val selectGreaterThanZero = app("select", intList, intIsGreaterThanZero)
     val addOne = app("iadd", name, _1)
     val addOneOp = QuintLambda(uid, List(nParam), "def", addOne)
+    val setByExpression = app("setBy", intMap, _1, addOneOp)
   }
 
   // The Quint conversion class requires a QuintOutput object which,
@@ -113,10 +114,11 @@ class TestQuintEx extends AnyFunSuite {
       Q.addNameAndAcc -> QuintIntT(),
       Q.accumulatingOpp -> QuintOperT(List(QuintIntT(), QuintIntT()), QuintIntT()),
       Q.chooseSomeFromIntSet -> QuintIntT(),
-      Q.selectGreaterThanZero -> QuintSeqT(QuintIntT()),
       Q.intMap -> QuintFunT(QuintIntT(), QuintIntT()),
       Q.addOne -> QuintIntT(),
       Q.addOneOp -> QuintOperT(List(QuintIntT()), QuintIntT()),
+      Q.selectGreaterThanZero -> QuintSeqT(QuintIntT()),
+      Q.setByExpression -> QuintFunT(QuintIntT(), QuintIntT()),
   )
 
   // We construct a converter supplied with the needed type map
@@ -487,10 +489,10 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin setBy operator") {
     val expected = """
-        |[Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) EXCEPT ![1] =
-        |(LET __QUINT_LAMBDA0(n) ≜ n + 1 IN __QUINT_LAMBDA0(Apalache!SetAsFun({<<0, 1>>, <<3, 42>>})[1]))]
+        |LET __quint_var0 ≜ Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) IN
+        |[__quint_var0() EXCEPT ![1] = (LET __QUINT_LAMBDA0(n) ≜ n + 1 IN __QUINT_LAMBDA0(__quint_var0()[1]))]
         """.stripMargin.linesIterator.mkString(" ").trim
-    assert(convert(Q.app("setBy", Q.intMap, Q._1, Q.addOneOp)) == expected)
+    assert(convert(Q.setByExpression) == expected)
   }
 
   test("can convert builtin put operator application") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -475,9 +475,9 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin set operator") {
     assert(
-        convert(Q.app("set", Q.intMap, Q._1, Q._42))
+        convert(Q.app("set", Q.intMap, Q._3, Q._2))
           ==
-            "[Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) EXCEPT ![1] = 42]"
+            "[Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) EXCEPT ![3] = 2]"
     )
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -112,6 +112,7 @@ class TestQuintEx extends AnyFunSuite {
       Q.accumulatingOpp -> QuintOperT(List(QuintIntT(), QuintIntT()), QuintIntT()),
       Q.chooseSomeFromIntSet -> QuintIntT(),
       Q.selectGreaterThanZero -> QuintSeqT(QuintIntT()),
+      Q.intMap -> QuintFunT(QuintIntT(), QuintIntT()),
   )
 
   // We construct a converter supplied with the needed type map
@@ -448,8 +449,13 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("assert", Q.nIsGreaterThanZero)) == "n > 0")
   }
 
-  ignore("can convert builtin put operator application") {
-    // TODO(#2480): extend when we have support for `Map()`
-    assert(convert(Q.app("put", Q.intMap, Q._3, Q._42)) == "")
+  test("can convert builtin put operator application") {
+    val expected = """
+        |LET __quint_var0 ≜ Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) IN
+        |LET __quint_var1 ≜ DOMAIN __quint_var0() IN
+        |[__quint_var2 ∈ ({3} ∪ __quint_var1()) ↦ IF (__quint_var2 = 3) THEN 42 ELSE __quint_var0()[__quint_var2]]
+        """.stripMargin.linesIterator.mkString(" ").trim
+
+    assert(convert(Q.app("put", Q.intMap, Q._3, Q._42)) == expected)
   }
 }


### PR DESCRIPTION
Closes #2439 
Closes #2437

Thanks to @konnov for the guidance and @thpani for managing the hairiest part around `put`.

This also includes a fix for misnamed quint addition operator `isum` -> `iadd`.
 
-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change