### PR TITLE
Fix unit test CI on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,13 +90,13 @@ jobs:
         operating-system: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17
       - name: Coursier cache
         uses: coursier/cache-action@v6
+      - name: Coursier setup
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
       - name: Set APALACHE_HOME env
         # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
         run: echo "APALACHE_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV


### PR DESCRIPTION
Hello :octocat: 

This fixes our unit tests setup in MacOS, which has recently started failing due to cache misses.

This follows instructions from https://github.com/coursier/setup-action

Before: https://github.com/informalsystems/apalache/actions/runs/8939732842/job/24556354036?pr=2891
After: https://github.com/informalsystems/apalache/actions/runs/8943811456/job/24569332724?pr=2891