### PR TITLE
Add case to handle oneOf outside of nondet

### DIFF
--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -409,6 +409,15 @@ class Quint(quintOutput: QuintOutput) {
       val applicationBuilder: Seq[QuintEx] => NullaryOpReader[TBuilderInstruction] = opName match {
         // First we check for application of builtin operators
 
+        // Illegal builtins
+        // We expect that these builins will be eliminated in earlier stages
+        // of the translation (e.g., inside special forms like `nondet`) or
+        // via rewrites in quint.
+        case "oneOf" =>
+          // See https://github.com/informalsystems/apalache/issues/2774
+          throw new QuintIRParseError(
+              s"`oneOf` can only occur as the principle operator of a `nondet` declaration: `oneOf` operator with id ${id} applied to ${quintArgs}")
+
         // Booleans
         case "eq"      => binaryApp(opName, tla.eql)
         case "neq"     => binaryApp(opName, tla.neql)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -751,4 +751,10 @@ class TestQuintEx extends AnyFunSuite {
     // And if our conversion logic is correct, we can convert this to Apalache's IR:
     assert(convert(expr) == """LET polyConst1(x) ≜ 1 IN (polyConst1("s")) + (polyConst1(TRUE))""")
   }
+
+  test("oneOf operator occuring outside of a nondet binding is an error") {
+    // See https://github.com/informalsystems/apalache/issues/2774
+    val err = intercept[QuintIRParseError](convert(Q.oneOfSet))
+    assert(err.getMessage().contains("`oneOf` can only occur as the principle operator of a `nondet` declaration"))
+  }
 }


### PR DESCRIPTION
Closes #2774

This is a workaround for https://github.com/informalsystems/quint/issues/381. 

The nub of the issue is that quint currently allows `oneOf` to occur outside of
`nondet` bindings, but we don't want to support this behavior in verification.
Our expectation is that we will make this illegal in quint, but in the mean time
this change will ensure less cryptic errors until the quint type discipline for
the operator is improved.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change