### PR TITLE
Support quint binding operator passed by name

### DIFF
--- a/.unreleased/bug-fixes/quint-binding-ops-by-name.md
+++ b/.unreleased/bug-fixes/quint-binding-ops-by-name.md
@@ -1,0 +1,2 @@
+Fix conversion of quint binding operators to support operator passed by name.
+See #2520.

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -60,13 +60,13 @@ class TestQuintEx extends AnyFunSuite {
     }
 
     // Scalar values
-    val tt = e(QuintBool(uid, true), QuintIntT())
+    val tt = e(QuintBool(uid, true), QuintBoolT())
     val _0 = e(QuintInt(uid, 0), QuintIntT())
     val _1 = e(QuintInt(uid, 1), QuintIntT())
     val _2 = e(QuintInt(uid, 2), QuintIntT())
     val _3 = e(QuintInt(uid, 3), QuintIntT())
     val _42 = e(QuintInt(uid, 42), QuintIntT())
-    val s = e(QuintStr(uid, "s"), QuintIntT())
+    val s = e(QuintStr(uid, "s"), QuintStrT())
 
     // Names and parameters
     val name = e(QuintName(uid, "n"), QuintIntT())

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -75,6 +75,7 @@ class TestQuintEx extends AnyFunSuite {
     val accParam = param("acc", QuintIntT())
     val xParam = param("x", QuintIntT())
     val namedIntToBoolOp = e(QuintName(uid, "intToBoolOp"), QuintOperT(Seq(QuintIntT()), QuintBoolT()))
+    val namedInt2ToBoolOp = e(QuintName(uid, "int2ToBoolOp"), QuintOperT(Seq(QuintIntT(), QuintIntT()), QuintBoolT()))
 
     // Definitions and compound data types
     val fooDef = QuintDef.QuintOpDef(uid, "foo", "val", tt)
@@ -264,6 +265,17 @@ class TestQuintEx extends AnyFunSuite {
             QuintBoolT())) == "∃(<<n, acc>>) ∈ {<<1, 2>>, <<1, 2>>}: TRUE")
   }
 
+  test("can convert builtin exists operator when predicate is supplied by name") {
+    assert(convert(Q.app("exists", Q.intSet, Q.namedIntToBoolOp)(
+            QuintBoolT())) == "∃__quint_var0 ∈ {1, 2, 3}: (intToBoolOp(__quint_var0))")
+  }
+
+  test("can convert builtin exists operator when multi-arity predicate is supplied by name") {
+    assert(convert(Q.app("exists", Q.intPairSet, Q.namedInt2ToBoolOp)(QuintBoolT()))
+      ==
+        "∃(<<__quint_var0, __quint_var1>>) ∈ {<<1, 2>>, <<1, 2>>}: (int2ToBoolOp(__quint_var0, __quint_var1))")
+  }
+
   test("can convert builtin forall operator application") {
     assert(convert(Q.app("forall", Q.intSet, Q.intIsGreaterThanZero)(QuintBoolT())) == "∀n ∈ {1, 2, 3}: (n > 0)")
   }
@@ -273,12 +285,23 @@ class TestQuintEx extends AnyFunSuite {
             QuintBoolT())) == "∀(<<n, acc>>) ∈ {<<1, 2>>, <<1, 2>>}: TRUE")
   }
 
+  test("can convert builtin forall operator when predicate is supplied by name") {
+    assert(convert(Q.app("forall", Q.intSet, Q.namedIntToBoolOp)(
+            QuintBoolT())) == "∀__quint_var0 ∈ {1, 2, 3}: (intToBoolOp(__quint_var0))")
+  }
+
+  test("can convert builtin forall operator when multi-arity predicate is supplied by name") {
+    assert(convert(Q.app("forall", Q.intPairSet, Q.namedInt2ToBoolOp)(QuintBoolT()))
+      ==
+        "∀(<<__quint_var0, __quint_var1>>) ∈ {<<1, 2>>, <<1, 2>>}: (int2ToBoolOp(__quint_var0, __quint_var1))")
+  }
+
   test("converting binary binding operator with missing lambda fails") {
     val exn = intercept[QuintIRParseError] {
       convert(Q.app("forall", Q.intSet, Q.intSet)(QuintBoolT()))
     }
     assert(exn.getMessage.contains(
-            "Input was not a valid representation of the QuintIR: Operator forall is a binding operator requiring a lambda as it's second argument"))
+            "Input was not a valid representation of the QuintIR: Operator forall is a binding operator requiring an operator as it's second argument"))
   }
 
   test("converting binary binding operator with invalid arity fails") {


### PR DESCRIPTION
Closes #2516

Adds a case to the binaryBindingApp combinator to handle "binder" passed by
name. This is a pretty straightforward conversion akin to an eta conversion. 

I've tested this in a (WIP) integration test in the quint repo.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change