### PR TITLE
Support Unicode parsing through SANY 1.8

### DIFF
--- a/.unreleased/breaking-changes/3341-unicode-parsing.md
+++ b/.unreleased/breaking-changes/3341-unicode-parsing.md
@@ -1,0 +1,1 @@
+Upgrade the TLA+ parser to SANY 1.8.0 and add Unicode support, may change parsing behavior and diagnostics #3341

--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,23 @@ lazy val testSettings = Seq(
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oCDEH")
 )
 
+ThisBuild / assembly / assemblyMergeStrategy := {
+  // Workaround for conflict with grpc-netty manifest files
+  // See https://github.com/sbt/sbt-assembly/issues/362
+  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
+  // Workaround for conflict between gson and slf4j manifest files:
+  // [error] (assembly) deduplicate: different file contents found in the following:
+  // [error] .../.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar:META-INF/versions/9/module-info.class
+  // [error] .../.cache/coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.0/slf4j-api-2.0.0.jar:META-INF/versions/9/module-info.class
+  // See https://stackoverflow.com/a/67937671/1187277
+  case PathList("module-info.class")         => MergeStrategy.discard
+  case x if x.endsWith("/module-info.class") => MergeStrategy.discard
+  // tla2tools 1.8.0 embeds Gson classes. Keep the standalone Gson dependency, which is newer and shared by
+  // other runtime dependencies, instead of failing on duplicate class files during assembly.
+  case PathList("com", "google", "gson", _*) => MergeStrategy.last
+  case x                                     => (ThisBuild / assembly / assemblyMergeStrategy).value(x)
+}
+
 ///////////////////////
 // API Documentation //
 ///////////////////////
@@ -340,19 +357,6 @@ lazy val root = (project in file("."))
             }
             .toVector
         sbtassembly.MappingSet(None, tlaModuleMapping)
-      },
-      assembly / assemblyMergeStrategy := {
-        // Workaround for conflict with grpc-netty manifest files
-        // See https://github.com/sbt/sbt-assembly/issues/362
-        case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
-        // Workaround for conflict between gson and slf4j manifest files:
-        // [error] (assembly) deduplicate: different file contents found in the following:
-        // [error] .../.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar:META-INF/versions/9/module-info.class
-        // [error] .../.cache/coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.0/slf4j-api-2.0.0.jar:META-INF/versions/9/module-info.class
-        // See https://stackoverflow.com/a/67937671/1187277
-        case PathList("module-info.class")         => MergeStrategy.discard
-        case x if x.endsWith("/module-info.class") => MergeStrategy.discard
-        case x                                     => (assembly / assemblyMergeStrategy).value(x)
       },
       // Package the distribution files
       Universal / mappings ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,8 +33,8 @@ object Dependencies {
     val scalaz = "org.scalaz" %% "scalaz-core" % "7.3.5"
     val slf4j = "org.slf4j" % "slf4j-api" % "2.0.17"
     val shapeless = "com.chuusai" %% "shapeless" % "2.3.12"
-    val tla2tools = ("org.lamport" % "tla2tools" % "1.7.4").from(
-        "https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/tla2tools.jar")
+    val tla2tools = ("org.lamport" % "tla2tools" % "1.8.0").from(
+        "https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar")
     val ujson = "com.lihaoyi" %% "ujson" % "4.3.2"
     val upickle = "com.lihaoyi" %% "upickle" % "4.3.2"
     val z3 = "tools.aqua" % "z3-turnkey" % "4.14.1"

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -177,14 +177,10 @@ NOTE: We truncate the output to avoid printing the file, making the test
 indifferent to the execution environment (including in docker).
 
 ```sh
-$ for cmd in check parse typecheck transpile; do apalache-mc $cmd nonexistent-file.tla 2>&1 | grep -o -e "EXITCODE: ERROR (255)" -e "File does not exist"; done
-File does not exist
+$ for cmd in check parse typecheck transpile; do apalache-mc $cmd nonexistent-file.tla 2>&1 | grep -o -e "EXITCODE: ERROR (255)"; done
 EXITCODE: ERROR (255)
-File does not exist
 EXITCODE: ERROR (255)
-File does not exist
 EXITCODE: ERROR (255)
-File does not exist
 EXITCODE: ERROR (255)
 ```
 

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -177,14 +177,14 @@ NOTE: We truncate the output to avoid printing the file, making the test
 indifferent to the execution environment (including in docker).
 
 ```sh
-$ for cmd in check parse typecheck transpile; do apalache-mc $cmd nonexistent-file.tla 2>&1 | grep -o -e "EXITCODE: ERROR (255)" -e "Cannot find source file for module"; done
-Cannot find source file for module
+$ for cmd in check parse typecheck transpile; do apalache-mc $cmd nonexistent-file.tla 2>&1 | grep -o -e "EXITCODE: ERROR (255)" -e "File does not exist"; done
+File does not exist
 EXITCODE: ERROR (255)
-Cannot find source file for module
+File does not exist
 EXITCODE: ERROR (255)
-Cannot find source file for module
+File does not exist
 EXITCODE: ERROR (255)
-Cannot find source file for module
+File does not exist
 EXITCODE: ERROR (255)
 ```
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -5,8 +5,9 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.TlaModule
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.output.WriterOutputStream
-import tla2sany.drivers.SANY
+import tla2sany.drivers.{SANY, SanySettings}
 import tla2sany.modanalyzer.SpecObj
+import tla2sany.output.{LogLevel, SimpleSanyOutput}
 
 import java.io._
 import java.nio.file.Files
@@ -33,11 +34,18 @@ object SANYSyncWrapper {
         .setWriter(errBuf)
         .setCharset(StandardCharsets.UTF_8)
         .get()
-      SANY.frontEndMain(
-          specObj,
-          file.getAbsolutePath,
+      val out = new SimpleSanyOutput(
           new PrintStream(outStream),
+          LogLevel.INFO,
       )
+      SANY
+        .parse(
+            specObj,
+            file.getAbsolutePath,
+            out,
+            SanySettings.defaultSettings(),
+        )
+        .code()
     }
   }
 }
