### PR TITLE
`SparseOracle` refactor

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/SparseOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/SparseOracle.scala
@@ -1,0 +1,43 @@
+package at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.oracles
+
+import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
+import at.forsyte.apalache.tla.bmcmt.stratifiedRules.RewriterScope
+import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
+import at.forsyte.apalache.tla.types.tla
+
+/**
+ * Given an `oracle` and a set `values` of size `N`, such that {{{values \subseteq {0,...,oracle.size},}}} a
+ * `SparseOracle` `o` acts as a compression of `oracle` with `o.size = N`, such that for any scope `s` and any element
+ * `i \in values`, the following holds:
+ * {{{o.chosenValueIsEqualToIndexedValue(s,indexOf(i)) = oracle.chosenValueIsEqualToIndexedValue(s,i),}}} where
+ * `indexOf` is a bijective mapping from `values` to `{0,..., N}`.
+ *
+ * @author
+ *   Jure Kukovec
+ *
+ * @param oracle
+ *   the backend oracle that ranges over values 0..|S|-1
+ * @param values
+ *   the set S of oracle values
+ */
+class SparseOracle(oracle: Oracle, val values: Set[Int]) extends Oracle {
+  private[oracles] val sortedValues: Seq[Int] = values.toSeq.sorted
+
+  override def size: Int = values.size
+
+  def chosenValueIsEqualToIndexedValue(scope: RewriterScope, index: BigInt): TBuilderInstruction =
+    sortedValues
+      .map { oracle.chosenValueIsEqualToIndexedValue(scope, _) }
+      .applyOrElse[Int, TBuilderInstruction](index.toInt, _ => tla.bool(false))
+
+  override def caseAssertions(
+      scope: RewriterScope,
+      assertions: Seq[TBuilderInstruction],
+      elseAssertionsOpt: Option[Seq[TBuilderInstruction]] = None): TBuilderInstruction =
+    oracle.caseAssertions(scope, assertions, elseAssertionsOpt)
+
+  override def getIndexOfChosenValueFromModel(solverContext: SolverContext): BigInt = {
+    val rawIdx: Int = oracle.getIndexOfChosenValueFromModel(solverContext).toInt
+    sortedValues.indexOf(rawIdx)
+  }
+}

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/SparseOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/SparseOracle.scala
@@ -6,29 +6,37 @@ import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
 import at.forsyte.apalache.tla.types.tla
 
 /**
- * Given an `oracle` and a set `values` of size `N`, such that {{{values \subseteq {0,...,oracle.size},}}} a
- * `SparseOracle` `o` acts as a compression of `oracle` with `o.size = N`, such that for any scope `s` and any element
- * `i \in values`, the following holds:
- * {{{o.chosenValueIsEqualToIndexedValue(s,indexOf(i)) = oracle.chosenValueIsEqualToIndexedValue(s,i),}}} where
- * `indexOf` is a bijective mapping from `values` to `{0,..., N}`.
+ * Given a set `indices` of size `N`, sparse oracle is able to answer {{{chosenValueIsEqualToIndexedValue(_, i),}}} for
+ * any `i \in indices`, despite having a size, which may be smaller than some (ot all) elements of `indices`.
+ * {{{chosenValueIsEqualToIndexedValue(_, j),}}} for any `j` not in `indices` does not hold.
+ *
+ * Internally, every SparseOracle `s` maintains an oracle `o` of size `N-1`, such that for every scope `X`, and any
+ * index `i \in indices` the following holds:
+ * {{{s.chosenValueIsEqualToIndexedValue(X,i) = o.chosenValueIsEqualToIndexedValue(x, idxMap(i),}}} where `idxMap` is
+ * some bijection from `indices` to `{0,...,N-1}`.
  *
  * @author
  *   Jure Kukovec
  *
- * @param oracle
- *   the backend oracle that ranges over values 0..|S|-1
+ * @param mkOracle
+ *   the method to create the backend oracle, of a given size
  * @param values
  *   the set S of oracle values
  */
