### PR TITLE
Update flake and improve nix setup for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,8 @@ it here!
 We provide a nix shell in case you want to use nix to manage your development
 environment and dependencies. The primary benefits of using the nix shell is
 that it allows us to keep environments consistent, and distribute updates to
-environment dependencies.
+environment dependencies. Alternatively, you can also use `direnv` to load
+dependencies from nix.
 
 #### Getting Nix
 
@@ -201,6 +202,19 @@ Once you have `nix` installed, build and enter the clean development shell with:
 ```sh
 $ nix develop
 ```
+
+#### Loading nix dependencies with direnv
+
+If you want to use direnv to setup your environment with nix (instead of using a
+shell), you will need to add `use flake;` to your `.envrc`, and then running
+`direnv allow`:
+
+```sh
+echo "use flake;" >> .envrc && direnv allow
+```
+
+You can also add a `direnv` extension/package to your IDE of choice to have
+those dependencies set up for the IDE to use.
 
 #### Updating nix dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,11 +206,11 @@ $ nix develop
 #### Loading nix dependencies with direnv
 
 If you want to use direnv to setup your environment with nix (instead of using a
-shell), you will need to add `use flake;` to your `.envrc`, and then running
-`direnv allow`:
+shell), you will need to add `use flake;` to your `.local-envrc`, and then
+running `direnv allow`:
 
 ```sh
-echo "use flake;" >> .envrc && direnv allow
+echo "use flake;" >> .local-envrc && direnv allow
 ```
 
 You can also add a `direnv` extension/package to your IDE of choice to have

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684879512,
-        "narHash": "sha256-BoAOf19Dshtfu6BDPznrKO97oeCkXlYfa1Hyt0Qv8VU=",
+        "lastModified": 1709780214,
+        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e6e049b7a24decd1f0caee8b035913795697c699",
+        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Hello :octocat: 

This PR:
1. Updates `flake.nix` to remove sourcing of `.envrc` file which resulted in a circular dependency if `direnv` was used to load nix. Other changes in `flake.nix` are just auto-formatting.
2. Adds instructions to `CONTRIBUTING.md` with how to use nix with `direnv`.
3. Updates `flake.lock` (with `nix flake update`) so the pinned version of `metals` is compatible with the scala version declared in `build.sbt`.

