### PR TITLE
fix the output for \div and /

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -1,15 +1,15 @@
 package at.forsyte.apalache.io.lir
 
-import java.io.{File, FileWriter, PrintWriter}
+import at.forsyte.apalache.io.PrettyPrinterError
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values._
-import at.forsyte.apalache.tla.lir._
 import org.bitbucket.inkytonik.kiama.output.PrettyPrinter
-import at.forsyte.apalache.tla.lir.UntypedPredefs._
 
+import java.io.{File, FileWriter, PrintWriter}
 import scala.collection.immutable.{HashMap, HashSet}
-import at.forsyte.apalache.io.PrettyPrinterError
 
 /**
  * <p>A pretty printer to a file that formats a TLA+ expression to a given text width (normally, 80 characters). As
@@ -701,26 +701,26 @@ object PrettyWriter {
 
   protected val binaryOps =
     HashMap(
-        TlaOper.eq -> "=",
-        TlaOper.ne -> "/=",
-        TlaBoolOper.implies -> "=>",
-        TlaBoolOper.equiv -> "<=>",
-        TlaArithOper.plus -> "+",
-        TlaArithOper.minus -> "-",
-        TlaArithOper.mult -> "*",
-        TlaArithOper.div -> "/",
-        TlaArithOper.mod -> "%",
-        TlaArithOper.realDiv -> "/.",
-        TlaArithOper.exp -> "^",
-        TlaArithOper.dotdot -> "..",
-        TlaArithOper.lt -> "<",
-        TlaArithOper.gt -> ">",
-        TlaArithOper.le -> "<=",
-        TlaArithOper.ge -> ">=",
-        TlaSetOper.in -> "\\in",
-        TlaSetOper.notin -> "\\notin",
-        TlaSetOper.cap -> "\\intersect",
-        TlaSetOper.cup -> "\\union",
+      TlaOper.eq -> "=",
+      TlaOper.ne -> "/=",
+      TlaBoolOper.implies -> "=>",
+      TlaBoolOper.equiv -> "<=>",
+      TlaArithOper.plus -> "+",
+      TlaArithOper.minus -> "-",
+      TlaArithOper.mult -> "*",
+      TlaArithOper.div -> "\\div",
+      TlaArithOper.mod -> "%",
+      TlaArithOper.realDiv -> "/",
+      TlaArithOper.exp -> "^",
+      TlaArithOper.dotdot -> "..",
+      TlaArithOper.lt -> "<",
+      TlaArithOper.gt -> ">",
+      TlaArithOper.le -> "<=",
+      TlaArithOper.ge -> ">=",
+      TlaSetOper.in -> "\\in",
+      TlaSetOper.notin -> "\\notin",
+      TlaSetOper.cap -> "\\intersect",
+      TlaSetOper.cup -> "\\union",
         TlaSetOper.setminus -> "\\",
         TlaSetOper.subseteq -> "\\subseteq",
         TlaActionOper.composition -> "\\cdot",

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -8,9 +8,9 @@ import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
-import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
 
 import java.io.{PrintWriter, StringWriter}
 
@@ -296,6 +296,20 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     writer.write(not(eql(int(1), int(2))))
     printWriter.flush()
     assert("~(1 = 2)" == stringWriter.toString)
+  }
+
+  test("5 \\div 3") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(div(int(5), int(3)))
+    printWriter.flush()
+    assert("5 \\div 3" == stringWriter.toString)
+  }
+
+  test("5 / 3") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(OperEx(TlaArithOper.realDiv, int(5), int(3)))
+    printWriter.flush()
+    assert("5 / 3" == stringWriter.toString)
   }
 
   test("[S -> T]") {


### PR DESCRIPTION
This is a small fix of the pretty printer. I noticed that `x \div y` and `x / y` were written as `x / y` and `x /. y`, respectively. This produced output that could not be fed back into Apalache.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
