### PR TITLE
Translate Quint `assert`

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -355,6 +355,7 @@ class Quint(moduleData: QuintOutput) {
         case "assign"    => binaryApp(opName, (lhs, rhs) => tla.assign(tla.prime(lhs), rhs))
         case "actionAll" => variadicApp(args => tla.and(args: _*))
         case "actionAny" => variadicApp(args => tla.or(args: _*))
+        case "assert"    => unaryApp(opName, identity) // `assert` does not have side-effects in Apalache
 
         // Otherwise, the applied operator is defined, and not a builtin
         case definedOpName => { args =>

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -411,4 +411,8 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin tuples operator application") {
     assert(convert(Q.app("tuples", Q.intSet, Q.intSet, Q.intSet)) == "{1, 2, 3} × {1, 2, 3} × {1, 2, 3}")
   }
+
+  test("can convert builtin assert operator") {
+    assert(convert(Q.app("assert", Q.nIsGreaterThanZero)) == "n > 0")
+  }
 }


### PR DESCRIPTION
Towards #2437, #2479

Add in-code translation for Quint `assert`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change