### PR TITLE
Increase max inbound gRPC message size

### DIFF
--- a/.unreleased/bug-fixes/2623-grpc-msg-size.md
+++ b/.unreleased/bug-fixes/2623-grpc-msg-size.md
@@ -1,0 +1,1 @@
+Increase max inbound gRPC message size, see #2623

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -2,8 +2,6 @@ package at.forsyte.apalache.shai.v1
 
 import zio.{console, Ref, ZEnv, ZIO}
 
-import scala.language.existentials
-
 import java.util.UUID
 import scalapb.zio_grpc.ServerMain
 import scalapb.zio_grpc.ServiceList
@@ -31,6 +29,10 @@ class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
 
   def services: ServiceList[ZEnv] =
     ServiceList.addM(createTransExplorerService).addM(createCmdExecutorService)
+
+  // Enable existential types; builder's signature below cannot be expressed using wildcards.
+  // This is needed even if the type below is omitted / inferred.
+  import scala.language.existentials
 
   // Double max inbound message size to 8MB
   // Fixes `io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size`:

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -1,10 +1,14 @@
 package at.forsyte.apalache.shai.v1
 
 import zio.{console, Ref, ZEnv, ZIO}
+
+import scala.language.existentials
+
 import java.util.UUID
 import scalapb.zio_grpc.ServerMain
 import scalapb.zio_grpc.ServiceList
 import com.typesafe.scalalogging.LazyLogging
+import io.grpc.ServerBuilder
 
 /**
  * The Shai RPC server handling gRPC requests to interact with the model checker
@@ -27,6 +31,12 @@ class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
 
   def services: ServiceList[ZEnv] =
     ServiceList.addM(createTransExplorerService).addM(createCmdExecutorService)
+
+  // Double max inbound message size to 8MB
+  // Fixes `io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size`:
+  // https://github.com/informalsystems/apalache/issues/2622
+  override def builder: (x0) forSome { type x0 <: ServerBuilder[x0] } =
+    super.builder.maxInboundMessageSize(8 * 1024 * 1024)
 }
 
 object RpcServer {


### PR DESCRIPTION
Increase max inbound gRPC message size to 8MB

This fixes an issue where large-enough Quint specs fail with
```
io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 5177182
```

Closes #2622

ℹ️ Auto-merge is **ON**

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
