### PR TITLE
Add support for infinite sets in set inclusion for the (fun)arrays encoding

### DIFF
--- a/.unreleased/bug-fixes/fixSetInclusionwithArrays.md
+++ b/.unreleased/bug-fixes/fixSetInclusionwithArrays.md
@@ -1,0 +1,1 @@
+fix crash on the arrays encoding when having a subset relation containing infinite sets, see #2810

--- a/test/tla/FunInInfiniteSubset.tla
+++ b/test/tla/FunInInfiniteSubset.tla
@@ -1,0 +1,22 @@
+--------------- MODULE FunInInfiniteSubset -----------------
+
+EXTENDS Integers
+
+P == {"P1_OF_P"}
+
+VARIABLE
+    \* @type: P -> Set(Int);
+    myVariable
+
+Init ==
+    myVariable = [p \in P |-> {0}]
+
+Step(p) ==
+    myVariable' = [q \in P |-> {0}]
+
+Next == \E p \in P : Step(p)
+
+TypeOkay == myVariable \in [P -> SUBSET Int]
+TypeOkay_ == TypeOkay
+
+=============================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2812,6 +2812,18 @@ $ apalache-mc check --inv=Sanity FunExcept3.tla | sed 's/[IEW]@.*//'
 EXITCODE: OK
 ```
 
+### check FunInInfiniteSubset (array-encoding)
+
+A regression test for function membership in the presence of infinite sets.
+
+See https://github.com/informalsystems/apalache/issues/2810
+
+```sh
+$ apalache-mc check --init=TypeOkay_ --inv=TypeOkay --length=1 FunInInfiniteSubset.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check ERC20.tla
 
 ```sh

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInclusionRuleWithArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInclusionRuleWithArrays.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt.implicitConversions.Crossable
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
-import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, PowSetT, UnknownT}
+import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, InfSetT, PowSetT, UnknownT}
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, RewritingRule, SymbState, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir.{BoolT1, OperEx, RecT1, SetT1, TlaEx, TupT1}
 import at.forsyte.apalache.tla.lir.convenience._
@@ -33,6 +33,9 @@ class SetInclusionRuleWithArrays(rewriter: SymbStateRewriter) extends RewritingR
         val rightCell = rightState.arena.findCellByNameEx(rightState.ex)
         (leftCell.cellType, rightCell.cellType) match {
           case (CellTFrom(SetT1(_)), CellTFrom(SetT1(_))) =>
+            subset(rightState, leftCell, rightCell, false)
+
+          case (CellTFrom(SetT1(_)), InfSetT(_)) =>
             subset(rightState, leftCell, rightCell, false)
 
           case (CellTFrom(SetT1(SetT1(t1))), PowSetT(SetT1(t2))) =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInclusionRuleWithFunArrays.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInclusionRuleWithFunArrays.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, PowSetT}
+import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, InfSetT, PowSetT}
 import at.forsyte.apalache.tla.lir.{OperEx, SetT1}
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
@@ -29,6 +29,9 @@ class SetInclusionRuleWithFunArrays(rewriter: SymbStateRewriter) extends Rewriti
         val rightCell = rightState.asCell
         (leftCell.cellType, rightCell.cellType) match {
           case (CellTFrom(SetT1(_)), CellTFrom(SetT1(_))) =>
+            rewriter.lazyEq.subsetEq(rightState, leftCell, rightCell)
+
+          case (CellTFrom(SetT1(_)), InfSetT(_)) =>
             rewriter.lazyEq.subsetEq(rightState, leftCell, rightCell)
 
           case (CellTFrom(SetT1(SetT1(t1))), PowSetT(SetT1(t2))) =>


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change

This PR fixes a crash on the `arrays` and `funArrays` encodings. See the associated issue for details. Closes #2810.