### PR TITLE
Update commons-io to 2.12.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val commonsBeanutils =
       "commons-beanutils" % "commons-beanutils" % "1.9.4" // Apparently an untracked dependency of commonsConfiguration2
     val commonsConfiguration2 = "org.apache.commons" % "commons-configuration2" % "2.9.0"
-    val commonsIo = "commons-io" % "commons-io" % "2.11.0"
+    val commonsIo = "commons-io" % "commons-io" % "2.12.0"
     val guice = "com.google.inject" % "guice" % "5.1.0"
     val kiama = "org.bitbucket.inkytonik.kiama" %% "kiama" % "2.5.0"
     val logbackClassic = "ch.qos.logback" % "logback-classic" % logbackVersion

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -12,6 +12,7 @@ import java.io._
 import java.nio.file.Files
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
+import java.nio.charset.StandardCharsets
 
 // The SANY parser is not thread safe. This singleton object is used to create a
 // mutex around its execution.
@@ -27,10 +28,15 @@ import scala.util.{Failure, Success, Try}
 object SANYSyncWrapper {
   def loadSpecObject(specObj: SpecObj, file: File, errBuf: Writer): Int = {
     this.synchronized {
+      val outStream = WriterOutputStream
+        .builder()
+        .setWriter(errBuf)
+        .setCharset(StandardCharsets.UTF_8)
+        .get()
       SANY.frontEndMain(
           specObj,
           file.getAbsolutePath,
-          new PrintStream(new WriterOutputStream(errBuf, "UTF8")),
+          new PrintStream(outStream),
       )
     }
   }


### PR DESCRIPTION
Builds on Scala Steward's #2575 and fixes a deprecation warning breaking our CI.

<!-- Please ensure that your PR includes the following, as needed -->

- [-] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [-] Documentation added for any new functionality
- [-] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change