### PR TITLE
Consider nullary ops in Quint assume

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -677,8 +677,7 @@ class Quint(moduleData: QuintOutput) {
           case QuintConst(id, name, _) => Some(None, TlaConstDecl(name)(typeTagOfId(id)))
           case QuintVar(id, name, _)   => Some(None, TlaVarDecl(name)(typeTagOfId(id)))
           case QuintAssume(_, _, quintEx) =>
-            val nullaryOpNameContext = Set[String]()
-            val tlaEx = build(tlaExpression(quintEx).run(nullaryOpNameContext))
+            val tlaEx = build(tlaExpression(quintEx).run(nullaryOps))
             // assume declarations have no entry in the type map, and are always typed bool
             Some(None, TlaAssumeDecl(tlaEx)(Typed(BoolT1)))
           case op: QuintOpDef if op.qualifier == "run" =>


### PR DESCRIPTION
Small fix to correctly consider nullary operators inside a Quint `assume` statement.

Thanks @shonfeder for confirming this fix.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~[Entries added to `./unreleased/`][changelog format] for any new functionality~

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
