### PR TITLE
Translate Quint `foldr`

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -344,7 +344,6 @@ class Quint(moduleData: QuintOutput) {
         // TODO: list operations requiring rewiring  https://github.com/informalsystems/apalache/issues/2437
         case "range" => null
         case "foldr" =>
-          // TODO: unique names for LET-INs!
           quintArgs =>
             ternaryApp(opName,
                 (seq, init, op) => {
@@ -358,9 +357,9 @@ class Quint(moduleData: QuintOutput) {
                   //  LET __s_len == Len(__s) IN
                   //  LET __get_ith(__i) == __s[__s_len - __i + 1] IN
                   //  SubSeq(__ApalacheMkSeq(__ApalacheSeqCapacity(__s), __get_ith), 1, __s_len)
-                  val sParam = tla.param("__s", seqType)
+                  val sParam = tla.param(uniqueVarName(), seqType)
                   val s = tla.name(sParam._1.name, sParam._2)
-                  val iParam = tla.param("__i", IntT1)
+                  val iParam = tla.param(uniqueVarName(), IntT1)
                   val i = tla.name(iParam._1.name, iParam._2)
                   val s_lenDecl = tla.decl(uniqueLambdaName(), tla.len(seq))
                   val s_len = tla.name(s_lenDecl.name, OperT1(Seq(), IntT1))
@@ -372,9 +371,9 @@ class Quint(moduleData: QuintOutput) {
                   // FoldRight(__op(_, _), __seq, __base) ==
                   //  LET __map (__y, __x) == __op(__x, __y) IN
                   //  __ApalacheFoldSeq(__map, __base, Reverse(__seq))
-                  val xParam = tla.param("__x", elemType)
+                  val xParam = tla.param(uniqueVarName(), elemType)
                   val x = tla.name(xParam._1.name, xParam._2)
-                  val yParam = tla.param("__y", accType)
+                  val yParam = tla.param(uniqueVarName(), accType)
                   val y = tla.name(yParam._1.name, yParam._2)
                   val reverse = tla.name(reverseDecl.name, OperT1(Seq(seqType), seqType))
                   tla.letIn(tla.foldSeq(tla.lambda(uniqueLambdaName(), tla.appOp(op, x, y), yParam, xParam), init,

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -343,7 +343,43 @@ class Quint(moduleData: QuintOutput) {
                 })(quintArgs)
         // TODO: list operations requiring rewiring  https://github.com/informalsystems/apalache/issues/2437
         case "range" => null
-        case "foldr" => null
+        case "foldr" =>
+          // TODO: unique names for LET-INs!
+          quintArgs =>
+            ternaryApp(opName,
+                (seq, init, op) => {
+                  val seqType = Quint.typeToTlaType(types(quintArgs(0).id).typ)
+                  val elemType = seqType match {
+                    case SeqT1(elem) => elem
+                    case invalidType => throw new QuintIRParseError(s"sequence ${seq} has invalid type ${invalidType}")
+                  }
+                  val accType = Quint.typeToTlaType(types(quintArgs(1).id).typ)
+                  // Reverse(__s) ==
+                  //  LET __s_len == Len(__s) IN
+                  //  LET __get_ith(__i) == __s[__s_len - __i + 1] IN
+                  //  SubSeq(__ApalacheMkSeq(__ApalacheSeqCapacity(__s), __get_ith), 1, __s_len)
+                  val sParam = tla.param("__s", seqType)
+                  val s = tla.name(sParam._1.name, sParam._2)
+                  val iParam = tla.param("__i", IntT1)
+                  val i = tla.name(iParam._1.name, iParam._2)
+                  val s_lenDecl = tla.decl(uniqueLambdaName(), tla.len(seq))
+                  val s_len = tla.name(s_lenDecl.name, OperT1(Seq(), IntT1))
+                  val get_ith = tla.lambda(uniqueLambdaName(),
+                      tla.app(s, tla.plus(tla.minus(tla.appOp(s_len), i), tla.int(1))), iParam)
+                  val reverseDecl = tla.decl(uniqueLambdaName(),
+                      tla.letIn(tla.subseq(tla.mkSeqConst(tla.apalacheSeqCapacity(s), get_ith), tla.int(1),
+                              tla.appOp(s_len)), s_lenDecl), sParam)
+                  // FoldRight(__op(_, _), __seq, __base) ==
+                  //  LET __map (__y, __x) == __op(__x, __y) IN
+                  //  __ApalacheFoldSeq(__map, __base, Reverse(__seq))
+                  val xParam = tla.param("__x", elemType)
+                  val x = tla.name(xParam._1.name, xParam._2)
+                  val yParam = tla.param("__y", accType)
+                  val y = tla.name(yParam._1.name, yParam._2)
+                  val reverse = tla.name(reverseDecl.name, OperT1(Seq(seqType), seqType))
+                  tla.letIn(tla.foldSeq(tla.lambda(uniqueLambdaName(), tla.appOp(op, x, y), yParam, xParam), init,
+                          tla.appOp(reverse, seq)), reverseDecl)
+                })(quintArgs)
 
         // Tuples
         case "Tup" => variadicApp(args => tla.tuple(args: _*))

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -399,11 +399,12 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin foldr operator application") {
     val expected = {
       val slenDecl = "__QUINT_LAMBDA1 ≜ Len(<<1, 2, 3>>)"
-      val get_ith = "LET __QUINT_LAMBDA2(__i) ≜ __s[(__QUINT_LAMBDA1() - __i) + 1] IN __QUINT_LAMBDA2"
+      val get_ith =
+        "LET __QUINT_LAMBDA2(__quint_var1) ≜ __quint_var0[(__QUINT_LAMBDA1() - __quint_var1) + 1] IN __QUINT_LAMBDA2"
       val reverseDecl =
-        s"__QUINT_LAMBDA3(__s) ≜ LET ${slenDecl} IN Sequences!SubSeq(Apalache!MkSeq(ApalacheInternal!__ApalacheSeqCapacity(__s), ${get_ith}), 1, __QUINT_LAMBDA1())"
+        s"__QUINT_LAMBDA3(__quint_var0) ≜ LET ${slenDecl} IN Sequences!SubSeq(Apalache!MkSeq(ApalacheInternal!__ApalacheSeqCapacity(__quint_var0), ${get_ith}), 1, __QUINT_LAMBDA1())"
       val map =
-        "LET __QUINT_LAMBDA4(__y, __x) ≜ LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0(__x, __y) IN __QUINT_LAMBDA4"
+        "LET __QUINT_LAMBDA4(__quint_var3, __quint_var2) ≜ LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0(__quint_var2, __quint_var3) IN __QUINT_LAMBDA4"
       val reversedSeq = "__QUINT_LAMBDA3(<<1, 2, 3>>)"
       s"LET ${reverseDecl} IN Apalache!ApaFoldSeqLeft(${map}, 0, ${reversedSeq})"
     }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -396,6 +396,20 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("select", Q.intList, Q.intIsGreaterThanZero)) == expected)
   }
 
+  test("can convert builtin foldr operator application") {
+    val expected = {
+      val slenDecl = "__QUINT_LAMBDA1 ≜ Len(<<1, 2, 3>>)"
+      val get_ith = "LET __QUINT_LAMBDA2(__i) ≜ __s[(__QUINT_LAMBDA1() - __i) + 1] IN __QUINT_LAMBDA2"
+      val reverseDecl =
+        s"__QUINT_LAMBDA3(__s) ≜ LET ${slenDecl} IN Sequences!SubSeq(Apalache!MkSeq(ApalacheInternal!__ApalacheSeqCapacity(__s), ${get_ith}), 1, __QUINT_LAMBDA1())"
+      val map =
+        "LET __QUINT_LAMBDA4(__y, __x) ≜ LET __QUINT_LAMBDA0(acc, n) ≜ isum(n, acc) IN __QUINT_LAMBDA0(__x, __y) IN __QUINT_LAMBDA4"
+      val reversedSeq = "__QUINT_LAMBDA3(<<1, 2, 3>>)"
+      s"LET ${reverseDecl} IN Apalache!ApaFoldSeqLeft(${map}, 0, ${reversedSeq})"
+    }
+    assert(convert(Q.app("foldr", Q.intList, Q._0, Q.accumulatingOpp)) == expected)
+  }
+
   test("can convert builtin Tup operator application") {
     assert(convert(Q.app("Tup", Q._0, Q._1)) == "<<0, 1>>")
   }


### PR DESCRIPTION
Towards #2437, #2479

As discussed synchronously, add an in-code translation for Quint `foldr`.

I will rebase onto `main` once #2483 is reviewed & merged.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
