### PR TITLE
Use tla.rowRec to decode RecRowT1 cells

### DIFF
--- a/.unreleased/bug-fixes/2684-decode-recrow.md
+++ b/.unreleased/bug-fixes/2684-decode-recrow.md
@@ -1,0 +1,1 @@
+Fixed a bug when decoding certain record types, see #2684

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SymbStateDecoder.scala
@@ -165,9 +165,10 @@ class SymbStateDecoder(solverContext: SolverContext, rewriter: SymbStateRewriter
       arena: PureArenaAdapter,
       cell: ArenaCell,
       fieldTypes: SortedMap[String, TlaType1]): TBuilderInstruction =
-    tla.rec(fieldTypes.keySet.toList.map { k =>
-      k -> decodeCellToTlaEx(arena, recordOps.getField(arena, cell, k))
-    }: _*)
+    tla.rowRec(None,
+        fieldTypes.keySet.toList.map { k =>
+          k -> decodeCellToTlaEx(arena, recordOps.getField(arena, cell, k))
+        }: _*)
 
   private def decodeVariantToTlaEx(
       arena: PureArenaAdapter,


### PR DESCRIPTION
Fixes #2683 

SymbStateDecoder is calling `tla.rec()` to decode a `RecRowT1` cell.
This leads to a type mismatch in `LazyEquality` (described in #2683) when asserting a path constraint, because we compare the original `RecRowT1` to the decoded `RecT1`.

Construct a RecRowT1 for cells of such type, via `tla.rowRec()`.

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