-class SparseOracle(oracle: Oracle, val values: Set[Int]) extends Oracle {
+class SparseOracle(mkOracle: Int => Oracle, val values: Set[Int]) extends Oracle {
+  private[oracles] val oracle = mkOracle(values.size)
   private[oracles] val sortedValues: Seq[Int] = values.toSeq.sorted
+  private[oracles] val indexMap: Map[Int, Int] = Map(sortedValues.zipWithIndex: _*)
 
   override def size: Int = values.size
 
   def chosenValueIsEqualToIndexedValue(scope: RewriterScope, index: BigInt): TBuilderInstruction =
-    sortedValues
-      .map { oracle.chosenValueIsEqualToIndexedValue(scope, _) }
-      .applyOrElse[Int, TBuilderInstruction](index.toInt, _ => tla.bool(false))
+    indexMap
+      .get(index.toInt)
+      .map {
+        oracle.chosenValueIsEqualToIndexedValue(scope, _)
+      }
+      .getOrElse(tla.bool(false))
 
   override def caseAssertions(
       scope: RewriterScope,
@@ -37,7 +45,7 @@ class SparseOracle(oracle: Oracle, val values: Set[Int]) extends Oracle {
     oracle.caseAssertions(scope, assertions, elseAssertionsOpt)
 
   override def getIndexOfChosenValueFromModel(solverContext: SolverContext): BigInt = {
-    val rawIdx: Int = oracle.getIndexOfChosenValueFromModel(solverContext).toInt
-    sortedValues.indexOf(rawIdx)
+    val oracleIdx = oracle.getIndexOfChosenValueFromModel(solverContext).toInt
+    sortedValues.applyOrElse[Int, Int](oracleIdx, _ => -1)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestSparseOracle.scala
@@ -1,0 +1,88 @@
+package at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.oracles
+
+import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
+import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
+import at.forsyte.apalache.tla.bmcmt.stratifiedRules.RewriterScope
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.typecomp.TBuilderInstruction
+import at.forsyte.apalache.tla.types.tla
+import org.junit.runner.RunWith
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+import org.scalatestplus.scalacheck.Checkers
+
+@RunWith(classOf[JUnitRunner])
+class TestSparseOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
+
+  var initScope: RewriterScope = RewriterScope.initial()
+
+  override def beforeEach(): Unit = {
+    initScope = RewriterScope.initial()
+  }
+
+  val intGen: Gen[Int] = Gen.choose(-10, 10)
+  val nonNegIntGen: Gen[Int] = Gen.choose(0, 10)
+
+  val maxSizeAndSetGen: Gen[(Int, Set[Int])] = for {
+    max <- nonNegIntGen
+    elems <- Gen.listOfN(max, Gen.choose(0, max))
+  } yield (max, elems.toSet)
+
+  val maxSizeIndexAndSetGen: Gen[(Int, Int, Set[Int])] = for {
+    max <- Gen.choose(1, 20) // we want size > 0
+    elems <- Gen.listOfN(max, Gen.choose(0, max))
+    set =
+      if (elems.nonEmpty) elems.toSet
+      else Set(0) // we don't want the degenerate case where set is empty, so we just pad it with 0
+    idx <- Gen.choose(0, set.size - 1)
+  } yield (max, idx, set)
+
+  test("chosenValueIsEqualToIndexedValue forwards to the original oracle correctly") {
+    val prop =
+      forAll(Gen.zip(maxSizeAndSetGen, intGen)) { case ((size, set), index) =>
+        val (scope, intOracle) = IntOracle.create(initScope, size)
+        val oracle = new SparseOracle(intOracle, set)
+        val cmp: TlaEx = oracle.chosenValueIsEqualToIndexedValue(scope, index)
+        if (index < 0 || index >= oracle.size)
+          cmp == tla.bool(false).build
+        else {
+          cmp == intOracle.chosenValueIsEqualToIndexedValue(scope, oracle.sortedValues(index)).build
+        }
+      }
+
+    check(prop, minSuccessful(1000), sizeRange(4))
+  }
+
+  val (assertionsA, assertionsB): (Seq[TBuilderInstruction], Seq[TBuilderInstruction]) = 0
+    .to(10)
+    .map { i =>
+      (tla.name(s"A$i", BoolT1), tla.name(s"B$i", BoolT1))
+    }
+    .unzip
+
+  // "caseAssertions" tests ignored, since SparseOracle literally just invokes the underlying oracle's method,
+  // which should have its own tests
+
+  // TODO: Enable test after #2743
+  // We cannot test getIndexOfChosenValueFromModel without running the solver
+  ignore("getIndexOfChosenValueFromModel recovers the index correctly") {
+    val prop =
+      forAll(maxSizeIndexAndSetGen) { case (size, index, set) =>
+        val ctx = new Z3SolverContext(SolverConfig.default)
+        val paa = PureArenaAdapter.create(ctx) // We use PAA, since it performs the basic context initialization
+        val (scope, intOracle) = IntOracle.create(initScope.copy(arena = paa.arena), size)
+        ctx.declareCell(intOracle.intCell)
+        val oracle = new SparseOracle(intOracle, set)
+        val eql = oracle.chosenValueIsEqualToIndexedValue(scope, index)
+        ctx.assertGroundExpr(eql)
+        ctx.sat()
+        oracle.getIndexOfChosenValueFromModel(ctx) == index
+      }
+
+    // 1000 is too many, since each run invokes the solver
+    check(prop, minSuccessful(80), sizeRange(4))
+  }
+}


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

Following the pattern laid out in #2709 for `IntOracle`, this PR introduces the same alterations to `SparseOracle`.

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
