### PR TITLE
Translate Quint `range`

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -341,8 +341,14 @@ class Quint(moduleData: QuintOutput) {
                   val testLambda = tla.lambda(uniqueLambdaName(), ite, resultParam, elemParam)
                   tla.foldSeq(testLambda, tla.emptySeq(elemType), seq)
                 })(quintArgs)
-        // TODO: list operations requiring rewiring  https://github.com/informalsystems/apalache/issues/2437
-        case "range" => null
+        case "range" =>
+          binaryApp(opName,
+              (low, high) => {
+                val iParam = tla.param(uniqueVarName(), IntT1)
+                val i = tla.name(iParam._1.name, iParam._2)
+                tla.mkSeqConst(tla.minus(high, low),
+                    tla.lambda(uniqueLambdaName(), tla.minus(tla.plus(low, i), tla.int(1)), iParam))
+              })
         case "foldr" =>
           quintArgs =>
             ternaryApp(opName,

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -396,6 +396,11 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("select", Q.intList, Q.intIsGreaterThanZero)) == expected)
   }
 
+  test("can convert builtin range operator application") {
+    assert(convert(Q.app("range", Q._3,
+            Q._42)) == "Apalache!MkSeq(42 - 3, LET __QUINT_LAMBDA0(__quint_var0) ≜ (3 + __quint_var0) - 1 IN __QUINT_LAMBDA0)")
+  }
+
   test("can convert builtin foldr operator application") {
     val expected = {
       val slenDecl = "__QUINT_LAMBDA1 ≜ Len(<<1, 2, 3>>)"


### PR DESCRIPTION
Towards #2437, #2479, closes #2489

Add in-code translation for Quint `range`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change