### PR TITLE
Continue simulation on SMT timeout in enabledness check

### DIFF
--- a/.unreleased/bug-fixes/2758-sim-timeout.md
+++ b/.unreleased/bug-fixes/2758-sim-timeout.md
@@ -1,0 +1,1 @@
+Continue simulation on SMT timeout in enabledness check, see #2758

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/SeqModelChecker.scala
@@ -262,8 +262,12 @@ class SeqModelChecker[ExecutorContextT](
               logger.info(s"Step ${trex.stepNo}: Transition #$no is disabled")
 
             case None =>
-              searchState.onResult(RuntimeError())
-              return (Set.empty, Set.empty) // UNKNOWN or timeout
+              if (params.isRandomSimulation) {
+                logger.info(s"Step ${trex.stepNo}: Transition #$no enabledness is UNKNOWN; assuming it is disabled")
+              } else {
+                searchState.onResult(RuntimeError())
+                return (Set.empty, Set.empty) // UNKNOWN or timeout
+              }
           }
           // recover from the snapshot
           trex.recover(snapshot.get)


### PR DESCRIPTION
Prevent Apalache from halting the (global) search if an enabledness query times out in `simulate`.

This is a simple fix that considers a transition disabled if the corresponding SMT query times out in `simulate` mode.

A more comprehensive treatment of timeouts in `simulate` would be more invasive: It would require us to differentiate timeouts from other `UNKNOWN` Z3 results, and to define (or parameterize) the expected search behavior if invariant or deadlock checks time out during simulation.

Partially addresses #2316 and unblocks https://github.com/informalsystems/quint/issues/1196.

- [ ] ~Tests added for any new code~
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
