### PR TITLE
Fix Quint translation of `Nat` and `Int`

### DIFF
--- a/.unreleased/bug-fixes/2621-qnt-nat-int.md
+++ b/.unreleased/bug-fixes/2621-qnt-nat-int.md
@@ -1,0 +1,1 @@
+Fix Quint translation of `Nat` and `Int`, see #2621

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -640,8 +640,10 @@ class Quint(moduleData: QuintOutput) {
         case QuintStr(_, s)  => Reader(_ => tla.str(s))
         case QuintName(id, name) =>
           name match {
-            // special case: predefined set BOOLEAN is Bool in Quint
+            // special case: Nat, Int and BOOLEAN are built-in values
             case "Bool" => Reader(_ => tla.booleanSet())
+            case "Int"  => Reader(_ => tla.intSet())
+            case "Nat"  => Reader(_ => tla.natSet())
             // general case: some other name
             case _ =>
               val t = Quint.typeToTlaType(types(id).typ)


### PR DESCRIPTION
Translate `Nat`, `Int` to their built-in values.

We already considered `Bool`, because its name in TLA+ is different, but `Nat` and `Int` were missing.


ℹ️ Auto-merge is on