### PR TITLE
Fix inlining of named assumptions

### DIFF
--- a/.unreleased/bug-fixes/3326-named-assumption-inliner.md
+++ b/.unreleased/bug-fixes/3326-named-assumption-inliner.md
@@ -1,0 +1,1 @@
+Fixed a preprocessing failure when a named ASSUME declaration is referenced from an operator body, see #3326.

--- a/test/tla/InlineAssumptions3318.tla
+++ b/test/tla/InlineAssumptions3318.tla
@@ -1,0 +1,21 @@
+----------------------- MODULE InlineAssumptions3318 -------------------------
+(*
+  A regression test for the issue identified in:
+  https://github.com/apalache-mc/apalache/issues/3318
+*)
+EXTENDS Integers
+
+VARIABLE
+  \* @type: Int;
+  x
+
+ASSUME NamedAssumption == 1 = 1
+
+Init == /\ x = 0
+        /\ NamedAssumption
+
+Next == UNCHANGED x
+
+Inv == x = 0
+
+================================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3013,6 +3013,16 @@ State 1: state invariant 0 [Inv2] violated.
 EXITCODE: ERROR (12)
 ```
 
+### check InlineAssumptions3318.tla
+
+Regression test for ensuring that assumptions are inlined properly.
+
+```sh
+$ apalache-mc check --inv=Inv InlineAssumptions3318.tla | sed 's/I@.*//'
+...
+EXITCODE: OK
+```
+
 ## running the typecheck command
 
 ### typecheck Empty.tla reports no error

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/Inliner.scala
@@ -79,11 +79,23 @@ class Inliner(
           val newDecl = tracker.trackDecl { _ => theoremDecl.copy(body = newBody)(theoremDecl.typeTag) }(theoremDecl)
           (scope, decls :+ newDecl)
         case assumeDecl: TlaAssumeDecl =>
-          // Add the assumption to the scope, as the user may invoke a named assumption in an operator body.
+          // Add a named assumption to the scope, as the user may invoke it in an operator body.
+          // We keep the original declaration as TlaAssumeDecl, but expose a synthetic nullary operator to the inliner.
           // See https://github.com/apalache-mc/apalache/issues/3326
           val newBody = transform(scope)(assumeDecl.body)
           val newDecl = tracker.trackDecl { _ => assumeDecl.copy(body = newBody)(assumeDecl.typeTag) }(assumeDecl)
-          (scope, decls :+ newDecl)
+
+          val newScope = assumeDecl.definedName match {
+            case Some(name) =>
+              val operType = OperT1(Seq.empty, newBody.typeTag.asTlaType1())
+              val syntheticDecl = TlaOperDecl(name, List.empty, newBody)(Typed(operType))
+              scope + (name -> syntheticDecl)
+
+            case None =>
+              scope
+          }
+
+          (newScope, decls :+ newDecl)
         case _ => (scope, decls :+ decl)
       }
     }

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestInliner.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestInliner.scala
@@ -266,6 +266,43 @@ class TestInliner extends AnyFunSuite with BeforeAndAfterEach with ScalaCheckPro
     assert(actualBody == ABody)
   }
 
+  test("Named ASSUME is visible when inlining operator bodies") {
+    val assumptionBody =
+      tla.eql(tla.int(1).as(IntT1), tla.int(1).as(IntT1)).as(BoolT1)
+
+    val assumeDecl =
+      TlaAssumeDecl(Some("NamedAssumption"), assumptionBody)(Typed(BoolT1))
+
+    val assumptionType = OperT1(Seq.empty, BoolT1)
+
+    val initBody =
+      tla
+        .and(
+            tla.eql(tla.name("x").as(IntT1), tla.int(0).as(IntT1)).as(BoolT1),
+            tla.appOp(tla.name("NamedAssumption").as(assumptionType)).as(BoolT1),
+        )
+        .as(BoolT1)
+
+    val initDecl =
+      TlaOperDecl("Init", List.empty, initBody)(Typed(OperT1(Seq.empty, BoolT1)))
+
+    val module = mkModule(assumeDecl, initDecl)
+
+    val txModule = inlinerKeepNullary.transformModule(module)
+
+    val actualBody = txModule.declarations(1).asInstanceOf[TlaOperDecl].body
+
+    val expectedBody =
+      tla
+        .and(
+            tla.eql(tla.name("x").as(IntT1), tla.int(0).as(IntT1)).as(BoolT1),
+            assumptionBody,
+        )
+        .as(BoolT1)
+
+    assert(actualBody == expectedBody)
+  }
+
   test("Inlining works correctly on nonbasic arguments:  B == e, A(x) == x, A(B()) ~~> e") {
     val BBody = tla.int(0).as(IntT1)
     val BType = OperT1(Seq.empty, IntT1)


### PR DESCRIPTION
Fixes #3326.

## Summary

This PR fixes a preprocessing failure that happens when a named `ASSUME` declaration is referenced from an operator body.

After #3323, the SANY importer correctly handles named assumptions used as operators. However, the inliner did not expose named assumptions in its scope, so references such as `NamedAssumption` could survive the inline pass and later fail in `FlatLanguagePred` as undeclared operators.

This change keeps named assumptions as `TlaAssumeDecl`s in the module declarations, but exposes them to the inliner as synthetic nullary operators.

## Changes

- Expose named assumptions as synthetic nullary operators in the inliner scope
- Add a regression test for a named assumption referenced from an operator body
- Add an unreleased bug-fix changelog entry

## Testing

- `sbt scalafmtCheckAll`
- `sbt "tla_pp/testOnly at.forsyte.apalache.tla.pp.TestInliner"`
- Manual end-to-end check with a TLA+ module containing a named assumption referenced from `Init`, resulting in `EXITCODE: OK`