### PR TITLE
Account for possible output in CLI server test

### DIFF
--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3918,6 +3918,7 @@ up and output its welcome message, before killing it:
 $ apalache-mc server & pid=$! && sleep 3 && kill $pid
 ...
 The Apalache server is running on port 8822. Press Ctrl-C to stop.
+...
 ```
 
 ### server mode: server can be started at different port
@@ -3926,6 +3927,7 @@ The Apalache server is running on port 8822. Press Ctrl-C to stop.
 $ apalache-mc server --port=8888 & pid=$! && sleep 3 && kill $pid
 ...
 The Apalache server is running on port 8888. Press Ctrl-C to stop.
+...
 ```
 
 ## quint input


### PR DESCRIPTION
It's possible for output to be printed after the welcome message in
these tests. This change accounts for that.

An example of the incorrect failures on this case is https://github.com/informalsystems/apalache/actions/runs/6225708423/job/16896714985?pr=2739

It's just a race condition on the output.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change