### PR TITLE
Update TLC cfg file syntax

### DIFF
--- a/docs/src/apalache/tlc-config.md
+++ b/docs/src/apalache/tlc-config.md
@@ -124,7 +124,7 @@ StateConstraints ::=
 // that restricts the transitions to be explored.
 // APALACHE IGNORES THIS CONFIGURATION OPTION.
 ActionConstraints ::=
-    ("ACTION-CONSTRAINT" | "ACTION-CONSTRAINTS") ident*
+    ("ACTION_CONSTRAINT" | "ACTION_CONSTRAINTS") ident*
 
 // Set the name of an operator that produces a set of permutations
 // for symmetry reduction.


### PR DESCRIPTION
Action constraints in cfg files are labelled with `ACTION_CONSTRAINT` or `ACTION_CONSTRAINTS`, not `ACTION-CONSTRAINT` or `ACTION-CONSTRAINTS` (underscore instead of a hyphen).

Based on this comment in the TLC source code, I believe it changed from a hyphen to an underscore in 2009 https://github.com/tlaplus/tlaplus/blob/a41cbafc66b1dd225156aaca38ad35ec330f4ae9/toolbox/org.lamport.tla.toolbox.tool.tlc/src/org/lamport/tla/toolbox/tool/tlc/launch/TLCModelLaunchDelegate.java#L588
