### PR TITLE
Support application of polymorphic operators in typed builder

### DIFF
--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/FlexibleEquality.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/FlexibleEquality.scala
@@ -1,53 +1,26 @@
 package at.forsyte.apalache.tla.typecomp.signatures
 
-import at.forsyte.apalache.tla.lir.{FunT1, RecRowT1, RecT1, RowT1, SeqT1, SetT1, TlaType1, TupT1}
+import at.forsyte.apalache.tla.lir.TlaType1
 
-import scala.collection.immutable.SortedMap
-import at.forsyte.apalache.tla.lir.VarT1
+import at.forsyte.apalache.tla.types.TypeUnifier
+import at.forsyte.apalache.tla.types.TypeVarPool
+import at.forsyte.apalache.tla.types.Substitution
 
 /**
  * Determines flexible equality ([[compatible]]), i.e. an equivalence relation over TT1, which is equality for
  * non-record types, but allows the comparison of records types with compatible fields
  *
  * @author
- *   Jure Kukovec
+ *   Jure Kukovec, ShonFeder
  */
 object FlexibleEquality {
 
-  // None if no common supertype, Some(e) if compatible, and common supertype is e.
-  def commonSupertype(lhs: TlaType1, rhs: TlaType1): Option[TlaType1] = (lhs, rhs) match {
-    case (a, b) if a == b     => Some(a)
-    case (VarT1(_), b)        => Some(b)
-    case (a, VarT1(_))        => Some(a)
-    case (SeqT1(l), SeqT1(r)) => commonSupertype(l, r).map(SeqT1)
-    case (SetT1(l), SetT1(r)) => commonSupertype(l, r).map(SetT1)
-    case (FunT1(lD, lC), FunT1(rD, rC)) =>
-      for {
-        domT <- commonSupertype(lD, rD)
-        cdmT <- commonSupertype(lC, rC)
-      } yield FunT1(domT, cdmT)
-    case (TupT1(lElems @ _*), TupT1(rElems @ _*)) if lElems.size == rElems.size =>
-      val commonTup = lElems.zip(rElems).flatMap { case (l, r) => commonSupertype(l, r) }
-      if (commonTup.size == lElems.size) Some(TupT1(commonTup: _*))
-      else None
-    case (RecT1(lFields), RecT1(rFields)) =>
-      val intersect = lFields.keySet.intersect(rFields.keySet)
-      val intersectMapOpt = intersect.foldLeft(Option(SortedMap.empty[String, TlaType1])) { case (mapOpt, e) =>
-        for {
-          map <- mapOpt
-          supertype <- commonSupertype(lFields(e), rFields(e))
-        } yield map + (e -> supertype)
-      }
-      intersectMapOpt.map { m =>
-        RecT1(
-            (lFields ++ rFields) ++ m // ++ m last overrides the entries for all e \in intersect with the computed unions
-        )
-      }
-    case (l: RecRowT1, r: RecT1)                       => commonSupertype(r, l)
-    case (l: RecT1, RecRowT1(RowT1(fieldTypes, None))) => commonSupertype(l, RecT1(fieldTypes))
-    case (RecRowT1(RowT1(lFieldTypes, None)), RecRowT1(RowT1(rFieldTypes, None))) =>
-      commonSupertype(RecT1(lFieldTypes), RecT1(rFieldTypes))
-    case _ => None
+  // None if no common supertype, Some(e) if compatible, and the common supertype is e.
+  def commonSupertype(lhs: TlaType1, rhs: TlaType1): Option[TlaType1] = {
+    // TypeUnifier is not threadsafe, and creating a new instance
+    // for each invocation prevents race conditions in the tests
+    val typeUnifier = new TypeUnifier(new TypeVarPool())
+    typeUnifier.unify(Substitution.empty, lhs, rhs).map(_._2)
   }
 
   def commonSeqSupertype(seq: Seq[TlaType1]): Option[TlaType1] =

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/FlexibleEquality.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/FlexibleEquality.scala
@@ -3,6 +3,7 @@ package at.forsyte.apalache.tla.typecomp.signatures
 import at.forsyte.apalache.tla.lir.{FunT1, RecRowT1, RecT1, RowT1, SeqT1, SetT1, TlaType1, TupT1}
 
 import scala.collection.immutable.SortedMap
+import at.forsyte.apalache.tla.lir.VarT1
 
 /**
  * Determines flexible equality ([[compatible]]), i.e. an equivalence relation over TT1, which is equality for
@@ -16,6 +17,8 @@ object FlexibleEquality {
   // None if no common supertype, Some(e) if compatible, and common supertype is e.
   def commonSupertype(lhs: TlaType1, rhs: TlaType1): Option[TlaType1] = (lhs, rhs) match {
     case (a, b) if a == b     => Some(a)
+    case (VarT1(_), b)        => Some(b)
+    case (a, VarT1(_))        => Some(a)
     case (SeqT1(l), SeqT1(r)) => commonSupertype(l, r).map(SeqT1)
     case (SetT1(l), SetT1(r)) => commonSupertype(l, r).map(SetT1)
     case (FunT1(lD, lC), FunT1(rD, rC)) =>

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/FlexibleEquality.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/signatures/FlexibleEquality.scala
@@ -17,8 +17,8 @@ object FlexibleEquality {
 
   // None if no common supertype, Some(e) if compatible, and the common supertype is e.
   def commonSupertype(lhs: TlaType1, rhs: TlaType1): Option[TlaType1] = {
-    // TypeUnifier is not threadsafe, and creating a new instance
-    // for each invocation prevents race conditions in the tests
+    // TypeUnifier is not threadsafe, and creating a new instance for each invocation
+    // prevents race conditions (e.g., in the tests and in the server)
     val typeUnifier = new TypeUnifier(new TypeVarPool())
     typeUnifier.unify(Substitution.empty, lhs, rhs).map(_._2)
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/types/TypeUnifier.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/types/TypeUnifier.scala
@@ -223,6 +223,11 @@ class TypeUnifier(varPool: TypeVarPool) {
       case (RecRowT1(RowT1(lfields, lv)), RecRowT1(RowT1(rfields, rv))) =>
         unifyRows(lfields, rfields, lv, rv).map(t => RecRowT1(t))
 
+      case (rec @ RecT1(_), rowRec @ RecRowT1(_)) => compute(rowRec, rec)
+
+      // An old record type can be treated as a monomorphic row-typed record
+      case (rowRec @ RecRowT1(_), RecT1(fields)) => compute(rowRec, RecRowT1(RowT1(fields, None)))
+
       case (VariantT1(RowT1(lfields, lv)), VariantT1(RowT1(rfields, rv))) =>
         unifyRows(lfields, rfields, lv, rv).map(t => VariantT1(t))
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TlaType1Gen.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TlaType1Gen.scala
@@ -179,6 +179,10 @@ trait TlaType1Gen {
  */
 trait TlaType1ConcreteGen extends TlaType1Gen {
   override val genRowVar = Gen.const(None)
+
+  // The concrete primitive types are monomorphic
+  override def genPrimitive: Gen[TlaType1] = genPrimitiveMono
+
   override def genTypeTree: Gen[TlaType1] = lzy {
     sized { size =>
       if (size <= 1) {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/BuilderTest.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/BuilderTest.scala
@@ -234,7 +234,9 @@ trait BuilderTest extends AnyFunSuite with BeforeAndAfter with Checkers with App
 
     val uninterpretedIndexAndTypeGen: Gen[(String, ConstT1)] = Gen.zip(nonEmptyStrGen, uninterpretedTypeGen)
 
-    protected val tt1gen: TlaType1Gen = new TlaType1Gen {}
+    // We only test over "concrete types",
+    // because we only need the builder to build things that can be build.
+    protected val tt1gen: TlaType1Gen = new TlaType1ConcreteGen {}
 
     val singleTypeGen: Gen[TlaType1] = tt1gen.genType1
     val doubleTypeGen: Gen[(TlaType1, TlaType1)] = Gen.zip(singleTypeGen, singleTypeGen)

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestBaseBuilder.scala
@@ -51,6 +51,13 @@ class TestBaseBuilder extends BuilderTest {
     checkRun(Generators.singleTypeGen)(run(TlaOper.ne, builder.neql))
   }
 
+  // Regression test for https://github.com/informalsystems/apalache/issues/2559
+  test("can build application of polymorphic operator") {
+    val polyConst1 = builder.name("polyConst1", OperT1(Seq(VarT1("a")), IntT1))
+    val instruction = builder.appOp(polyConst1, builder.str("s"))
+    assert(build(instruction).toString == """polyConst1("s")""")
+  }
+
   test("appOp") {
     type T = (TBuilderInstruction, Seq[TBuilderInstruction])
 

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestRowTypedRecords.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestRowTypedRecords.scala
@@ -9,6 +9,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop._
+import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
 class TestRowTypedRecords extends AnyFunSuite with Checkers {
@@ -26,5 +27,27 @@ class TestRowTypedRecords extends AnyFunSuite with Checkers {
       }
 
     check(prop, minSuccessful(1000), sizeRange(4))
+  }
+
+  test("can construct application of row-polymorphic operator to two different, compatible records") {
+    val builder = new ScopedBuilder()
+    // [ f1 |-> 1 ]
+    val a = builder.rowRec(None, "f1" -> builder.int(1))
+    // [ f1 |-> 1, f2 |-> "s" ]
+    val b = builder.rowRec(None, "f1" -> builder.int(2), "f2" -> builder.str("s"))
+    // {f1: Int | a}
+    val openRecType = RecRowT1(RowT1(VarT1(1), "f1" -> IntT1))
+    // op : ({f1: Int | a}) => Int
+    val opName = builder.name("op", OperT1(Seq(openRecType), IntT1))
+    // << op(a), op(b) >>
+    val operatorApplications =
+      builder.seq(
+          builder.appOp(opName, a),
+          builder.appOp(opName, b),
+      )
+
+    // Regresson test for https://github.com/informalsystems/apalache/issues/2581
+    assert(Try(build(operatorApplications)).isSuccess,
+        "Failed to build the application of row-polymorphic operator to compatible records")
   }
 }


### PR DESCRIPTION
Closes #2559
Closes #2581

It appears that the typed builder is not currently able to handle constructing application of polymorphic operator.

This adds a regression test for this omission and a fix to unblock it.

The fix is to replace the limited and more ad-hoc type compatibility check used in the builder previously with the same type unifier we use for type checking. The result is

- More code reuse.
- More correct checks on type compatibility in the builder.
- Less code.

This will unblock #2552.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change