### PR TITLE
Increase gRPC message size limit from 8MB to 64MB

### DIFF
--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -37,11 +37,11 @@ class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
   // This is needed even if the type below is omitted / inferred.
   import scala.language.existentials
 
-  // Double max inbound message size to 8MB
+  // Set max inbound message size to 64MB
   // Fixes `io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size`:
   // https://github.com/informalsystems/apalache/issues/2622
   override def builder: (x0) forSome { type x0 <: ServerBuilder[x0] } =
-    super.builder.maxInboundMessageSize(8 * 1024 * 1024)
+    super.builder.maxInboundMessageSize(64 * 1024 * 1024)
 
   override def run(args: List[String]) = {
     myAppLogic.catchAll { t =>


### PR DESCRIPTION
Hello :octocat: 

I've been hitting this limit and this increases it. Closes https://github.com/informalsystems/quint/issues/1389

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
