### PR TITLE
Add support for default cases in quint match expressions

### DIFF
--- a/.unreleased/bug-fixes/fix-default-cases.md
+++ b/.unreleased/bug-fixes/fix-default-cases.md
@@ -1,0 +1,1 @@
+Fix missing support for default match cases in quint conversion (#2792)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -416,7 +416,7 @@ class Quint(quintOutput: QuintOutput) {
 
     // the quint builtin operator representing match expressions looks like
     //
-    // matchVariant(expr, "F1", elim_1, ..., "Fn", elim_n, "_", defaultElim)
+    // matchVariant(expr, "F1", elim_1, ..., "Fn", elim_n[, "_", defaultElim])
     //
     // Where each `elim_i` is an operator applying to value wrapped in field `Fi` of a variant.
     //


### PR DESCRIPTION
This is a followup to #2783, which omitted support for the "wildcard",
default match case in match expressions.

I found this problem when checking the `Paxos` spec in the quint repo.  In
addition to the unit test added here, I've verified that this solves the problem
on a few quint specs locally. Integration tests confirming this will be
forthcoming in the quint repo.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change