### PR TITLE
Fix index increment logic in Quint index conversion

### DIFF
--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -377,15 +377,19 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin nth operator application") {
-    assert(convert(Q.app("nth", Q.intList, Q._1)) == "(<<1, 2, 3>>)[2]")
+    assert(convert(Q.app("nth", Q.intList, Q._1)) == "(<<1, 2, 3>>)[1 + 1]")
+  }
+
+  test("can convert builtin nth operator application to variable index") {
+    assert(convert(Q.app("nth", Q.intList, Q.name)) == "(<<1, 2, 3>>)[n + 1]")
   }
 
   test("can convert builtin replaceAt operator application") {
-    assert(convert(Q.app("replaceAt", Q.intList, Q._1, Q._42)) == "[<<1, 2, 3>> EXCEPT ![2] = 42]")
+    assert(convert(Q.app("replaceAt", Q.intList, Q._1, Q._42)) == "[<<1, 2, 3>> EXCEPT ![(1 + 1)] = 42]")
   }
 
   test("can convert builtin slice operator application") {
-    assert(convert(Q.app("slice", Q.intList, Q._0, Q._1)) == "Sequences!SubSeq(<<1, 2, 3>>, 1, 2)")
+    assert(convert(Q.app("slice", Q.intList, Q._0, Q._1)) == "Sequences!SubSeq(<<1, 2, 3>>, 0 + 1, 1 + 1)")
   }
 
   test("can convert builtin select operator application") {


### PR DESCRIPTION
We were only handling incrementing integer literals, which is
inadequate, since it doesn't account for expressions such as variables
of compound expressions.

Followup to #2474 

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
