### PR TITLE
Fix argument order of `WF`/`SF` in Quint translation

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -579,8 +579,8 @@ class Quint(moduleData: QuintOutput) {
           // Temporal operators
           case "always"     => unaryApp(opName, tla.box)
           case "eventually" => unaryApp(opName, tla.diamond)
-          case "weakFair"   => binaryApp(opName, tla.WF)
-          case "strongFair" => binaryApp(opName, tla.SF)
+          case "weakFair"   => binaryApp(opName, (action, vars) => tla.WF(vars, action))
+          case "strongFair" => binaryApp(opName, (action, vars) => tla.SF(vars, action))
 
           case "ite" => ternaryApp(opName, tla.ite)
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -705,11 +705,11 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert weakFair operator") {
-    assert(convert(Q.app("weakFair", Q.tt, Q.tt)(QuintBoolT())) == "WF_TRUE(TRUE)")
+    assert(convert(Q.app("weakFair", Q.tt, Q.name)(QuintBoolT())) == "WF_n(TRUE)")
   }
 
   test("can convert strongFair operator") {
-    assert(convert(Q.app("strongFair", Q.tt, Q.tt)(QuintBoolT())) == "SF_TRUE(TRUE)")
+    assert(convert(Q.app("strongFair", Q.tt, Q.name)(QuintBoolT())) == "SF_n(TRUE)")
   }
 
   test("can convert polymorphic operator applied polymorphically") {


### PR DESCRIPTION
Flip arguments of `WF` and `SF` in Quint -> Apalache translation

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
