### PR TITLE
Refactor ITF JSON serialization

### DIFF
--- a/json-rpc/src/main/scala/com/github/apalachemc/apalache/jsonrpc/JsonRpcServer.scala
+++ b/json-rpc/src/main/scala/com/github/apalachemc/apalache/jsonrpc/JsonRpcServer.scala
@@ -8,9 +8,9 @@ import at.forsyte.apalache.infra.passes.options.SMTEncoding.OOPSLA19
 import at.forsyte.apalache.infra.passes.options.{Config, SourceOption}
 import at.forsyte.apalache.infra.tlc.config.InitNextSpec
 import at.forsyte.apalache.io.ConfigManager
-import at.forsyte.apalache.io.itf.ItfJsonToTla
-import at.forsyte.apalache.io.json.jackson.{JacksonRepresentation, ScalaFromJacksonAdapter}
-import at.forsyte.apalache.io.lir.{ItfCounterexampleWriter, Trace}
+import at.forsyte.apalache.io.itf.{ItfJsonToTla, TlaToItfJson}
+import at.forsyte.apalache.io.json.jackson.{JacksonRepresentation, ScalaFromJacksonAdapter, ScalaToJacksonAdapter}
+import at.forsyte.apalache.io.lir.Trace
 import at.forsyte.apalache.tla.bmcmt.ModelCheckerContext
 import at.forsyte.apalache.tla.bmcmt.config.CheckerModule
 import at.forsyte.apalache.tla.bmcmt.passes.BoundedCheckerPassImpl
@@ -32,7 +32,6 @@ import org.eclipse.jetty.compression.server.CompressionHandler
 import org.eclipse.jetty.compression.gzip.GzipCompression
 import org.eclipse.jetty.compression.zstandard.ZstandardCompression
 
