### PR TITLE
Avoid shadowed field in when setting Z3 parameters

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -504,7 +504,6 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext with LazyL
       Some(sat())
     } else {
       def setTimeout(tm: Int): Unit = {
-        val params = z3context.mkParams()
         params.add("timeout", tm)
         z3solver.setParameters(params)
         log(s";; ${params}")


### PR DESCRIPTION
Reuse the global Z3 `Params` object when setting a timeout in `Z3SolverContext`.

This was shadowing the global parameter object, on which we set the random seed.
So, perhaps, this fixez #2120? 🫣🤞