### PR TITLE
Extend Variants when pretty printing TLA+ in Shai

### DIFF
--- a/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestCmdExecutorService.scala
+++ b/shai/src/test/scala/at/forsyte/apalache/shai/v1/TestCmdExecutorService.scala
@@ -126,7 +126,7 @@ object TestCmdExecutorService extends DefaultRunnableSpec {
         val expectedPayload =
           """|----------------------------------- MODULE M -----------------------------------
              |
-             |EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache
+             |EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache, Variants
              |
              |Foo == TRUE
              |

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -339,7 +339,7 @@ EXITCODE: OK
 $ cat output.tla | head
 -------------------------------- MODULE output --------------------------------
 
-EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache
+EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache, Variants
 
 CONSTANT
   (*
@@ -414,7 +414,7 @@ EXITCODE: OK
 $ cat output.tla | head
 -------------------------------- MODULE output --------------------------------
 
-EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache
+EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache, Variants
 
 CONSTANT
   (*
@@ -3920,7 +3920,7 @@ EXITCODE: OK
 $ cat module-lookup/subdir-no-dummy/output.tla
 -------------------------------- MODULE output --------------------------------
 
-EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache
+EXTENDS Integers, Sequences, FiniteSets, TLC, Apalache, Variants
 
 Init == TRUE
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/TlaWriter.scala
@@ -41,6 +41,6 @@ object TlaWriter {
   /**
    * The names of all standard modules that are supported by Apalache IR.
    */
-  val STANDARD_MODULES = List("Integers", "Sequences", "FiniteSets", "TLC", "Apalache")
+  val STANDARD_MODULES = List("Integers", "Sequences", "FiniteSets", "TLC", "Apalache", "Variants")
 
 }


### PR DESCRIPTION
Fixes an error in the existing TLA+ generated from quint, thanks to report from @bugarela

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change