-import java.io.StringReader
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.{Lock, ReentrantLock}
 import java.util.concurrent.{LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
@@ -71,6 +70,7 @@ class ExplorationService(config: Try[Config.ApalacheConfig]) extends LazyLogging
   private val snapshots: CheckerSnapshotsPerSession = new CheckerSnapshotsPerSession()
   // Shared Jackson mapper for JSON serialization/deserialization.
   private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  private val itfJson = new TlaToItfJson[JacksonRepresentation](ScalaToJacksonAdapter)
 
   /**
    * A trivial health check.
@@ -519,7 +519,7 @@ class ExplorationService(config: Try[Config.ApalacheConfig]) extends LazyLogging
                 .getOrElse(NextModelStatus.UNKNOWN)
 
               // Serialize the old operator value to JSON
-              val oldValueInJson = ujsonToJackson(ItfCounterexampleWriter.exprToJson(oldTlaExpr))
+              val oldValueInJson = itfJson.exprToJson(oldTlaExpr).value
               NextModelResult(params.sessionId, oldValue = oldValueInJson, hasOld = NextModelStatus.TRUE,
                   hasNext = hasNext)
           }
@@ -612,9 +612,7 @@ class ExplorationService(config: Try[Config.ApalacheConfig]) extends LazyLogging
         val counterexample = Trace(checkerContext.checkerInput.rootModule, path.map(_.assignments).toIndexedSeq,
             path.map(_ => SortedSet[String]()).toIndexedSeq, ())
         // Serialize the counterexample to JSON
-        val ujsonTrace =
-          ItfCounterexampleWriter.mkJson(checkerContext.checkerInput.rootModule, counterexample.states)
-        ujsonToJackson(ujsonTrace)
+        itfJson.mkJson(checkerContext.checkerInput.rootModule, counterexample.states).value
 
       case _ =>
         // no trace or unknown
@@ -652,11 +650,7 @@ class ExplorationService(config: Try[Config.ApalacheConfig]) extends LazyLogging
                 (path.last.assignments, path.length - 2)
             }
 
-          // Serialize the single state in the same format as ItfCounterexampleWriter.stateToJson
-          val meta = ujson.Obj(at.forsyte.apalache.io.itf.INDEX_FIELD -> ujson.Num(lastIndex))
-          val fields = lastState.toList.sortBy(_._1).map(p => (p._1, ItfCounterexampleWriter.exprToJson(p._2)))
-          val ujsonState = ujson.Obj(at.forsyte.apalache.io.itf.META_FIELD -> meta, fields: _*)
-          ujsonToJackson(ujsonState)
+          itfJson.stateToJson(lastState, lastIndex).value
         }
 
       case _ =>
@@ -676,7 +670,7 @@ class ExplorationService(config: Try[Config.ApalacheConfig]) extends LazyLogging
           Left(msg)
 
         case Some(tlaExpr) =>
-          Right(ujsonToJackson(ItfCounterexampleWriter.exprToJson(tlaExpr)))
+          Right(itfJson.exprToJson(tlaExpr).value)
       }
     }
 
@@ -736,10 +730,6 @@ class ExplorationService(config: Try[Config.ApalacheConfig]) extends LazyLogging
         )
       }
   }
-
-  /** Convert a UJSON value to Jackson's JsonNode. */
-  private def ujsonToJackson(ujsonValue: ujson.Value): JsonNode =
-    mapper.readTree(new StringReader(ujsonValue.render()))
 
   /** Look up the session's checker context, or return a ServiceError. */
   private def getCheckerContext(

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/itf/TlaToItfJson.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/itf/TlaToItfJson.scala
@@ -1,0 +1,129 @@
+package at.forsyte.apalache.io.itf
+
+import at.forsyte.apalache.io.json.{JsonRepresentation, ScalaToJsonAdapter}
+import at.forsyte.apalache.io.lir.{NameReplacementMap, Trace}
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.lir.oper.TlaOper.deinterleave
+import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaFunOper, TlaSetOper, VariantOper}
+import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
+
+import java.util.Calendar
+
+/**
+ * Converts TLA+ trace values to the Informal Trace Format JSON shape.
+ *
+ * @param adapter
+ *   JSON representation adapter
+ * @tparam T
+ *   concrete JSON representation
+ */
+class TlaToItfJson[T <: JsonRepresentation](adapter: ScalaToJsonAdapter[T]) {
+
+  /**
+   * Produce a JSON representation of a counterexample in the ITF format.
+   *
+   * @param rootModule
+   *   the module that produced the counterexample
+   * @param states
+   *   a sequence of next states
+   * @return
+   *   the JSON representation of the counterexample in the ITF format
+   */
+  def mkJson(rootModule: TlaModule, states: IndexedSeq[Trace.State]): T = {
+    val state0 = states match {
+      case constInit +: Seq()          => constInit
+      case constInit +: initState +: _ => constInit ++ initState
+      case Seq()                       => throw new IllegalArgumentException("Expected at least one state, found none")
+    }
+    val mappedStates = state0 +: states.drop(2)
+
+    val metaFields = Seq(
+        FORMAT_FIELD -> adapter.fromStr("ITF"),
+        FORMAT_DESCRIPTION_FIELD -> adapter.fromStr("https://apalache-mc.org/docs/adr/015adr-trace.html"),
+        DESCRIPTION_FIELD -> adapter.fromStr("Created by Apalache on %s".format(Calendar.getInstance().getTime)),
+        VAR_TYPES_FIELD -> adapter.mkObj(rootModule.varDeclarations.map { varDecl =>
+          varDecl.name -> adapter.fromStr(TlaType1.fromTypeTag(varDecl.typeTag).toString)
+        }: _*),
+    ) ++ Option.when(NameReplacementMap.store.nonEmpty)(
+        VARIABLES_TO_EXPRESSIONS_FIELD -> adapter.mkObj(NameReplacementMap.store.toSeq.map { case (name, expression) =>
+          name -> adapter.fromStr(expression)
+        }: _*)
+    )
+
+    val rootFields =
+      Seq(META_FIELD -> adapter.mkObj(metaFields: _*)) ++
+        paramsToJson(rootModule).map(PARAMS_FIELD -> _).toSeq ++
+        Seq(
+            VARS_FIELD -> varsToJson(rootModule),
+            STATES_FIELD -> adapter.fromIterable(mappedStates.zipWithIndex.map((stateToJson _).tupled)),
+        )
+
+    adapter.mkObj(rootFields: _*)
+  }
+
+  private def varsToJson(root: TlaModule): T = {
+    val names = root.declarations.collect { case TlaVarDecl(name) =>
+      adapter.fromStr(name)
+    }
+    adapter.fromIterable(names)
+  }
+
+  private def paramsToJson(root: TlaModule): Option[T] = {
+    val names = root.declarations.collect { case TlaConstDecl(name) =>
+      adapter.fromStr(name)
+    }
+    Option.when(names.nonEmpty)(adapter.fromIterable(names))
+  }
+
+  def stateToJson(state: Trace.State, index: Int): T = {
+    val meta = adapter.mkObj(INDEX_FIELD -> adapter.fromInt(index))
+    val fields = (META_FIELD -> meta) +: state.toList.sortBy(_._1).map { case (name, value) =>
+      name -> exprToJson(value)
+    }
+    adapter.mkObj(fields: _*)
+  }
+
+  /**
+   * Convert an individual TLA+ expression to its JSON representation in the ITF format.
+   */
+  def exprToJson(ex: TlaEx): T = ex match {
+    case ValEx(TlaInt(num)) =>
+      adapter.mkObj(BIG_INT_FIELD -> adapter.fromStr(num.toString(10)))
+
+    case ValEx(TlaBool(b)) =>
+      adapter.fromBool(b)
+
+    case ValEx(TlaStr(str)) =>
+      adapter.fromStr(str)
+
+    case tuple @ OperEx(TlaFunOper.tuple, args @ _*) =>
+      tuple.typeTag match {
+        case Typed(SeqT1(_)) =>
+          adapter.fromIterable(args.map(exprToJson))
+
+        case _ =>
+          adapter.mkObj(TUP_FIELD -> adapter.fromIterable(args.map(exprToJson)))
+      }
+
+    case OperEx(TlaSetOper.enumSet, args @ _*) =>
+      adapter.mkObj(SET_FIELD -> adapter.fromIterable(args.map(exprToJson)))
+
+    case OperEx(TlaFunOper.rec, args @ _*) =>
+      val (keyEs, valueEs) = deinterleave(args)
+      val keys = keyEs.collect { case ValEx(TlaStr(s)) => s }
+      val values = valueEs.map(exprToJson)
+      adapter.mkObj(keys.zip(values): _*)
+
+    case OperEx(VariantOper.variant, ValEx(TlaStr(tagName)), valueEx) =>
+      adapter.mkObj(TAG_FIELD -> adapter.fromStr(tagName), VALUE_FIELD -> exprToJson(valueEx))
+
+    case OperEx(ApalacheOper.setAsFun, OperEx(TlaSetOper.enumSet, args @ _*)) =>
+      val keyValueArrays = args.collect { case OperEx(TlaFunOper.tuple, key, value) =>
+        adapter.fromIterable(Seq(exprToJson(key), exprToJson(value)))
+      }
+      adapter.mkObj(MAP_FIELD -> adapter.fromIterable(keyValueArrays))
+
+    case e =>
+      adapter.mkObj(UNSERIALIZABLE_FIELD -> adapter.fromStr(e.toString))
+  }
+}

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/ItfCounterexampleWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/ItfCounterexampleWriter.scala
@@ -1,14 +1,10 @@
 package at.forsyte.apalache.io.lir
 
-import at.forsyte.apalache.io.itf._
+import at.forsyte.apalache.io.itf.TlaToItfJson
+import at.forsyte.apalache.io.json.ujsonimpl.{ScalaToUJsonAdapter, UJsonRepresentation}
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.TlaOper.deinterleave
-import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaFunOper, TlaSetOper, VariantOper}
-import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
 
 import java.io.PrintWriter
