### PR TITLE
Replace deprecated sonatype resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,8 @@ ThisBuild / organization := "at.forsyte"
 ThisBuild / scalaVersion := "2.13.11"
 
 // Add resolver for Sonatype OSS Snapshots and Releases Maven repository
-ThisBuild / resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases"),
-)
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 // Shared dependencies accross all sub projects
 ThisBuild / libraryDependencies ++= Seq(


### PR DESCRIPTION
Update deprecated calls that append Sonatype resolvers in `build.sbt`.
This fixes the following deprecation warnings when building:

```
/home/runner/work/apalache/apalache/build.sbt:27: warning: method sonatypeRepo in class ResolverFunctions is deprecated (since 1.7.0): Use sonatypeOssRepos instead e.g. `resolvers ++= Resolver.sonatypeOssRepos("snapshots")`
    Resolver.sonatypeRepo("snapshots"),
             ^
/home/runner/work/apalache/apalache/build.sbt:28: warning: method sonatypeRepo in class ResolverFunctions is deprecated (since 1.7.0): Use sonatypeOssRepos instead e.g. `resolvers ++= Resolver.sonatypeOssRepos("snapshots")`
    Resolver.sonatypeRepo("releases"),
             ^
```