### PR TITLE
Account for predefined set names

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -633,13 +633,19 @@ class Quint(moduleData: QuintOutput) {
         case QuintInt(_, i)  => Reader(_ => tla.int(i))
         case QuintStr(_, s)  => Reader(_ => tla.str(s))
         case QuintName(id, name) =>
-          val t = Quint.typeToTlaType(types(id).typ)
-          Reader { nullaryOpNames =>
-            if (nullaryOpNames.contains(name)) {
-              tla.appOp(tla.name(name, OperT1(Seq(), t)))
-            } else {
-              tla.name(name, t)
-            }
+          name match {
+            // special case: predefined set BOOLEAN is Bool in Quint
+            case "Bool" => Reader(_ => tla.booleanSet())
+            // general case: some other name
+            case _ =>
+              val t = Quint.typeToTlaType(types(id).typ)
+              Reader { nullaryOpNames =>
+                if (nullaryOpNames.contains(name)) {
+                  tla.appOp(tla.name(name, OperT1(Seq(), t)))
+                } else {
+                  tla.name(name, t)
+                }
+              }
           }
         case QuintLet(_, binding: QuintDef.QuintOpDef, scope) if binding.qualifier == "nondet" =>
           nondetBinding(binding, scope)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -122,6 +122,9 @@ class TestQuintEx extends AnyFunSuite {
 
     // Names and parameters
     val name = e(QuintName(uid, "n"), QuintIntT())
+    val nameBoolSet = e(QuintName(uid, "Bool"), QuintSetT(QuintBoolT()))
+    val nameIntSet = e(QuintName(uid, "Int"), QuintSetT(QuintIntT()))
+    val nameNatSet = e(QuintName(uid, "Nat"), QuintSetT(QuintIntT()))
     val nParam = param("n", QuintIntT())
     val acc = e(QuintName(uid, "acc"), QuintIntT())
     val accParam = param("acc", QuintIntT())
@@ -204,6 +207,12 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert name") {
     assert(convert(Q.name) == "n")
+  }
+
+  test("converts predefined sets") {
+    assert(convert(Q.nameBoolSet) == "BOOLEAN")
+    assert(convert(Q.nameIntSet) == "Int")
+    assert(convert(Q.nameNatSet) == "Nat")
   }
 
   test("can convert let expression") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -122,9 +122,6 @@ class TestQuintEx extends AnyFunSuite {
 
     // Names and parameters
     val name = e(QuintName(uid, "n"), QuintIntT())
-    val nameBoolSet = e(QuintName(uid, "Bool"), QuintSetT(QuintBoolT()))
-    val nameIntSet = e(QuintName(uid, "Int"), QuintSetT(QuintIntT()))
-    val nameNatSet = e(QuintName(uid, "Nat"), QuintSetT(QuintIntT()))
     val nParam = param("n", QuintIntT())
     val acc = e(QuintName(uid, "acc"), QuintIntT())
     val accParam = param("acc", QuintIntT())
@@ -209,10 +206,10 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.name) == "n")
   }
 
-  test("converts predefined sets") {
-    assert(convert(Q.nameBoolSet) == "BOOLEAN")
-    assert(convert(Q.nameIntSet) == "Int")
-    assert(convert(Q.nameNatSet) == "Nat")
+  test("can convert predefined sets") {
+    assert(convert(Q.nam("Bool", QuintSetT(QuintBoolT()))) == "BOOLEAN")
+    assert(convert(Q.nam("Int", QuintSetT(QuintIntT()))) == "Int")
+    assert(convert(Q.nam("Nat", QuintSetT(QuintIntT()))) == "Nat")
   }
 
   test("can convert let expression") {


### PR DESCRIPTION
Predefined set `BOOLEAN` requires special conversion of its Quint name `Bool`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
