### PR TITLE
Translate quint `select`

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -329,6 +329,10 @@ class Quint(moduleData: QuintOutput) {
                     case SeqT1(elem) => elem
                     case invalidType => throw new QuintIRParseError(s"sequence ${seq} has invalid type ${invalidType}")
                   }
+                  // SelectSeq(__s, __Test(_)) ==
+                  //    LET __AppendIfTest(__res, __e) ==
+                  //      IF __Test(__e) THEN Append(__res, __e) ELSE __res IN
+                  // __ApalacheFoldSeq(__AppendIfTest, <<>>, __s)
                   val resultParam = tla.param(uniqueVarName(), seqType)
                   val elemParam = tla.param(uniqueVarName(), elemType)
                   val result = tla.name(resultParam._1.name, resultParam._2)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -329,10 +329,10 @@ class Quint(moduleData: QuintOutput) {
                     case SeqT1(elem) => elem
                     case invalidType => throw new QuintIRParseError(s"sequence ${seq} has invalid type ${invalidType}")
                   }
-                  val elemParam = tla.param("__e", elemType)
-                  val resultParam = tla.param("__res", seqType)
-                  val elem = tla.name(elemParam._1.name, elemParam._2)
+                  val resultParam = tla.param(uniqueVarName(), seqType)
+                  val elemParam = tla.param(uniqueVarName(), elemType)
                   val result = tla.name(resultParam._1.name, resultParam._2)
+                  val elem = tla.name(elemParam._1.name, elemParam._2)
                   val ite = tla.ite(tla.appOp(test, elem), tla.append(result, elem), result)
                   val testLambda = tla.lambda(uniqueLambdaName(), ite, resultParam, elemParam)
                   tla.foldSeq(testLambda, tla.emptySeq(elemType), seq)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -107,7 +107,7 @@ class TestQuintEx extends AnyFunSuite {
   )
 
   // We construct a converter supplied with the needed type map
-  val quint = new Quint(QuintOutput(
+  def quint = new Quint(QuintOutput(
           "typechecking",
           List(QuintModule(0, "MockedModule", List())),
           typeMapping.map { case (ex, typ) =>
@@ -146,7 +146,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert multi argument lambda") {
-    assert(convert(Q.accumulatingOpp) == """LET __QUINT_LAMBDA1(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA1""")
+    assert(convert(Q.accumulatingOpp) == """LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0""")
   }
 
   test("can convert operator application") {
@@ -310,7 +310,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin fold operator application") {
-    val expected = "Apalache!ApaFoldSet(LET __QUINT_LAMBDA2(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA2, 1, {1, 2, 3})"
+    val expected = "Apalache!ApaFoldSet(LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0, 1, {1, 2, 3})"
     assert(convert(Q.app("fold", Q.intSet, Q._1, Q.accumulatingOpp)) == expected)
   }
 
@@ -372,7 +372,7 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin foldl operator application") {
     val expected =
-      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA3(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA3, 0, <<1, 2, 3>>)"
+      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0, 0, <<1, 2, 3>>)"
     assert(convert(Q.app("foldl", Q.intList, Q._0, Q.accumulatingOpp)) == expected)
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -388,6 +388,14 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("slice", Q.intList, Q._0, Q._1)) == "Sequences!SubSeq(<<1, 2, 3>>, 1, 2)")
   }
 
+  test("can convert builtin select operator application") {
+    val isGreatThanZeroLambda = "LET __QUINT_LAMBDA0(n) ≜ n > 0 IN __QUINT_LAMBDA0(__e)"
+    val selectLambda =
+      s"LET __QUINT_LAMBDA1(__res, __e) ≜ IF (${isGreatThanZeroLambda}) THEN (Append(__res, __e)) ELSE __res IN __QUINT_LAMBDA1"
+    val expected = s"Apalache!ApaFoldSeqLeft(${selectLambda}, <<>>, <<1, 2, 3>>)"
+    assert(convert(Q.app("select", Q.intList, Q.intIsGreaterThanZero)) == expected)
+  }
+
   test("can convert builtin Tup operator application") {
     assert(convert(Q.app("Tup", Q._0, Q._1)) == "<<0, 1>>")
   }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -389,9 +389,9 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin select operator application") {
-    val isGreatThanZeroLambda = "LET __QUINT_LAMBDA0(n) ≜ n > 0 IN __QUINT_LAMBDA0(__e)"
+    val isGreatThanZeroLambda = "LET __QUINT_LAMBDA0(n) ≜ n > 0 IN __QUINT_LAMBDA0(__quint_var1)"
     val selectLambda =
-      s"LET __QUINT_LAMBDA1(__res, __e) ≜ IF (${isGreatThanZeroLambda}) THEN (Append(__res, __e)) ELSE __res IN __QUINT_LAMBDA1"
+      s"LET __QUINT_LAMBDA1(__quint_var0, __quint_var1) ≜ IF (${isGreatThanZeroLambda}) THEN (Append(__quint_var0, __quint_var1)) ELSE __quint_var0 IN __QUINT_LAMBDA1"
     val expected = s"Apalache!ApaFoldSeqLeft(${selectLambda}, <<>>, <<1, 2, 3>>)"
     assert(convert(Q.app("select", Q.intList, Q.intIsGreaterThanZero)) == expected)
   }


### PR DESCRIPTION
Towards #2437, #2479

As discussed synchronously, add an in-code translation for `select`/`SelectSeq`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
