### PR TITLE
Translate Quint open row tuples to sparse tuples

### DIFF
--- a/.unreleased/bug-fixes/2634-quint-open-tuple.md
+++ b/.unreleased/bug-fixes/2634-quint-open-tuple.md
@@ -1,0 +1,1 @@
+Fix a bug when translating certain Quint tuple types, see #2634

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
@@ -47,7 +47,7 @@ private class QuintTypeConverter extends LazyLogging {
       case Row.Nil()  => (acc0, None)
       case Row.Var(v) => (acc0, Some(VarT1(getVarNo(v))))
       case Row.Cell(fields, other) =>
-        val acc1 = acc0 ++ fields.map { f => f.fieldName.toInt + 1 -> convert(f.fieldType) }
+        val acc1 = acc0 ++ fields.map { f => (f.fieldName.toInt + 1) -> convert(f.fieldType) }
         aux(other, acc1)
     }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
@@ -4,7 +4,9 @@ import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import at.forsyte.apalache.io.quint.QuintType._
-import at.forsyte.apalache.tla.lir.{FunT1, IntT1, RecRowT1, RowT1, StrT1, TlaType1, TupT1, VarT1, VariantT1}
+import at.forsyte.apalache.tla.lir.{
+  FunT1, IntT1, RecRowT1, RowT1, SparseTupT1, StrT1, TlaType1, TupT1, VarT1, VariantT1,
+}
 
 /**
  * Tests the conversion of quint types, represented as QuintTypes, into TlaType1
@@ -27,15 +29,15 @@ class TestQuintTypes extends AnyFunSuite {
   test("Quint tuple types are converted correctly") {
     val tuple =
       // i.e.: (int, string)
-      QuintTupleT(Row.Cell(List(RecordField("1", QuintIntT()), RecordField("2", QuintStrT())), Row.Nil()))
+      QuintTupleT(Row.Cell(List(RecordField("0", QuintIntT()), RecordField("1", QuintStrT())), Row.Nil()))
     assert(translate(tuple) == TupT1(IntT1, StrT1))
   }
 
-  test("Polymorphic Quint tuples types are converted to plain, closed tuples") {
+  test("Polymorphic Quint tuples types are converted to sparse tuples") {
     val tuple =
       // i.e.: (int, string | r)
-      QuintTupleT(Row.Cell(List(RecordField("1", QuintIntT()), RecordField("2", QuintStrT())), Row.Var("r")))
-    assert(translate(tuple) == TupT1(IntT1, StrT1))
+      QuintTupleT(Row.Cell(List(RecordField("0", QuintIntT()), RecordField("1", QuintStrT())), Row.Var("r")))
+    assert(translate(tuple) == SparseTupT1(1 -> IntT1, 2 -> StrT1))
   }
 
   test("Open Quint record types are converted into open TlaType1 records") {


### PR DESCRIPTION
Translate Quint open row tuples to sparse tuples.

Also fixes an offset in the previous (non-sparse) tuple test.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
