### PR TITLE
Quiet docker integration wrapper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,7 +248,12 @@ jobs:
         run: make docker
       - name: Run integration tests in docker container
         run: |
-          nix develop -c bash -c "source ./test/.envrc && test/mdx-test.py --debug"
+          nix develop -c bash -c '
+            export HOME="$PWD/test/tla"
+            export JVM_ARGS="-Duser.home=/var/apalache"
+            source ./test/.envrc
+            test/mdx-test.py --debug
+          '
         env:
           USE_DOCKER: true
           APALACHE_TAG: latest

--- a/bin/run-in-docker-container
+++ b/bin/run-in-docker-container
@@ -13,15 +13,8 @@ GROUP_ID=${GROUP_ID:-1000}
 groupadd --gid "$GROUP_ID" --non-unique apalache
 useradd --create-home --shell /bin/bash --uid "$USER_ID" --non-unique --gid "$GROUP_ID" apalache
 
-# Ensure the apalache user owns their home
+# Ensure the apalache user owns their home.
 chown -R apalache:apalache /home/apalache
-
-# Docker creates bind mounts before the entrypoint runs. Mounting the host's
-# ~/.tlaplus directly under /home/apalache would pre-create the home directory
-# and make useradd --create-home warn, so the wrapper mounts it under /mnt and
-# we link it into the newly-created home here.
-ln -s /mnt/host-tlaplus /home/apalache/.tlaplus
-chown -h apalache:apalache /home/apalache/.tlaplus
 
 echo 'Assuming you bind-mounted your local directory into /var/apalache...'
 cd /var/apalache

--- a/bin/run-in-docker-container
+++ b/bin/run-in-docker-container
@@ -13,12 +13,15 @@ GROUP_ID=${GROUP_ID:-1000}
 groupadd --gid "$GROUP_ID" --non-unique apalache
 useradd --create-home --shell /bin/bash --uid "$USER_ID" --non-unique --gid "$GROUP_ID" apalache
 
-# Since we bound mount the users ~/.tlaplus into the home dir, useradd won't
-# populate the existing home with the usual skeleton, so we do that as a followup.
-cp -r /etc/skel/. /home/apalache
-
 # Ensure the apalache user owns their home
 chown -R apalache:apalache /home/apalache
+
+# Docker creates bind mounts before the entrypoint runs. Mounting the host's
+# ~/.tlaplus directly under /home/apalache would pre-create the home directory
+# and make useradd --create-home warn, so the wrapper mounts it under /mnt and
+# we link it into the newly-created home here.
+ln -s /mnt/host-tlaplus /home/apalache/.tlaplus
+chown -h apalache:apalache /home/apalache/.tlaplus
 
 echo 'Assuming you bind-mounted your local directory into /var/apalache...'
 cd /var/apalache

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -28,7 +28,9 @@ cmd="docker run \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
     --rm \
     -v $(pwd):/var/apalache \
-    -v "$HOME/.tlaplus":/home/apalache/.tlaplus \
+    -v "$HOME/.tlaplus":/mnt/host-tlaplus \
     ${img} ${*}"
->&2 echo "# running command: ${cmd}"
+if [ "${APALACHE_DOCKER_DEBUG:-false}" = "true" ]; then
+    >&2 echo "# running command: ${cmd}"
+fi
 $cmd

--- a/script/run-docker.sh
+++ b/script/run-docker.sh
@@ -28,7 +28,6 @@ cmd="docker run \
     -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
     --rm \
     -v $(pwd):/var/apalache \
-    -v "$HOME/.tlaplus":/mnt/host-tlaplus \
     ${img} ${*}"
 if [ "${APALACHE_DOCKER_DEBUG:-false}" = "true" ]; then
     >&2 echo "# running command: ${cmd}"


### PR DESCRIPTION
## Problem

The docker integration job runs the mdx CLI tests with `USE_DOCKER=true`, which shadows `apalache-mc` with `script/run-docker.sh`.

The CVC5 CLI snippets added on https://github.com/apalache-mc/apalache/pull/3335 are strict: they pipe stdout through `sed | grep` and expect only the Apalache result lines. In docker mode, two unrelated stderr prints were captured by mdx:

- `script/run-docker.sh` always printed `# running command: docker run ...`.
- The image entrypoint bind-mounted host `~/.tlaplus` directly to `/home/apalache/.tlaplus`. Docker creates bind mounts before the entrypoint runs, so `/home/apalache` already existed when `useradd --create-home` ran. That made `useradd` print warnings about the existing home directory.

Older docker mdx runs did not expose this because many existing sections use ellipses that tolerate incidental output.

## Fix

- Make the docker wrapper command echo opt-in via `APALACHE_DOCKER_DEBUG=true`.
- Mount host `~/.tlaplus` at `/mnt/host-tlaplus` instead of under `/home/apalache`.
- Keep `useradd --create-home` in the container entrypoint, then symlink `/home/apalache/.tlaplus` to the mounted directory after the home exists.

This preserves the runtime UID/GID-matching `apalache` user while avoiding docker/mdx noise in CLI integration output.

## Validation

- `bash -n script/run-docker.sh`
- `bash -n bin/run-in-docker-container`