-import java.util.Calendar
-import scala.collection.mutable
 
 /**
  * This class produces counterexamples in the Informal Trace Format.
@@ -25,6 +21,7 @@ class ItfCounterexampleWriter(writer: PrintWriter) extends CounterexampleWriter 
 }
 
 object ItfCounterexampleWriter {
+  private val ujsonEncoder = new TlaToItfJson[UJsonRepresentation](ScalaToUJsonAdapter)
 
   /**
    * Produce a JSON representation of a counterexample in the ITF format
@@ -36,110 +33,16 @@ object ItfCounterexampleWriter {
    * @return
    *   the JSON representation of the counterexample in the ITF format
    */
-  def mkJson(rootModule: TlaModule, states: IndexedSeq[Trace.State]): ujson.Value = {
-    // merge constant initialization and variable initialization into a single state
-    val state0 = states match {
-      case constInit +: Seq()          => constInit
-      case constInit +: initState +: _ => constInit ++ initState
-      case Seq()                       => throw new IllegalArgumentException("Expected at least one state, found none")
-    }
-    val mappedStates = state0 +: states.drop(2)
-    // construct the root JSON object
-    val rootMap: mutable.LinkedHashMap[String, ujson.Value] = mutable.LinkedHashMap()
+  def mkJson(rootModule: TlaModule, states: IndexedSeq[Trace.State]): ujson.Value =
+    ujsonEncoder.mkJson(rootModule, states).value
 
-    val metaInformation: Map[String, ujson.Value] = {
-      val varTypes = Map[String, ujson.Value](
-          VAR_TYPES_FIELD -> ujson.Obj.from(
-              rootModule.varDeclarations.map { varDecl =>
-                varDecl.name -> TlaType1.fromTypeTag(varDecl.typeTag).toString
-              }
-          )
-      )
-      val descriptions = Map[String, ujson.Value](
-          FORMAT_DESCRIPTION_FIELD -> "https://apalache-mc.org/docs/adr/015adr-trace.html",
-          DESCRIPTION_FIELD -> "Created by Apalache on %s".format(Calendar.getInstance().getTime),
-      )
-
-      varTypes ++ descriptions ++
-        Option.when(NameReplacementMap.store.nonEmpty)(VARIABLES_TO_EXPRESSIONS_FIELD -> NameReplacementMap.store)
-    }
-
-    rootMap.put(META_FIELD,
-        ujson.Obj(
-            FORMAT_FIELD -> "ITF",
-            metaInformation.toSeq: _*
-        ))
-    paramsToJson(rootModule).foreach(params => rootMap.put(PARAMS_FIELD, params))
-    rootMap.put(VARS_FIELD, varsToJson(rootModule))
-    rootMap.put(STATES_FIELD, ujson.Arr(mappedStates.zipWithIndex.map((stateToJson _).tupled): _*))
-    ujson.Obj.from(rootMap)
-  }
-
-  private def varsToJson(root: TlaModule): ujson.Value = {
-    val names = root.declarations.collect { case TlaVarDecl(name) =>
-      ujson.Str(name)
-    }
-    ujson.Arr(names: _*)
-  }
-
-  private def paramsToJson(root: TlaModule): Option[ujson.Value] = {
-    val names = root.declarations.collect { case TlaConstDecl(name) =>
-      ujson.Str(name)
-    }
-    if (names.isEmpty) None else Some(ujson.Arr(names: _*))
-  }
-
-  private def stateToJson(state: Map[String, TlaEx], index: Int): ujson.Value = {
-    val meta = ujson.Obj(INDEX_FIELD -> ujson.Num(index))
-    val map = state.toList.sortBy(_._1).map(p => (p._1, exprToJson(p._2)))
-    ujson.Obj(META_FIELD -> meta, map: _*)
-  }
+  def stateToJson(state: Trace.State, index: Int): ujson.Value =
+    ujsonEncoder.stateToJson(state, index).value
 
   /**
    * Convert an individual TLA+ expression to its JSON representation in the ITF format.
    * @return
    *   a function that converts TLA+ expressions to JSON values
    */
