### PR TITLE
[DRAFT] Remove unnecessary CI cache workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,9 +139,7 @@ jobs:
             ${{ runner.os }}-sbt-
             ${{ runner.os }}-
       - name: Cache nix store
-        # Workaround for cache action not playing well with permissions
-        # See https://github.com/actions/cache/issues/324
-        uses: john-shaffer/cache@59429c0461095f341a8cf7388e5d3aef37b95edd
+        uses: actions/cache@v3
         with:
           path: |
             /nix/store
@@ -168,9 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache nix store
-        # Workaround for cache action not playing well with permissions
-        # See https://github.com/actions/cache/issues/324
-        uses: john-shaffer/cache@59429c0461095f341a8cf7388e5d3aef37b95edd
+        uses: actions/cache@v3
         with:
           path: |
             /nix/store


### PR DESCRIPTION
Remove CI workaround for `actions/cache` that runs `tar` using `sudo`, replacing it with up-to-date cache action.

---

This was meant to fix #2611 by replacing

https://github.com/informalsystems/apalache/blob/97c24e863b861322b9776288b821c7894adf535e/.github/workflows/main.yml#L143-L145

with an updated `actions/cache@v3.3.1`.

Unfortunately, that only results in the issue getting propagated into Ubuntu CI runs as well (on top of macOS).