### PR TITLE
Fix converting empty quint maps construction

### DIFF
--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -462,7 +462,7 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("Tup", Q._0, Q._1)(QuintTupleT.ofTypes(QuintIntT(), QuintIntT()))) == "<<0, 1>>")
   }
 
-  test("can convert builtin Tup operator application to heterogeneous elemens") {
+  test("can convert builtin Tup operator application to heterogeneous elements") {
     assert(convert(Q.app("Tup", Q._0, Q.s)(QuintTupleT.ofTypes(QuintStrT(), QuintStrT()))) == "<<0, \"s\">>")
   }
 
@@ -482,6 +482,10 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin Map operator") {
     assert(convert(Q.app("Map", Q.intTup1, Q.intTup2)(QuintFunT(QuintIntT(),
                 QuintIntT()))) == "Apalache!SetAsFun({<<0, 1>>, <<3, 42>>})")
+  }
+
+  test("can convert builtin Map operator for empty maps") {
+    assert(convert(Q.app("Map")(QuintFunT(QuintIntT(), QuintIntT()))) == "Apalache!SetAsFun({})")
   }
 
   test("can convert builtin get operator") {


### PR DESCRIPTION
Found this while writing the integration tests for maps. I had just forgottent
to construct the appropriate element type in the case we needed to construct an
empty function.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change