-  def exprToJson: TlaEx => ujson.Value = {
-    case ValEx(TlaInt(num)) =>
-      ujson.Obj(BIG_INT_FIELD -> ujson.Str(num.toString(10)))
-
-    case ValEx(TlaBool(b)) =>
-      ujson.Bool(b)
-
-    case ValEx(TlaStr(str)) =>
-      ujson.Str(str)
-
-    case ex @ OperEx(TlaFunOper.tuple, args @ _*) =>
-      ex.typeTag match {
-        case Typed(SeqT1(_)) =>
-          ujson.Arr(args.map(exprToJson): _*)
-
-        case _ =>
-          ujson.Obj(TUP_FIELD -> ujson.Arr(args.map(exprToJson): _*))
-      }
-
-    case OperEx(TlaSetOper.enumSet, args @ _*) =>
-      ujson.Obj(SET_FIELD -> ujson.Arr(args.map(exprToJson): _*))
-
-    case OperEx(TlaFunOper.rec, args @ _*) =>
-      val (keyEs, valuesEs) = deinterleave(args)
-      val keys = keyEs.collect { case ValEx(TlaStr(s)) => s }
-      val values = valuesEs.map(exprToJson)
-      ujson.Obj.from(keys.zip(values))
-
-    case OperEx(VariantOper.variant, ValEx(TlaStr(tagName)), valueEx) =>
-      ujson.Obj(TAG_FIELD -> ujson.Str(tagName), VALUE_FIELD -> exprToJson(valueEx))
-
-    case OperEx(ApalacheOper.setAsFun, OperEx(TlaSetOper.enumSet, args @ _*)) =>
-      val keyValueArrays = args.collect { case OperEx(TlaFunOper.tuple, key, value) =>
-        ujson.Arr(exprToJson(key), exprToJson(value))
-      }
-      ujson.Obj(MAP_FIELD -> ujson.Arr(keyValueArrays: _*))
-
-    case e =>
-      // We don't know how to serialize this TLA+ expression (e.g., Int, Nat, FunSet, PowSet).
-      // Output it as a serialization error.
-      ujson.Obj(UNSERIALIZABLE_FIELD -> ujson.Str(e.toString))
-  }
+  def exprToJson: TlaEx => ujson.Value = ex => ujsonEncoder.exprToJson(ex).value
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/itf/TestTlaToItfJson.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/itf/TestTlaToItfJson.scala
@@ -1,0 +1,66 @@
+package at.forsyte.apalache.io.itf
+
+import at.forsyte.apalache.io.json.jackson.{JacksonRepresentation, ScalaFromJacksonAdapter, ScalaToJacksonAdapter}
+import at.forsyte.apalache.io.json.ujsonimpl.{ScalaToUJsonAdapter, UJsonRepresentation}
+import at.forsyte.apalache.io.lir.Trace
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.types.tla
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+import scala.collection.immutable.SortedMap
+
+@RunWith(classOf[JUnitRunner])
+class TestTlaToItfJson extends AnyFunSuite {
+  private val ujsonEncoder = new TlaToItfJson[UJsonRepresentation](ScalaToUJsonAdapter)
+  private val jacksonEncoder = new TlaToItfJson[JacksonRepresentation](ScalaToJacksonAdapter)
+
+  test("UJson encoder emits ITF trace") {
+    val intTag = Typed(IntT1)
+    val module = TlaModule("test", List(TlaVarDecl("x")(intTag)))
+    val trace = IndexedSeq[Trace.State](
+        SortedMap(),
+        SortedMap("x" -> tla.int(1).build),
+        SortedMap("x" -> tla.int(2).build),
+    )
+
+    val actualJson = ujsonEncoder.mkJson(module, trace).value
+    val expectedJson = ujson.read("""{
+      "#meta": {
+        "format": "ITF",
+        "format-description": "https://apalache-mc.org/docs/adr/015adr-trace.html",
+        "varTypes": { "x": "Int" }
+      },
+      "vars": [ "x" ],
+      "states": [
+        { "#meta": { "index": 0 }, "x": { "#bigint": "1" } },
+        { "#meta": { "index": 1 }, "x": { "#bigint": "2" } }
+      ]
+    }""")
+
+    assert(actualJson("#meta")("format") == expectedJson("#meta")("format"))
+    assert(actualJson("#meta")("format-description") == expectedJson("#meta")("format-description"))
+    assert(actualJson("#meta")("varTypes") == expectedJson("#meta")("varTypes"))
+    assert(actualJson("vars") == expectedJson("vars"))
+    assert(actualJson("states") == expectedJson("states"))
+  }
+
+  test("Jackson encoder emits parseable ITF trace") {
+    val intTag = Typed(IntT1)
+    val module = TlaModule("test", List(TlaVarDecl("x")(intTag)))
+    val trace = IndexedSeq[Trace.State](
+        SortedMap(),
+        SortedMap("x" -> tla.int(1).build),
+        SortedMap("x" -> tla.int(2).build),
+    )
+
+    val json = jacksonEncoder.mkJson(module, trace)
+    val parsed = new ItfJsonToTla(ScalaFromJacksonAdapter).parseTrace(json)
+
+    assert(parsed.contains(IndexedSeq(
+            SortedMap("x" -> tla.int(1).build),
+            SortedMap("x" -> tla.int(2).build),
+        )))
+  }
+}

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/itf/TestTlaToItfJson.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/itf/TestTlaToItfJson.scala
@@ -59,8 +59,8 @@ class TestTlaToItfJson extends AnyFunSuite {
     val parsed = new ItfJsonToTla(ScalaFromJacksonAdapter).parseTrace(json)
 
     assert(parsed.contains(IndexedSeq(
-            SortedMap("x" -> tla.int(1).build),
-            SortedMap("x" -> tla.int(2).build),
-        )))
+                SortedMap("x" -> tla.int(1).build),
+                SortedMap("x" -> tla.int(2).build),
+            )))
   }
 }


### PR DESCRIPTION
Closes #3211. Reducing the tech debt. Removing UJson <-> Jackson roundtrips.
