### PR TITLE
Fix conversion of quint indices operator

### DIFF
--- a/.unreleased/bug-fixes/quint-indexing.md
+++ b/.unreleased/bug-fixes/quint-indexing.md
@@ -1,1 +1,1 @@
-Fix conversion of quint list indexing operator. See #2495.
+Fix quint list conversion. See #2495, #2509, #2510.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -256,6 +256,20 @@ class Quint(moduleData: QuintOutput) {
           case args => tla.enumSet(args: _*)
         }
 
+      def listConstruction(id: Int): Converter =
+        variadicApp {
+          // Empty lists must be handled specially since we cannot infer their type
+          // from the given arguments
+          case Seq() =>
+            val elementType = types(id).typ match {
+              case QuintSeqT(t) => Quint.typeToTlaType(t)
+              case invalidType =>
+                throw new QuintIRParseError(s"List with id ${id} has invalid type ${invalidType}")
+            }
+            tla.emptySeq(elementType)
+          case args => tla.seq(args: _*)
+        }
+
       def selectSeq(opName: String): Converter =
         quintArgs =>
           binaryApp(opName,
@@ -412,7 +426,7 @@ class Quint(moduleData: QuintOutput) {
           }
 
           // Lists (Sequences)
-          case "List"      => variadicApp(args => tla.seq(args: _*))
+          case "List"      => MkTla.listConstruction(id)
           case "append"    => binaryApp(opName, tla.append)
           case "concat"    => binaryApp(opName, tla.concat)
           case "head"      => unaryApp(opName, tla.head)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -71,6 +71,7 @@ class TestQuintEx extends AnyFunSuite {
     val intPair = app("Tup", _1, _2)
     val intList = app("List", _1, _2, _3)
     val intPairSet = app("Set", intPair, intPair)
+    val emptyIntList = app("List")
     val emptyIntSet = app("Set")
     val setOfIntSets = app("Set", intSet, intSet, intSet)
     val intTup1 = app("Tup", _0, _1)
@@ -126,6 +127,7 @@ class TestQuintEx extends AnyFunSuite {
       Q.setByExpression -> QuintFunT(QuintIntT(), QuintIntT()),
       Q.oneOfSet -> QuintIntT(),
       Q.nondetBinding -> QuintIntT(),
+      Q.emptyIntList -> QuintSeqT(QuintIntT()),
   )
 
   // We construct a converter supplied with the needed type map
@@ -366,6 +368,10 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin List operator application") {
     assert(convert(Q.app("List", Q._1, Q._2, Q._3)) == "<<1, 2, 3>>")
+  }
+
+  test("can convert builtin List operator application for empty list") {
+    assert(convert(Q.emptyIntList) == "<<>>")
   }
 
   test("can convert builtin append operator application") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -389,7 +389,9 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin indices operator application") {
-    assert(convert(Q.app("indices", Q.intList)) == "DOMAIN (<<1, 2, 3>>)")
+    val expected =
+      "LET __quint_var0 ≜ DOMAIN (<<1, 2, 3>>) IN IF (__quint_var0() = {}) THEN {} ELSE ((__quint_var0() ∪ {0}) ∖ {Len(<<1, 2, 3>>)})"
+    assert(convert(Q.app("indices", Q.intList)) == expected)
   }
 
   test("can convert builtin foldl operator application") {


### PR DESCRIPTION
Closes #2509

Since quint lists are 0-indexed, we need to adjust the indices produced by
`DOMAIN`.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change