### PR TITLE
Pin the jdk in docker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -409,7 +409,7 @@ docker / dockerfile := {
   val readme = rootDir / "README.md"
 
   new Dockerfile {
-    from("eclipse-temurin:17")
+    from("eclipse-temurin:17-jdk-noble")
 
     workDir(dwd)
 


### PR DESCRIPTION
Since docker-tests started to fail, pinning jdk
