### PR TITLE
Arena fix for Gen

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -270,7 +270,7 @@ trait TestSymbStateDecoder extends RewriterBase {
     assertBuildEqual(vrt1, decodedEx)
   }
 
-  test("decode gen: Regression for #2702") { rewriterType: SMTEncoding =>
+  test("decode gen: Regression #1 for #2702") { rewriterType: SMTEncoding =>
     val valName = tla.name("gen", SetT1(IntT1))
     val genEx = tla.gen(1, SetT1(IntT1))
     val x = tla.name("x", IntT1)
@@ -295,6 +295,34 @@ trait TestSymbStateDecoder extends RewriterBase {
           case OperEx(TlaSetOper.enumSet, args @ _*) =>
             args.forall { _ == tla.int(0).build }
           case _ => false
+        }
+    )
+  }
+
+  test("decode gen: Regression #2 for #2702") { rewriterType: SMTEncoding =>
+    val valName = tla.name("gen", SetT1(IntT1))
+    val genEx = tla.gen(1, SetT1(IntT1))
+    val x = tla.name("x", IntT1)
+    val cond = tla.forall(x, valName, tla.neql(x, tla.int(42)))
+
+    val ex = tla.and(tla.eql(valName, genEx), cond)
+
+    val arenaWithGenCell = arena.appendCell(SetT1(IntT1))
+    val genCell = arenaWithGenCell.topCell
+
+    val rewriter = create(rewriterType)
+    val state = new SymbState(ex, arenaWithGenCell, Binding("gen" -> genCell))
+    val rewrittenState = rewriter.rewriteUntilDone(state)
+    assert(solverContext.sat())
+
+    val decoder = new SymbStateDecoder(solverContext, rewriter)
+
+    val decodedVal: TlaEx = decoder.decodeCellToTlaEx(rewrittenState.arena, genCell)
+
+    assert(
+        decodedVal match {
+          case OperEx(TlaSetOper.enumSet, args @ _*) => !args.contains(tla.int(42).build)
+          case _                                     => false
         }
     )
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -2,9 +2,11 @@ package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
-import at.forsyte.apalache.tla.types.tla._
 import at.forsyte.apalache.tla.types.parser.DefaultType1Parser
+import at.forsyte.apalache.tla.types.tla
+import at.forsyte.apalache.tla.types.tla._
 
 trait TestSymbStateDecoder extends RewriterBase {
   private val parser = DefaultType1Parser
@@ -267,4 +269,34 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     assertBuildEqual(vrt1, decodedEx)
   }
+
+  test("decode gen: Regression for #2702") { rewriterType: SMTEncoding =>
+    val valName = tla.name("gen", SetT1(IntT1))
+    val genEx = tla.gen(1, SetT1(IntT1))
+    val x = tla.name("x", IntT1)
+    val cond = tla.forall(x, valName, tla.eql(x, tla.int(0)))
+
+    val ex = tla.and(tla.eql(valName, genEx), cond)
+
+    val arenaWithGenCell = arena.appendCell(SetT1(IntT1))
+    val genCell = arenaWithGenCell.topCell
+
+    val rewriter = create(rewriterType)
+    val state = new SymbState(ex, arenaWithGenCell, Binding("gen" -> genCell))
+    val rewrittenState = rewriter.rewriteUntilDone(state)
+    assert(solverContext.sat())
+
+    val decoder = new SymbStateDecoder(solverContext, rewriter)
+
+    val decodedVal: TlaEx = decoder.decodeCellToTlaEx(rewrittenState.arena, genCell)
+
+    assert(
+        decodedVal match {
+          case OperEx(TlaSetOper.enumSet, args @ _*) =>
+            args.forall { _ == tla.int(0).build }
+          case _ => false
+        }
+    )
+  }
+
 }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

closes #2702 

Arenas for `Gen`-created sets were incorrectly always using fixed pointers, meaning that in the reconstruction (and subsequent output) these sets were shown to contain elements, which the underlying SMT constraints did not imply. The fix is to use a pointer with an unconstrained SMT value instead, and let the solver determine memberships, if any.

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