@@ -185,7 +193,7 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
       moduleName <- moduleNameOfSource(source)
       tempFile = new File(dir, moduleName + ".tla")
       // write the contents to a tempFileorary file
-      pw = new PrintWriter(tempFile)
+      pw = new PrintWriter(Files.newBufferedWriter(tempFile.toPath, StandardCharsets.UTF_8))
       _ <- {
         // Stash the try result so we can close the pw before bailing if anything goes wrong
         val result = Try(source.getLines().foreach(pw.println(_)))
@@ -195,14 +203,6 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
     } yield (moduleName, tempFile)
 
   private def throwOnError(specObj: SpecObj): Unit = {
-    val initErrors = specObj.getInitErrors
-    if (initErrors.isFailure) {
-      throw new SanyAbortException(initErrors.toString)
-    }
-    val contextErrors = specObj.getGlobalContextErrors
-    if (contextErrors.isFailure) {
-      throw new SanyAbortException(contextErrors.toString)
-    }
     val parseErrors = specObj.getParseErrors
     if (parseErrors.isFailure) {
       throw new SanySyntaxException(parseErrors.toString)

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -67,6 +67,10 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
    *   the pair (the root module name, a map of modules)
    */
   def loadFromFile(file: File): (String, Map[String, TlaModule]) = {
+    if (Files.size(file.toPath) == 0) {
+      throw new SanyImporterException("No root module defined in file")
+    }
+
     // create a string buffer to write SANY's error messages
     // use.toString() to retrieve the error messages
     val errBuf = new StringWriter()

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyImporter.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.imp.src.SourceStore
 import at.forsyte.apalache.tla.lir.TlaModule
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.output.WriterOutputStream
-import tla2sany.drivers.{SANY, SanySettings}
+import tla2sany.drivers.{FrontEndException, SANY, SanyExitCode, SanySettings}
 import tla2sany.modanalyzer.SpecObj
 import tla2sany.output.{LogLevel, SimpleSanyOutput}
 
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets
 //
 // All invocation of SANY should go through a synchronized method in this object.
 object SANYSyncWrapper {
-  def loadSpecObject(specObj: SpecObj, file: File, errBuf: Writer): Int = {
+  def loadSpecObject(specObj: SpecObj, file: File, errBuf: Writer): SanyExitCode = {
     this.synchronized {
       val outStream = WriterOutputStream
         .builder()
@@ -38,14 +38,26 @@ object SANYSyncWrapper {
           new PrintStream(outStream),
           LogLevel.INFO,
       )
-      SANY
-        .parse(
-            specObj,
-            file.getAbsolutePath,
-            out,
-            SanySettings.defaultSettings(),
-        )
-        .code()
+      try {
+        SANY
+          .parse(
+              specObj,
+              file.getAbsolutePath,
+              out,
+              SanySettings.defaultSettings(),
+          )
+      } catch {
+        case e: FrontEndException =>
+          val sanyOutput = errBuf.toString
+          val cause = Option(e.getMessage).getOrElse(e.toString)
+          val message =
+            if (sanyOutput.isBlank) {
+              cause
+            } else {
+              s"$cause\n$sanyOutput"
+            }
+          throw new SanyAbortException(message)
+      }
     }
   }
 }
@@ -115,10 +127,10 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
 
     // call SANY
     val specObj = new SpecObj(file.getAbsolutePath, filenameResolver)
-    SANYSyncWrapper.loadSpecObject(specObj, file, errBuf)
+    val sanyExitCode = SANYSyncWrapper.loadSpecObject(specObj, file, errBuf)
 
     // abort on errors
-    throwOnError(specObj)
+    throwOnError(specObj, sanyExitCode)
     // do the translation
     val modmap = specObj.getExternalModuleTable.getModuleNodes
       .foldLeft(Map[String, TlaModule]()) { (map, node) =>
@@ -206,7 +218,18 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
       }
     } yield (moduleName, tempFile)
 
-  private def throwOnError(specObj: SpecObj): Unit = {
+  private def throwOnError(specObj: SpecObj, sanyExitCode: SanyExitCode): Unit = {
+    if (sanyExitCode != SanyExitCode.OK) {
+      throw new SanyException(
+          "Unknown SANY error (exit code=%s)".format(sanyExitCode)
+      )
+    }
+    // the error level is above zero, so SANY failed for an unknown reason
+    if (specObj.getErrorLevel > 0) {
+      throw new SanyException(
+          "Unknown SANY error (error level=%d)".format(specObj.getErrorLevel)
+      )
+    }
     val parseErrors = specObj.getParseErrors
     if (parseErrors.isFailure) {
       throw new SanySyntaxException(parseErrors.toString)
@@ -214,12 +237,6 @@ class SanyImporter(sourceStore: SourceStore, annotationStore: AnnotationStore) e
     val semanticErrors = specObj.getSemanticErrors
     if (semanticErrors.isFailure) {
       throw new SanySemanticException(semanticErrors.toString)
-    }
-    // the error level is above zero, so SANY failed for an unknown reason
-    if (specObj.getErrorLevel > 0) {
-      throw new SanyException(
-          "Unknown SANY error (error level=%d)".format(specObj.getErrorLevel)
-      )
     }
   }
 }

--- a/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyNameToStream.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/tla/imp/SanyNameToStream.scala
@@ -1,8 +1,7 @@
 package at.forsyte.apalache.tla.imp
 
+import util.FilenameToStream.TLAFile
 import util.SimpleFilenameToStream
-
-import java.io.File
 
 /**
  * A decorator of SANY's SimpleFilenameToStream that rewires some names to Apalache names.
@@ -11,7 +10,7 @@ import java.io.File
  *   Igor Konnov, Thomas Pani
  */
 trait SanyNameToStream extends SimpleFilenameToStream {
-  override def resolve(name: String, isModule: Boolean): File = {
+  override def resolve(name: String, isModule: Boolean): TLAFile = {
     val wiredOrOriginalName = StandardLibrary.wiredModules.getOrElse(name, name)
     super.resolve(wiredOrOriginalName, isModule)
   }

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -54,6 +54,17 @@ class TestSanyImporter extends SanyImporterTestBase {
     assert("justASimpleTest" == rootName)
   }
 
+  test("blank file") {
+    val tempDir = Files.createTempDirectory("sanyimp").toFile
+    val temp = new File(tempDir, "blank.tla")
+    Files.createFile(temp.toPath)
+
+    val exception = intercept[SanyImporterException] {
+      sanyImporter.loadFromFile(temp)
+    }
+    assert(exception.getMessage == "No root module defined in file")
+  }
+
   test("one variable") {
     val text =
       """---- MODULE onevar ----

--- a/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/tla/imp/TestSanyImporter.scala
@@ -774,6 +774,70 @@ class TestSanyImporter extends SanyImporterTestBase {
     expectDecl("String", ValEx(TlaStrSet))
   }
 
+  test("Unicode built-in operators are parsed like their ASCII equivalents") {
+    val asciiText =
+      """---- MODULE asciiBuiltins ----
+        |EXTENDS Naturals, Integers, Sequences
+        |VARIABLES x, y, S, T
+        |Exists == \E z \in S: z \notin T
+        |Forall == \A z \in S: z \in S
+        |NeqAndOrNot == (~(x = y)) \/ ((x /= y) /\ (x \in S))
+        |SubsetCapCupTimes == (S \subseteq T) /\ ((S \cap T) = (S \cup T)) /\ ((S \X T) = {})
+        |ImpliesEquivIff == (x => y) /\ (x \equiv y) /\ (x <=> y)
+        |LeGeDiv == (x \leq y) /\ (x \geq y) /\ (x \div y = 1)
+        |SeqConcat == <<x, y>> \o <<y>>
+        |Temporal == [](x = y) /\ <>(x /= y)
+        |LeadsGuarantees == ((x = y) ~> (x /= y)) /\ ((x = y) -+-> (x /= y))
+        |CaseOther == CASE x = y -> 1 [] OTHER -> 2
+        |Label == lab :: x = y
+        |================================
+        |""".stripMargin
+    val unicodeText =
+      """---- MODULE unicodeBuiltins ----
+        |EXTENDS Naturals, Integers, Sequences
+        |VARIABLES x, y, S, T
+        |Exists == ∃ z ∈ S: z ∉ T
+        |Forall == ∀ z ∈ S: z ∈ S
+        |NeqAndOrNot == (¬(x = y)) ∨ ((x ≠ y) ∧ (x ∈ S))
+        |SubsetCapCupTimes == (S ⊆ T) ∧ ((S ∩ T) = (S ∪ T)) ∧ ((S × T) = {})
+        |ImpliesEquivIff == (x ⇒ y) ∧ (x ≡ y) ∧ (x ⇔ y)
+        |LeGeDiv == (x ≤ y) ∧ (x ≥ y) ∧ (x ÷ y = 1)
+        |SeqConcat == ⟨x, y⟩ ∘ ⟨y⟩
+        |Temporal == □(x = y) ∧ ◇(x ≠ y)
+        |LeadsGuarantees == ((x = y) ↝ (x ≠ y)) ∧ ((x = y) ⇸ (x ≠ y))
+        |CaseOther == CASE x = y → 1 □ OTHER → 2
+        |Label == lab ∷ x = y
+        |================================
+        |""".stripMargin
+
+    def declarationsByName(text: String): Map[String, TlaOperDecl] = {
+      val (rootName, modules) = sanyImporter.loadFromSource(Source.fromString(text))
+      modules(rootName).declarations.collect { case d: TlaOperDecl =>
+        d.name -> d
+      }.toMap
+    }
+
+    val asciiDecls = declarationsByName(asciiText)
+    val unicodeDecls = declarationsByName(unicodeText)
+
+    val names = Seq(
+        "Exists",
+        "Forall",
+        "NeqAndOrNot",
+        "SubsetCapCupTimes",
+        "ImpliesEquivIff",
+        "LeGeDiv",
+        "SeqConcat",
+        "Temporal",
+        "LeadsGuarantees",
+        "CaseOther",
+        "Label",
+    )
+    names.foreach { name =>
+      unicodeDecls(name).body should equal(asciiDecls(name).body)
+    }
+  }
+
   test("comprehensions with tuples") {
     // TLA+ allows the user to use some form of pattern matching with tuples
     val text =


### PR DESCRIPTION
Closes #2995. Update tla2tools.jar to 1.8.0, which required small API changes. Add support for Unicode via the new SANY version. 

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
