### PR TITLE
Fix conversion of quint foldr

### DIFF
--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -427,21 +427,6 @@ class TestQuintEx extends AnyFunSuite {
             Q._42)) == "Apalache!MkSeq(42 - 3, LET __QUINT_LAMBDA0(__quint_var0) ≜ (3 + __quint_var0) - 1 IN __QUINT_LAMBDA0)")
   }
 
-  test("can convert builtin foldr operator application") {
-    val expected = {
-      val slenDecl = "__QUINT_LAMBDA1 ≜ Len(<<1, 2, 3>>)"
-      val get_ith =
-        "LET __QUINT_LAMBDA2(__quint_var1) ≜ __quint_var0[(__QUINT_LAMBDA1() - __quint_var1) + 1] IN __QUINT_LAMBDA2"
-      val reverseDecl =
-        s"__QUINT_LAMBDA3(__quint_var0) ≜ LET ${slenDecl} IN Sequences!SubSeq(Apalache!MkSeq(ApalacheInternal!__ApalacheSeqCapacity(__quint_var0), ${get_ith}), 1, __QUINT_LAMBDA1())"
-      val map =
-        "LET __QUINT_LAMBDA4(__quint_var3, __quint_var2) ≜ LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0(__quint_var2, __quint_var3) IN __QUINT_LAMBDA4"
-      val reversedSeq = "__QUINT_LAMBDA3(<<1, 2, 3>>)"
-      s"LET ${reverseDecl} IN Apalache!ApaFoldSeqLeft(${map}, 0, ${reversedSeq})"
-    }
-    assert(convert(Q.app("foldr", Q.intList, Q._0, Q.accumulatingOpp)) == expected)
-  }
-
   test("can convert builtin Tup operator application") {
     assert(convert(Q.app("Tup", Q._0, Q._1)) == "<<0, 1>>")
   }


### PR DESCRIPTION
We were constructing an unneeded lambda wrapper, that was also
triggering a type err on the secondary type-checking pass.

```
    <unknown>: internal error in type checking: Bug in ToEtcExpr. Expected an operator name, found: LET __QUINT_LAMBDA1(x, y) ≜ x + y IN __QUINT_LAMBDA1 E@15:46:23.130
    at.forsyte.apalache.infra.AdaptedException: <unknown>: internal error in type checking: Bug in ToEtcExpr. Expected an operator name, found: LET __QUINT_LAMBDA1(x, y) ≜ x + y IN __QUINT_LAMBDA1
        at at.forsyte.apalache.infra.passes.PassChainExecutor$.run(PassChainExecutor.scala:39)
        at at.forsyte.apalache.tla.tooling.opt.CheckCmd.run(CheckCmd.scala:132)
        at at.forsyte.apalache.tla.Tool$.runCommand(Tool.scala:138)
        at at.forsyte.apalache.tla.Tool$.run(Tool.scala:118)
        at at.forsyte.apalache.tla.Tool$.main(Tool.scala:40)
        at at.forsyte.apalache.tla.Tool.main(Tool.scala)
```

This didn't show up until writing integration tests for quint.

Followup to #2488

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change