### PR TITLE
Extend unification error message in appOp

### DIFF
--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeBaseBuilder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeBaseBuilder.scala
@@ -50,7 +50,9 @@ class UnsafeBaseBuilder extends ProtoBuilder {
           case _ => buildBySignatureLookup(TlaOper.apply, retypedOp +: retypedArgs: _*)
         }
       case None =>
-        throw new TBuilderTypeException(s"Operator application argument types do not unify with the operator type.")
+        throw new TBuilderTypeException(
+            s"Operator application argument types ${mockOperT} do not unify with the operator type ${opType} in ${Op}(${args
+                .mkString(", ")}).")
     }
 
   }


### PR DESCRIPTION
Extend the exception message with expected and actual types, and the affected expression.