### PR TITLE
Fix rewriter disposal in offline execution context

### DIFF
--- a/.unreleased/bug-fixes/2785-rewriter-disposal.md
+++ b/.unreleased/bug-fixes/2785-rewriter-disposal.md
@@ -1,0 +1,1 @@
+Fix truncation of SMT debug logs, see #2785

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -160,7 +160,7 @@ class BoundedCheckerPassImpl @Inject() (
     val checker =
       new SeqModelChecker[SnapshotT](params, input, filteredTrex, Seq(DumpFilesModelCheckerListener))
     val outcome = checker.run()
-    rewriter.dispose()
+    executorContext.dispose()
     logger.info(s"The outcome is: " + outcome)
     outcome
   }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/OfflineExecutionContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/trex/OfflineExecutionContext.scala
@@ -44,6 +44,7 @@ class OfflineExecutionContext(var rewriter: SymbStateRewriter, renaming: Increme
   override def recover(snapshot: OfflineExecutionContextSnapshot): Unit = {
     val solver = RecordingSolverContext.createZ3(Some(snapshot.smtLog), snapshot.solverConfig)
     // TODO: issue #105, remove references to SolverContext, so recovery becomes less of a hack
+
     val newRewriter = rewriter match {
       case _: SymbStateRewriterImplWithArrays =>
         new SymbStateRewriterImplWithArrays(solver, renaming, rewriter.exprGradeStore)
@@ -54,6 +55,8 @@ class OfflineExecutionContext(var rewriter: SymbStateRewriter, renaming: Increme
     newRewriter.config = rewriter.config
     newRewriter.recover(snapshot.rewriterSnapshot)
     newRewriter.solverContext = solver
+
+    rewriter.dispose()
     rewriter = newRewriter
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/ExecutorBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/ExecutorBase.scala
@@ -29,7 +29,7 @@ trait ExecutorBase[SnapshotT] extends FixtureAnyFunSuite {
     val exeCtx = exeCtxFactory(rewriter)
 
     // Tmp file to capture the noisy stdout from these tests
-    // otherwise they pollut stdout on our CI making it hard to see failures
+    // otherwise they pollute stdout on our CI making it hard to see failures
     val tmp = File.createTempFile("tla-bmcmt-test-output-", ".tmp")
     tmp.deleteOnExit()
 
@@ -37,7 +37,7 @@ trait ExecutorBase[SnapshotT] extends FixtureAnyFunSuite {
       System.setOut(new PrintStream(new FileOutputStream(tmp)))
       test(exeCtx)
     } finally {
-      rewriter.dispose()
+      exeCtx.dispose()
       System.setOut(System.out)
     }
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndArrays.scala
@@ -1,11 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
-import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
-import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
-import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatestplus.junit.JUnitRunner
@@ -18,12 +14,6 @@ class TestTransitionExecutorWithIncrementalAndArrays
     val solver =
       new Z3SolverContext(SolverConfig(debug = false, profile = false, randomSeed = 0,
               smtEncoding = SMTEncoding.Arrays))
-    val rewriter = new SymbStateRewriterImpl(solver, new IncrementalRenaming(new IdleTracker), new ExprGradeStoreImpl())
-    val exeCtx = new IncrementalExecutionContext(rewriter)
-    try {
-      test(exeCtx)
-    } finally {
-      exeCtx.dispose()
-    }
+    withFixtureInContext(solver, new IncrementalExecutionContext(_), test)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndArrays.scala
@@ -23,7 +23,7 @@ class TestTransitionExecutorWithIncrementalAndArrays
     try {
       test(exeCtx)
     } finally {
-      rewriter.dispose()
+      exeCtx.dispose()
     }
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndFunArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndFunArrays.scala
@@ -22,7 +22,7 @@ class TestTransitionExecutorWithIncrementalAndFunArrays
     try {
       test(exeCtx)
     } finally {
-      rewriter.dispose()
+      exeCtx.dispose()
     }
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndFunArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithIncrementalAndFunArrays.scala
@@ -1,11 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
-import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
-import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
-import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatestplus.junit.JUnitRunner
@@ -17,12 +13,6 @@ class TestTransitionExecutorWithIncrementalAndFunArrays
   override protected def withFixture(test: OneArgTest): Outcome = {
     val solver = new Z3SolverContext(SolverConfig(debug = false, profile = false, randomSeed = 0,
             smtEncoding = SMTEncoding.FunArrays))
-    val rewriter = new SymbStateRewriterImpl(solver, new IncrementalRenaming(new IdleTracker), new ExprGradeStoreImpl())
-    val exeCtx = new IncrementalExecutionContext(rewriter)
-    try {
-      test(exeCtx)
-    } finally {
-      exeCtx.dispose()
-    }
+    withFixtureInContext(solver, new IncrementalExecutionContext(_), test)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndArrays.scala
@@ -23,7 +23,7 @@ class TestTransitionExecutorWithOfflineAndArrays extends TestTransitionExecutorI
     try {
       test(exeCtx)
     } finally {
-      rewriter.dispose()
+      exeCtx.dispose()
     }
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndArrays.scala
@@ -1,12 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
-import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
-import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatestplus.junit.JUnitRunner
@@ -16,14 +13,6 @@ class TestTransitionExecutorWithOfflineAndArrays extends TestTransitionExecutorI
   override protected def withFixture(test: OneArgTest): Outcome = {
     val solver = RecordingSolverContext
       .createZ3(None, SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = SMTEncoding.Arrays))
-    new UniqueNameGenerator
-    val renaming = new IncrementalRenaming(new IdleTracker)
-    val rewriter = new SymbStateRewriterImpl(solver, renaming, new ExprGradeStoreImpl())
-    val exeCtx = new OfflineExecutionContext(rewriter, renaming)
-    try {
-      test(exeCtx)
-    } finally {
-      exeCtx.dispose()
-    }
+    withFixtureInContext(solver, new OfflineExecutionContext(_, new IncrementalRenaming(new IdleTracker)), test)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndFunArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndFunArrays.scala
@@ -24,7 +24,7 @@ class TestTransitionExecutorWithOfflineAndFunArrays
     try {
       test(exeCtx)
     } finally {
-      rewriter.dispose()
+      exeCtx.dispose()
     }
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndFunArrays.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorWithOfflineAndFunArrays.scala
@@ -1,12 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt.trex
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.bmcmt.SymbStateRewriterImpl
-import at.forsyte.apalache.tla.bmcmt.analyses._
 import at.forsyte.apalache.tla.bmcmt.smt.{RecordingSolverContext, SolverConfig}
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
-import at.forsyte.apalache.tla.pp.UniqueNameGenerator
 import org.junit.runner.RunWith
 import org.scalatest.Outcome
 import org.scalatestplus.junit.JUnitRunner
@@ -17,14 +14,6 @@ class TestTransitionExecutorWithOfflineAndFunArrays
   override protected def withFixture(test: OneArgTest): Outcome = {
     val solver = RecordingSolverContext
       .createZ3(None, SolverConfig(debug = false, profile = false, randomSeed = 0, smtEncoding = SMTEncoding.FunArrays))
-    new UniqueNameGenerator
-    val renaming = new IncrementalRenaming(new IdleTracker)
-    val rewriter = new SymbStateRewriterImpl(solver, renaming, new ExprGradeStoreImpl())
-    val exeCtx = new OfflineExecutionContext(rewriter, renaming)
-    try {
-      test(exeCtx)
-    } finally {
-      exeCtx.dispose()
-    }
+    withFixtureInContext(solver, new OfflineExecutionContext(_, new IncrementalRenaming(new IdleTracker)), test)
   }
 }


### PR DESCRIPTION
Fix disposal of rewriters in `OfflineExecutionContext`.
We previously omitted disposing of rewriters that were obsoleted by a call to `ctx.recover()`.
At the very least, this resulted in truncated SMT debug logs, see #2136 

We also fix a small protocol violation, where `BoundedCheckerPassImpl` was disposing of the rewriter directly, instead of disposing of the offline execution context (which in turn disposes of the rewriter).

Closes #2136

- [ ] ~Tests added for any new code~
- [ ] ~Ran `make fmt-fix` (or had formatting run automatically on all files edited)~
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
