### PR TITLE
Add exhaustive UTFPrinter tests

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestVCGenerator.scala
@@ -110,10 +110,10 @@ class TestVCGenerator extends AnyFunSuite {
 
     val mod = loadFromText("inv", text)
     val newMod = mkVCGen().genInv(mod, "Inv")
-    assertDecl(newMod, "VCInv$0", "L0:: x > 0")
-    assertDecl(newMod, "VCInv$1", "L0:: x < 10")
-    assertDecl(newMod, "VCNotInv$0", "¬(L0:: x > 0)")
-    assertDecl(newMod, "VCNotInv$1", "¬(L0:: x < 10)")
+    assertDecl(newMod, "VCInv$0", "L0∷ x > 0")
+    assertDecl(newMod, "VCInv$1", "L0∷ x < 10")
+    assertDecl(newMod, "VCNotInv$0", "¬(L0∷ x > 0)")
+    assertDecl(newMod, "VCNotInv$1", "¬(L0∷ x < 10)")
   }
 
   test("conjunction under universals") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -297,7 +297,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin idiv operator application") {
-    assert(convert(Q.app("idiv", Q._42, Q._42)(QuintIntT())) == "42 // 42")
+    assert(convert(Q.app("idiv", Q._42, Q._42)(QuintIntT())) == "42 ÷ 42")
   }
 
   test("can convert builtin imod operator application") {
@@ -348,7 +348,7 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin exists operator application using tuple-bound names") {
     assert(convert(Q.app("exists", Q.intPairSet, Q.int2ToBool)(
-            QuintBoolT())) == "∃(<<n, acc>>) ∈ {<<1, 2>>, <<1, 2>>}: TRUE")
+            QuintBoolT())) == "∃(⟨n, acc⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: TRUE")
   }
 
   test("can convert builtin exists operator when predicate is supplied by name") {
@@ -359,7 +359,7 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin exists operator when multi-arity predicate is supplied by name") {
     assert(convert(Q.app("exists", Q.intPairSet, Q.namedInt2ToBoolOp)(QuintBoolT()))
       ==
-        "∃(<<__quint_var0, __quint_var1>>) ∈ {<<1, 2>>, <<1, 2>>}: (int2ToBoolOp(__quint_var0, __quint_var1))")
+        "∃(⟨__quint_var0, __quint_var1⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: (int2ToBoolOp(__quint_var0, __quint_var1))")
   }
 
   test("can convert builtin forall operator application") {
@@ -368,7 +368,7 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin forall operator application using tuple-bound names") {
     assert(convert(Q.app("forall", Q.intPairSet, Q.int2ToBool)(
-            QuintBoolT())) == "∀(<<n, acc>>) ∈ {<<1, 2>>, <<1, 2>>}: TRUE")
+            QuintBoolT())) == "∀(⟨n, acc⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: TRUE")
   }
 
   test("can convert builtin forall operator when predicate is supplied by name") {
@@ -379,7 +379,7 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin forall operator when multi-arity predicate is supplied by name") {
     assert(convert(Q.app("forall", Q.intPairSet, Q.namedInt2ToBoolOp)(QuintBoolT()))
       ==
-        "∀(<<__quint_var0, __quint_var1>>) ∈ {<<1, 2>>, <<1, 2>>}: (int2ToBoolOp(__quint_var0, __quint_var1))")
+        "∀(⟨__quint_var0, __quint_var1⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: (int2ToBoolOp(__quint_var0, __quint_var1))")
   }
 
   test("converting binary binding operator with missing lambda fails") {
@@ -470,72 +470,72 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin List operator application") {
-    assert(convert(Q.app("List", Q._1, Q._2, Q._3)(QuintSeqT(QuintIntT()))) == "<<1, 2, 3>>")
+    assert(convert(Q.app("List", Q._1, Q._2, Q._3)(QuintSeqT(QuintIntT()))) == "⟨1, 2, 3⟩")
   }
 
   test("can convert builtin List operator application for empty list") {
-    assert(convert(Q.emptyIntList) == "<<>>")
+    assert(convert(Q.emptyIntList) == "⟨⟩")
   }
 
   test("can convert builtin append operator application") {
-    assert(convert(Q.app("append", Q.intList, Q._42)(QuintSeqT(QuintIntT()))) == "Append(<<1, 2, 3>>, 42)")
+    assert(convert(Q.app("append", Q.intList, Q._42)(QuintSeqT(QuintIntT()))) == "Append(⟨1, 2, 3⟩, 42)")
   }
 
   test("can convert builtin concat operator application") {
-    assert(convert(Q.app("concat", Q.intList, Q.intList)(QuintSeqT(QuintIntT()))) == "(<<1, 2, 3>>) ∘ (<<1, 2, 3>>)")
+    assert(convert(Q.app("concat", Q.intList, Q.intList)(QuintSeqT(QuintIntT()))) == "(⟨1, 2, 3⟩) ∘ (⟨1, 2, 3⟩)")
   }
 
   test("can convert builtin head operator application") {
-    assert(convert(Q.app("head", Q.intList)(QuintIntT())) == "Head(<<1, 2, 3>>)")
+    assert(convert(Q.app("head", Q.intList)(QuintIntT())) == "Head(⟨1, 2, 3⟩)")
   }
 
   test("can convert builtin tail operator application") {
-    assert(convert(Q.app("tail", Q.intList)(QuintSeqT(QuintIntT()))) == "Tail(<<1, 2, 3>>)")
+    assert(convert(Q.app("tail", Q.intList)(QuintSeqT(QuintIntT()))) == "Tail(⟨1, 2, 3⟩)")
   }
 
   test("can convert builtin length operator application") {
-    assert(convert(Q.app("length", Q.intList)(QuintIntT())) == "Len(<<1, 2, 3>>)")
+    assert(convert(Q.app("length", Q.intList)(QuintIntT())) == "Len(⟨1, 2, 3⟩)")
   }
 
   test("can convert builtin indices operator application") {
     val expected =
-      "LET __quint_var0 ≜ DOMAIN (<<1, 2, 3>>) IN IF (__quint_var0() = {}) THEN {} ELSE ((__quint_var0() ∪ {0}) ∖ {Len(<<1, 2, 3>>)})"
+      "LET __quint_var0 ≜ DOMAIN (⟨1, 2, 3⟩) IN IF (__quint_var0() = {}) THEN {} ELSE ((__quint_var0() ∪ {0}) ∖ {Len(⟨1, 2, 3⟩)})"
     assert(convert(Q.app("indices", Q.intList)(QuintSetT(QuintIntT()))) == expected)
   }
 
   test("can convert builtin foldl operator application") {
     val expected =
-      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0, 0, <<1, 2, 3>>)"
+      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA0(acc, n) ≜ n + acc IN __QUINT_LAMBDA0, 0, ⟨1, 2, 3⟩)"
     assert(convert(Q.app("foldl", Q.intList, Q._0, Q.accumulatingOpp)(QuintSeqT(QuintIntT()))) == expected)
   }
 
   test("can convert builtin nth operator application") {
-    assert(convert(Q.app("nth", Q.intList, Q._1)(QuintIntT())) == "(<<1, 2, 3>>)[1 + 1]")
+    assert(convert(Q.app("nth", Q.intList, Q._1)(QuintIntT())) == "(⟨1, 2, 3⟩)[1 + 1]")
   }
 
   test("can convert builtin nth operator application to variable index") {
-    assert(convert(Q.app("nth", Q.intList, Q.name)(QuintIntT())) == "(<<1, 2, 3>>)[n + 1]")
+    assert(convert(Q.app("nth", Q.intList, Q.name)(QuintIntT())) == "(⟨1, 2, 3⟩)[n + 1]")
   }
 
   test("can convert builtin replaceAt operator application") {
     assert(convert(Q.app("replaceAt", Q.intList, Q._1, Q._42)(
-            QuintSeqT(QuintIntT()))) == "[<<1, 2, 3>> EXCEPT ![<<1 + 1>>] = 42]")
+            QuintSeqT(QuintIntT()))) == "[⟨1, 2, 3⟩ EXCEPT ![⟨1 + 1⟩] = 42]")
   }
 
   test("can convert builtin slice operator application") {
     assert(convert(Q.app("slice", Q.intList, Q._0, Q._1)(
-            QuintSeqT(QuintIntT()))) == "Sequences!SubSeq(<<1, 2, 3>>, 0 + 1, 1)")
+            QuintSeqT(QuintIntT()))) == "Sequences!SubSeq(⟨1, 2, 3⟩, 0 + 1, 1)")
   }
 
   test("can convert builtin select operator application") {
     val expected =
-      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA2(__quint_var0, __QUINT_LAMBDA1) ≜ IF (LET __QUINT_LAMBDA0(n) ≜ n > 0 IN __QUINT_LAMBDA0(__QUINT_LAMBDA1)) THEN (Append(__quint_var0, __QUINT_LAMBDA1)) ELSE __quint_var0 IN __QUINT_LAMBDA2, <<>>, <<1, 2, 3>>)"
+      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA2(__quint_var0, __QUINT_LAMBDA1) ≜ IF (LET __QUINT_LAMBDA0(n) ≜ n > 0 IN __QUINT_LAMBDA0(__QUINT_LAMBDA1)) THEN (Append(__quint_var0, __QUINT_LAMBDA1)) ELSE __quint_var0 IN __QUINT_LAMBDA2, ⟨⟩, ⟨1, 2, 3⟩)"
     assert(convert(Q.selectGreaterThanZero) == expected)
   }
 
   test("can convert builtin select operator application with named test operator") {
     val expected =
-      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA1(__quint_var0, __QUINT_LAMBDA0) ≜ IF (intToBoolOp(__QUINT_LAMBDA0)) THEN (Append(__quint_var0, __QUINT_LAMBDA0)) ELSE __quint_var0 IN __QUINT_LAMBDA1, <<>>, <<1, 2, 3>>)"
+      "Apalache!ApaFoldSeqLeft(LET __QUINT_LAMBDA1(__quint_var0, __QUINT_LAMBDA0) ≜ IF (intToBoolOp(__QUINT_LAMBDA0)) THEN (Append(__quint_var0, __QUINT_LAMBDA0)) ELSE __quint_var0 IN __QUINT_LAMBDA1, ⟨⟩, ⟨1, 2, 3⟩)"
     assert(convert(Q.selectNamedIntToBoolOp) == expected)
   }
 
