### PR TITLE
Ignore Quint run declarations

### DIFF
--- a/.unreleased/bug-fixes/ignore-quint-runs.md
+++ b/.unreleased/bug-fixes/ignore-quint-runs.md
@@ -1,0 +1,2 @@
+Quint `run` declarations are now ignored, allow verification of quint specs
+including those definitions. (See #2572)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -668,6 +668,9 @@ class Quint(moduleData: QuintOutput) {
             val nullaryOpNameContext = Set[String]()
             val tlaEx = build(tlaExpression(quintEx).run(nullaryOpNameContext))
             Some(None, TlaAssumeDecl(tlaEx)(typeTagOfId(id)))
+          case op: QuintOpDef if op.qualifier == "run" =>
+            // We don't currently support run definitions
+            None
           case op: QuintOpDef =>
             val (tlaInstruction, maybeName) = opDefConverter(op).run(nullaryOps)
             val tlaDecl =


### PR DESCRIPTION
We don't currently support Quint runs in Apalache, and don't have any
immanent plans to do so.

I cannot think of any tests that are simpler than the change to
introduce this logic, so unless anyone can suggest one, I'll claim the
correctness of this change is self evident :)

Closes informalsystems/quint#896

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [-] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change