### PR TITLE
Translate Quint `put`

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -341,7 +341,52 @@ class Quint(moduleData: QuintOutput) {
         case "setOfMaps" => binaryApp(opName, tla.funSet)
         case "set"       => ternaryApp(opName, tla.except)
         case "setBy"     => null
-        case "put"       => null
+        case "put"       =>
+          // put(map, key, value) ~~> (key :> value) @@ map
+          quintArgs =>
+            ternaryApp(opName,
+                (map, key, value) => {
+                  // (1) build `key :> value` == `[ _ \in {key} |-> value ]`
+                  // extract types
+                  val mapType = Quint.typeToTlaType(types(quintArgs(0).id).typ)
+                  val keyType = Quint.typeToTlaType(types(quintArgs(1).id).typ)
+                  val valType = Quint.typeToTlaType(types(quintArgs(2).id).typ)
+                  // f1 == key :> value
+                  val f1 = tla.funDef(value, (tla.name(uniqueVarName(), keyType), tla.enumSet(key)))
+
+                  // (2) build (key :> value) @@ map, where
+                  // __f1 @@ __f2 ==
+                  //    LET __f1_cache == __f1
+                  //        __f2_cache == __f2
+                  //    IN
+                  //    LET __d1 == DOMAIN __f1_cache
+                  //        __d2 == DOMAIN __f2_cache
+                  //    IN
+                  //    [__x \in __d1 \union __d2 |-> IF __x \in __d1 THEN __f1_cache[__x] ELSE __f2_cache[__x]]
+                  val f2 = map
+                  // string names
+                  val cacheName1 = uniqueVarName()
+                  val cacheName2 = uniqueVarName()
+                  val domName1 = uniqueVarName()
+                  val domName2 = uniqueVarName()
+                  // TLA+ name expressions
+                  val cache1 = tla.name(cacheName1, mapType)
+                  val cache2 = tla.name(cacheName2, mapType)
+                  val dom1 = tla.name(domName1, SetT1(valType))
+                  val dom2 = tla.name(domName2, SetT1(valType))
+                  // build the final funDef, i.e., the LET-IN body
+                  val bindingVar = tla.name(uniqueVarName(), keyType)
+                  val ite = tla.ite(tla.in(bindingVar, dom1), tla.app(cache1, bindingVar), tla.app(cache2, bindingVar))
+                  val composed = tla.funDef(ite, (bindingVar, tla.cup(dom1, dom2)))
+                  // build the entire LET-IN
+                  tla.letIn(
+                      composed,
+                      tla.decl(cacheName1, f1),
+                      tla.decl(cacheName2, f2),
+                      tla.decl(domName1, tla.dom(cache1)),
+                      tla.decl(domName2, tla.dom(cache2)),
+                  )
+                })(quintArgs)
 
         // Actions
         case "assign"    => binaryApp(opName, (lhs, rhs) => tla.assign(tla.prime(lhs), rhs))

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -71,6 +71,9 @@ class TestQuintEx extends AnyFunSuite {
     val intPairSet = app("Set", intPair, intPair)
     val emptyIntSet = app("Set")
     val setOfIntSets = app("Set", intSet, intSet, intSet)
+    val intTup1 = app("Tup", _0, _1)
+    val intTup2 = app("Tup", _3, _42)
+    val intMap = app("Map", intTup1, intTup2) // Map(0 -> 1, 3 -> 42)
     // For use in folds
     val addNameAndAcc = app("isum", name, acc)
     val accumulatingOpp = QuintLambda(uid, List(accParam, nParam), "def", addNameAndAcc)
@@ -409,4 +412,8 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("tuples", Q.intSet, Q.intSet, Q.intSet)) == "{1, 2, 3} × {1, 2, 3} × {1, 2, 3}")
   }
 
+  ignore("can convert builtin put operator application") {
+    // TODO(#2480): extend when we have support for `Map()`
+    assert(convert(Q.app("put", Q.intMap, Q._3, Q._42)) == "")
+  }
 }


### PR DESCRIPTION
Translate Quint `put`

Merges into the Maps PR (#2480). This is missing a test, that we'll have to add once we have the `Map()` constructor.

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

Closes #2493 