### PR TITLE
Use single typevar map for entire spec

### DIFF
--- a/.unreleased/bug-fixes/2629-typevar-translation.md
+++ b/.unreleased/bug-fixes/2629-typevar-translation.md
@@ -1,0 +1,1 @@
+Fix an issue with translating Quint type variables, see #2629

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
@@ -120,7 +120,7 @@ private class QuintTypeConverter extends LazyLogging {
     RowT1(fieldTypes: _*)
   }
 
-  private val convert: QuintType => TlaType1 = {
+  val convert: QuintType => TlaType1 = {
     case QuintBoolT()             => BoolT1
     case QuintIntT()              => IntT1
     case QuintStrT()              => StrT1
@@ -134,14 +134,4 @@ private class QuintTypeConverter extends LazyLogging {
     case QuintRecordT(row)        => RecRowT1(rowToRowT1(row))
     case QuintUnionT(_, variants) => VariantT1(unionToRowT1(variants))
   }
-}
-
-/**
- * Convert a QuintType to a TlaType1.
- *
- * Constructs a fresh scope for translating Quint type variables to Apalache type variables (see
- * QuintTypeConverter.getVarNo() for details).
- */
-object QuintTypeConverter {
-  def apply(quintType: QuintType): TlaType1 = new QuintTypeConverter().convert(quintType)
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.io.quint
 
-import at.forsyte.apalache.tla.lir.{IntT1, OperT1, RecRowT1, RowT1, SetT1, TlaEx, Typed, VarT1}
+import at.forsyte.apalache.tla.lir.{IntT1, OperT1, RecRowT1, RowT1, SetT1, TlaEx, TlaType1, Typed, VarT1}
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
@@ -177,6 +177,8 @@ class TestQuintEx extends AnyFunSuite {
         table = lookupMap.toMap,
     )
   }
+
+  val translate: QuintType => TlaType1 = (new QuintTypeConverter).convert(_)
 
   def translate(qex: QuintEx): TlaEx = {
     val translator = new Quint(Q.quintOutput)
@@ -536,7 +538,7 @@ class TestQuintEx extends AnyFunSuite {
     val exp = translate(quintEx)
     val expectedTlaType = RecRowT1(RowT1(VarT1("a"), ("s", IntT1), ("t", IntT1)))
 
-    assert(QuintTypeConverter(typ) == expectedTlaType)
+    assert(translate(typ) == expectedTlaType)
     assert(exp.typeTag == Typed(expectedTlaType))
     assert(exp.toString == """["s" ↦ 1, "t" ↦ 2]""")
   }
@@ -578,7 +580,7 @@ class TestQuintEx extends AnyFunSuite {
 
     val tlaRecTyp = RecRowT1(RowT1(VarT1("a"), ("s", IntT1)))
     val expectedTlaType = OperT1(Seq(tlaRecTyp), tlaRecTyp)
-    assert(QuintTypeConverter(opType) == expectedTlaType)
+    assert(translate(opType) == expectedTlaType)
     assert(tlaOpDef.typeTag == Typed(expectedTlaType))
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
@@ -3,9 +3,8 @@ package at.forsyte.apalache.io.quint
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
-
 import at.forsyte.apalache.io.quint.QuintType._
-import at.forsyte.apalache.tla.lir.{FunT1, IntT1, RecRowT1, RowT1, StrT1, TupT1, VarT1, VariantT1}
+import at.forsyte.apalache.tla.lir.{FunT1, IntT1, RecRowT1, RowT1, StrT1, TlaType1, TupT1, VarT1, VariantT1}
 
 /**
  * Tests the conversion of quint types, represented as QuintTypes, into TlaType1
@@ -13,42 +12,44 @@ import at.forsyte.apalache.tla.lir.{FunT1, IntT1, RecRowT1, RowT1, StrT1, TupT1,
 @RunWith(classOf[JUnitRunner])
 class TestQuintTypes extends AnyFunSuite {
 
+  val translate: QuintType => TlaType1 = (new QuintTypeConverter).convert(_)
+
   test("Quint's named type variables are converted into numbered TlaType1 variables") {
     val typeVar = QuintVarT("foo")
-    assert(QuintTypeConverter(typeVar) == VarT1(0))
+    assert(translate(typeVar) == VarT1(0))
   }
 
   test("Multiple Quint named type variables are converted into sequentially numbered TlaType1 variables") {
     val polyFun = QuintFunT(QuintVarT("a"), QuintVarT("b"))
-    assert(QuintTypeConverter(polyFun) == FunT1(VarT1(0), VarT1(1)))
+    assert(translate(polyFun) == FunT1(VarT1(0), VarT1(1)))
   }
 
   test("Quint tuple types are converted correctly") {
     val tuple =
       // i.e.: (int, string)
       QuintTupleT(Row.Cell(List(RecordField("1", QuintIntT()), RecordField("2", QuintStrT())), Row.Nil()))
-    assert(QuintTypeConverter(tuple) == TupT1(IntT1, StrT1))
+    assert(translate(tuple) == TupT1(IntT1, StrT1))
   }
 
   test("Polymorphic Quint tuples types are converted to plain, closed tuples") {
     val tuple =
       // i.e.: (int, string | r)
       QuintTupleT(Row.Cell(List(RecordField("1", QuintIntT()), RecordField("2", QuintStrT())), Row.Var("r")))
-    assert(QuintTypeConverter(tuple) == TupT1(IntT1, StrT1))
+    assert(translate(tuple) == TupT1(IntT1, StrT1))
   }
 
   test("Open Quint record types are converted into open TlaType1 records") {
     val record =
       // i.e.: { f1: int, f2: string | r }
       QuintRecordT(Row.Cell(List(RecordField("f1", QuintIntT()), RecordField("f2", QuintStrT())), Row.Var("r")))
-    assert(QuintTypeConverter(record) == RecRowT1(RowT1(VarT1(0), ("f1" -> IntT1), ("f2" -> StrT1))))
+    assert(translate(record) == RecRowT1(RowT1(VarT1(0), ("f1" -> IntT1), ("f2" -> StrT1))))
   }
 
   test("Closed Quint record types are converted into closed TlaType1 records") {
     val record =
       // i.e.: { f1: int, f2: string }
       QuintRecordT(Row.Cell(List(RecordField("f1", QuintIntT()), RecordField("f2", QuintStrT())), Row.Nil()))
-    assert(QuintTypeConverter(record) == RecRowT1(RowT1(("f1" -> IntT1), ("f2" -> StrT1))))
+    assert(translate(record) == RecRowT1(RowT1(("f1" -> IntT1), ("f2" -> StrT1))))
   }
 
   test("Quint unions are converted into TlaType1 variants") {
@@ -65,7 +66,7 @@ class TestQuintTypes extends AnyFunSuite {
     val expectedVariant =
       // i.e.: t1({ f1: Int }) | t2({ f2: Str })
       VariantT1(RowT1("t1" -> RecRowT1(RowT1(("f1" -> IntT1))), "t2" -> RecRowT1(RowT1(("f2" -> StrT1)))))
-    assert(QuintTypeConverter(variant) == expectedVariant)
+    assert(translate(variant) == expectedVariant)
   }
 
   // tictactoe.json is located in tla-io/src/test/resources/tictactoe.json
@@ -73,6 +74,6 @@ class TestQuintTypes extends AnyFunSuite {
     val tictactoeQuintJson = scala.io.Source.fromResource("tictactoe.json").mkString
     val quintTypes = QuintOutput.read(tictactoeQuintJson).get.types
     // All type conversions go through
-    quintTypes.map { case (id, t) => (id, t.typ, QuintTypeConverter(t.typ)) }
+    quintTypes.map { case (id, t) => (id, t.typ, translate(t.typ)) }
   }
 }


### PR DESCRIPTION
Use a single type converter for an entire quint spec.

We previously used one type converter per sub-expression. This re-initialized the map for translating Quint type variables (named) to Apalache TypeSystem 1 type variables (numbered), causing wrong type annotations. For example the type of the following Quint was translated as `(a,a) => {src: a, ts: a}`.

```bluespec
/// `p.msgFrom(ts)` is a message sent from `p` at time `ts` 
def msgFrom(p, ts) = {src: p, ts : ts}
```

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
