### PR TITLE
Shorten error message on builder errors

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -176,8 +176,8 @@ class Quint(quintOutput: QuintOutput) {
           case lambda @ QuintLambda(_, Seq(), _, _) =>
             throw new QuintIRParseError(
                 s"""|Operator ${op} is a binding operator requiring a non nullary
-                  |operator as its second argument, but it was given the nullary
-                  | ${lambda}""".stripMargin
+                    |operator as its second argument, but it was given the nullary
+                    | ${lambda}""".stripMargin
             )
           case QuintLambda(_, params, _, scope) =>
             // uniquely rename parameters of name "_" to prevent shadowing of nested "_"s
@@ -201,7 +201,7 @@ class Quint(quintOutput: QuintOutput) {
               case invalidType =>
                 throw new QuintIRParseError(
                     s"""|Operator ${op} is a binding operator requiring an operator as it's second argument,
-                      |but it was given ${opName} with type ${invalidType}""".stripMargin
+                        |but it was given ${opName} with type ${invalidType}""".stripMargin
                 )
             }
             val tlaArgs = paramTypes.map(typ => tla.name(nameGen.uniqueVarName(), typeConv.convert(typ)))
@@ -215,7 +215,7 @@ class Quint(quintOutput: QuintOutput) {
           case invalidBinder =>
             throw new QuintIRParseError(
                 s"""|Operator ${op} is a binding operator requiring an operator as it's second argument,
-                  |but it was given ${invalidBinder}""".stripMargin
+                    |but it was given ${invalidBinder}""".stripMargin
             )
         }
       case wrongNumberOfArgs => throwOperatorArityError(op, "binary", wrongNumberOfArgs)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -662,7 +662,7 @@ class Quint(quintOutput: QuintOutput) {
               // conversion logic or quint construction, and this is an internal error
               case err @ (_: TBuilderScopeException | _: TBuilderTypeException) =>
                 throw new QuintIRParseError(
-                    s"Conversion failed while building operator definition ${op}: ${err.getMessage()}")
+                    s"Conversion failed while building operator definition `${op.name}`: ${err.getMessage}")
             }
           Some(maybeName, tlaDecl)
       })


### PR DESCRIPTION
Shorten the error message, if the typed builder fails to build a `QuintOpDef`.
Previously, this was printing the entire operator definition IR, which pollutes output, but isn't very useful. Now, this just prints the operator name that failed to build.

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
