### PR TITLE
Use type given by quint to build lambda bodies

### DIFF
--- a/.unreleased/bug-fixes/quint-lambda-types-conversion.md
+++ b/.unreleased/bug-fixes/quint-lambda-types-conversion.md
@@ -1,2 +1,3 @@
-Use the type inferred by Quint to build lambda bodies, avoiding mismatches with
+When converting Quint lambdas, derive the return type from the Quint type inferred for 
+the lambda, rather the type inferred for the body expression, avoiding mismatches with
 Apalache type variables. (#2856)

--- a/.unreleased/bug-fixes/quint-lambda-types-conversion.md
+++ b/.unreleased/bug-fixes/quint-lambda-types-conversion.md
@@ -1,0 +1,2 @@
+Use the type inferred by Quint to build lambda bodies, avoiding mismatches with
+Apalache type variables. (#2856)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -82,18 +82,18 @@ class Quint(quintOutput: QuintOutput) {
   // operators that take parameters, but these require different constructs
   // in Apalache's IR. Thus, we need to decompose the parts of a QuintLambda
   // for two different purposes.
-  private val lambdaBodyAndParams: QuintLambda => NullaryOpReader[(TBuilderInstruction, Seq[(OperParam, TlaType1)])] = {
+  private val lambdaBodyAndParams: QuintLambda => NullaryOpReader[(TBuilderInstruction, Seq[(OperParam, TlaType1)], TlaType1)] = {
     case ex @ QuintLambda(id, paramNames, _, body) =>
-      val quintParamTypes = types(id).typ match {
-        case QuintOperT(types, _) => types
-        case invalidType          => throw new QuintIRParseError(s"lambda ${ex} has invalid type ${invalidType}")
+      val (quintParamTypes, quintResType) = types(id).typ match {
+        case QuintOperT(types, resType) => (types, resType)
+        case invalidType                => throw new QuintIRParseError(s"lambda ${ex} has invalid type ${invalidType}")
       }
       val operParams = paramNames.zip(quintParamTypes).map(operParam)
       val paramTypes = quintParamTypes.map(typeConv.convert(_))
       val typedParams = operParams.zip(paramTypes)
       for {
         tlaBody <- tlaExpression(body)
-      } yield (tlaBody, typedParams)
+      } yield (tlaBody, typedParams, typeConv.convert(quintResType))
   }
 
   private def typeTagOfId(id: BigInt): TypeTag = {
@@ -668,7 +668,7 @@ class Quint(quintOutput: QuintOutput) {
       (expr match {
         // Parameterized operators are defined in Quint using Lambdas
         case lam: QuintLambda =>
-          lambdaBodyAndParams(lam)
+          lambdaBodyAndParams(lam).map { case (body, params, _) => (body, params) }
         // Otherwise it's an operator with no params
         case other => tlaExpression(other).map(b => (b, List()))
       }).map {
@@ -716,8 +716,8 @@ class Quint(quintOutput: QuintOutput) {
             .map(tlaExpr => tla.letIn(tlaExpr, tlaOpDef))
         }
       case lam: QuintLambda =>
-        lambdaBodyAndParams(lam).map { case (body, typedParams) =>
-          tla.lambda(nameGen.uniqueLambdaName(), body, typedParams: _*)
+        lambdaBodyAndParams(lam).map { case (body, typedParams, resultType) =>
+          tla.lambda(nameGen.uniqueLambdaName(), body, resultType, typedParams: _*)
         }
       case app: QuintApp => tlaApplication(app)
     }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -637,6 +637,12 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(quintMatch) == expected)
   }
 
+  test("prefers quint types over inferred types") {
+    // Regression on https://github.com/informalsystems/quint/issues/1393
+    val expr = Q.lam(Seq("x" -> QuintBoolT()), Q.nam("x", QuintVarT("t0")), QuintBoolT())
+    assert(translate(expr).typeTag == Typed(OperT1(Seq(BoolT1), BoolT1)))
+  }
+
   test("can convert builtin assert operator") {
     assert(convert(Q.app("assert", Q.nIsGreaterThan0)(QuintBoolT())) == "n > 0")
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/ScopedBuilder.scala
@@ -299,6 +299,21 @@ class ScopedBuilder(val strict: Boolean = true)
     } yield ex
   }
 
+  /** Alternative to lambda, which accepts an explicit result type */
+  def lambda(
+      uniqueName: String,
+      body: TBuilderInstruction,
+      resultType: TlaType1,
+      params: TypedParam*): TBuilderInstruction = {
+    params.foreach(validateParamType)
+    for {
+      bodyEx <- body
+      paramTypes = params.map(_._2)
+      operType = OperT1(paramTypes, resultType) // use given type instead of type tag
+      ex <- letIn(name(uniqueName, operType), decl(uniqueName, body, params: _*))
+    } yield ex
+  }
+
   /** {{{LET decl(...) = ... IN body}}} */
   def letIn(body: TBuilderInstruction, decl: TBuilderOperDeclInstruction): TBuilderInstruction = for {
     usedBeforeDecl <- getAllUsed // decl name may not appear in decl body


### PR DESCRIPTION
Hello :octocat: 

Fixes https://github.com/informalsystems/quint/issues/1393

The issue happened because we were only using the types given by Quint in the type map to annotate parameters, but not the result type of lambdas. This way, there was a mismatch in variable names on Apalache type inference (used for the body) and Quint type inference (used for the parameters).

This PR ensures that we always use Quint types.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [X] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
