### PR TITLE
Simplification of function sets with statically empty codomains

### DIFF
--- a/test/tla/Bug1058.tla
+++ b/test/tla/Bug1058.tla
@@ -5,7 +5,9 @@ VARIABLE
   \* @type: Int -> Int;
   f
 
-Init == f \in [{1} -> {}]
+Init == 
+  \/ f \in [{1} -> {}]
+  \/ f \in [{} -> {}] 
 
 Next == f' = f
 

--- a/test/tla/Bug1058.tla
+++ b/test/tla/Bug1058.tla
@@ -8,6 +8,7 @@ VARIABLE
 Init == 
   \/ f \in [{1} -> {}]
   \/ f \in [{} -> {}] 
+  \/ f \in [{} -> {1}] 
 
 Next == f' = f
 

--- a/test/tla/Bug1058.tla
+++ b/test/tla/Bug1058.tla
@@ -1,0 +1,12 @@
+---- MODULE Bug1058 ----
+EXTENDS Naturals
+
+VARIABLE
+  \* @type: Int -> Int;
+  f
+
+Init == f \in [{1} -> {}]
+
+Next == f' = f
+
+====

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2387,6 +2387,14 @@ Input error (see the manual): SubstRule: Variable N is not assigned a value
 EXITCODE: ERROR (255)
 ```
 
+### check Bug1058.tla throws no exception: regression for #Bug1058
+
+```sh
+$ apalache-mc check Bug1058.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: ERROR (12)
+```
+
 ### check Bug1136.tla reports no error: regression for #1136
 
 ```sh

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2387,12 +2387,12 @@ Input error (see the manual): SubstRule: Variable N is not assigned a value
 EXITCODE: ERROR (255)
 ```
 
-### check Bug1058.tla throws no exception: regression for #Bug1058
+### check Bug1058.tla reports no error: regression for #Bug1058
 
 ```sh
 $ apalache-mc check Bug1058.tla | sed 's/[IEW]@.*//'
 ...
-EXITCODE: ERROR (12)
+EXITCODE: OK
 ```
 
 ### check Bug1136.tla reports no error: regression for #1136

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -220,6 +220,10 @@ abstract class ConstSimplifierBase {
     case OperEx(TlaBoolOper.forall, _, set, ValEx(TlaBool(false))) =>
       simplifyShallow(OperEx(TlaOper.eq, set, emptySet(set.typeTag))(boolTag))
 
+    // [ _ -> {} ] <=> {}
+    case funSet @ OperEx(TlaSetOper.funSet, _, OperEx(TlaSetOper.enumSet)) =>
+      emptySet(funSet.typeTag)
+
     // default
     case ex =>
       ex

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -221,8 +221,8 @@ abstract class ConstSimplifierBase {
     case OperEx(TlaBoolOper.forall, _, set, ValEx(TlaBool(false))) =>
       simplifyShallow(OperEx(TlaOper.eq, set, emptySet(set.typeTag))(boolTag))
 
-    // [{} -> {}] <=> [{} -> {Gen(1)}]
-    case funSet @ OperEx(TlaSetOper.funSet, OperEx(TlaSetOper.enumSet), OperEx(TlaSetOper.enumSet)) =>
+    // [{} -> X] <=> [{} -> {Gen(1)}]
+    case funSet @ OperEx(TlaSetOper.funSet, OperEx(TlaSetOper.enumSet), _) =>
       val funSetT = TlaType1.fromTypeTag(funSet.typeTag)
       funSetT match {
         case SetT1(FunT1(domElemT, cdmElemT)) =>

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -226,8 +226,8 @@ abstract class ConstSimplifierBase {
       val funSetT = TlaType1.fromTypeTag(funSet.typeTag)
       funSetT match {
         case SetT1(FunT1(domElemT, cdmElemT)) =>
-          val mockCdm = tla.enumSet(tla.gen(1, cdmElemT))
-          simplifyShallow(tla.funSet(tla.emptySet(domElemT), mockCdm))
+          val mockCdm = tla.gen(1, SetT1(cdmElemT))
+          tla.funSet(tla.emptySet(domElemT), mockCdm)
         case t =>
           throw new TypingException(s"Function-set $funSet should have a set-of-functions type, found: $t", funSet.ID)
       }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -62,7 +62,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe simplifier.simplify(ex)).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -87,7 +88,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           expressions :+ (tla.exp(tla.int(0), ex).as(IntT1))
         }
       } catch {
-        case _: TlaInputError =>
+        case _: TlaInputError   =>
+        case _: TypingException =>
       }
 
       expressions.forall({ expression =>
@@ -97,7 +99,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe (tla.int(0).as(IntT1))).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -118,7 +121,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe (tla.int(1).as(IntT1))).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -248,7 +252,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe (tla.bool(true).as(BoolT1))).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -269,7 +274,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe (tla.bool(false).as(BoolT1))).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -297,7 +303,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe simplifier.simplify(ex)).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -320,7 +327,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
           (result shouldBe simplifier.simplify(negatedEx)).withClue(s"when simplifying ${expression.toString}")
           true
         } catch {
-          case _: TlaInputError => true
+          case _: TlaInputError   => true
+          case _: TypingException => true
         }
       })
 
@@ -526,7 +534,8 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
 
               true
             } catch {
-              case _: TlaInputError => true
+              case _: TlaInputError   => true
+              case _: TypingException => true
             }
           }
       }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

closes #1058 

Recall that `[A -> B]` is defined as the set of functions `f`, for which `D(f) = A` and `\A x \in A: f(x) \in B`. If `B = {}`, then `f(x) \in B` can never be true, so `\A x \in A: f(x) \in B` is `\A x \in A: FALSE`, which depends on whether `A` is exactly empty or not.

The PR introduces a preprocessing step, which rewrites `[A -> {}]` into 
  1. `{}`, if `A` is not statically empty
  1. `[{} -> Gen(1)]` if `A = {}`. The reason is that the only member of `[{} -> B]` for _any_ `B` is the empty function. In terms of Apalache, this means a function, which evaluates to an arbitrary (type-correct) value everywhere, so we can freely replace `B` with a set of of arbitrary type-correct values (produced via `Gen`).

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