@@ -586,7 +586,7 @@ class TestQuintEx extends AnyFunSuite {
   test("can convert builtin with operator application") {
     val typ = QuintRecordT.ofFieldTypes(("s", QuintIntT()), ("t", QuintIntT()))
     val rec = Q.app("Rec", Q.s, Q._1, Q.t, Q._2)(typ)
-    assert(convert(Q.app("with", rec, Q.s, Q._42)(typ)) == """[["s" ↦ 1, "t" ↦ 2] EXCEPT ![<<"s">>] = 42]""")
+    assert(convert(Q.app("with", rec, Q.s, Q._42)(typ)) == """[["s" ↦ 1, "t" ↦ 2] EXCEPT ![⟨"s"⟩] = 42]""")
   }
 
   test("operator def conversion preserves row-typing") {
@@ -611,15 +611,15 @@ class TestQuintEx extends AnyFunSuite {
   /// TUPLES
 
   test("can convert builtin Tup operator application") {
-    assert(convert(Q.app("Tup", Q._0, Q._1)(QuintTupleT.ofTypes(QuintIntT(), QuintIntT()))) == "<<0, 1>>")
+    assert(convert(Q.app("Tup", Q._0, Q._1)(QuintTupleT.ofTypes(QuintIntT(), QuintIntT()))) == "⟨0, 1⟩")
   }
 
   test("can convert builtin Tup operator application to heterogeneous elements") {
-    assert(convert(Q.app("Tup", Q._0, Q.s)(QuintTupleT.ofTypes(QuintStrT(), QuintStrT()))) == "<<0, \"s\">>")
+    assert(convert(Q.app("Tup", Q._0, Q.s)(QuintTupleT.ofTypes(QuintStrT(), QuintStrT()))) == "⟨0, \"s\"⟩")
   }
 
   test("can convert builtin item operator application") {
-    assert(convert(Q.app("item", Q.intPair, Q._1)(QuintIntT())) == "(<<1, 2>>)[1]")
+    assert(convert(Q.app("item", Q.intPair, Q._1)(QuintIntT())) == "(⟨1, 2⟩)[1]")
   }
 
   test("can convert builtin tuples operator application") {
@@ -653,8 +653,8 @@ class TestQuintEx extends AnyFunSuite {
     )(typ)
     val expected =
       """|CASE (Variants!VariantTag(Variants!Variant("F1", 42)) = "F1") → (LET __QUINT_LAMBDA0(x) ≜ 1 IN __QUINT_LAMBDA0(Variants!VariantGetUnsafe("F1", Variants!Variant("F1", 42))))
-         |☐ (Variants!VariantTag(Variants!Variant("F1", 42)) = "F2") → (LET __QUINT_LAMBDA1(y) ≜ 2 IN __QUINT_LAMBDA1(Variants!VariantGetUnsafe("F2", Variants!Variant("F1", 42))))
-         |☐ OTHER → (LET __QUINT_LAMBDA2(_) ≜ 2 IN __QUINT_LAMBDA2({}))""".stripMargin
+         |□ (Variants!VariantTag(Variants!Variant("F1", 42)) = "F2") → (LET __QUINT_LAMBDA1(y) ≜ 2 IN __QUINT_LAMBDA1(Variants!VariantGetUnsafe("F2", Variants!Variant("F1", 42))))
+         |□ OTHER → (LET __QUINT_LAMBDA2(_) ≜ 2 IN __QUINT_LAMBDA2({}))""".stripMargin
         .replace('\n', ' ')
     assert(convert(quintMatch) == expected)
   }
@@ -665,7 +665,7 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin Map operator") {
     assert(convert(Q.app("Map", Q.intTup1, Q.intTup2)(QuintFunT(QuintIntT(),
-                QuintIntT()))) == "Apalache!SetAsFun({<<0, 1>>, <<3, 42>>})")
+                QuintIntT()))) == "Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩})")
   }
 
   test("can convert builtin Map operator for empty maps") {
@@ -673,17 +673,17 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin get operator") {
-    assert(convert(Q.app("get", Q.intMap, Q._0)(QuintIntT())) == "Apalache!SetAsFun({<<0, 1>>, <<3, 42>>})[0]")
+    assert(convert(Q.app("get", Q.intMap, Q._0)(QuintIntT())) == "Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩})[0]")
   }
 
   test("can convert builtin keys operator") {
     assert(convert(Q.app("keys", Q.intMap)(
-            QuintSetT(QuintIntT()))) == "DOMAIN Apalache!SetAsFun({<<0, 1>>, <<3, 42>>})")
+            QuintSetT(QuintIntT()))) == "DOMAIN Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩})")
   }
 
   test("can convert builtin setToMap operator") {
     assert(convert(Q.app("setToMap", Q.intPairSet)(QuintFunT(QuintIntT(),
-                QuintIntT()))) == "Apalache!SetAsFun({<<1, 2>>, <<1, 2>>})")
+                QuintIntT()))) == "Apalache!SetAsFun({⟨1, 2⟩, ⟨1, 2⟩})")
   }
 
   val intMapT = QuintSetT(QuintFunT(QuintIntT(), QuintIntT()))
@@ -696,7 +696,7 @@ class TestQuintEx extends AnyFunSuite {
     assert(
         convert(Q.app("set", Q.intMap, Q._3, Q._2)(intMapT))
           ==
-            "[Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) EXCEPT ![<<3>>] = 2]"
+            "[Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩}) EXCEPT ![⟨3⟩] = 2]"
     )
   }
 
@@ -706,8 +706,8 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin setBy operator") {
     val expected = """
-        |LET __quint_var0 ≜ Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) IN
-        |[__quint_var0() EXCEPT ![<<1>>] = (LET __QUINT_LAMBDA0(n) ≜ n + 1 IN __QUINT_LAMBDA0(__quint_var0()[1]))]
+        |LET __quint_var0 ≜ Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩}) IN
+        |[__quint_var0() EXCEPT ![⟨1⟩] = (LET __QUINT_LAMBDA0(n) ≜ n + 1 IN __QUINT_LAMBDA0(__quint_var0()[1]))]
         """.stripMargin.linesIterator.mkString(" ").trim
     assert(convert(Q.setByExpression) == expected)
   }
@@ -727,7 +727,7 @@ class TestQuintEx extends AnyFunSuite {
 
   test("can convert builtin put operator application") {
     val expected = """
-        |LET __quint_var0 ≜ Apalache!SetAsFun({<<0, 1>>, <<3, 42>>}) IN
+        |LET __quint_var0 ≜ Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩}) IN
         |LET __quint_var1 ≜ DOMAIN __quint_var0() IN
         |[__quint_var2 ∈ ({3} ∪ __quint_var1()) ↦ IF (__quint_var2 = 3) THEN 42 ELSE __quint_var0()[__quint_var2]]
         """.stripMargin.linesIterator.mkString(" ").trim
@@ -743,7 +743,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert val __label_Foo = ...") {
-    assert(convert(Q.labelledExpr) == "Foo:: n > 0")
+    assert(convert(Q.labelledExpr) == "Foo∷ n > 0")
   }
 
   test("can convert let binding with reference to name in scope") {
@@ -786,11 +786,11 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert always operator") {
-    assert(convert(Q.app("always", Q.tt)(QuintBoolT())) == "☐TRUE")
+    assert(convert(Q.app("always", Q.tt)(QuintBoolT())) == "□TRUE")
   }
 
   test("can convert eventually operator") {
-    assert(convert(Q.app("eventually", Q.tt)(QuintBoolT())) == "♢TRUE")
+    assert(convert(Q.app("eventually", Q.tt)(QuintBoolT())) == "◇TRUE")
   }
 
   test("can convert weakFair operator") {
@@ -802,7 +802,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert leadsTo operator") {
-    assert(convert(Q.app("leadsTo", Q.tt, Q.tt)(QuintBoolT())) == "TRUE \u21DD TRUE")
+    assert(convert(Q.app("leadsTo", Q.tt, Q.tt)(QuintBoolT())) == "TRUE ↝ TRUE")
   }
 
   test("can convert polymorphic operator applied polymorphically") {
@@ -844,7 +844,7 @@ class TestQuintEx extends AnyFunSuite {
 
     val expr = Q.app("Tup", noneInt, noneBool)(QuintTupleT.ofTypes(optionInt, optionBool))
 
-    assert(convert(expr) == """<<None(), None()>>""")
+    assert(convert(expr) == """⟨None(), None()⟩""")
   }
 
   test("oneOf operator occuring outside of a nondet binding is an error") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -347,8 +347,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin exists operator application using tuple-bound names") {
-    assert(convert(Q.app("exists", Q.intPairSet, Q.int2ToBool)(
-            QuintBoolT())) == "∃(⟨n, acc⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: TRUE")
+    assert(convert(Q.app("exists", Q.intPairSet, Q.int2ToBool)(QuintBoolT())) == "∃(⟨n, acc⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: TRUE")
   }
 
   test("can convert builtin exists operator when predicate is supplied by name") {
@@ -367,8 +366,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin forall operator application using tuple-bound names") {
-    assert(convert(Q.app("forall", Q.intPairSet, Q.int2ToBool)(
-            QuintBoolT())) == "∀(⟨n, acc⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: TRUE")
+    assert(convert(Q.app("forall", Q.intPairSet, Q.int2ToBool)(QuintBoolT())) == "∀(⟨n, acc⟩) ∈ {⟨1, 2⟩, ⟨1, 2⟩}: TRUE")
   }
 
   test("can convert builtin forall operator when predicate is supplied by name") {
@@ -677,8 +675,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin keys operator") {
-    assert(convert(Q.app("keys", Q.intMap)(
-            QuintSetT(QuintIntT()))) == "DOMAIN Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩})")
+    assert(convert(Q.app("keys", Q.intMap)(QuintSetT(QuintIntT()))) == "DOMAIN Apalache!SetAsFun({⟨0, 1⟩, ⟨3, 42⟩})")
   }
 
   test("can convert builtin setToMap operator") {

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -33,13 +33,15 @@ object UTFPrinter extends Printer {
   val m_forall = "\u2200"
   val m_exists = "\u2203"
   val m_cdot = "\u22C5"
-  val m_box = "\u2610"
-  val m_diamond = "\u2662"
+  val m_box = "\u25A1"
+  val m_diamond = "\u25C7"
   val m_rarrow = "\u2192"
   val m_ring = "\u2218"
-  val m_guarantee = "\u2945"
-  val m_leadsto = "\u21DD"
+  val m_guarantee = "\u21F8"
+  val m_leadsto = "\u219D"
   val m_mapto = "\u21A6"
+  val m_langle = "\u27E8"
+  val m_rangle = "\u27E9"
   val m_cap = "\u2229"
   val m_cup = "\u222A"
   val m_subset = "\u2282"
@@ -49,6 +51,8 @@ object UTFPrinter extends Printer {
   val m_setminus = "\u2216"
   val m_times = "\u00D7"
   val m_defeq = "\u225C"
+  val m_div = "\u00F7"
+  val m_label_as = "\u2237"
 
   def pad(s: String): String = " %s ".format(s)
 
@@ -102,6 +106,7 @@ object UTFPrinter extends Printer {
           case TlaDecimal(d)   => d.toString
           case TlaStr(s)       => "\"" + s + "\""
           case TlaBool(b)      => if (b) "TRUE" else "FALSE"
+          case TlaRealInfinity => "Infinity"
           case s: TlaPredefSet => s.name
           case _               => ""
         }
@@ -132,7 +137,7 @@ object UTFPrinter extends Printer {
           case TlaArithOper.uminus  => mkOpApp("-%s", args: _*)
           case TlaArithOper.minus   => mkOpApp("%s - %s", args: _*)
           case TlaArithOper.mult    => mkOpApp("%s * %s", args: _*)
-          case TlaArithOper.div     => mkOpApp("%s // %s", args: _*)
+          case TlaArithOper.div     => mkOpApp("%%s %s %%s".format(m_div), args: _*)
           case TlaArithOper.mod     => mkOpApp("%s %% %s", args: _*)
           case TlaArithOper.realDiv => mkOpApp("%s / %s", args: _*)
           case TlaArithOper.exp     => mkOpApp("%s ^ %s", args: _*)
@@ -173,7 +178,7 @@ object UTFPrinter extends Printer {
             "[%s EXCEPT %s]".format(apply(args.head), opAppPattern(args.tail, 2, "![%s] = %s", ", "))
           case TlaFunOper.funDef =>
             "[%s %s %s]".format(opAppStrPairs(args.tail, pad(m_in), ", "), m_mapto, apply(args.head))
-          case TlaFunOper.tuple => "<<%s>>".format(str(args))
+          case TlaFunOper.tuple => "%s%s%s".format(m_langle, str(args), m_rangle)
 
           case TlaSeqOper.append => "Append(%s)".format(str(args))
           case TlaSeqOper.concat => mkOpApp("%%s %s %%s".format(m_ring), args: _*)
@@ -204,9 +209,9 @@ object UTFPrinter extends Printer {
             }
             val argsStr = args.tail.tail.map(apply).mkString(", ")
             if (args.lengthCompare(2) > 0) {
-              s"$label($argsStr):: $body"
+              s"$label($argsStr)$m_label_as $body"
             } else {
-              s"$label:: $body"
+              s"$label$m_label_as $body"
             }
 
           case _ =>
@@ -291,6 +296,8 @@ object SimplePrinter extends Printer {
       case UTFPrinter.m_guarantee => "-+->"
       case UTFPrinter.m_leadsto   => "~>"
       case UTFPrinter.m_mapto     => "|->"
+      case UTFPrinter.m_langle    => "<<"
+      case UTFPrinter.m_rangle    => ">>"
       case UTFPrinter.m_cap       => "\\cap"
       case UTFPrinter.m_cup       => "\\cup"
       case UTFPrinter.m_subset    => "\\subset"
@@ -299,6 +306,8 @@ object SimplePrinter extends Printer {
       case UTFPrinter.m_supseteq  => "\\supseteq"
       case UTFPrinter.m_setminus  => "\\"
       case UTFPrinter.m_times     => "x"
+      case UTFPrinter.m_div       => "\\div"
+      case UTFPrinter.m_label_as  => "::"
       case _                      => p_str
     }
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/io/Printer.scala
@@ -292,7 +292,7 @@ object SimplePrinter extends Printer {
       case UTFPrinter.m_box       => "[]"
       case UTFPrinter.m_diamond   => "<>"
       case UTFPrinter.m_rarrow    => "->"
-      case UTFPrinter.m_ring      => "o"
+      case UTFPrinter.m_ring      => "\\o"
       case UTFPrinter.m_guarantee => "-+->"
       case UTFPrinter.m_leadsto   => "~>"
       case UTFPrinter.m_mapto     => "|->"

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -1,7 +1,8 @@
 package at.forsyte.apalache.tla.lir
 
 import at.forsyte.apalache.tla.lir.io.UTFPrinter
-import at.forsyte.apalache.tla.lir.values.TlaInt
+import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaFunOper, TlaSeqOper}
+import at.forsyte.apalache.tla.lir.values._
 import at.forsyte.apalache.tla.lir.convenience._
 
 import org.junit.runner.RunWith
@@ -12,6 +13,35 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
 @RunWith(classOf[JUnitRunner])
 class TestPrinter extends AnyFunSuite {
   val toUtf = UTFPrinter
+
+  private def assertPrint(ex: TlaEx, expected: String): Unit = {
+    assert(toUtf(ex) == expected)
+  }
+
+  private def assertDeclPrint(decl: TlaDecl, expected: String): Unit = {
+    assert(toUtf(decl) == expected)
+  }
+
+  test("Test UTF8: literals and simple expressions") {
+    assertPrint(NullEx, "<[NULL]>")
+    assertPrint(tla.name("x"), "x")
+    assertPrint(tla.int(42), "42")
+    assertPrint(tla.bigInt(BigInt("9223372036854775808")), "9223372036854775808")
+    assertPrint(tla.decimal(BigDecimal("3.14")), "3.14")
+    assertPrint(tla.str("hello"), "\"hello\"")
+    assertPrint(tla.bool(true), "TRUE")
+    assertPrint(tla.bool(false), "FALSE")
+    assertPrint(tla.booleanSet(), "BOOLEAN")
+    assertPrint(tla.stringSet(), "STRING")
+    assertPrint(tla.intSet(), "Int")
+    assertPrint(tla.natSet(), "Nat")
+    assertPrint(ValEx(TlaRealSet), "Real")
+    assertPrint(ValEx(TlaRealInfinity), "")
+
+    val decl = TlaOperDecl("c", List(), tla.int(1))
+    assertPrint(tla.letIn(tla.appOp(tla.name("c")), decl), "LET c ≜ 1 IN c()")
+    assert(toUtf(tla.plus(tla.name("a"), tla.name("b")), p_rmSpace = true) == "a+b")
+  }
 
   test("Test UTF8: TlaOper") {
     val S = tla.name("S")
@@ -58,6 +88,9 @@ class TestPrinter extends AnyFunSuite {
     assert(chooseEx2 == "CHOOSE x %s S : p".format(toUtf.m_in))
     assert(chooseEx3 == "CHOOSE x : (p %s q)".format(toUtf.m_and))
     assert(chooseEx4 == "CHOOSE x %s (S %s T) : (p %s q)".format(toUtf.m_in, toUtf.m_times, toUtf.m_and))
+
+    assertPrint(tla.label(tla.eql(a, b), "lab"), "lab:: a = b")
+    assertPrint(tla.label(tla.eql(a, b), "lab", "i", "j"), "lab(\"i\", \"j\"):: a = b")
 
   }
 
@@ -141,13 +174,167 @@ class TestPrinter extends AnyFunSuite {
 
   }
 
-  test("Test UTF8: TlaArithOper") {}
+  test("Test UTF8: TlaArithOper") {
+    val a = tla.name("a")
+    val b = tla.name("b")
+    val c = tla.name("c")
+
+    assertPrint(tla.plus(a, b), "a + b")
+    assertPrint(tla.minus(a, b), "a - b")
+    assertPrint(tla.uminus(a), "-a")
+    assertPrint(tla.uminus(tla.plus(a, b)), "-(a + b)")
+    assertPrint(tla.mult(a, b), "a * b")
+    assertPrint(tla.div(a, b), "a // b")
+    assertPrint(tla.mod(a, b), "a % b")
+    assertPrint(tla.rDiv(a, b), "a / b")
+    assertPrint(tla.exp(a, b), "a ^ b")
+    assertPrint(tla.dotdot(a, b), "a .. b")
+    assertPrint(tla.lt(a, b), "a < b")
+    assertPrint(tla.gt(a, b), "a > b")
+    assertPrint(tla.le(a, b), "a ≤ b")
+    assertPrint(tla.ge(a, b), "a ≥ b")
+    assertPrint(tla.plus(tla.mult(a, b), c), "(a * b) + c")
+  }
+
+  test("Test UTF8: TlaActionOper") {
+    val p = tla.name("p")
+    val q = tla.name("q")
+    val x = tla.name("x")
+
+    assertPrint(tla.prime(x), "x'")
+    assertPrint(tla.prime(tla.plus(x, tla.int(1))), "(x + 1)'")
+    assertPrint(tla.stutt(p, x), "[p]_x")
+    assertPrint(tla.nostutt(p, x), "<p>_x")
+    assertPrint(tla.enabled(p), "ENABLED p")
+    assertPrint(tla.enabled(tla.and(p, q)), "ENABLED (p ∧ q)")
+    assertPrint(tla.unchanged(x), "UNCHANGED x")
+    assertPrint(tla.unchangedTup(tla.name("x"), tla.name("y")), "UNCHANGED (<<x, y>>)")
+    assertPrint(tla.comp(p, q), "p ⋅ q")
+    assertPrint(tla.comp(tla.and(p, q), tla.or(p, q)), "(p ∧ q) ⋅ (p ∨ q)")
+  }
+
+  test("Test UTF8: TlaControlOper") {
+    val a = tla.name("a")
+    val b = tla.name("b")
+    val c = tla.name("c")
+    val p = tla.name("p")
+    val q = tla.name("q")
+
+    assertPrint(tla.caseSplit(p, a), "CASE p → a")
+    assertPrint(tla.caseSplit(p, a, q, b), "CASE p → a ☐ q → b")
+    assertPrint(tla.caseOther(c, p, a), "CASE p → a ☐ OTHER → c")
+    assertPrint(tla.caseOther(c, p, a, q, b), "CASE p → a ☐ q → b ☐ OTHER → c")
+    assertPrint(tla.ite(p, a, b), "IF p THEN a ELSE b")
+    assertPrint(tla.ite(tla.and(p, q), tla.plus(a, b), tla.minus(a, b)), "IF (p ∧ q) THEN (a + b) ELSE (a - b)")
+  }
+
+  test("Test UTF8: TlaTempOper") {
+    val p = tla.name("p")
+    val q = tla.name("q")
+    val x = tla.name("x")
+
+    assertPrint(tla.AA(x, p), "[∀]x . p")
+    assertPrint(tla.EE(x, p), "[∃]x . p")
+    assertPrint(tla.box(p), "☐p")
+    assertPrint(tla.box(tla.and(p, q)), "☐(p ∧ q)")
+    assertPrint(tla.diamond(p), "♢p")
+    assertPrint(tla.diamond(tla.or(p, q)), "♢(p ∨ q)")
+    assertPrint(tla.guarantees(p, q), "p ⥅ q")
+    assertPrint(tla.leadsTo(p, q), "p ⇝ q")
+    assertPrint(tla.SF(x, p), "SF_x(p)")
+    assertPrint(tla.WF(x, p), "WF_x(p)")
+  }
+
+  test("Test UTF8: TlaFiniteSetOper") {
+    val S = tla.name("S")
+
+    assertPrint(tla.card(S), "Cardinality(S)")
+    assertPrint(tla.card(tla.enumSet(tla.int(1), tla.int(2))), "Cardinality({1, 2})")
+    assertPrint(tla.isFin(S), "IsFiniteSet(S)")
+    assertPrint(tla.isFin(tla.powSet(S)), "IsFiniteSet(SUBSET S)")
+  }
+
+  test("Test UTF8: TlaFunOper") {
+    val S = tla.name("S")
+    val T = tla.name("T")
+    val a = tla.name("a")
+    val b = tla.name("b")
+    val f = tla.name("f")
+    val i = tla.name("i")
+    val j = tla.name("j")
+    val v = tla.name("v")
+    val x = tla.name("x")
+    val y = tla.name("y")
+
+    assertPrint(tla.appFun(f, i), "f[i]")
+    assertPrint(tla.appFun(tla.appFun(f, i), j), "f[i][j]")
+    assertPrint(tla.dom(f), "DOMAIN f")
+    assertPrint(tla.dom(tla.appFun(f, i)), "DOMAIN f[i]")
+    assertPrint(tla.enumFun(tla.str("foo"), a, tla.str("bar"), b), "[\"foo\" ↦ a, \"bar\" ↦ b]")
+    assertPrint(tla.except(f, i, v), "[f EXCEPT ![i] = v]")
+    assertPrint(tla.except(f, i, v, j, a), "[f EXCEPT ![i] = v, ![j] = a]")
+    assertPrint(tla.funDef(tla.plus(x, y), x, S), "[x ∈ S ↦ x + y]")
+    assertPrint(tla.funDef(tla.plus(x, y), x, S, y, T), "[x ∈ S, y ∈ T ↦ x + y]")
+    assertPrint(tla.tuple(), "<<>>")
+    assertPrint(tla.tuple(a), "<<a>>")
+    assertPrint(tla.tuple(a, b), "<<a, b>>")
+    assertPrint(tla.recFunRef(), "FUN_REC_REF")
+    assertPrint(tla.recFunDef(tla.plus(x, tla.int(1)), x, S), "FUN_REC_CTOR(x + 1, x, S)")
+  }
+
+  test("Test UTF8: TlaSeqOper") {
+    val S = tla.name("S")
+    val T = tla.name("T")
+    val a = tla.name("a")
+    val b = tla.name("b")
+    val s = tla.name("s")
+
+    assertPrint(tla.append(s, a), "Append(s, a)")
+    assertPrint(tla.append(tla.tuple(a), b), "Append(<<a>>, b)")
+    assertPrint(tla.concat(S, T), "S ∘ T")
+    assertPrint(tla.concat(tla.append(S, a), T), "(Append(S, a)) ∘ T")
+    assertPrint(tla.head(s), "Head(s)")
+    assertPrint(tla.tail(s), "Tail(s)")
+    assertPrint(tla.len(s), "Len(s)")
+    assertPrint(tla.subseq(s, tla.int(1), tla.int(2)), "Sequences!SubSeq(s, 1, 2)")
+    assertPrint(OperEx(TlaSeqOper.subseq, tla.concat(S, T), tla.int(1), tla.len(S)), "Sequences!SubSeq(S ∘ T, 1, Len(S))")
+  }
 
   test("Test UTF8: TlaSetOper") {
-    val inEx1: String = toUtf(tla.in(tla.name("a"), tla.name("b")))
-    val inEx2: String = toUtf(tla.and(tla.in(tla.name("a"), tla.name("b")), tla.in(tla.name("c"), tla.name("d"))))
+    val S = tla.name("S")
+    val T = tla.name("T")
+    val a = tla.name("a")
+    val b = tla.name("b")
+    val c = tla.name("c")
+    val d = tla.name("d")
+    val p = tla.name("p")
+    val x = tla.name("x")
+    val y = tla.name("y")
+
+    val inEx1: String = toUtf(tla.in(a, b))
+    val inEx2: String = toUtf(tla.and(tla.in(a, b), tla.in(c, d)))
     assert(inEx1 == "a %s b".format(toUtf.m_in))
     assert(inEx2 == "a %s b %s c %s d".format(toUtf.m_in, toUtf.m_and, toUtf.m_in))
+
+    assertPrint(tla.emptySet(), "{}")
+    assertPrint(tla.enumSet(a, b, c), "{a, b, c}")
+    assertPrint(tla.in(tla.plus(a, b), S), "(a + b) ∈ S")
+    assertPrint(tla.notin(a, S), "a ∉ S")
+    assertPrint(tla.cap(S, T), "S ∩ T")
+    assertPrint(tla.cup(S, T), "S ∪ T")
+    assertPrint(tla.setminus(S, T), "S ∖ T")
+    assertPrint(tla.subseteq(S, T), "S ⊆ T")
+    assertPrint(tla.filter(x, S, p), "{x ∈ S: p}")
+    assertPrint(tla.filter(x, tla.cup(S, T), tla.and(p, tla.in(x, S))), "{x ∈ (S ∪ T): (p ∧ x ∈ S)}")
+    assertPrint(tla.funSet(S, T), "[S → T]")
+    assertPrint(tla.map(tla.plus(x, y), x, S), "{x + y : x ∈ S}")
+    assertPrint(tla.map(tla.plus(x, y), x, S, y, T), "{x + y : x ∈ S, y ∈ T}")
+    assertPrint(tla.powSet(S), "SUBSET S")
+    assertPrint(tla.recSet(tla.str("foo"), S, tla.str("bar"), T), "[\"foo\": S, \"bar\": T]")
+    assertPrint(tla.seqSet(S), "Seq(S)")
+    assertPrint(tla.times(S, T), "S × T")
+    assertPrint(tla.times(S, T, tla.enumSet(a, b)), "S × T × {a, b}")
+    assertPrint(tla.union(S), "UNION S")
   }
 
   test("Test UTF8: TlaAssumeDecl") {
@@ -157,6 +344,21 @@ class TestPrinter extends AnyFunSuite {
 
     val unnamedAssume: String = toUtf(TlaAssumeDecl(None, tla.eql(x, tla.bool(true))))
     assert(unnamedAssume == s"ASSUME x = TRUE")
+  }
+
+  test("Test UTF8: declarations") {
+    assertDeclPrint(TlaConstDecl("C"), "CONSTANT C")
+    assertDeclPrint(TlaVarDecl("x"), "VARIABLE x")
+    assertDeclPrint(TlaOperDecl("A", List(), tla.int(1)), "A ≜ 1")
+    assertDeclPrint(TlaOperDecl("A", List(OperParam("x"), OperParam("y")), tla.plus(tla.name("x"), tla.name("y"))),
+        "A(x, y) ≜ x + y")
+    assertDeclPrint(TlaOperDecl("Apply", List(OperParam("F", 2), OperParam("x", 0)), tla.int(1)),
+        "Apply(F(_, _), x) ≜ 1")
+
+    val err = intercept[RuntimeException] {
+      toUtf(TlaTheoremDecl("Thm", tla.bool(true)))
+    }
+    assert(err.getMessage.contains("Unexpected declaration"))
   }
 
   // regression
@@ -176,5 +378,14 @@ class TestPrinter extends AnyFunSuite {
     val letInEx = tla.letIn(tla.appOp(c), decl)
     val caseEx = tla.caseOther(letInEx, p, a)
     assert(toUtf(caseEx).contains("OTHER → (LET c"))
+  }
+
+  test("Test UTF8: default operator printing") {
+    val x = tla.name("x")
+    val S = tla.name("S")
+
+    assertPrint(OperEx(TlaFunOper.recFunRef), "FUN_REC_REF")
+    assertPrint(OperEx(TlaFunOper.recFunDef, x, x, S), "FUN_REC_CTOR(x, x, S)")
+    assertPrint(OperEx(ApalacheOper.gen, S), "Apalache!Gen(S)")
   }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -297,7 +297,8 @@ class TestPrinter extends AnyFunSuite {
     assertPrint(tla.tail(s), "Tail(s)")
     assertPrint(tla.len(s), "Len(s)")
     assertPrint(tla.subseq(s, tla.int(1), tla.int(2)), "Sequences!SubSeq(s, 1, 2)")
-    assertPrint(OperEx(TlaSeqOper.subseq, tla.concat(S, T), tla.int(1), tla.len(S)), "Sequences!SubSeq(S ∘ T, 1, Len(S))")
+    assertPrint(OperEx(TlaSeqOper.subseq, tla.concat(S, T), tla.int(1), tla.len(S)),
+        "Sequences!SubSeq(S ∘ T, 1, Len(S))")
   }
 
   test("Test UTF8: TlaSetOper") {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/TestPrinter.scala
@@ -36,7 +36,7 @@ class TestPrinter extends AnyFunSuite {
     assertPrint(tla.intSet(), "Int")
     assertPrint(tla.natSet(), "Nat")
     assertPrint(ValEx(TlaRealSet), "Real")
-    assertPrint(ValEx(TlaRealInfinity), "")
+    assertPrint(ValEx(TlaRealInfinity), "Infinity")
 
     val decl = TlaOperDecl("c", List(), tla.int(1))
     assertPrint(tla.letIn(tla.appOp(tla.name("c")), decl), "LET c ≜ 1 IN c()")
@@ -89,8 +89,8 @@ class TestPrinter extends AnyFunSuite {
     assert(chooseEx3 == "CHOOSE x : (p %s q)".format(toUtf.m_and))
     assert(chooseEx4 == "CHOOSE x %s (S %s T) : (p %s q)".format(toUtf.m_in, toUtf.m_times, toUtf.m_and))
 
-    assertPrint(tla.label(tla.eql(a, b), "lab"), "lab:: a = b")
-    assertPrint(tla.label(tla.eql(a, b), "lab", "i", "j"), "lab(\"i\", \"j\"):: a = b")
+    assertPrint(tla.label(tla.eql(a, b), "lab"), "lab∷ a = b")
+    assertPrint(tla.label(tla.eql(a, b), "lab", "i", "j"), "lab(\"i\", \"j\")∷ a = b")
 
   }
 
@@ -184,7 +184,7 @@ class TestPrinter extends AnyFunSuite {
     assertPrint(tla.uminus(a), "-a")
     assertPrint(tla.uminus(tla.plus(a, b)), "-(a + b)")
     assertPrint(tla.mult(a, b), "a * b")
-    assertPrint(tla.div(a, b), "a // b")
+    assertPrint(tla.div(a, b), "a ÷ b")
     assertPrint(tla.mod(a, b), "a % b")
     assertPrint(tla.rDiv(a, b), "a / b")
     assertPrint(tla.exp(a, b), "a ^ b")
@@ -208,7 +208,7 @@ class TestPrinter extends AnyFunSuite {
     assertPrint(tla.enabled(p), "ENABLED p")
     assertPrint(tla.enabled(tla.and(p, q)), "ENABLED (p ∧ q)")
     assertPrint(tla.unchanged(x), "UNCHANGED x")
-    assertPrint(tla.unchangedTup(tla.name("x"), tla.name("y")), "UNCHANGED (<<x, y>>)")
+    assertPrint(tla.unchangedTup(tla.name("x"), tla.name("y")), "UNCHANGED (⟨x, y⟩)")
     assertPrint(tla.comp(p, q), "p ⋅ q")
     assertPrint(tla.comp(tla.and(p, q), tla.or(p, q)), "(p ∧ q) ⋅ (p ∨ q)")
   }
@@ -221,9 +221,9 @@ class TestPrinter extends AnyFunSuite {
     val q = tla.name("q")
 
     assertPrint(tla.caseSplit(p, a), "CASE p → a")
-    assertPrint(tla.caseSplit(p, a, q, b), "CASE p → a ☐ q → b")
-    assertPrint(tla.caseOther(c, p, a), "CASE p → a ☐ OTHER → c")
-    assertPrint(tla.caseOther(c, p, a, q, b), "CASE p → a ☐ q → b ☐ OTHER → c")
+    assertPrint(tla.caseSplit(p, a, q, b), "CASE p → a □ q → b")
+    assertPrint(tla.caseOther(c, p, a), "CASE p → a □ OTHER → c")
+    assertPrint(tla.caseOther(c, p, a, q, b), "CASE p → a □ q → b □ OTHER → c")
     assertPrint(tla.ite(p, a, b), "IF p THEN a ELSE b")
     assertPrint(tla.ite(tla.and(p, q), tla.plus(a, b), tla.minus(a, b)), "IF (p ∧ q) THEN (a + b) ELSE (a - b)")
   }
@@ -235,12 +235,12 @@ class TestPrinter extends AnyFunSuite {
 
     assertPrint(tla.AA(x, p), "[∀]x . p")
     assertPrint(tla.EE(x, p), "[∃]x . p")
-    assertPrint(tla.box(p), "☐p")
-    assertPrint(tla.box(tla.and(p, q)), "☐(p ∧ q)")
-    assertPrint(tla.diamond(p), "♢p")
-    assertPrint(tla.diamond(tla.or(p, q)), "♢(p ∨ q)")
-    assertPrint(tla.guarantees(p, q), "p ⥅ q")
-    assertPrint(tla.leadsTo(p, q), "p ⇝ q")
+    assertPrint(tla.box(p), "□p")
+    assertPrint(tla.box(tla.and(p, q)), "□(p ∧ q)")
+    assertPrint(tla.diamond(p), "◇p")
+    assertPrint(tla.diamond(tla.or(p, q)), "◇(p ∨ q)")
+    assertPrint(tla.guarantees(p, q), "p ⇸ q")
+    assertPrint(tla.leadsTo(p, q), "p ↝ q")
     assertPrint(tla.SF(x, p), "SF_x(p)")
     assertPrint(tla.WF(x, p), "WF_x(p)")
   }
@@ -275,9 +275,9 @@ class TestPrinter extends AnyFunSuite {
     assertPrint(tla.except(f, i, v, j, a), "[f EXCEPT ![i] = v, ![j] = a]")
     assertPrint(tla.funDef(tla.plus(x, y), x, S), "[x ∈ S ↦ x + y]")
     assertPrint(tla.funDef(tla.plus(x, y), x, S, y, T), "[x ∈ S, y ∈ T ↦ x + y]")
-    assertPrint(tla.tuple(), "<<>>")
-    assertPrint(tla.tuple(a), "<<a>>")
-    assertPrint(tla.tuple(a, b), "<<a, b>>")
+    assertPrint(tla.tuple(), "⟨⟩")
+    assertPrint(tla.tuple(a), "⟨a⟩")
+    assertPrint(tla.tuple(a, b), "⟨a, b⟩")
     assertPrint(tla.recFunRef(), "FUN_REC_REF")
     assertPrint(tla.recFunDef(tla.plus(x, tla.int(1)), x, S), "FUN_REC_CTOR(x + 1, x, S)")
   }
@@ -290,7 +290,7 @@ class TestPrinter extends AnyFunSuite {
     val s = tla.name("s")
 
     assertPrint(tla.append(s, a), "Append(s, a)")
-    assertPrint(tla.append(tla.tuple(a), b), "Append(<<a>>, b)")
+    assertPrint(tla.append(tla.tuple(a), b), "Append(⟨a⟩, b)")
     assertPrint(tla.concat(S, T), "S ∘ T")
     assertPrint(tla.concat(tla.append(S, a), T), "(Append(S, a)) ∘ T")
     assertPrint(tla.head(s), "Head(s)")


### PR DESCRIPTION
Closes #3336. The test coverage of `UTFPrinter` is quite sparse, so this PR adds tests to eliminate tech debt. Also, these changes highlighted the mismatches between the now standard UTF8 characters and our older output format.