### PR TITLE
Preprocess nested TypeOK function ranges

### DIFF
--- a/.unreleased/features/simplification3343.md
+++ b/.unreleased/features/simplification3343.md
@@ -1,0 +1,1 @@
+Extend set simplification rules to handle previously missing cases (#3343)

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/pp/OptPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/pp/OptPassImpl.scala
@@ -32,7 +32,7 @@ class OptPassImpl @Inject() (
       List(
           ConstSimplifier(tracker),
           ExprOptimizer(gen, tracker),
-          SetMembershipSimplifier(tracker),
+          SetMembershipSimplifier(gen, tracker),
           ConstSimplifier(tracker),
       ) ///
 

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/pp/PreproPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/pp/PreproPassImpl.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.lir.storage.ChangeListener
 import at.forsyte.apalache.tla.lir.transformations.standard._
 import at.forsyte.apalache.tla.lir.transformations.{TlaModuleTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.{ModuleProperty, TlaModule}
-import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, UniqueNameGenerator}
+import at.forsyte.apalache.tla.pp.{Desugarer, Keramelizer, Normalizer, SetMembershipSimplifier, UniqueNameGenerator}
 import com.google.inject.Inject
 import at.forsyte.apalache.infra.passes.options.OptionGroup
 import at.forsyte.apalache.infra.passes.DerivedPredicates
@@ -53,6 +53,7 @@ class PreproPassImpl @Inject() (
           ("Desugarer", ModuleByExTransformer(Desugarer(gen, varSet, tracker))),
           ("UniqueRenamer", renaming.renameInModule),
           ("Normalizer", ModuleByExTransformer(Normalizer(tracker))),
+          ("SetMembershipSimplifier", ModuleByExTransformer(SetMembershipSimplifier.beforeKeramelizer(gen, tracker))),
           ("Keramelizer", ModuleByExTransformer(Keramelizer(gen, tracker))),
       )
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -6,6 +6,8 @@ import at.forsyte.apalache.tla.lir.transformations.standard.FlatLanguagePred
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values._
 
+import scala.annotation.tailrec
+
 /**
  * A simplifier that rewrites expressions commonly found in `TypeOK`. Assumes expressions to be well-typed.
  *
@@ -134,24 +136,21 @@ class SetMembershipSimplifier(
     }
   }
 
-  private def isFunctionSetWithReducibleNonTypeDefRange(set: TlaEx): Boolean = set match {
-    case OperEx(TlaSetOper.funSet, _, codomain) if !isTypeDefining(codomain) =>
-      codomain match {
-        case ValEx(TlaNatSet)                         => true
-        case nested @ OperEx(TlaSetOper.funSet, _, _) => isFunctionSetWithReducibleNonTypeDefRange(nested)
-        case _                                        => false
-      }
+  private def simplifyBeforeKeramelizer(elem: TlaEx, set: TlaEx): Option[TlaEx] = {
+    @tailrec
+    def isReducibleNonTypeDefRange(codomain: TlaEx): Boolean = codomain match {
+      case ValEx(TlaNatSet)                             => true
+      case OperEx(TlaSetOper.funSet, _, nestedCodomain) => isReducibleNonTypeDefRange(nestedCodomain)
+      case _                                            => false
+    }
+    set match {
+      // Keep the early pass narrow. In particular, do not simplify assignments such as `b' \in BOOLEAN`.
+      case OperEx(TlaSetOper.funSet, _, OperEx(TlaSetOper.funSet, _, nestedCodomain))
+          if isReducibleNonTypeDefRange(nestedCodomain) =>
+        simplifyMembership(elem, set)
 
-    case _ => false
-  }
-
-  private def simplifyBeforeKeramelizer(elem: TlaEx, set: TlaEx): Option[TlaEx] = set match {
-    // Keep the early pass narrow. In particular, do not simplify assignments such as `b' \in BOOLEAN`.
-    case OperEx(TlaSetOper.funSet, _, codomain @ OperEx(TlaSetOper.funSet, _, nestedCodomain))
-        if isReducibleNonTypeDefRange(nestedCodomain) =>
-      simplifyMembership(elem, set)
-
-    case _ => None
+      case _ => None
+    }
   }
 
   /**

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -24,13 +24,21 @@ import at.forsyte.apalache.tla.lir.values._
  *   - `tup \in TDS1 \X ... \X TDSn` ~> `TRUE`
  *   - `rec \in [name_1: TDS1, ..., name_n: TDSn]` ~> `TRUE`
  *
+ * @param gen
+ *   the unique name generator, used for generating bound variable names when simplifying function range constraints
+ * @param tracker
+ *   the transformation tracker, used for tracking transformations and their effects on the TLA+ expressions
+ * @param beforeKeramelizer
+ *   whether to perform only a subset of the simplifications that can be safely performed before applying
+ *   [[Keramelizer]]
+ *
  * @author
  *   Thomas Pani
  */
 class SetMembershipSimplifier(
     gen: UniqueNameGenerator,
     tracker: TransformationTracker,
-    earlyPreKeramelizerMode: Boolean = false)
+    beforeKeramelizer: Boolean = false)
     extends AbstractTransformer(tracker) {
   private val boolTag = Typed(BoolT1)
   private val intTag = Typed(IntT1)
@@ -155,7 +163,7 @@ class SetMembershipSimplifier(
   private def transformMembership: PartialFunction[TlaEx, TlaEx] = {
     case ex @ OperEx(TlaSetOper.in, name, set) =>
       val simplified =
-        if (earlyPreKeramelizerMode) {
+        if (beforeKeramelizer) {
           simplifyBeforeKeramelizer(name, set)
         } else {
           simplifyMembership(name, set)
@@ -171,5 +179,5 @@ object SetMembershipSimplifier {
     new SetMembershipSimplifier(gen, tracker)
 
   def beforeKeramelizer(gen: UniqueNameGenerator, tracker: TransformationTracker): SetMembershipSimplifier =
-    new SetMembershipSimplifier(gen, tracker, earlyPreKeramelizerMode = true)
+    new SetMembershipSimplifier(gen, tracker, beforeKeramelizer = true)
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -20,13 +20,18 @@ import at.forsyte.apalache.tla.lir.values._
  *   - `set \in SUBSET TDS` ~> `TRUE`
  *   - `fun \in [TDS1 -> TDS2]` ~> `TRUE`
  *   - `fun \in [Dom -> TDS]` ~> `DOMAIN fun = Dom`
+ *   - `fun \in [Dom -> Nat]` ~> `DOMAIN fun = Dom /\ \A x \in Dom: fun[x] >= 0`
  *   - `tup \in TDS1 \X ... \X TDSn` ~> `TRUE`
  *   - `rec \in [name_1: TDS1, ..., name_n: TDSn]` ~> `TRUE`
  *
  * @author
  *   Thomas Pani
  */
-class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTransformer(tracker) {
+class SetMembershipSimplifier(
+    gen: UniqueNameGenerator,
+    tracker: TransformationTracker,
+    earlyPreKeramelizerMode: Boolean = false)
+    extends AbstractTransformer(tracker) {
   private val boolTag = Typed(BoolT1)
   private val intTag = Typed(IntT1)
   private def trueVal: ValEx = ValEx(TlaBool(true))(boolTag)
@@ -75,6 +80,72 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
     case _ => false
   }
 
+  private def getElemType(e: TlaEx): TlaType1 = {
+    e.typeTag match {
+      case Typed(SetT1(elemType)) => elemType
+      case t                      =>
+        throw new MalformedTlaError(s"Expected a set, found: $t", e)
+    }
+  }
+
+  private def domainEq(fun: TlaEx, domain: TlaEx): TlaEx =
+    OperEx(TlaOper.eq, OperEx(TlaFunOper.domain, fun)(domain.typeTag), domain)(boolTag)
+
+  private def natConstraint(elem: TlaEx): TlaEx =
+    OperEx(TlaArithOper.ge, elem, ValEx(TlaInt(0))(intTag))(boolTag)
+
+  /**
+   * Try to reduce a type-invariant membership to cheaper constraints. This deliberately stays conservative: it only
+   * descends into function codomains when the codomain membership itself can be reduced.
+   */
+  private def simplifyMembership(elem: TlaEx, set: TlaEx): Option[TlaEx] = {
+    set match {
+      // x \in TDS  ~>  TRUE
+      case set if isTypeDefining(set) => Some(trueVal)
+
+      // x \in Nat  ~>  x >= 0
+      case ValEx(TlaNatSet) => Some(natConstraint(elem))
+
+      // fun \in [Dom -> TDS]  ~>  DOMAIN fun = Dom
+      case OperEx(TlaSetOper.funSet, domain, codomain) if isTypeDefining(codomain) =>
+        Some(domainEq(elem, domain))
+
+      // fun \in [Dom -> Range]  ~>  DOMAIN fun = Dom /\ \A x \in Dom: fun[x] \in Range,
+      // if the range check can itself be reduced by this simplifier.
+      case OperEx(TlaSetOper.funSet, domain, codomain) =>
+        val domElemType = getElemType(domain)
+        val codomainElemType = getElemType(codomain)
+        val domElem = NameEx(gen.newName())(Typed(domElemType))
+        val app = OperEx(TlaFunOper.app, elem, domElem)(Typed(codomainElemType))
+        simplifyMembership(app, codomain).map { rangeConstraint =>
+          OperEx(TlaBoolOper.and, domainEq(elem, domain),
+              OperEx(TlaBoolOper.forall, domElem, domain, rangeConstraint)(boolTag))(boolTag)
+        }
+
+      case _ => None
+    }
+  }
+
+  private def isFunctionSetWithReducibleNonTypeDefRange(set: TlaEx): Boolean = set match {
+    case OperEx(TlaSetOper.funSet, _, codomain) if !isTypeDefining(codomain) =>
+      codomain match {
+        case ValEx(TlaNatSet)                         => true
+        case nested @ OperEx(TlaSetOper.funSet, _, _) => isFunctionSetWithReducibleNonTypeDefRange(nested)
+        case _                                        => false
+      }
+
+    case _ => false
+  }
+
+  private def simplifyBeforeKeramelizer(elem: TlaEx, set: TlaEx): Option[TlaEx] = set match {
+    // Keep the early pass narrow. In particular, do not simplify assignments such as `b' \in BOOLEAN`.
+    case OperEx(TlaSetOper.funSet, _, codomain @ OperEx(TlaSetOper.funSet, _, _))
+        if isFunctionSetWithReducibleNonTypeDefRange(codomain) =>
+      simplifyMembership(elem, set)
+
+    case _ => None
+  }
+
   /**
    * Simplifies expressions commonly found in `TypeOK`, assuming they are well-typed.
    *
@@ -83,25 +154,22 @@ class SetMembershipSimplifier(tracker: TransformationTracker) extends AbstractTr
    */
   private def transformMembership: PartialFunction[TlaEx, TlaEx] = {
     case ex @ OperEx(TlaSetOper.in, name, set) =>
-      set match {
-        // x \in TDS  ~>  TRUE
-        case set if isTypeDefining(set) => trueVal
-
-        // x \in Nat  ~>  x >= 0
-        case ValEx(TlaNatSet) => OperEx(TlaArithOper.ge, name, ValEx(TlaInt(0))(intTag))(boolTag)
-
-        // fun \in [Dom -> TDS]  ~>  DOMAIN fun = Dom    (fun \in [TDS1 -> TDS2] is handled above)
-        case OperEx(TlaSetOper.funSet, domain, set2) if isTypeDefining(set2) =>
-          OperEx(TlaOper.eq, OperEx(TlaFunOper.domain, name)(domain.typeTag), domain)(boolTag)
-
-        // otherwise, return `ex` unchanged
-        case _ => ex
-      }
+      val simplified =
+        if (earlyPreKeramelizerMode) {
+          simplifyBeforeKeramelizer(name, set)
+        } else {
+          simplifyMembership(name, set)
+        }
+      simplified.getOrElse(ex)
     // return non-set membership expressions unchanged
     case ex => ex
   }
 }
 
 object SetMembershipSimplifier {
-  def apply(tracker: TransformationTracker): SetMembershipSimplifier = new SetMembershipSimplifier(tracker)
+  def apply(gen: UniqueNameGenerator, tracker: TransformationTracker): SetMembershipSimplifier =
+    new SetMembershipSimplifier(gen, tracker)
+
+  def beforeKeramelizer(gen: UniqueNameGenerator, tracker: TransformationTracker): SetMembershipSimplifier =
+    new SetMembershipSimplifier(gen, tracker, earlyPreKeramelizerMode = true)
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/SetMembershipSimplifier.scala
@@ -139,8 +139,8 @@ class SetMembershipSimplifier(
 
   private def simplifyBeforeKeramelizer(elem: TlaEx, set: TlaEx): Option[TlaEx] = set match {
     // Keep the early pass narrow. In particular, do not simplify assignments such as `b' \in BOOLEAN`.
-    case OperEx(TlaSetOper.funSet, _, codomain @ OperEx(TlaSetOper.funSet, _, _))
-        if isFunctionSetWithReducibleNonTypeDefRange(codomain) =>
+    case OperEx(TlaSetOper.funSet, _, codomain @ OperEx(TlaSetOper.funSet, _, nestedCodomain))
+        if isReducibleNonTypeDefRange(nestedCodomain) =>
       simplifyMembership(elem, set)
 
     case _ => None

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestSetMembershipSimplifier.scala
@@ -3,7 +3,9 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
+import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -40,6 +42,8 @@ class TestSetMembershipSimplifier
   private val strName = tla.name("s").as(StrT1)
   private val intName = tla.name("i").as(IntT1)
   private val funName = tla.name("fun").as(FunT1(IntT1, BoolT1))
+  private val intFunName = tla.name("intFun").as(FunT1(IntT1, IntT1))
+  private val nestedIntFunName = tla.name("nestedIntFun").as(FunT1(IntT1, FunT1(IntT1, IntT1)))
 
   private val boolSet = tla.booleanSet().as(boolSetT)
   private val strSet = tla.stringSet().as(strSetT)
@@ -83,7 +87,7 @@ class TestSetMembershipSimplifier
     tla.recSet(tla.str("a").as(StrT1), intSet, tla.str("b").as(StrT1), boolSet).as(SetT1(recType))
 
   override def beforeEach(): Unit = {
-    simplifier = SetMembershipSimplifier(new IdleTracker)
+    simplifier = SetMembershipSimplifier(new UniqueNameGenerator, new IdleTracker)
   }
 
   /* *** tests for all supported types of type-defining sets *** */
@@ -186,6 +190,72 @@ class TestSetMembershipSimplifier
     val funSetType = SetT1(FunT1(BoolT1, IntT1))
     val funConstToBoolean = tla.in(funName, tla.funSet(domain, boolSet).as(funSetType)).as(BoolT1)
     simplifier(funConstToBoolean) shouldBe tla.eql(tla.dom(funName).as(intSetT), domain).as(BoolT1)
+  }
+
+  test("rewrites function into Nat to domain and range constraints") {
+    // f \in [RM -> Nat]  ~>  DOMAIN f = RM /\ \A x \in RM: f[x] >= 0
+    val domain = tla.name("RM").as(intSetT)
+    val funSetType = SetT1(FunT1(IntT1, IntT1))
+    val funToNat = tla.in(intFunName, tla.funSet(domain, tla.natSet()).as(funSetType)).as(BoolT1)
+
+    simplifier(funToNat) match {
+      case OperEx(TlaBoolOper.and, OperEx(TlaOper.eq, OperEx(TlaFunOper.domain, NameEx("intFun")), NameEx("RM")),
+              OperEx(TlaBoolOper.forall, NameEx(arg), NameEx("RM"),
+                  OperEx(TlaArithOper.ge, OperEx(TlaFunOper.app, NameEx("intFun"), NameEx(appArg)),
+                      ValEx(TlaInt(zero))))) =>
+        arg shouldBe appArg
+        zero shouldBe BigInt(0)
+
+      case other => fail(s"Unexpected simplified expression: $other")
+    }
+  }
+
+  test("rewrites nested function into Nat to nested domain and range constraints") {
+    // f \in [RM -> [RM -> Nat]]
+    // ~> DOMAIN f = RM /\ \A x \in RM: DOMAIN f[x] = RM /\ \A y \in RM: f[x][y] >= 0
+    val domain = tla.name("RM").as(intSetT)
+    val innerFunSetType = SetT1(FunT1(IntT1, IntT1))
+    val outerFunSetType = SetT1(FunT1(IntT1, FunT1(IntT1, IntT1)))
+    val innerFunSet = tla.funSet(domain, tla.natSet()).as(innerFunSetType)
+    val nestedFunToNat = tla.in(nestedIntFunName, tla.funSet(domain, innerFunSet).as(outerFunSetType)).as(BoolT1)
+
+    simplifier(nestedFunToNat) match {
+      case OperEx(TlaBoolOper.and, OperEx(TlaOper.eq, OperEx(TlaFunOper.domain, NameEx("nestedIntFun")), NameEx("RM")),
+              OperEx(TlaBoolOper.forall, NameEx(outerArg), NameEx("RM"),
+                  OperEx(TlaBoolOper.and,
+                      OperEx(TlaOper.eq,
+                          OperEx(TlaFunOper.domain, OperEx(TlaFunOper.app, NameEx("nestedIntFun"), NameEx(domainArg))),
+                          NameEx("RM")),
+                      OperEx(TlaBoolOper.forall, NameEx(innerArg), NameEx("RM"),
+                          OperEx(TlaArithOper.ge,
+                              OperEx(TlaFunOper.app,
+                                  OperEx(TlaFunOper.app, NameEx("nestedIntFun"), NameEx(appOuterArg)),
+                                  NameEx(appInnerArg)), ValEx(TlaInt(zero))))))) =>
+        outerArg shouldBe domainArg
+        outerArg shouldBe appOuterArg
+        innerArg shouldBe appInnerArg
+        zero shouldBe BigInt(0)
+
+      case other => fail(s"Unexpected simplified expression: $other")
+    }
+  }
+
+  test("pre-keramelizer mode rewrites only nested function ranges") {
+    val preKeramelizerSimplifier = SetMembershipSimplifier.beforeKeramelizer(new UniqueNameGenerator, new IdleTracker)
+    val domain = tla.name("RM").as(intSetT)
+
+    val intNameInNat = tla.in(intName, tla.natSet()).as(BoolT1)
+    preKeramelizerSimplifier(intNameInNat) shouldBe intNameInNat
+
+    val funSetType = SetT1(FunT1(IntT1, IntT1))
+    val funToNat = tla.in(intFunName, tla.funSet(domain, tla.natSet()).as(funSetType)).as(BoolT1)
+    preKeramelizerSimplifier(funToNat) shouldBe funToNat
+
+    val innerFunSetType = SetT1(FunT1(IntT1, IntT1))
+    val outerFunSetType = SetT1(FunT1(IntT1, FunT1(IntT1, IntT1)))
+    val innerFunSet = tla.funSet(domain, tla.natSet()).as(innerFunSetType)
+    val nestedFunToNat = tla.in(nestedIntFunName, tla.funSet(domain, innerFunSet).as(outerFunSetType)).as(BoolT1)
+    preKeramelizerSimplifier(nestedFunToNat) should not be nestedFunToNat
   }
 
   /* *** rewriting of `Nat` *** */


### PR DESCRIPTION
Closes #3200. Extending set preprocessing to include the form that was previously missing. 

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality
