### PR TITLE
Set the core pool size to the number of logical cores

### DIFF
--- a/json-rpc/src/main/scala/com/github/apalachemc/apalache/jsonrpc/JsonRpcServer.scala
+++ b/json-rpc/src/main/scala/com/github/apalachemc/apalache/jsonrpc/JsonRpcServer.scala
@@ -648,6 +648,8 @@ class JsonRpcServlet(service: ExplorationService) extends HttpServlet with LazyL
         t
       },
   )
+  logger.info("Created thread pool with core pool size %d, max pool size %d, keep alive %d sec"
+        .format(Runtime.getRuntime.availableProcessors(), MAX_POOL_SIZE, KEEP_ALIVE_SEC))
   // data mapper for JSON serialization/deserialization
   // using Jackson with Scala module for better compatibility with case classes
   private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)


### PR DESCRIPTION
Currently, the core pool size is statically set to 16. This underutilizes a machine with a larger number of logical cores, e.g., 32. In this PR, we set the core pool size to the number of logical cores.