### PR TITLE
Add the `hub` dependency to release CI

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -37,4 +37,5 @@ jobs:
           git config --global user.email "github@actions.ci"
       - name: Prepare release
         run: |
+          sudo apt-get update && sudo apt-get install -y hub
           ./script/release-prepare.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.APALACHE_BOT_TOKEN }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
+          sudo apt-get update && sudo apt-get install -y hub
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "github@actions.ci"
           git checkout HEAD~1


### PR DESCRIPTION
This is required for our release script, due to an update to the github
runners that removed this utility from the default machines:
https://github.com/actions/runner-images/issues/8362

That update broke our release pipeline, but we didn't catch it until now because
we had nothing to release.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [-] Tests added for any new code
- [-] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [-] Documentation added for any new functionality
- [-] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change