### PR TITLE
Migrate rewriter tests to typed builder

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
@@ -3,7 +3,8 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.lir.{BoolT1, IntT1}
+import at.forsyte.apalache.tla.types.{tla => typedTla, tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
@@ -21,6 +22,10 @@ trait RewriterBase extends FixtureAnyFunSuite {
 
   protected def assertBuildEqual(a: BuilderT, b: BuilderT): Unit =
     assert(a.build == b.build)
+
+  protected def boolName(name: String): TBuilderInstruction = typedTla.name(name, BoolT1)
+  protected def intName(name: String): TBuilderInstruction = typedTla.name(name, IntT1)
+  protected def cellEx(cell: ArenaCell): TBuilderInstruction = typedTla.name(cell.toString, cell.cellType.toTlaType1)
 
   protected def create(rewriterType: SMTEncoding): SymbStateRewriter = {
     rewriterType match {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.Continue
 import at.forsyte.apalache.tla.lir.IntT1
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterAction extends RewriterBase {
   test("""x' is rewritten to the binding of x'""") { rewriterType: SMTEncoding =>

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT}
-import at.forsyte.apalache.tla.types.tlaU._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 /**
  * Tests for assignments. The assignments were at the core of Apalache 0.5.x. In Apalache 0.6.x, they are preprocessed
@@ -12,22 +12,22 @@ import at.forsyte.apalache.tla.types.tlaU._
 trait TestSymbStateRewriterAssignment extends RewriterBase {
   val ibI: TlaType1 = TupT1(IntT1, BoolT1, SetT1(IntT1))
 
-  private val set12: BuilderT = enumSet(int(1), int(2))
-  private val x_prime: BuilderT = prime(name("x", IntT1))
-  private val x_primeS: BuilderT = prime(name("x", SetT1(IntT1)))
-  private val x_primeFbi: BuilderT = prime(name("x", FunT1(BoolT1, IntT1)))
-  private val x_primeFii: BuilderT = prime(name("x", FunT1(IntT1, IntT1)))
-  private val x_primeFib: BuilderT = prime(name("x", FunT1(IntT1, BoolT1)))
-  private val y_prime: BuilderT = prime(name("y", IntT1))
-  private val boundName: BuilderT = name("t", IntT1)
-  private val boundNameS: BuilderT = name("t", SetT1(IntT1))
-  private val boundNameFbi: BuilderT = name("t", FunT1(BoolT1, IntT1))
-  private val boundNameFii: BuilderT = name("t", FunT1(IntT1, IntT1))
-  private val boundNameFib: BuilderT = name("t", FunT1(IntT1, BoolT1))
-  private val boolset: BuilderT = enumSet(bool(false), bool(true))
+  private val set12: TBuilderInstruction = tla.enumSet(tla.int(1), tla.int(2))
+  private val x_prime: TBuilderInstruction = tla.prime(tla.name("x", IntT1))
+  private val x_primeS: TBuilderInstruction = tla.prime(tla.name("x", SetT1(IntT1)))
+  private val x_primeFbi: TBuilderInstruction = tla.prime(tla.name("x", FunT1(BoolT1, IntT1)))
+  private val x_primeFii: TBuilderInstruction = tla.prime(tla.name("x", FunT1(IntT1, IntT1)))
+  private val x_primeFib: TBuilderInstruction = tla.prime(tla.name("x", FunT1(IntT1, BoolT1)))
+  private val y_prime: TBuilderInstruction = tla.prime(tla.name("y", IntT1))
+  private val boundName: TBuilderInstruction = tla.name("t", IntT1)
+  private val boundNameS: TBuilderInstruction = tla.name("t", SetT1(IntT1))
+  private val boundNameFbi: TBuilderInstruction = tla.name("t", FunT1(BoolT1, IntT1))
+  private val boundNameFii: TBuilderInstruction = tla.name("t", FunT1(IntT1, IntT1))
+  private val boundNameFib: TBuilderInstruction = tla.name("t", FunT1(IntT1, BoolT1))
+  private val boolset: TBuilderInstruction = tla.enumSet(tla.bool(false), tla.bool(true))
 
   test("""\E t \in {1, 2}: x' \in {t} ~~> TRUE and [x -> $C$k]""") { rewriterType: SMTEncoding =>
-    val asgn = skolem(exists(boundName, set12, assign(x_prime, boundName)))
+    val asgn = tla.skolem(tla.exists(boundName, set12, tla.assign(x_prime, boundName)))
 
     val state = new SymbState(asgn, arena, Binding())
 
@@ -40,48 +40,48 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(nextState.binding.contains("x'"))
     val boundCell = nextState.binding("x'")
     rewriter.push()
-    solverContext.assertGroundExpr(eql(boundCell.toBuilder, int(1)))
+    solverContext.assertGroundExpr(tla.eql(cellEx(boundCell), tla.int(1)))
     assert(solverContext.sat()) // ok
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(eql(boundCell.toBuilder, int(2)))
+    solverContext.assertGroundExpr(tla.eql(cellEx(boundCell), tla.int(2)))
     assert(solverContext.sat()) // also possible
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(eql(boundCell.toBuilder, int(3)))
+    solverContext.assertGroundExpr(tla.eql(cellEx(boundCell), tla.int(3)))
     assertUnsatOrExplain() // should not be possible
   }
 
   test("""assign in conjunction""") { rewriterType: SMTEncoding =>
     val and1 =
-      and(
-          assign(x_prime, int(1)),
-          assign(y_prime, int(2)),
+      tla.and(
+          tla.assign(x_prime, tla.int(1)),
+          tla.assign(y_prime, tla.int(2)),
       )
 
     val state = new SymbState(and1, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val x_cell = nextState.binding("x'").toBuilder
-    val y_cell = nextState.binding("y'").toBuilder
+    val x_cell = cellEx(nextState.binding("x'"))
+    val y_cell = cellEx(nextState.binding("y'"))
 
     assert(solverContext.sat()) // no contradiction introduced
     rewriter.push()
-    solverContext.assertGroundExpr(eql(x_cell, int(1)))
-    solverContext.assertGroundExpr(eql(y_cell, int(2)))
+    solverContext.assertGroundExpr(tla.eql(x_cell, tla.int(1)))
+    solverContext.assertGroundExpr(tla.eql(y_cell, tla.int(2)))
     assert(solverContext.sat()) // ok
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(neql(x_cell, int(1)))
+    solverContext.assertGroundExpr(tla.neql(x_cell, tla.int(1)))
     assertUnsatOrExplain() // should not be possible
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(neql(y_cell, int(2)))
+    solverContext.assertGroundExpr(tla.neql(y_cell, tla.int(2)))
     assertUnsatOrExplain() // should not be possible
   }
 
   test("""\E t \in {}: x' = t ~~> FALSE""") { rewriterType: SMTEncoding =>
-    val asgn = skolem(exists(boundName, emptySet(IntT1), assign(x_prime, boundName)))
+    val asgn = tla.skolem(tla.exists(boundName, tla.emptySet(IntT1), tla.assign(x_prime, boundName)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -98,11 +98,11 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
   test("""\E t \in \in {t_2 \in {1}: FALSE}: x' \in {t} ~~> FALSE""") { rewriterType: SMTEncoding =>
     // a regression test
-    def empty(set: BuilderT): BuilderT = {
-      filter(name("t_2", IntT1), set, bool(false))
+    def empty(set: TBuilderInstruction): TBuilderInstruction = {
+      tla.filter(tla.name("t_2", IntT1), set, tla.bool(false))
     }
 
-    val asgn = skolem(exists(boundName, empty(enumSet(int(1))), assign(x_prime, boundName)))
+    val asgn = tla.skolem(tla.exists(boundName, empty(tla.enumSet(tla.int(1))), tla.assign(x_prime, boundName)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -110,12 +110,12 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     // no contradiction should be introduced
     assert(solverContext.sat())
     // the assignment gives us false
-    assertTlaExAndRestore(rewriter, nextState.setRex(not(unchecked(nextState.ex))))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.not(tla.unchecked(nextState.ex))))
   }
 
   test("""x' \in {1} /\ x' = 1 ~~> TRUE and [x -> $C$k]""") { rewriterType: SMTEncoding =>
-    val asgn = assign(x_prime, int(1))
-    val and1 = and(asgn, eql(x_prime, int(1)))
+    val asgn = tla.assign(x_prime, tla.int(1))
+    val and1 = tla.and(asgn, tla.eql(x_prime, tla.int(1)))
 
     val state = new SymbState(and1, arena, Binding())
     val rewriter = create(rewriterType)
@@ -136,13 +136,13 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(solverContext.sat()) // ok
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(not(unchecked(nextState.ex)))
+    solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
     assert(!solverContext.sat())
   }
 
   test("""\E t \in {{1, 2}, {2, 3}}: x' \in {t} ~~> TRUE and [x -> $C$k]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(set12, enumSet(int(2), int(3)))
-    val asgn = skolem(exists(boundNameS, set, assign(x_primeS, boundNameS)))
+    val set = tla.enumSet(set12, tla.enumSet(tla.int(2), tla.int(3)))
+    val asgn = tla.skolem(tla.exists(boundNameS, set, tla.assign(x_primeS, boundNameS)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -158,21 +158,21 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
     // may equal to {1, 2}
     rewriter.push()
-    val eq12 = eql(boundCell.toBuilder, set12)
+    val eq12 = tla.eql(cellEx(boundCell), set12)
     val eqState12 = rewriter.rewriteUntilDone(nextState.setRex(eq12))
     solverContext.assertGroundExpr(eqState12.ex)
     assert(solverContext.sat()) // ok
     rewriter.pop()
     // may equal to {2, 3}
     rewriter.push()
-    val eq23 = eql(boundCell.toBuilder, enumSet(int(2), int(3)))
+    val eq23 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(2), tla.int(3)))
     val eqState23 = rewriter.rewriteUntilDone(nextState.setRex(eq23))
     solverContext.assertGroundExpr(eqState23.ex)
     assert(solverContext.sat()) // also possible
     rewriter.pop()
     // not equal to {1, 3}
     rewriter.push()
-    val eq13 = eql(boundCell.toBuilder, enumSet(int(1), int(3)))
+    val eq13 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(3)))
     val eqState13 = rewriter.rewriteUntilDone(nextState.setRex(eq13))
     solverContext.assertGroundExpr(eqState13.ex)
     assertUnsatOrExplain() // should not be possible
@@ -181,19 +181,19 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
   test("""\E t \in {{1, 2}, {1+1, 2, 3}} \ {{2, 3}}: x' \in {t} ~~> TRUE and [x -> $C$k]""") {
     rewriterType: SMTEncoding =>
       // equal elements in different sets mess up picking from a set
-      def setminus(left: BuilderT, right: BuilderT): BuilderT = {
+      def setminus(left: TBuilderInstruction, right: TBuilderInstruction): TBuilderInstruction = {
         // this is how Keramelizer translates setminus
-        filter(name("t_2", SetT1(IntT1)), left, not(eql(name("t_2", SetT1(IntT1)), right)))
+        tla.filter(tla.name("t_2", SetT1(IntT1)), left, tla.not(tla.eql(tla.name("t_2", SetT1(IntT1)), right)))
 
       }
 
-      val set1to3 = enumSet(plus(int(1), int(1)), int(2), int(3))
-      val set12 = enumSet(int(1), int(2))
-      val twoSets = enumSet(set12, set1to3)
-      val set23 = enumSet(int(2), int(3))
+      val set1to3 = tla.enumSet(tla.plus(tla.int(1), tla.int(1)), tla.int(2), tla.int(3))
+      val set12 = tla.enumSet(tla.int(1), tla.int(2))
+      val twoSets = tla.enumSet(set12, set1to3)
+      val set23 = tla.enumSet(tla.int(2), tla.int(3))
       val minus = setminus(twoSets, set23)
       val asgn =
-        skolem(exists(boundNameS, minus, assign(x_primeS, boundNameS)))
+        tla.skolem(tla.exists(boundNameS, minus, tla.assign(x_primeS, boundNameS)))
 
       val state = new SymbState(asgn, arena, Binding())
       val rewriter = create(rewriterType)
@@ -208,7 +208,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
       // may equal to {1, 2}
       rewriter.push()
-      val eq12 = eql(boundCell.toBuilder, enumSet(int(1), int(2)))
+      val eq12 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(2)))
 
       val eqState12 = rewriter.rewriteUntilDone(nextState.setRex(eq12))
       solverContext.assertGroundExpr(eqState12.ex)
@@ -216,7 +216,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
       rewriter.pop()
       // not equal to {1, 3}
       rewriter.push()
-      val eq13 = eql(boundCell.toBuilder, enumSet(int(1), int(3)))
+      val eq13 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(3)))
 
       val eqState13 = rewriter.rewriteUntilDone(nextState.setRex(eq13))
       solverContext.assertGroundExpr(eqState13.ex)
@@ -224,7 +224,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
       rewriter.pop()
       // not equal to {2, 3}
       rewriter.push()
-      val eq23 = eql(boundCell.toBuilder, enumSet(int(2), int(3)))
+      val eq23 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(2), tla.int(3)))
 
       val eqState23 = rewriter.rewriteUntilDone(nextState.setRex(eq23))
       solverContext.assertGroundExpr(eqState23.ex)
@@ -232,7 +232,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
       rewriter.pop()
       // 2 is in the result
       rewriter.push()
-      val in23 = in(int(2), boundCell.toBuilder)
+      val in23 = tla.in(tla.int(2), cellEx(boundCell))
 
       val inState23 = rewriter.rewriteUntilDone(nextState.setRex(in23))
       solverContext.assertGroundExpr(inState23.ex)
@@ -241,9 +241,9 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
   }
 
   test("""\E t \in SUBSET {1, 2}: x' \in {t} ~~> TRUE and [x -> $C$k]""") { rewriterType: SMTEncoding =>
-    val set = powSet(set12)
+    val set = tla.powSet(set12)
     val asgn =
-      skolem(exists(boundNameS, set, assign(x_primeS, boundNameS)))
+      tla.skolem(tla.exists(boundNameS, set, tla.assign(x_primeS, boundNameS)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -264,7 +264,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(solverContext.sat())
     // may equal to {1, 2}
     rewriter.push()
-    val eq12 = eql(boundCell.toBuilder, set12)
+    val eq12 = tla.eql(cellEx(boundCell), set12)
 
     val eqState12 = rewriter.rewriteUntilDone(nextState.setRex(eq12))
     solverContext.assertGroundExpr(eqState12.ex)
@@ -272,7 +272,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // may equal to {1}
     rewriter.push()
-    val eq1 = eql(boundCell.toBuilder, enumSet(int(1)))
+    val eq1 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1)))
 
     val eqState1 = rewriter.rewriteUntilDone(nextState.setRex(eq1))
     solverContext.assertGroundExpr(eqState1.ex)
@@ -280,7 +280,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // may equal to {2}
     rewriter.push()
-    val eq2 = eql(boundCell.toBuilder, enumSet(int(2)))
+    val eq2 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(2)))
 
     val eqState2 = rewriter.rewriteUntilDone(nextState.setRex(eq2))
     solverContext.assertGroundExpr(eqState2.ex)
@@ -288,7 +288,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // may equal to {}, but this needs a type annotation
     rewriter.push()
-    val eqEmpty = eql(boundCell.toBuilder, emptySet(IntT1))
+    val eqEmpty = tla.eql(cellEx(boundCell), tla.emptySet(IntT1))
 
     val eqStateEmpty = rewriter.rewriteUntilDone(nextState.setRex(eqEmpty))
     solverContext.assertGroundExpr(eqStateEmpty.ex)
@@ -296,7 +296,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // not equal to {1, 2, 3}
     rewriter.push()
-    val eq13 = eql(boundCell.toBuilder, enumSet(int(1), int(2), int(3)))
+    val eq13 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(2), tla.int(3)))
 
     val eqState13 = rewriter.rewriteUntilDone(nextState.setRex(eq13))
     solverContext.assertGroundExpr(eqState13.ex)
@@ -305,12 +305,12 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
   test("""\E t \in {[x \in BOOLEAN |-> 0], [x2 \in BOOLEAN |-> 1]}: x' \in {t} ~~> TRUE""") {
     rewriterType: SMTEncoding =>
-      val fun0 = funDef(int(0), name("x2", BoolT1) -> booleanSet())
-      val fun1 = funDef(int(1), name("x3", BoolT1) -> booleanSet())
-      val fun2 = funDef(int(2), name("x4", BoolT1) -> booleanSet())
-      val set = enumSet(fun0, fun1)
+      val fun0 = tla.funDef(tla.int(0), tla.name("x2", BoolT1) -> tla.booleanSet())
+      val fun1 = tla.funDef(tla.int(1), tla.name("x3", BoolT1) -> tla.booleanSet())
+      val fun2 = tla.funDef(tla.int(2), tla.name("x4", BoolT1) -> tla.booleanSet())
+      val set = tla.enumSet(fun0, fun1)
       val asgn =
-        skolem(exists(boundNameFbi, set, assign(x_primeFbi, boundNameFbi)))
+        tla.skolem(tla.exists(boundNameFbi, set, tla.assign(x_primeFbi, boundNameFbi)))
 
       val state = new SymbState(asgn, arena, Binding())
       val rewriter = create(rewriterType)
@@ -324,33 +324,33 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
       // may equal to fun0
       rewriter.push()
-      val eqFun0 = eql(boundCell.toBuilder, fun0)
+      val eqFun0 = tla.eql(cellEx(boundCell), fun0)
       val eqStateFun0 = rewriter.rewriteUntilDone(nextState.setRex(eqFun0))
       solverContext.assertGroundExpr(eqStateFun0.ex)
       assert(solverContext.sat()) // ok
       rewriter.pop()
       // may equal to fun1
       rewriter.push()
-      val eqFun1 = eql(boundCell.toBuilder, fun1)
+      val eqFun1 = tla.eql(cellEx(boundCell), fun1)
       val eqStateFun1 = rewriter.rewriteUntilDone(nextState.setRex(eqFun1))
       solverContext.assertGroundExpr(eqStateFun1.ex)
       assert(solverContext.sat()) // also possible
       rewriter.pop()
       // not equal to fun2
       rewriter.push()
-      val eqFun2 = eql(boundCell.toBuilder, fun2)
+      val eqFun2 = tla.eql(cellEx(boundCell), fun2)
       val eqStateFun2 = rewriter.rewriteUntilDone(nextState.setRex(eqFun2))
       solverContext.assertGroundExpr(eqStateFun2.ex)
       assertUnsatOrExplain() // should not be possible
   }
 
   test("""\E t \in [BOOLEAN -> {0, 1}]: x' \in {t} ~~> TRUE""") { rewriterType: SMTEncoding =>
-    val fun0 = funDef(int(0), name("x", BoolT1) -> booleanSet())
-    val fun1 = funDef(int(1), name("x", BoolT1) -> booleanSet())
-    val fun2 = funDef(int(2), name("x", BoolT1) -> booleanSet())
-    val set = funSet(booleanSet(), enumSet(int(0), int(1)))
+    val fun0 = tla.funDef(tla.int(0), tla.name("x", BoolT1) -> tla.booleanSet())
+    val fun1 = tla.funDef(tla.int(1), tla.name("x", BoolT1) -> tla.booleanSet())
+    val fun2 = tla.funDef(tla.int(2), tla.name("x", BoolT1) -> tla.booleanSet())
+    val set = tla.funSet(tla.booleanSet(), tla.enumSet(tla.int(0), tla.int(1)))
     val asgn =
-      skolem(exists(boundNameFbi, set, assign(x_primeFbi, boundNameFbi)))
+      tla.skolem(tla.exists(boundNameFbi, set, tla.assign(x_primeFbi, boundNameFbi)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -371,21 +371,21 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(solverContext.sat())
     // may equal to fun0
     rewriter.push()
-    val eqFun0 = eql(boundCell.toBuilder, fun0)
+    val eqFun0 = tla.eql(cellEx(boundCell), fun0)
     val eqStateFun0 = rewriter.rewriteUntilDone(nextState.setRex(eqFun0))
     solverContext.assertGroundExpr(eqStateFun0.ex)
     assert(solverContext.sat()) // ok
     rewriter.pop()
     // may equal to fun1
     rewriter.push()
-    val eqFun1 = eql(boundCell.toBuilder, fun1)
+    val eqFun1 = tla.eql(cellEx(boundCell), fun1)
     val eqStateFun1 = rewriter.rewriteUntilDone(nextState.setRex(eqFun1))
     solverContext.assertGroundExpr(eqStateFun1.ex)
     assert(solverContext.sat()) // also possible
     rewriter.pop()
     // not equal to fun2
     rewriter.push()
-    val eqFun2 = eql(boundCell.toBuilder, fun2)
+    val eqFun2 = tla.eql(cellEx(boundCell), fun2)
     val eqStateFun2 = rewriter.rewriteUntilDone(nextState.setRex(eqFun2))
     solverContext.assertGroundExpr(eqStateFun2.ex)
     assertUnsatOrExplain() // should not be possible
@@ -393,9 +393,9 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
   test("""\E t \in [{} -> {0, 1}]: x' \in {t} ~~> FALSE""") { rewriterType: SMTEncoding =>
     // regression
-    val set = funSet(emptySet(IntT1), enumSet(int(0), int(1)))
+    val set = tla.funSet(tla.emptySet(IntT1), tla.enumSet(tla.int(0), tla.int(1)))
     val asgn =
-      skolem(exists(boundNameFii, set, assign(x_primeFii, boundNameFii)))
+      tla.skolem(tla.exists(boundNameFii, set, tla.assign(x_primeFii, boundNameFii)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -408,10 +408,10 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
   }
 
   test("""\E t \in [0..(5 - 1) -> BOOLEAN]: x' \in {t} ~~> TRUE""") { rewriterType: SMTEncoding =>
-    val domain = dotdot(int(0), minus(int(5), int(1)))
-    val set = funSet(domain, boolset)
+    val domain = tla.dotdot(tla.int(0), tla.minus(tla.int(5), tla.int(1)))
+    val set = tla.funSet(domain, boolset)
     val asgn =
-      skolem(exists(boundNameFib, set, assign(x_primeFib, boundNameFib)))
+      tla.skolem(tla.exists(boundNameFib, set, tla.assign(x_primeFib, boundNameFib)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -429,26 +429,26 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
   }
 
   test("""\E t \in [0..4 -> Nat]: x' <- t""") { rewriterType: SMTEncoding =>
-    val domain = dotdot(int(0), int(4))
-    val set = funSet(domain, natSet())
+    val domain = tla.dotdot(tla.int(0), tla.int(4))
+    val set = tla.funSet(domain, tla.natSet())
     val asgn =
-      skolem(exists(boundNameFii, set, assign(x_primeFii, boundNameFii)))
+      tla.skolem(tla.exists(boundNameFii, set, tla.assign(x_primeFii, boundNameFii)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     assert(rewriter.solverContext.sat())
     val x = nextState.binding("x'")
-    val pred = ge(app(x.toBuilder, int(1)), int(0))
+    val pred = tla.ge(tla.app(cellEx(x), tla.int(1)), tla.int(0))
 
     assertTlaExAndRestore(rewriter, nextState.setRex(pred))
   }
 
   test("""\E t \in [0..4 -> Int]: x' <- t""") { rewriterType: SMTEncoding =>
-    val domain = dotdot(int(0), int(4))
-    val set = funSet(domain, intSet())
+    val domain = tla.dotdot(tla.int(0), tla.int(4))
+    val set = tla.funSet(domain, tla.intSet())
     val asgn =
-      skolem(exists(boundNameFii, set, assign(x_primeFii, boundNameFii)))
+      tla.skolem(tla.exists(boundNameFii, set, tla.assign(x_primeFii, boundNameFii)))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -459,13 +459,13 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
   // the model checker will never meet such an expression, as it will be optimized into several existentials by ExprOptimizer
   test("""\E t \in {<<1, FALSE, {1, 3}>>, <<2, TRUE, {4}>>}: x' = t""") { rewriterType: SMTEncoding =>
-    val set1 = enumSet(int(1), int(3))
-    val tuple1 = tuple(int(1), bool(false), set1)
-    val set2 = enumSet(int(4))
-    val tuple2 = tuple(int(2), bool(true), set2)
-    val set = enumSet(tuple1, tuple2)
+    val set1 = tla.enumSet(tla.int(1), tla.int(3))
+    val tuple1 = tla.tuple(tla.int(1), tla.bool(false), set1)
+    val set2 = tla.enumSet(tla.int(4))
+    val tuple2 = tla.tuple(tla.int(2), tla.bool(true), set2)
+    val set = tla.enumSet(tuple1, tuple2)
     val asgn =
-      skolem(exists(name("t", ibI), set, assign(prime(name("x", ibI)), name("t", ibI))))
+      tla.skolem(tla.exists(tla.name("t", ibI), set, tla.assign(tla.prime(tla.name("x", ibI)), tla.name("t", ibI))))
 
     val state = new SymbState(asgn, arena, Binding())
     val rewriter = create(rewriterType)
@@ -476,10 +476,10 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
         assert(TupT1(IntT1, BoolT1, SetT1(IntT1)) == cell.cellType.toTlaType1)
 
         val membershipTest =
-          and(
-              in(app(prime(name("x", ibI)), int(1)), set12),
-              in(app(prime(name("x", ibI)), int(2)), boolset),
-              in(app(prime(name("x", ibI)), int(3)), enumSet(set1, set2)),
+          tla.and(
+              tla.in(tla.app(tla.prime(tla.name("x", ibI)), tla.int(1)), set12),
+              tla.in(tla.app(tla.prime(tla.name("x", ibI)), tla.int(2)), boolset),
+              tla.in(tla.app(tla.prime(tla.name("x", ibI)), tla.int(3)), tla.enumSet(set1, set2)),
           )
 
         assertTlaExAndRestore(rewriter, nextState.setRex(membershipTest))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
@@ -3,9 +3,9 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.SymbStateRewriter.NoRule
 import at.forsyte.apalache.tla.bmcmt.types.CellTFrom
-import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterBool extends RewriterBase {
   // these are handy variables that will be overwritten by before
@@ -13,7 +13,6 @@ trait TestSymbStateRewriterBool extends RewriterBase {
   private var y: ArenaCell = new ArenaCell(100001, CellTFrom(IntT1))
   private var set: ArenaCell = new ArenaCell(100001, CellTFrom(SetT1(IntT1)))
   private var xyBinding = Binding()
-  private val boolTypes = Map("b" -> BoolT1, "i" -> IntT1, "I" -> SetT1(IntT1))
 
   def prepareArena(): Unit = {
     arena = arena.appendCell(BoolT1) // we have to give bindings to the type finder
@@ -27,7 +26,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("FALSE ~~> $C$0") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla.bool(false).typed()
+    val ex = tla.bool(false)
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -42,7 +41,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("TRUE ~~> $C$1") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla.bool(true).typed()
+    val ex = tla.bool(true)
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -57,7 +56,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("BOOLEAN ~~> c_BOOLEAN") { rewriterType: SMTEncoding =>
     prepareArena()
-    val boolset = tla.booleanSet().typed(SetT1(BoolT1))
+    val boolset = tla.booleanSet()
     val state = new SymbState(boolset, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -73,9 +72,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
   test("x => y ~~> ~x \\/ y") { rewriterType: SMTEncoding =>
     // outside of KerA+, should be handled by Keramelizer and Normalizer
     prepareArena()
-    val ex = tla
-      .impl(tla.name("x") ? "b", tla.name("y") ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.impl(boolName("x"), boolName("y"))
     val state = new SymbState(ex, arena, xyBinding)
     assert(NoRule() == create(rewriterType).rewriteOnce(state))
   }
@@ -86,9 +83,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     val left = arena.topCell
     arena = arena.appendCell(BoolT1)
     val right = arena.topCell
-    val ex = tla
-      .equiv(left.toNameEx ? "b", right.toNameEx ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.equiv(cellEx(left), cellEx(right))
     val state = new SymbState(ex, arena, xyBinding)
     assert(NoRule() == create(rewriterType).rewriteOnce(state))
   }
@@ -97,19 +92,16 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     // this tricky test comes from Bakery, where an assignment is made in one branch of a conjunction
     prepareArena()
     val exists =
-      tla
-        .apalacheSkolem(tla.exists(tla.name("i") ? "i", tla.enumSet() ? "I",
-            tla.in(tla.prime(tla.name("x") ? "i") ? "i", tla.enumSet(tla.name("i") ? "i") ? "I") ? "b") ? "b")
-        .typed(boolTypes, "b")
-    val ite = tla
-      .ite(exists, tla.prime(tla.name("x") ? "i") ? "i", tla.int(0))
-      .typed(boolTypes, "b")
+      tla.skolem(
+          tla.exists(intName("i"), tla.emptySet(IntT1), tla.in(tla.prime(intName("x")), tla.enumSet(intName("i"))))
+      )
+    val ite = tla.ite(exists, tla.prime(intName("x")), tla.int(0))
 
     val state = new SymbState(ite, arena, Binding())
     val rewriter = createWithoutCache(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
-    val eq = tla.eql(tla.int(0), nextState.ex).typed(BoolT1)
+    val eq = tla.eql(tla.int(0), tla.unchecked(nextState.ex))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
@@ -118,22 +110,20 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell
 
-    val ex = tla.not(cell.toNameEx ? "b").typed(boolTypes, "b")
+    val ex = tla.not(cellEx(cell))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case NameEx(_) =>
-            val eq = tla
-              .eql(cell.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-              .typed(boolTypes, "b")
+            val eq = tla.eql(cellEx(cell), cellEx(arena.cellFalse()))
             solverContext.assertGroundExpr(eq)
             solverContext.assertGroundExpr(nextState.ex)
             rewriter.push()
             assert(solverContext.sat())
             rewriter.pop()
-            solverContext.assertGroundExpr(tla.not(nextState.ex).typed(BoolT1))
+            solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
             assert(!solverContext.sat())
 
           case _ =>
@@ -147,63 +137,49 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""~x ~~> TRUE""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla
-      .not(tla.name("x") ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.not(boolName("x"))
     val binding = Binding("x" -> arena.cellFalse())
     val state = new SymbState(ex, arena, binding)
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(nextState.ex, tla.bool(true)).typed(BoolT1)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.unchecked(nextState.ex), tla.bool(true))))
   }
 
   test("""FALSE = TRUE ~~> FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla
-      .eql(arena.cellFalse().toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.eql(cellEx(arena.cellFalse()), cellEx(arena.cellTrue()))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val eq = tla
-      .eql(nextState.ex, arena.cellFalse().toNameEx ? "b")
-      .typed(boolTypes, "b")
+    val eq = tla.eql(tla.unchecked(nextState.ex), cellEx(arena.cellFalse()))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("""x = TRUE ~~> FALSE when x = FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla
-      .eql(tla.name("x") ? "b", tla.bool(true) ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.eql(boolName("x"), tla.bool(true))
     val binding = Binding("x" -> arena.cellFalse())
     val state = new SymbState(ex, arena, binding)
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val eq = tla.eql(nextState.ex, tla.bool(false)).typed(BoolT1)
+    val eq = tla.eql(tla.unchecked(nextState.ex), tla.bool(false))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("""~(x = TRUE) ~~> TRUE when x = FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla
-      .not(tla.eql(tla.name("x") ? "b", tla.bool(true)) ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.not(tla.eql(boolName("x"), tla.bool(true)))
     val binding = Binding("x" -> arena.cellFalse())
     val state = new SymbState(ex, arena, binding)
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val eq = tla
-      .eql(nextState.ex, tla.bool(true))
-      .typed(boolTypes, "b")
+    val eq = tla.eql(tla.unchecked(nextState.ex), tla.bool(true))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("""FALSE /\ TRUE ~~> $B$0""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla
-      .and(tla.bool(false), tla.bool(true))
-      .typed(BoolT1)
+    val ex = tla.and(tla.bool(false), tla.bool(true))
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -222,9 +198,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val c2 = arena.topCell
 
-    val ex = tla
-      .and(c1.toNameEx ? "b", c2.toNameEx ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.and(cellEx(c1), cellEx(c2))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
@@ -234,20 +208,14 @@ trait TestSymbStateRewriterBool extends RewriterBase {
             assert(solverContext.sat())
             solverContext.assertGroundExpr(nextState.ex)
             rewriter.push()
-            val eq1 = tla
-              .eql(c1.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-              .typed(boolTypes, "b")
+            val eq1 = tla.eql(cellEx(c1), cellEx(arena.cellFalse()))
             solverContext.assertGroundExpr(eq1)
             assert(!solverContext.sat())
             rewriter.pop()
-            val eq2 = tla
-              .eql(c1.toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
-              .typed(boolTypes, "b")
+            val eq2 = tla.eql(cellEx(c1), cellEx(arena.cellTrue()))
             solverContext.assertGroundExpr(eq2)
             assert(solverContext.sat())
-            val eq3 = tla
-              .eql(c2.toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
-              .typed(boolTypes, "b")
+            val eq3 = tla.eql(cellEx(c2), cellEx(arena.cellTrue()))
             solverContext.assertGroundExpr(eq3)
             assert(solverContext.sat())
 
@@ -262,7 +230,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""empty \/ ~~> $B$0""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla.or().typed(BoolT1)
+    val ex = tla.or()
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -276,7 +244,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""empty /\ ~~> $B$1""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla.and().typed(BoolT1)
+    val ex = tla.and()
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -290,7 +258,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""FALSE \/ TRUE ~~> $B$1""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla.or(tla.bool(false), tla.bool(true)).typed(BoolT1)
+    val ex = tla.or(tla.bool(false), tla.bool(true))
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -309,25 +277,19 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val right = arena.topCell
 
-    val ex = tla
-      .or(left.toNameEx ? "b", right.toNameEx ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.or(cellEx(left), cellEx(right))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case NameEx(_) =>
-            val eq1 = tla
-              .eql(left.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-              .typed(boolTypes, "b")
+            val eq1 = tla.eql(cellEx(left), cellEx(arena.cellFalse()))
             solverContext.assertGroundExpr(eq1)
             solverContext.assertGroundExpr(nextState.ex)
             rewriter.push()
             assert(solverContext.sat())
-            val eq2 = tla
-              .eql(right.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-              .typed(boolTypes, "b")
+            val eq2 = tla.eql(cellEx(right), cellEx(arena.cellFalse()))
             solverContext.assertGroundExpr(eq2)
             assert(!solverContext.sat())
 
@@ -347,9 +309,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val right = arena.topCell
 
-    val ex = tla
-      .not(tla.eql(left.toNameEx ? "b", right.toNameEx ? "b") ? "b")
-      .typed(boolTypes, "b")
+    val ex = tla.not(tla.eql(cellEx(left), cellEx(right)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -359,40 +319,28 @@ trait TestSymbStateRewriterBool extends RewriterBase {
         rewriter.push()
         // both false
         assert(solverContext.sat())
-        val eq1 = tla
-          .eql(left.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-          .typed(boolTypes, "b")
+        val eq1 = tla.eql(cellEx(left), cellEx(arena.cellFalse()))
         solverContext.assertGroundExpr(eq1)
         assert(solverContext.sat())
         rewriter.push()
-        val eq2 = tla
-          .eql(right.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-          .typed(boolTypes, "b")
+        val eq2 = tla.eql(cellEx(right), cellEx(arena.cellFalse()))
         solverContext.assertGroundExpr(eq2)
         assert(!solverContext.sat())
         rewriter.pop()
-        val eq3 = tla
-          .eql(right.toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
-          .typed(boolTypes, "b")
+        val eq3 = tla.eql(cellEx(right), cellEx(arena.cellTrue()))
         solverContext.assertGroundExpr(eq3)
         assert(solverContext.sat())
         rewriter.pop()
         // both true
-        val eq4 = tla
-          .eql(left.toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
-          .typed(boolTypes, "b")
+        val eq4 = tla.eql(cellEx(left), cellEx(arena.cellTrue()))
         solverContext.assertGroundExpr(eq4)
         assert(solverContext.sat())
         rewriter.push()
-        val eq5 = tla
-          .eql(right.toNameEx ? "b", arena.cellTrue().toNameEx ? "b")
-          .typed(boolTypes, "b")
+        val eq5 = tla.eql(cellEx(right), cellEx(arena.cellTrue()))
         solverContext.assertGroundExpr(eq5)
         assert(!solverContext.sat())
         rewriter.pop()
-        val eq6 = tla
-          .eql(right.toNameEx ? "b", arena.cellFalse().toNameEx ? "b")
-          .typed(boolTypes, "b")
+        val eq6 = tla.eql(cellEx(right), cellEx(arena.cellFalse()))
         solverContext.assertGroundExpr(eq6)
         assert(solverContext.sat())
 
@@ -403,9 +351,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""\E x \in {}: TRUE ~~> FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla
-      .exists(tla.name("x") ? "i", tla.enumSet() ? "I", tla.bool(true))
-      .typed(boolTypes, "b")
+    val ex = tla.exists(intName("x"), tla.emptySet(IntT1), tla.bool(true))
     val state = new SymbState(ex, arena, Binding())
     val nextState = create(rewriterType).rewriteUntilDone(state)
     assert(arena.cellFalse().toNameEx == nextState.ex)
@@ -413,11 +359,8 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""\E x \in {1, 2, 3}: x = 2 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1))
-    val ex =
-      tla
-        .exists(tla.name("x") ? "i", set123, tla.eql(tla.int(2), tla.name("x") ? "i") ? "b")
-        .typed(boolTypes, "b")
+    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val ex = tla.exists(intName("x"), set123, tla.eql(tla.int(2), intName("x")))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -426,24 +369,20 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     solverContext.assertGroundExpr(nextState.ex)
     assert(solverContext.sat())
     rewriter.pop()
-    solverContext.assertGroundExpr(tla.not(nextState.ex).typed(BoolT1))
+    solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
     assertUnsatOrExplain()
   }
 
   /** Jure, 9.12.19: Why should this throw? */
   test("""\E x \in {1, 2}: y' := x ~~> 2 assignments, regression""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val set12 = tla
-      .enumSet(tla.int(1), tla.int(2))
-      .typed(SetT1(IntT1))
+    val set12 = tla.enumSet(tla.int(1), tla.int(2))
     // an assignment inside an existential quantifier is tricky, as we can multiple values to variables
-    val ex = tla
-      .exists(
-          tla.name("x") ? "i",
-          set12,
-          tla.assign(tla.prime(tla.name("y") ? "i") ? "i", tla.name("x") ? "i") ? "b",
-      )
-      .typed(boolTypes, "b")
+    val ex = tla.exists(
+        intName("x"),
+        set12,
+        tla.assign(tla.prime(intName("y")), intName("x")),
+    )
     ////
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -456,22 +395,18 @@ trait TestSymbStateRewriterBool extends RewriterBase {
       assert(solverContext.sat())
       rewriter.pop()
       rewriter.push()
-      solverContext.assertGroundExpr(tla.not(nextState.ex).typed(BoolT1))
+      solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
       assertUnsatOrExplain()
       rewriter.pop()
       rewriter.push()
       solverContext.assertGroundExpr(nextState.ex)
-      val eq1 = tla
-        .eql(tla.int(1), nextState.binding("y'").toNameEx ? "i")
-        .typed(boolTypes, "b")
+      val eq1 = tla.eql(tla.int(1), cellEx(nextState.binding("y'")))
       solverContext.assertGroundExpr(eq1)
       assert(solverContext.sat())
       rewriter.pop()
       rewriter.push()
       solverContext.assertGroundExpr(nextState.ex)
-      val eq2 = tla
-        .eql(tla.int(2), nextState.binding("y'").toNameEx ? "i")
-        .typed(boolTypes, "b")
+      val eq2 = tla.eql(tla.int(2), cellEx(nextState.binding("y'")))
       solverContext.assertGroundExpr(eq2)
       assert(solverContext.sat())
       rewriter.pop()
@@ -480,11 +415,8 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""\E x \in {1, 2, 3}: x > 4 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1))
-    val ex =
-      tla
-        .exists(tla.name("x") ? "i", set123, tla.gt(tla.name("x") ? "i", tla.int(4)) ? "b")
-        .typed(boolTypes, "b")
+    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val ex = tla.exists(intName("x"), set123, tla.gt(intName("x"), tla.int(4)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -493,44 +425,39 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     solverContext.assertGroundExpr(nextState.ex)
     assertUnsatOrExplain()
     rewriter.pop()
-    solverContext.assertGroundExpr(tla.not(nextState.ex).typed(BoolT1))
+    solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
     assert(solverContext.sat())
   }
 
   test("""\E x \in {t \in {1}: FALSE}: x > 4, regression""") { rewriterType: SMTEncoding =>
     prepareArena()
-    def dynEmpty(left: TlaEx): TlaEx = {
-      tla
-        .filter(tla.name("t") ? "i", left ? "I", tla.bool(false))
-        .typed(boolTypes, "I")
+    def dynEmpty(left: TBuilderInstruction): TBuilderInstruction = {
+      tla.filter(intName("t"), left, tla.bool(false))
     }
 
-    val emptySet = dynEmpty(tla.enumSet(tla.int(1)).typed(SetT1(IntT1)))
-    val pred = tla.gt(tla.name("x") ? "i", tla.int(4)).typed(boolTypes, "b")
-    val ex =
-      tla
-        .apalacheSkolem(tla.exists(tla.name("x") ? "i", emptySet, pred) ? "b")
-        .typed(boolTypes, "b")
+    val emptySet = dynEmpty(tla.enumSet(tla.int(1)))
+    val pred = tla.gt(intName("x"), tla.int(4))
+    val ex = tla.skolem(tla.exists(intName("x"), emptySet, pred))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
 
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat()) // regression test, the buggy implementation failed here
     // E x \in {} is false
-    assertTlaExAndRestore(rewriter, nextState.setRex(tla.not(nextState.ex).typed(BoolT1)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.not(tla.unchecked(nextState.ex))))
   }
 
   test("""skolem: \E i \in Nat: i = 10 /\ x' \in {i}""") { rewriterType: SMTEncoding =>
     prepareArena()
     // this works for skolem constants only
     val ex =
-      tla
-        .apalacheSkolem(tla.exists(tla.name("i") ? "i", tla.natSet() ? "I",
-            tla.and(
-                tla.eql(tla.name("i") ? "i", tla.int(10)) ? "b",
-                tla.assign(tla.prime(tla.name("x") ? "i") ? "i", tla.name("i") ? "i") ? "b",
-            ) ? "b") ? "b")
-        .typed(boolTypes, "b")
+      tla.skolem(
+          tla.exists(intName("i"), tla.natSet(),
+              tla.and(
+                  tla.eql(intName("i"), tla.int(10)),
+                  tla.assign(tla.prime(intName("x")), intName("i")),
+              ))
+      )
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
 
@@ -538,9 +465,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     assert(solverContext.sat())
     solverContext.assertGroundExpr(nextState.ex)
     val xp = nextState.binding("x'")
-    val eql = tla
-      .eql(xp.toNameEx ? "i", tla.int(10))
-      .typed(boolTypes, "b")
+    val eql = tla.eql(cellEx(xp), tla.int(10))
     assertTlaExAndRestore(rewriter, nextState.setRex(eql))
   }
 
@@ -548,24 +473,22 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     // this works for skolem constants only
     prepareArena()
     val ex =
-      tla
-        .apalacheSkolem(tla.exists(
-            tla.name("i") ? "i",
-            tla.dotdot(tla.name("a") ? "i", tla.name("b") ? "i") ? "I",
-            tla.and(
-                tla.eql(tla.mod(tla.name("i") ? "i", tla.int(3)) ? "i", tla.int(1)) ? "b",
-                tla.assign(tla.prime(tla.name("x") ? "i") ? "i", tla.name("i") ? "i") ? "b",
-            ) ? "b",
-        ) ? "b")
-        .typed(boolTypes, "b")
+      tla.skolem(tla.exists(
+              intName("i"),
+              tla.dotdot(intName("a"), intName("b")),
+              tla.and(
+                  tla.eql(tla.mod(intName("i"), tla.int(3)), tla.int(1)),
+                  tla.assign(tla.prime(intName("x")), intName("i")),
+              ),
+          ))
 
     val rewriter = create(rewriterType)
 
     // rewrite 5 and 9 first, to produce a and b
-    var state = new SymbState(tla.int(5).typed(), arena, Binding())
+    var state = new SymbState(tla.int(5), arena, Binding())
     state = rewriter.rewriteUntilDone(state)
     val aCell = state.asCell
-    state = rewriter.rewriteUntilDone(state.setRex(tla.int(9).typed()))
+    state = rewriter.rewriteUntilDone(state.setRex(tla.int(9)))
     val bCell = state.asCell
     val binding: Binding = Binding("a" -> aCell, "b" -> bCell)
 
@@ -573,19 +496,14 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     assert(solverContext.sat())
     solverContext.assertGroundExpr(nextState.ex)
     val xp = nextState.binding("x'")
-    val eq = tla
-      .eql(xp.toNameEx ? "i", tla.int(7))
-      .typed(boolTypes, "b")
+    val eq = tla.eql(cellEx(xp), tla.int(7))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("""\A x \in {1, 2, 3}: x < 10 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1))
-    val ex =
-      tla
-        .forall(tla.name("x") ? "i", set123, tla.lt(tla.name("x") ? "i", tla.int(10)) ? "b")
-        .typed(boolTypes, "b")
+    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val ex = tla.forall(intName("x"), set123, tla.lt(intName("x"), tla.int(10)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -594,17 +512,14 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     solverContext.assertGroundExpr(nextState.ex)
     assert(solverContext.sat())
     rewriter.pop()
-    solverContext.assertGroundExpr(tla.not(nextState.ex).typed(BoolT1))
+    solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
     assertUnsatOrExplain()
   }
 
   test("""\A x \in {1, 2, 3}: x > 2 ~~> $B$k""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3)).typed(SetT1(IntT1))
-    val ex =
-      tla
-        .forall(tla.name("x") ? "i", set123, tla.gt(tla.name("x") ? "i", tla.int(2)) ? "b")
-        .typed(boolTypes, "b")
+    val set123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val ex = tla.forall(intName("x"), set123, tla.gt(intName("x"), tla.int(2)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -613,7 +528,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     solverContext.assertGroundExpr(nextState.ex)
     assertUnsatOrExplain()
     rewriter.pop()
-    solverContext.assertGroundExpr(tla.not(nextState.ex).typed(BoolT1))
+    solverContext.assertGroundExpr(tla.not(tla.unchecked(nextState.ex)))
     assert(solverContext.sat())
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterControl.scala
@@ -1,106 +1,89 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.convenience.tla._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterControl extends RewriterBase {
-  private val types = Map(
-      "b" -> BoolT1,
-      "i" -> IntT1,
-      "I" -> SetT1(IntT1),
-      "O" -> OperT1(Seq(), IntT1),
-  )
-
   test("""IF 3 > 2 THEN 2 < 4 ELSE 5 < 1""") { rewriterType: SMTEncoding =>
-    val pred = gt(int(3), int(2))
-    val e1 = lt(int(2), int(4))
-    val e2 = lt(int(5), int(1))
-    val ifThenElse = ite(pred ? "b", e1 ? "b", e2 ? "b")
-      .typed(types, "b")
+    val pred = tla.gt(tla.int(3), tla.int(2))
+    val e1 = tla.lt(tla.int(2), tla.int(4))
+    val e2 = tla.lt(tla.int(5), tla.int(1))
+    val ifThenElse = tla.ite(pred, e1, e2)
 
     val state = new SymbState(ifThenElse, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state.setRex(ifThenElse))
   }
 
   test("""IF 3 < 2 THEN 2 < 4 ELSE 5 < 1""") { rewriterType: SMTEncoding =>
-    val pred = lt(int(3), int(2))
-    val e1 = lt(int(2), int(4))
-    val e2 = lt(int(5), int(1))
-    val ifThenElse = not(ite(pred ? "b", e1 ? "b", e2 ? "b") ? "b")
-      .typed(types, "b")
+    val pred = tla.lt(tla.int(3), tla.int(2))
+    val e1 = tla.lt(tla.int(2), tla.int(4))
+    val e2 = tla.lt(tla.int(5), tla.int(1))
+    val ifThenElse = tla.not(tla.ite(pred, e1, e2))
 
     val state = new SymbState(ifThenElse, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state.setRex(ifThenElse))
   }
 
   test("""IF 3 > 2 THEN 4 ELSE 1""") { rewriterType: SMTEncoding =>
-    val pred = gt(int(3), int(2))
-    val e1 = int(4)
-    val e2 = int(1)
-    val ifThenElse = ite(pred ? "b", e1, e2) ? "i"
-    val eq4 = eql(ifThenElse, int(4))
-      .typed(types, "b")
+    val pred = tla.gt(tla.int(3), tla.int(2))
+    val e1 = tla.int(4)
+    val e2 = tla.int(1)
+    val ifThenElse = tla.ite(pred, e1, e2)
+    val eq4 = tla.eql(ifThenElse, tla.int(4))
 
     val state = new SymbState(eq4, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""IF 3 < 2 THEN 4 ELSE 1""") { rewriterType: SMTEncoding =>
-    val pred = lt(int(3), int(2))
-    val e1 = int(4)
-    val e2 = int(1)
-    val ifThenElse = ite(pred ? "b", e1, e2) ? "i"
-    val eq4 = eql(ifThenElse, int(1))
-      .typed(types, "b")
+    val pred = tla.lt(tla.int(3), tla.int(2))
+    val e1 = tla.int(4)
+    val e2 = tla.int(1)
+    val ifThenElse = tla.ite(pred, e1, e2)
+    val eq4 = tla.eql(ifThenElse, tla.int(1))
 
     val state = new SymbState(eq4, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""IF 3 < 2 THEN {1, 2} ELSE {2, 3} equals {2, 3}""") { rewriterType: SMTEncoding =>
-    val pred = lt(int(3), int(2))
-    val e1 = enumSet(int(1), int(2))
-    val e2 = enumSet(int(2), int(3))
-    val ifThenElse = ite(pred ? "b", e1 ? "I", e2 ? "I")
-      .typed(types, "I")
-    val eq23 = eql(ifThenElse, e2 ? "I")
-      .typed(types, "b")
+    val pred = tla.lt(tla.int(3), tla.int(2))
+    val e1 = tla.enumSet(tla.int(1), tla.int(2))
+    val e2 = tla.enumSet(tla.int(2), tla.int(3))
+    val ifThenElse = tla.ite(pred, e1, e2)
+    val eq23 = tla.eql(ifThenElse, e2)
 
     val state = new SymbState(eq23, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""IF 1 = 1 THEN {2} ELSE {1} ]""") { rewriterType: SMTEncoding =>
-    val ifThenElse = ite(eql(int(1), int(1)) ? "b", enumSet(int(2)) ? "I", enumSet(int(1)) ? "I")
-    val eq = eql(enumSet(int(2)) ? "I", ifThenElse ? "I")
-      .typed(types, "b")
+    val ifThenElse = tla.ite(tla.eql(tla.int(1), tla.int(1)), tla.enumSet(tla.int(2)), tla.enumSet(tla.int(1)))
+    val eq = tla.eql(tla.enumSet(tla.int(2)), ifThenElse)
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""SE-ITE[5]: IF 2 < 3 THEN {1, 2} ELSE {2, 3} ~~> {1, 2}""") { rewriterType: SMTEncoding =>
-    val pred = lt(int(2), int(3))
-    val e1 = enumSet(int(1), int(2))
-    val e2 = enumSet(int(2), int(3))
-    val ifThenElse = ite(pred ? "b", e1 ? "I", e2 ? "I")
-      .typed(types, "I")
-    val eq = eql(ifThenElse, e1 ? "I")
-      .typed(types, "b")
+    val pred = tla.lt(tla.int(2), tla.int(3))
+    val e1 = tla.enumSet(tla.int(1), tla.int(2))
+    val e2 = tla.enumSet(tla.int(2), tla.int(3))
+    val ifThenElse = tla.ite(pred, e1, e2)
+    val eq = tla.eql(ifThenElse, e1)
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""1 + (IF 3 < 2 THEN 4 ELSE 1)""") { rewriterType: SMTEncoding =>
-    val pred = lt(int(3), int(2))
-    val e1 = int(4)
-    val e2 = int(1)
-    val addition = plus(int(1), ite(pred ? "b", e1 ? "i", e2 ? "i") ? "i")
-    val eq = eql(addition ? "i", int(2))
-      .typed(types, "b")
+    val pred = tla.lt(tla.int(3), tla.int(2))
+    val e1 = tla.int(4)
+    val e2 = tla.int(1)
+    val addition = tla.plus(tla.int(1), tla.ite(pred, e1, e2))
+    val eq = tla.eql(addition, tla.int(2))
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
@@ -108,15 +91,12 @@ trait TestSymbStateRewriterControl extends RewriterBase {
 
   // LET-IN is often used to cache computation results
   test("""LET A == 1 + 2 IN 1 + A equals 4""") { rewriterType: SMTEncoding =>
-    val decl = declOp("A", plus(int(1), int(2)) ? "i")
-      .typedOperDecl(types, "O")
-    val let = letIn(plus(int(1), appOp(name("A") ? "O") ? "i") ? "i", decl)
-      .typed(types, "i")
+    val decl = tla.decl("A", tla.plus(tla.int(1), tla.int(2)))
+    val let = tla.letIn(tla.plus(tla.int(1), tla.appOp(tla.name("A", OperT1(Seq(), IntT1)))), decl)
     val state = new SymbState(let, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val eq = eql(nextState.ex ? "i", int(4))
-      .typed(types, "b")
+    val eq = tla.eql(tla.unchecked(nextState.ex), tla.int(4))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterExpand.scala
@@ -1,37 +1,27 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.lir.TypedPredefs._
-import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, IntT1, SetT1}
+import at.forsyte.apalache.tla.lir.IntT1
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterExpand extends RewriterBase {
-  private val types = Map(
-      "b" -> BoolT1,
-      "i" -> IntT1,
-      "I" -> SetT1(IntT1),
-      "II" -> SetT1(SetT1(IntT1)),
-      "B" -> SetT1(BoolT1),
-      "i_TO_b" -> SetT1(FunT1(IntT1, BoolT1)),
-  )
-
   test("""Expand(SUBSET {1, 2})""") { rewriterType: SMTEncoding =>
-    val baseset = enumSet(int(1), int(2))
-    val expandPowset = apalacheExpand(powSet(baseset ? "I") ? "II")
-      .typed(types, "II")
-    val subsets = enumSet(enumSet() ? "I", enumSet(int(1)) ? "I", enumSet(int(2)) ? "I", enumSet(int(1), int(2)) ? "I")
-    val eq = eql(expandPowset, subsets ? "II")
-      .typed(types, "b")
+    val baseset = tla.enumSet(tla.int(1), tla.int(2))
+    val expandPowset = tla.expand(tla.powSet(baseset))
+    val subsets =
+      tla.enumSet(tla.emptySet(IntT1), tla.enumSet(tla.int(1)), tla.enumSet(tla.int(2)),
+          tla.enumSet(tla.int(1), tla.int(2)))
+    val eq = tla.eql(expandPowset, subsets)
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""Expand([{1, 2, 3} -> {FALSE, TRUE}]) fails as unsupported""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2), int(3))
-    val codomain = enumSet(bool(false), bool(true))
-    val set = apalacheExpand(funSet(domain ? "I", codomain ? "B") ? "i_TO_b")
-      .typed(types, "i_TO_b")
+    val domain = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val codomain = tla.enumSet(tla.bool(false), tla.bool(true))
+    val set = tla.expand(tla.funSet(domain, codomain))
     val state = new SymbState(set, arena, Binding())
     val rewriter = create(rewriterType)
     assertThrows[RewriterException](rewriter.rewriteUntilDone(state))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFiniteSets.scala
@@ -1,30 +1,25 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.lir.TypedPredefs._
-import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, TlaEx}
+import at.forsyte.apalache.tla.lir.IntT1
 import at.forsyte.apalache.tla.pp.TlaInputError
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterFiniteSets extends RewriterBase {
-  private val intT = IntT1
-  private val boolT = BoolT1
-  private val intSetT = SetT1(IntT1)
-  private val intSetSetT = SetT1(SetT1(IntT1))
-
   test("""Cardinality({1, 2, 3}) = 3""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(3).map(int): _*)
-    val cardinality = card(set.as(intSetT)).as(intT)
-    val eq = eql(cardinality, int(3)).as(boolT)
+    val set = tla.enumSet(1.to(3).map(i => tla.int(i)): _*)
+    val cardinality = tla.cardinality(set)
+    val eq = tla.eql(cardinality, tla.int(3))
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""Cardinality(SUBSET {1, 2}) throws""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(2).map(int): _*).as(intSetT)
-    val powerset = powSet(set).as(intSetSetT)
-    val cardinality = card(powerset).as(intT)
+    val set = tla.enumSet(1.to(2).map(i => tla.int(i)): _*)
+    val powerset = tla.powSet(set)
+    val cardinality = tla.cardinality(powerset)
 
     val state = new SymbState(cardinality, arena, Binding())
     assertThrows[TlaInputError] {
@@ -34,17 +29,17 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Cardinality({1, 2, 2, 2, 3, 3}) = 3""") { rewriterType: SMTEncoding =>
-    val set = enumSet(Seq(1, 2, 2, 2, 3, 3).map(int): _*)
-    val cardinality = card(set.as(intSetT)).as(intT)
-    val eq = eql(cardinality, int(3)).as(boolT)
+    val set = tla.enumSet(Seq(1, 2, 2, 2, 3, 3).map(i => tla.int(i)): _*)
+    val cardinality = tla.cardinality(set)
+    val eq = tla.eql(cardinality, tla.int(3))
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""Apalache!ConstCard(Cardinality({1, 2, 3}) >= 3)""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(3).map(int): _*)
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(3)).as(boolT)).as(boolT)
+    val set = tla.enumSet(1.to(3).map(i => tla.int(i)): _*)
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(3)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -55,8 +50,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({1, 2, 3}) >= 4)""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(3).map(int): _*)
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(4)).as(boolT)).as(boolT)
+    val set = tla.enumSet(1.to(3).map(i => tla.int(i)): _*)
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(4)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -67,8 +62,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({1, 2, 2, 3}) >= 4)""") { rewriterType: SMTEncoding =>
-    val set = enumSet(Seq(1, 2, 2, 3).map(int): _*)
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(4)).as(boolT)).as(boolT)
+    val set = tla.enumSet(Seq(1, 2, 2, 3).map(i => tla.int(i)): _*)
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(4)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -79,8 +74,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({1, 2, 2, 3, 3}) >= 4)""") { rewriterType: SMTEncoding =>
-    val set = enumSet(Seq(1, 2, 2, 3, 3).map(int): _*)
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(4)).as(boolT)).as(boolT)
+    val set = tla.enumSet(Seq(1, 2, 2, 3, 3).map(i => tla.int(i)): _*)
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(4)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -91,8 +86,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({}) >= 0)""") { rewriterType: SMTEncoding =>
-    val set = enumSet()
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(0)).as(boolT)).as(boolT)
+    val set = tla.emptySet(IntT1)
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(0)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -103,8 +98,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({}) >= 1)""") { rewriterType: SMTEncoding =>
-    val set = enumSet()
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(1)).as(boolT)).as(boolT)
+    val set = tla.emptySet(IntT1)
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(1)))
     val state = new SymbState(cardCmp, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -115,8 +110,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({x \in {}: FALSE}) >= 0)""") { rewriterType: SMTEncoding =>
-    val set = filter(name("x").as(intT), enumSet().as(intSetT), bool(false))
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(0)).as(boolT)).as(boolT)
+    val set = tla.filter(tla.name("x", IntT1), tla.emptySet(IntT1), tla.bool(false))
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(0)))
     val state = new SymbState(cardCmp, arena, Binding())
     // note that this optimization only works in the positive form. Its negation may be SAT.
     val rewriter = create(rewriterType)
@@ -127,8 +122,8 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Apalache!ConstCard(Cardinality({x \in {}: FALSE}) >= 1)""") { rewriterType: SMTEncoding =>
-    val set = filter(name("x").as(intT), enumSet().as(intSetT), bool(false))
-    val cardCmp = apalacheConstCard(ge(card(set.as(intSetT)).as(intT), int(1)).as(boolT)).as(boolT)
+    val set = tla.filter(tla.name("x", IntT1), tla.emptySet(IntT1), tla.bool(false))
+    val cardCmp = tla.constCard(tla.ge(tla.cardinality(set), tla.int(1)))
     val state = new SymbState(cardCmp, arena, Binding())
     // note that this optimization only works in the positive form. Its negation may be SAT.
     val rewriter = create(rewriterType)
@@ -139,22 +134,25 @@ trait TestSymbStateRewriterFiniteSets extends RewriterBase {
   }
 
   test("""Cardinality({1, 2, 3} \ {2}) = 2""") { rewriterType: SMTEncoding =>
-    def setminus(set: TlaEx, intVal: Int): TlaEx = {
-      filter(name("t").as(intT), set.as(intSetT), not(eql(name("t").as(intT), int(intVal)).as(boolT)).as(boolT)).as(
-          intSetT)
+    def setminus(set: TBuilderInstruction, intVal: Int): TBuilderInstruction = {
+      tla.filter(
+          tla.name("t", IntT1),
+          set,
+          tla.not(tla.eql(tla.name("t", IntT1), tla.int(intVal))),
+      )
     }
 
-    val set = setminus(enumSet(1.to(3).map(int): _*).as(intSetT), 2)
-    val cardinality = card(set.as(intSetT))
-    val eq = eql(cardinality.as(intT), int(2)).as(boolT)
+    val set = setminus(tla.enumSet(1.to(3).map(i => tla.int(i)): _*), 2)
+    val cardinality = tla.cardinality(set)
+    val eq = tla.eql(cardinality, tla.int(2))
 
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""IsFiniteSet({1, 2, 3}) = TRUE""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(3).map(int): _*)
-    val isFiniteSet = isFin(set.as(intSetT)).as(boolT)
+    val set = tla.enumSet(1.to(3).map(i => tla.int(i)): _*)
+    val isFiniteSet = tla.isFiniteSet(set)
     val state = new SymbState(isFiniteSet, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -3,38 +3,21 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.TypedPredefs._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterFun extends RewriterBase {
-  private val types =
-    Map(
-        "b" -> BoolT1,
-        "B" -> SetT1(BoolT1),
-        "i" -> IntT1,
-        "I" -> SetT1(IntT1),
-        "(i)" -> TupT1(IntT1),
-        "i_to_i" -> FunT1(IntT1, IntT1),
-        "i_to_I" -> FunT1(IntT1, SetT1(IntT1)),
-        "r" -> RecT1("a" -> IntT1),
-        "s" -> StrT1,
-        "S" -> SetT1(StrT1),
-        "(s)" -> TupT1(StrT1),
-        "i_to_s" -> FunT1(IntT1, StrT1),
-        "s_to_i" -> FunT1(StrT1, IntT1),
-        "i_to_r" -> FunT1(IntT1, RecT1("a" -> IntT1)),
-        "b_to_b" -> FunT1(BoolT1, BoolT1),
-        "b_TO_b" -> SetT1(FunT1(BoolT1, BoolT1)),
-        "i_to_b_to_b" -> FunT1(IntT1, FunT1(BoolT1, BoolT1)),
-    )
+  private val boolFunT: TlaType1 = FunT1(BoolT1, BoolT1)
+  private def intEnum(values: Int*): TBuilderInstruction = tla.enumSet(values.map(i => tla.int(i)): _*)
+  private def emptyIntSet: TBuilderInstruction = tla.emptySet(IntT1)
+  private def unchecked(ex: TlaEx): TBuilderInstruction = tla.unchecked(ex)
 
   test("""[x \in {1,2,3,4} |-> x / 3: ]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(4).map(int): _*)
-      .typed(types, "I")
-    val mapping = div(name("x") ? "i", int(3))
-      .typed(types, "i")
-    val fun = funDef(mapping, name("x") ? "i", set)
-      .typed(types, "i_to_i")
+    val set = intEnum(1, 2, 3, 4)
+
+    val mapping = tla.div(tla.name("x", IntT1), tla.int(3))
+
+    val fun = tla.funDef(mapping, tla.name("x", IntT1) -> set)
 
     val state = new SymbState(fun, arena, Binding())
     val rewriter = create(rewriterType)
@@ -57,19 +40,17 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test(""" [x \in {1,2,3} |-> IF x = 1 THEN {2} ELSE IF x = 2 THEN {3} ELSE {1} ]""") { rewriterType: SMTEncoding =>
-    val x = name("x")
-    val set = enumSet(1.to(3).map(int): _*)
-      .typed(types, "I")
+    val x = tla.name("x", IntT1)
+    val set = intEnum(1, 2, 3)
 
-    def intSet(i: Int) = enumSet(int(i)).typed(types, "I")
+    def intSet(i: Int) = tla.enumSet(tla.int(i))
 
-    val mapping = ite(
-        eql(x ? "i", int(1)) ? "b",
+    val mapping = tla.ite(
+        tla.eql(x, tla.int(1)),
         intSet(2),
-        ite(eql(x ? "i", int(2)) ? "b", intSet(3), intSet(1)) ? "I",
-    ).typed(types, "I")
-    val fun = funDef(mapping, x ? "i", set)
-      .typed(types, "i_to_I")
+        tla.ite(tla.eql(x, tla.int(2)), intSet(3), intSet(1)),
+    )
+    val fun = tla.funDef(mapping, x -> set)
 
     val state = new SymbState(fun, arena, Binding())
     val rewriter = create(rewriterType)
@@ -84,15 +65,14 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[x \in {1,2} |-> {} ][1] = {}""") { rewriterType: SMTEncoding =>
-    val x = name("x")
-    val set = enumSet(int(1), int(2))
-      .typed(types, "I")
-    val mapping = enumSet()
-      .typed(types, "I")
-    val fun = funDef(mapping, x ? "i", set)
-      .typed(types, "i_to_I")
-    val eq = eql(appFun(fun, int(1)) ? "I", enumSet() ? "I")
-      .typed(types, "b")
+    val x = tla.name("x", IntT1)
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+
+    val mapping = emptyIntSet
+
+    val fun = tla.funDef(mapping, x -> set)
+
+    val eq = tla.eql(tla.app(fun, tla.int(1)), emptyIntSet)
 
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
@@ -104,7 +84,7 @@ trait TestSymbStateRewriterFun extends RewriterBase {
         assert(solverContext.sat())
         solverContext.pop()
         solverContext.push()
-        solverContext.assertGroundExpr(not(result ? "b").typed(types, "b"))
+        solverContext.assertGroundExpr(tla.not(unchecked(result)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -113,14 +93,13 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[x \in {1,2} |-> IF x = 1 THEN {2} ELSE {1} ][1]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2))
-      .typed(types, "I")
-    val mapping = ite(eql(name("x") ? "i", int(1)) ? "b", enumSet(int(2)) ? "I", enumSet(int(1)) ? "I")
-      .typed(types, "I")
-    val fun = funDef(mapping, name("x") ? "i", set)
-      .typed(types, "i_to_I")
-    val eq = eql(enumSet(int(2)) ? "I", appFun(fun, int(1)) ? "I")
-      .typed(types, "b")
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+
+    val mapping = tla.ite(tla.eql(tla.name("x", IntT1), tla.int(1)), tla.enumSet(tla.int(2)), tla.enumSet(tla.int(1)))
+
+    val fun = tla.funDef(mapping, tla.name("x", IntT1) -> set)
+
+    val eq = tla.eql(tla.enumSet(tla.int(2)), tla.app(fun, tla.int(1)))
 
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
@@ -133,7 +112,7 @@ trait TestSymbStateRewriterFun extends RewriterBase {
         assert(solverContext.sat())
         solverContext.pop()
         solverContext.push()
-        solverContext.assertGroundExpr(not(nextState.ex ? "b").typed(types, "b"))
+        solverContext.assertGroundExpr(tla.not(unchecked(nextState.ex)))
         assert(!solverContext.sat())
         solverContext.pop()
 
@@ -144,14 +123,13 @@ trait TestSymbStateRewriterFun extends RewriterBase {
 
   // regression: this test did not work with EWD840
   test("""[x \in {1,2} |-> ["a" |-> x] ][1]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2))
-      .typed(types, "I")
-    val mapping = enumFun(str("a"), name("x") ? "i")
-      .typed(types, "r")
-    val fun = funDef(mapping, name("x") ? "i", set)
-      .typed(types, "i_to_r")
-    val eq = eql(enumFun(str("a"), int(1)) ? "r", appFun(fun, int(1)) ? "r")
-      .typed(types, "b")
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+
+    val mapping = tla.rec("a" -> tla.name("x", IntT1))
+
+    val fun = tla.funDef(mapping, tla.name("x", IntT1) -> set)
+
+    val eq = tla.eql(tla.rec("a" -> tla.int(1)), tla.app(fun, tla.int(1)))
 
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
@@ -164,7 +142,7 @@ trait TestSymbStateRewriterFun extends RewriterBase {
         assert(solverContext.sat())
         solverContext.pop()
         solverContext.push()
-        solverContext.assertGroundExpr(not(nextState.ex ? "b").typed(types, "b"))
+        solverContext.assertGroundExpr(tla.not(unchecked(nextState.ex)))
         assert(!solverContext.sat())
         solverContext.pop()
 
@@ -174,15 +152,14 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""f[4]""") { rewriterType: SMTEncoding =>
-    val x = name("x")
-    val set = enumSet(1.to(4).map(int): _*)
-      .typed(types, "I")
-    val mapping = mult(x ? "i", int(3))
-      .typed(types, "i")
-    val fun = funDef(mapping, x ? "i", set)
-      .typed(types, "i_to_i")
-    val app = appFun(fun, int(4))
-      .typed(types, "i")
+    val x = tla.name("x", IntT1)
+    val set = intEnum(1, 2, 3, 4)
+
+    val mapping = tla.mult(x, tla.int(3))
+
+    val fun = tla.funDef(mapping, x -> set)
+
+    val app = tla.app(fun, tla.int(4))
 
     val state = new SymbState(app, arena, Binding())
     val rewriter = create(rewriterType)
@@ -193,14 +170,14 @@ trait TestSymbStateRewriterFun extends RewriterBase {
         val cell = nextState.arena.findCellByName(name)
         cell.cellType match {
           case CellTFrom(IntT1) =>
-            val eq1 = eql(cell.toNameEx ? "i", int(12))
-              .typed(types, "b")
+            val eq1 = tla.eql(cellEx(cell), tla.int(12))
+
             solverContext.assertGroundExpr(eq1)
             rewriter.push()
             assert(solverContext.sat())
             rewriter.pop()
-            val eq2 = neql(cell.toNameEx ? "i", int(12))
-              .typed(types, "b")
+            val eq2 = tla.neql(cellEx(cell), tla.int(12))
+
             solverContext.assertGroundExpr(eq2)
             assert(!solverContext.sat())
 
@@ -214,11 +191,10 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[x \in {1, 2} |-> x][4] ~~> failure!""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2))
-      .typed(types, "I")
-    val fun = funDef(name("x") ? "i", name("x") ? "i", set)
-    val app = appFun(fun ? "i_to_i", int(4))
-      .typed(types, "i")
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+
+    val fun = tla.funDef(tla.name("x", IntT1), tla.name("x", IntT1) -> set)
+    val app = tla.app(fun, tla.int(4))
 
     val state = new SymbState(app, arena, Binding())
     val rewriter = create(rewriterType)
@@ -238,14 +214,13 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[x \in {3} |-> {1, x}][3]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(3))
-    val mapping = enumSet(int(1), name("x") ? "i")
-    val fun = funDef(mapping ? "I", name("x") ? "i", set ? "I")
-    val app = appFun(fun ? "i_to_I", int(3))
-      .typed(types, "I")
+    val set = tla.enumSet(tla.int(3))
+    val mapping = tla.enumSet(tla.int(1), tla.name("x", IntT1))
+    val fun = tla.funDef(mapping, tla.name("x", IntT1) -> set)
+    val app = tla.app(fun, tla.int(3))
 
-    val appEq = eql(app, enumSet(int(1), int(3)) ? "I")
-      .typed(types, "b")
+    val appEq = tla.eql(app, tla.enumSet(tla.int(1), tla.int(3)))
+
     val state = new SymbState(app, arena, Binding())
     val rewriter = create(rewriterType)
     assertTlaExAndRestore(rewriter, state.setRex(appEq))
@@ -254,9 +229,9 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   test("""[x \in {} |-> x][3]""") { rewriterType: SMTEncoding =>
     // regression: function application with an empty domain should not crash.
     // The result of this function is undefined in TLA+.
-    val fun = funDef(name("x") ? "i", name("x") ? "i", enumSet() ? "I")
-    val app = appFun(fun ? "i_to_i", int(3))
-      .typed(types, "i")
+    val fun = tla.funDef(tla.name("x", IntT1), tla.name("x", IntT1) -> emptyIntSet)
+    val app = tla.app(fun, tla.int(3))
+
     val state = new SymbState(app, arena, Binding())
     val rewriter = create(rewriterType)
     val _ = rewriter.rewriteUntilDone(state)
@@ -264,12 +239,11 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[y \in BOOLEAN |-> ~y] = [x \in BOOLEAN |-> ~x]""") { rewriterType: SMTEncoding =>
-    val fun1 = funDef(not(name("y") ? "b") ? "b", name("y") ? "b", booleanSet() ? "B")
-      .typed(types, "b_to_b")
-    val fun2 = funDef(not(name("x") ? "b") ? "b", name("x") ? "b", booleanSet() ? "B")
-      .typed(types, "b_to_b")
-    val eq1 = eql(fun1, fun2)
-      .typed(types, "b")
+    val fun1 = tla.funDef(tla.not(tla.name("y", BoolT1)), tla.name("y", BoolT1) -> tla.booleanSet())
+
+    val fun2 = tla.funDef(tla.not(tla.name("x", BoolT1)), tla.name("x", BoolT1) -> tla.booleanSet())
+
+    val eq1 = tla.eql(fun1, fun2)
 
     val state = new SymbState(eq1, arena, Binding())
     val rewriter = create(rewriterType)
@@ -278,16 +252,13 @@ trait TestSymbStateRewriterFun extends RewriterBase {
 
   // a function returning a function
   test("""[x \in {3} |-> [y \in BOOLEAN |-> ~y]][3]""") { rewriterType: SMTEncoding =>
-    val boolNegFun = funDef(not(name("y") ? "b") ? "b", name("y") ? "b", booleanSet() ? "B")
-      .typed(types, "b_to_b")
+    val boolNegFun = tla.funDef(tla.not(tla.name("y", BoolT1)), tla.name("y", BoolT1) -> tla.booleanSet())
 
-    val fun = funDef(boolNegFun, name("x") ? "i", enumSet(int(3)) ? "I")
-      .typed(types, "i_to_b_to_b")
-    val app = appFun(fun, int(3))
-      .typed(types, "b_to_b")
+    val fun = tla.funDef(boolNegFun, tla.name("x", IntT1) -> tla.enumSet(tla.int(3)))
 
-    val appEq = eql(app, boolNegFun)
-      .typed(BoolT1)
+    val app = tla.app(fun, tla.int(3))
+
+    val appEq = tla.eql(app, boolNegFun)
 
     val state = new SymbState(appEq, arena, Binding())
     val rewriter = create(rewriterType)
@@ -295,13 +266,12 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[x \in {1, 2} |-> IF x = 1 THEN 11 ELSE 2 * x][1]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2))
-    val pred = eql(name("x") ? "i", int(1))
-    val ifThenElse = ite(pred ? "b", int(11), mult(int(2), name("x") ? "i") ? "i")
-    val iteFun = funDef(ifThenElse ? "i", name("x") ? "i", set ? "I")
-    val iteFunElem = appFun(iteFun ? "i_to_i", int(1))
-    val iteFunElemNe11 = eql(iteFunElem ? "i", int(11))
-      .typed(types, "b")
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+    val pred = tla.eql(tla.name("x", IntT1), tla.int(1))
+    val ifThenElse = tla.ite(pred, tla.int(11), tla.mult(tla.int(2), tla.name("x", IntT1)))
+    val iteFun = tla.funDef(ifThenElse, tla.name("x", IntT1) -> set)
+    val iteFunElem = tla.app(iteFun, tla.int(1))
+    val iteFunElemNe11 = tla.eql(iteFunElem, tla.int(11))
 
     val state = new SymbState(iteFunElemNe11, arena, Binding())
     val rewriter = create(rewriterType)
@@ -309,13 +279,11 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""[[x \in {1, 2} |-> 2 * x] EXCEPT ![1] = 11]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2))
-    val mapExpr = mult(int(2), name("x") ? "i")
-    val fun = funDef(mapExpr ? "i", name("x") ? "i", set ? "I")
-      .typed(types, "i_to_i")
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+    val mapExpr = tla.mult(tla.int(2), tla.name("x", IntT1))
+    val fun = tla.funDef(mapExpr, tla.name("x", IntT1) -> set)
 
-    val newFun = except(fun, tuple(int(1)) ? "(i)", int(11))
-      .typed(types, "i_to_i")
+    val newFun = tla.except(fun, tla.int(1), tla.int(11))
 
     val state = new SymbState(newFun, arena, Binding())
     val rewriter = create(rewriterType)
@@ -334,20 +302,19 @@ trait TestSymbStateRewriterFun extends RewriterBase {
         fail("Unexpected rewriting result")
     }
 
-    val resFun1eq11 = eql(appFun(newFun, int(1)) ? "i", int(11))
-      .typed(types, "b")
+    val resFun1eq11 = tla.eql(tla.app(newFun, tla.int(1)), tla.int(11))
+
     assertTlaExAndRestore(rewriter, nextState.setRex(resFun1eq11))
   }
 
   test("""[[x \in {"a", "b"} |-> 3] EXCEPT !["a"] = 11]""") { rewriterType: SMTEncoding =>
-    val set = enumSet(str("a"), str("b"))
-    val mapExpr = int(3)
-    val fun = funDef(mapExpr ? "i", name("x") ? "s", set ? "S")
-      .typed(types, "s_to_i")
-    val newFun = except(fun, tuple(str("a")) ? "(s)", int(11))
-      .typed(types, "s_to_i")
-    val resFun1eq11 = eql(appFun(newFun, str("a")) ? "i", int(11))
-      .typed(types, "b")
+    val set = tla.enumSet(tla.str("a"), tla.str("b"))
+    val mapExpr = tla.int(3)
+    val fun = tla.funDef(mapExpr, tla.name("x", StrT1) -> set)
+
+    val newFun = tla.except(fun, tla.str("a"), tla.int(11))
+
+    val resFun1eq11 = tla.eql(tla.app(newFun, tla.str("a")), tla.int(11))
 
     val state = new SymbState(newFun, arena, Binding())
     val rewriter = create(rewriterType)
@@ -356,12 +323,11 @@ trait TestSymbStateRewriterFun extends RewriterBase {
 
   test("""fun in a set: \E x \in {[y \in BOOLEAN |-> ~y]}: x[FALSE]""") { rewriterType: SMTEncoding =>
     // this test was failing in the buggy implementation with PICK .. FROM and FUN-MERGE
-    val fun1 = funDef(not(name("y") ? "b") ? "b", name("y") ? "b", booleanSet() ? "B")
-      .typed(types, "b_to_b")
+    val fun1 = tla.funDef(tla.not(tla.name("y", BoolT1)), tla.name("y", BoolT1) -> tla.booleanSet())
+
     val existsForm =
-      apalacheSkolem(exists(name("x") ? "b_to_b", enumSet(fun1) ? "b_TO_b",
-          appFun(name("x") ? "b_to_b", bool(false)) ? "b") ? "b")
-        .typed(types, "b")
+      tla.skolem(tla.exists(tla.name("x", boolFunT), tla.enumSet(fun1),
+              tla.app(tla.name("x", boolFunT), tla.bool(false))))
 
     val rewriter = createWithoutCache(rewriterType)
 
@@ -370,13 +336,12 @@ trait TestSymbStateRewriterFun extends RewriterBase {
   }
 
   test("""DOMAIN [x \in {1,2,3} |-> x / 2: ]""") { rewriterType: SMTEncoding =>
-    val x = name("x")
-    val set = enumSet(int(1), int(2), int(3))
-    val mapping = div(x ? "i", int(2))
-    val fun = funDef(mapping ? "i", x ? "i", set ? "I")
-    val domain = dom(fun ? "i_to_i")
-    val eq = eql(domain ? "I", set ? "I")
-      .typed(types, "b")
+    val x = tla.name("x", IntT1)
+    val set = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val mapping = tla.div(x, tla.int(2))
+    val fun = tla.funDef(mapping, x -> set)
+    val domain = tla.dom(fun)
+    val eq = tla.eql(domain, set)
 
     val rewriter = create(rewriterType)
     val state = new SymbState(eq, arena, Binding())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -3,17 +3,17 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT}
-import at.forsyte.apalache.tla.types.tlaU._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterFunSet extends RewriterBase {
   val i_to_B: TlaType1 = FunT1(IntT1, SetT1(BoolT1))
   val i_to_i_to_B: TlaType1 = FunT1(IntT1, FunT1(IntT1, SetT1(BoolT1)))
 
   test("""[{1, 2, 3} -> {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2), int(3))
-    val codomain = enumSet(bool(false), bool(true))
-    val fs = funSet(domain, codomain)
+    val domain = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+    val codomain = tla.enumSet(tla.bool(false), tla.bool(true))
+    val fs = tla.funSet(domain, codomain)
     val state = new SymbState(fs, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -37,9 +37,9 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   }
 
   test("""[{1, 2} -> Expand(SUBSET {FALSE, TRUE})]""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = expand(powSet(enumSet(bool(false), bool(true))))
-    val fs = funSet(domain, codomain)
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.expand(tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true))))
+    val fs = tla.funSet(domain, codomain)
 
     val state = new SymbState(fs, arena, Binding())
     val rewriter = create(rewriterType)
@@ -62,14 +62,14 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // the existential over a function set should work without expanding the powerset!
   test("""Skolem(\E f \in [{1, 2} -> SUBSET {FALSE, TRUE}]: g' <- f)""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = powSet(enumSet(bool(false), bool(true)))
-    val pred = assign(prime(name("g", i_to_B)), name("f", i_to_B))
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
+    val pred = tla.assign(tla.prime(tla.name("g", i_to_B)), tla.name("f", i_to_B))
 
     val existsForm =
-      exists(name("f", i_to_B), funSet(domain, codomain), pred)
+      tla.exists(tla.name("f", i_to_B), tla.funSet(domain, codomain), pred)
 
-    val skolemEx = skolem(existsForm)
+    val skolemEx = tla.skolem(existsForm)
 
     val state = new SymbState(skolemEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -82,14 +82,14 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // the existential over a function set should work correctly in presence of duplicates
   test("""Skolem(\E f \in [{1, 2 - 1, 2} -> SUBSET {FALSE, TRUE}]: g' <- f)""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), minus(int(2), int(1)), int(2))
-//    val domain = enumSet(int(1), int(1), int(2))
-    val codomain = powSet(enumSet(bool(false), bool(true)))
-    val pred = assign(prime(name("g", i_to_B)), name("f", i_to_B))
+    val domain = tla.enumSet(tla.int(1), tla.minus(tla.int(2), tla.int(1)), tla.int(2))
+//    val domain = tla.enumSet(tla.int(1), tla.int(1), tla.int(2))
+    val codomain = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
+    val pred = tla.assign(tla.prime(tla.name("g", i_to_B)), tla.name("f", i_to_B))
 
-    val existsForm = exists(name("f", i_to_B), funSet(domain, codomain), pred)
+    val existsForm = tla.exists(tla.name("f", i_to_B), tla.funSet(domain, codomain), pred)
 
-    val skolemEx = skolem(existsForm)
+    val skolemEx = tla.skolem(existsForm)
 
     val state = new SymbState(skolemEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -98,20 +98,20 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
     assert(CellTFrom(FunT1(IntT1, SetT1(BoolT1))) == gprime.cellType)
     solverContext.assertGroundExpr(nextState.ex)
     // it should be impossible to return two different values for 1
-    val app1 = app(gprime.toBuilder, minus(int(2), int(1)))
-    val app2 = app(gprime.toBuilder, minus(int(3), int(2)))
-    val app1eqApp2 = eql(app1, app2)
+    val app1 = tla.app(cellEx(gprime), tla.minus(tla.int(2), tla.int(1)))
+    val app2 = tla.app(cellEx(gprime), tla.minus(tla.int(3), tla.int(2)))
+    val app1eqApp2 = tla.eql(app1, app2)
     assertTlaExAndRestore(rewriter, nextState.setRex(app1eqApp2))
   }
 
   // the existential over a function set should work without expanding the powerset!
   test("""Skolem(\E f \in [{1, 2} -> SUBSET {FALSE}]: f[1] = {TRUE})""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = powSet(enumSet(bool(false)))
-    val pred = eql(app(name("f", i_to_B), int(1)), enumSet(bool(true)))
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.powSet(tla.enumSet(tla.bool(false)))
+    val pred = tla.eql(tla.app(tla.name("f", i_to_B), tla.int(1)), tla.enumSet(tla.bool(true)))
 
-    val existsForm = exists(name("f", i_to_B), funSet(domain, codomain), pred)
-    val skolemEx = skolem(existsForm)
+    val existsForm = tla.exists(tla.name("f", i_to_B), tla.funSet(domain, codomain), pred)
+    val skolemEx = tla.skolem(existsForm)
 
     val state = new SymbState(skolemEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -122,18 +122,18 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // An existential over a function set that returns a function set to a powerset. Does it blow up your mind? :-)
   test("""Skolem(\E f \in [{1, 2} -> [{3} -> SUBSET {FALSE, TRUE}]]: g' <- f)""") { rewriterType: SMTEncoding =>
-    val domain1 = enumSet(int(1), int(2))
-    val domain2 = enumSet(int(3))
-    val codomain2 = powSet(enumSet(bool(false), bool(true)))
-    val codomain1 = funSet(domain2, codomain2)
-    val funset = funSet(domain1, codomain1)
+    val domain1 = tla.enumSet(tla.int(1), tla.int(2))
+    val domain2 = tla.enumSet(tla.int(3))
+    val codomain2 = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
+    val codomain1 = tla.funSet(domain2, codomain2)
+    val funset = tla.funSet(domain1, codomain1)
 
-    val pred = assign(prime(name("g", i_to_i_to_B)), name("f", i_to_i_to_B))
+    val pred = tla.assign(tla.prime(tla.name("g", i_to_i_to_B)), tla.name("f", i_to_i_to_B))
 
     val existsForm =
-      exists(name("f", i_to_i_to_B), funset, pred)
+      tla.exists(tla.name("f", i_to_i_to_B), funset, pred)
 
-    val skolemEx = skolem(existsForm)
+    val skolemEx = tla.skolem(existsForm)
 
     val state = new SymbState(skolemEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -146,24 +146,24 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // this should be fixed by implementing #91
   test("""[x \in {1, 2} |-> {x = 1}] \in [{1, 2} -> SUBSET {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = powSet(enumSet(bool(false), bool(true)))
-    val funset = funSet(domain, codomain)
-    val fun = funDef(enumSet(eql(name("x", IntT1), int(1))), name("x", IntT1) -> domain)
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
+    val funset = tla.funSet(domain, codomain)
+    val fun = tla.funDef(tla.enumSet(tla.eql(tla.name("x", IntT1), tla.int(1))), tla.name("x", IntT1) -> domain)
 
-    val funInFunSet = in(fun, funset)
+    val funInFunSet = tla.in(fun, funset)
 
     val state = new SymbState(funInFunSet, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""[x \in {1, 2} |-> 3] \in [{1, 2} -> {3, 4}]""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = enumSet(int(3), int(4))
-    val funset = funSet(domain, codomain)
-    val fun = funDef(int(3), name("x", IntT1) -> domain)
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.enumSet(tla.int(3), tla.int(4))
+    val funset = tla.funSet(domain, codomain)
+    val fun = tla.funDef(tla.int(3), tla.name("x", IntT1) -> domain)
 
-    val funInFunSet = in(fun, funset)
+    val funInFunSet = tla.in(fun, funset)
 
     val state = new SymbState(funInFunSet, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
@@ -172,21 +172,21 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   // this should be redundant in the presence of #91
   test("""[x \in {0, 1, 2} \ {0} |-> 3] \in [{1, 2} -> {3, 4}]""") { rewriterType: SMTEncoding =>
     // although 0 is in the function domain at the arena level, it does not belong to the set difference
-    def setminus(set: BuilderT, intVal: BigInt): BuilderT = {
-      filter(name("t", IntT1), set, not(eql(name("t", IntT1), int(intVal))))
+    def setminus(set: TBuilderInstruction, intVal: BigInt): TBuilderInstruction = {
+      tla.filter(tla.name("t", IntT1), set, tla.not(tla.eql(tla.name("t", IntT1), tla.int(intVal))))
 
     }
 
-    val domain1 = setminus(enumSet(0.to(2).map(i => int(BigInt(i))): _*), 0)
-    val domain2 = enumSet(1.to(2).map(i => int(BigInt(i))): _*)
+    val domain1 = setminus(tla.enumSet(0.to(2).map(i => tla.int(BigInt(i))): _*), 0)
+    val domain2 = tla.enumSet(1.to(2).map(i => tla.int(BigInt(i))): _*)
 
-    val codomain = enumSet(int(3), int(4))
+    val codomain = tla.enumSet(tla.int(3), tla.int(4))
 
-    val funset = funSet(domain2, codomain)
+    val funset = tla.funSet(domain2, codomain)
 
-    val fun = funDef(int(3), name("x", IntT1) -> domain1)
+    val fun = tla.funDef(tla.int(3), tla.name("x", IntT1) -> domain1)
 
-    val funInFunSet = in(fun, funset)
+    val funInFunSet = tla.in(fun, funset)
 
     val state = new SymbState(funInFunSet, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
@@ -194,13 +194,13 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // this should be fixed by implementing #91
   test("""[x \in {1, 2} |-> {TRUE}] \in [{1, 2} -> SUBSET {FALSE}]""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = powSet(enumSet(bool(false)))
-    val funset = funSet(domain, codomain)
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.powSet(tla.enumSet(tla.bool(false)))
+    val funset = tla.funSet(domain, codomain)
 
-    val fun = funDef(enumSet(bool(true)), name("x", IntT1) -> domain)
+    val fun = tla.funDef(tla.enumSet(tla.bool(true)), tla.name("x", IntT1) -> domain)
 
-    val funInFunSet = in(fun, funset)
+    val funInFunSet = tla.in(fun, funset)
 
     val state = new SymbState(funInFunSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -211,13 +211,13 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // this should be fixed by implementing #91
   test("""[x \in {1, 2} |-> {TRUE}] \in [{1, 2} -> SUBSET {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
-    val domain = enumSet(int(1), int(2))
-    val codomain = powSet(enumSet(bool(false), bool(true)))
-    val funset = funSet(domain, codomain)
+    val domain = tla.enumSet(tla.int(1), tla.int(2))
+    val codomain = tla.powSet(tla.enumSet(tla.bool(false), tla.bool(true)))
+    val funset = tla.funSet(domain, codomain)
 
-    val fun = funDef(enumSet(bool(true)), name("x", IntT1) -> domain)
+    val fun = tla.funDef(tla.enumSet(tla.bool(true)), tla.name("x", IntT1) -> domain)
 
-    val funInFunSet = in(fun, funset)
+    val funInFunSet = tla.in(fun, funset)
 
     val state = new SymbState(funInFunSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -228,9 +228,9 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
 
   // bugfix 27/12/2017
   test("""SE-FUNSET1: [0..(5 - 1) -> {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
-    val domain = dotdot(int(0), minus(int(5), int(1)))
-    val codomain = enumSet(bool(false), bool(true))
-    val fs = funSet(domain, codomain)
+    val domain = tla.dotdot(tla.int(0), tla.minus(tla.int(5), tla.int(1)))
+    val codomain = tla.enumSet(tla.bool(false), tla.bool(true))
+    val fs = tla.funSet(domain, codomain)
 
     val state = new SymbState(fs, arena, Binding())
     val rewriter = create(rewriterType)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
@@ -1,45 +1,41 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.lir.TypedPredefs._
-import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, NameEx, SetT1}
+import at.forsyte.apalache.tla.lir.{IntT1, NameEx}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterInt extends RewriterBase {
-  private val Int = IntT1
-  private val Bool = BoolT1
-  private val IntSet = SetT1(IntT1)
-
   test("$C$_i: Int = $C$_j: Int") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
-    val eq1 = eql(leftCell.toNameEx.as(Int), rightCell.toNameEx.as(Int)).as(Bool)
+    val eq1 = tla.eql(cellEx(leftCell), cellEx(rightCell))
     val state = new SymbState(eq1, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case predEx @ NameEx(_) =>
         assert(solverContext.sat())
-        val eq2 = eql(leftCell.toNameEx.as(Int), int(22)).as(Bool)
+        val eq2 = tla.eql(cellEx(leftCell), tla.int(22))
         solverContext.assertGroundExpr(eq2)
         rewriter.push()
-        val eq3 = eql(rightCell.toNameEx.as(Int), int(22)).as(Bool)
+        val eq3 = tla.eql(cellEx(rightCell), tla.int(22))
         solverContext.assertGroundExpr(eq3)
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.pop()
-        val eq4 = eql(rightCell.toNameEx.as(Int), int((1981))).as(Bool)
+        val eq4 = tla.eql(cellEx(rightCell), tla.int(1981))
         solverContext.assertGroundExpr(eq4)
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(solverContext.sat())
         rewriter.pop()
         solverContext.assertGroundExpr(predEx)
@@ -52,30 +48,30 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("$Z$Int = $Z$j ~~> $B$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
-    val state = new SymbState(eql(leftInt.as(Int), rightInt.as(Int)).as(Bool), arena, Binding())
+    val rightInt = arena.topCell
+    val state = new SymbState(tla.eql(cellEx(leftInt), cellEx(rightInt)), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case predEx @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(22)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(22)))
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.pop()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int((1981))).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(1981)))
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(solverContext.sat())
         rewriter.pop()
         solverContext.assertGroundExpr(predEx)
@@ -91,23 +87,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(lt(leftCell.toNameEx.as(Int), rightCell.toNameEx.as(Int)).as(Bool), arena, Binding())
+      new SymbState(tla.lt(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(eql(leftCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(3)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -121,23 +117,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(le(leftCell.toNameEx.as(Int), rightCell.toNameEx.as(Int)).as(Bool), arena, Binding())
+      new SymbState(tla.le(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(eql(leftCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(3)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -151,23 +147,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(gt(leftCell.toNameEx.as(Int), rightCell.toNameEx.as(Int)).as(Bool), arena, Binding())
+      new SymbState(tla.gt(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(eql(leftCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(3)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
         assert(solverContext.sat())
 
       case _ =>
@@ -176,9 +172,9 @@ trait TestSymbStateRewriterInt extends RewriterBase {
   }
 
   test("(composite expressions): 1 + 5 > 6 - 3 ~~> $B$_k") { rewriterType: SMTEncoding =>
-    val left = plus(int(1), int(5)).typed(IntT1)
-    val right = minus(int(6), int(3)).typed(IntT1)
-    val state = new SymbState(gt(left, right).typed(BoolT1), arena, Binding())
+    val left = tla.plus(tla.int(1), tla.int(5))
+    val right = tla.minus(tla.int(6), tla.int(3))
+    val state = new SymbState(tla.gt(left, right), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
@@ -188,7 +184,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         solverContext.assertGroundExpr(cmpEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(cmpEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(cmpEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -202,23 +198,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(ge(leftCell.toNameEx.as(Int), rightCell.toNameEx.as(Int)).as(Bool), arena, Binding())
+      new SymbState(tla.ge(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(eql(leftCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(eql(rightCell.toNameEx.as(Int), int(3)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
         assert(solverContext.sat())
 
       case _ =>
@@ -228,31 +224,31 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("~($Z$Int = $Z$j) ~~> $B$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
+    val rightInt = arena.topCell
     val state =
-      new SymbState(not(eql(leftInt.as(Int), rightInt.as(Int)).as(Bool)).as(Bool), arena, Binding())
+      new SymbState(tla.not(tla.eql(cellEx(leftInt), cellEx(rightInt))), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case predEx @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(22)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(22)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(22)))
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.pop()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(1981)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(1981)))
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(!solverContext.sat())
         rewriter.pop()
         solverContext.assertGroundExpr(predEx)
@@ -265,25 +261,25 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("$Z$Int + $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
-    val expr = plus(leftInt.as(Int), rightInt.as(Int)).as(Int)
+    val rightInt = arena.topCell
+    val expr = tla.plus(cellEx(leftInt), cellEx(rightInt))
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(1981)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(1981)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(36)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(36)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(2017)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(2017)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(2016)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(2016)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -293,25 +289,25 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("$Z$Int - $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
-    val expr = minus(leftInt.as(Int), rightInt.as(Int)).as(Int)
+    val rightInt = arena.topCell
+    val expr = tla.minus(cellEx(leftInt), cellEx(rightInt))
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(2017)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(2017)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(36)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(36)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(1981)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(1981)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(1980)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(1980)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -321,21 +317,21 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("-$Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
-    val expr = uminus(leftInt.as(Int)).as(Int)
+    val leftInt = arena.topCell
+    val expr = tla.uminus(cellEx(leftInt))
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(2017)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(2017)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(-2017)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(-2017)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(2017)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(2017)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -345,25 +341,25 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("$Z$Int * $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
-    val expr = mult(leftInt.as(Int), rightInt.as(Int)).as(Int)
+    val rightInt = arena.topCell
+    val expr = tla.mult(cellEx(leftInt), cellEx(rightInt))
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(7)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(7)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(28)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(28)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(30)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(30)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -373,25 +369,25 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("$Z$Int / $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
-    val expr = div(leftInt.as(Int), rightInt.as(Int)).as(Int)
+    val rightInt = arena.topCell
+    val expr = tla.div(cellEx(leftInt), cellEx(rightInt))
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(30)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(30)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(4)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(7)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(7)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(8)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(8)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -401,25 +397,25 @@ trait TestSymbStateRewriterInt extends RewriterBase {
 
   test("$Z$Int % $Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
-    val leftInt = arena.topCell.toNameEx
+    val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
-    val rightInt = arena.topCell.toNameEx
-    val expr = mod(leftInt.as(Int), rightInt.as(Int)).as(Int)
+    val rightInt = arena.topCell
+    val expr = tla.mod(cellEx(leftInt), cellEx(rightInt))
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(eql(leftInt.as(Int), int(30)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(30)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(rightInt.as(Int), int(7)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(7)))
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(2)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(2)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(eql(result.as(Int), int(1)).as(Bool))
+        solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(1)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -428,9 +424,9 @@ trait TestSymbStateRewriterInt extends RewriterBase {
   }
 
   test("""2..5  = {2, 3, 4, 5}""") { rewriterType: SMTEncoding =>
-    val expected = enumSet(2.until(6).map(int): _*).typed(SetT1(IntT1))
-    val range = dotdot(int(2), int(5)).typed(SetT1(IntT1))
-    val eqExpected = eql(range, expected).typed(BoolT1)
+    val expected = tla.enumSet(2.until(6).map(i => tla.int(i)): _*)
+    val range = tla.dotdot(tla.int(2), tla.int(5))
+    val eqExpected = tla.eql(range, expected)
 
     val state = new SymbState(eqExpected, arena, Binding())
     val rewriter = create(rewriterType)
@@ -443,7 +439,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(predEx.as(Bool)).as(Bool))
+        solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -452,9 +448,9 @@ trait TestSymbStateRewriterInt extends RewriterBase {
   }
 
   test("""SE-INT-RNG: 2..(6 - 1)  = {2, 3, 4, 5}""") { rewriterType: SMTEncoding =>
-    val expected = enumSet(2.to(5).map(int): _*).typed(SetT1(IntT1))
-    val range = dotdot(int(2), minus(int(6), int(1)).as(Int)).as(IntSet)
-    val eqExpected = eql(range, expected).typed(BoolT1)
+    val expected = tla.enumSet(2.to(5).map(i => tla.int(i)): _*)
+    val range = tla.dotdot(tla.int(2), tla.minus(tla.int(6), tla.int(1)))
+    val eqExpected = tla.eql(range, expected)
 
     val state = new SymbState(eqExpected, arena, Binding())
     val rewriter = create(rewriterType)
@@ -467,7 +463,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
-        val notPred = not(predEx.as(Bool)).as(Bool)
+        val notPred = tla.not(tla.unchecked(predEx))
         solverContext.assertGroundExpr(notPred)
         assert(!solverContext.sat())
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -3,39 +3,40 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
 import at.forsyte.apalache.tla.bmcmt.smt.{PreproSolverContext, SolverConfig, Z3SolverContext}
-import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.pp.TlaInputError
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import at.forsyte.apalache.tla.types.parser.DefaultType1Parser
 
 trait TestSymbStateRewriterSet extends RewriterBase {
   private val parser = DefaultType1Parser
-  private val intT = parser("Int")
-  private val intSetT = parser("Set(Int)")
-  private val int2SetT = parser("Set(Set(Int))")
-  private val int3SetT = parser("Set(Set(Set(Int)))")
-  private val int4SetT = parser("Set(Set(Set(Set(Int))))")
-  private val int5SetT = parser("Set(Set(Set(Set(Set(Int)))))")
-  private val boolT = parser("Bool")
-  private val boolSetT = parser("Set(Bool)")
-  private val intToBoolT = parser("Int -> Bool")
-  private val intBoolT = parser("<<Int, Bool>>")
-  private val intBoolSetT = parser("Set(<<Int, Bool>>)")
+  private val intT: TlaType1 = IntT1
+  private val intSetT: TlaType1 = SetT1(IntT1)
+  private val int2SetT: TlaType1 = SetT1(intSetT)
+  private val int3SetT: TlaType1 = SetT1(int2SetT)
+  private val boolT: TlaType1 = BoolT1
+
+  private def intEnum(values: Int*): TBuilderInstruction = tla.enumSet(values.map(i => tla.int(i)): _*)
+  private def emptyIntSet: TBuilderInstruction = tla.emptySet(IntT1)
+  private def emptyInt2Set: TBuilderInstruction = tla.emptySet(intSetT)
+  private def emptyInt3Set: TBuilderInstruction = tla.emptySet(int2SetT)
+  private def emptyInt4Set: TBuilderInstruction = tla.emptySet(int3SetT)
+  private def unchecked(ex: TlaEx): TBuilderInstruction = tla.unchecked(ex)
 
   test("""{ x, y, z } ~~> c_set""") { rewriterType: SMTEncoding =>
-    val ex = enumSet(name("x").as(intT), name("y").as(boolT), name("z").as(boolT)).as(boolSetT)
+    val ex = tla.enumSet(tla.name("x", boolT), tla.name("y", boolT), tla.name("z", boolT))
     val binding = Binding("x" -> arena.cellFalse(), "y" -> arena.cellTrue(), "z" -> arena.cellFalse())
     val state = new SymbState(ex, arena, binding)
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case set @ NameEx(_) =>
-            val falseInSet = apalacheSelectInSet(arena.cellFalse().toNameEx.as(boolT), set.as(boolSetT)).as(boolT)
+            val falseInSet = tla.selectInSet(cellEx(arena.cellFalse()), unchecked(set))
             solverContext.assertGroundExpr(falseInSet)
             assert(solverContext.sat())
             val notTrueInSet =
-              not(apalacheSelectInSet(arena.cellTrue().toNameEx.as(boolT), set.as(boolSetT)).as(boolT)).as(boolT)
+              tla.not(tla.selectInSet(cellEx(arena.cellTrue()), unchecked(set)))
             solverContext.assertGroundExpr(notTrueInSet)
             assert(!solverContext.sat())
 
@@ -49,7 +50,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{1, 3, 5} ~~> c_set""") { rewriterType: SMTEncoding =>
-    val ex = enumSet(int(1), int(3), int(5)).as(intSetT)
+    val ex = tla.enumSet(tla.int(1), tla.int(3), tla.int(5))
     val state = new SymbState(ex, arena, Binding())
     create(rewriterType).rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
@@ -66,14 +67,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{} \in {}""") { rewriterType: SMTEncoding =>
-    val ex = in(enumSet().as(intSetT), enumSet().as(int2SetT)).as(boolT)
+    val ex = tla.in(emptyIntSet, emptyInt2Set)
     val state = new SymbState(ex, arena, Binding())
     val nextState = create(rewriterType).rewriteUntilDone(state)
     assert(nextState.arena.cellFalse().toNameEx == nextState.ex)
   }
 
   test("""3 \in {1, 3, 5}""") { rewriterType: SMTEncoding =>
-    val ex = in(int(3), enumSet(int(1), int(3), int(5)).as(intSetT)).as(boolT)
+    val ex = tla.in(tla.int(3), tla.enumSet(tla.int(1), tla.int(3), tla.int(5)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -83,7 +84,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -92,9 +93,8 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{3} \in {{1}, {3}, {5}}""") { rewriterType: SMTEncoding =>
-    val ex = in(enumSet(int(3)).as(intSetT),
-        enumSet(enumSet(int(1)).as(intSetT), enumSet(int(3)).as(intSetT), enumSet(int(5)).as(intSetT)).as(int2SetT)).as(
-        boolT)
+    val ex = tla.in(tla.enumSet(tla.int(3)),
+        tla.enumSet(tla.enumSet(tla.int(1)), tla.enumSet(tla.int(3)), tla.enumSet(tla.int(5))))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -105,7 +105,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -114,7 +114,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""2 \in {1, 3, 5}""") { rewriterType: SMTEncoding =>
-    val ex = in(int(2), enumSet(int(1), int(3), int(5)).as(intSetT)).as(boolT)
+    val ex = tla.in(tla.int(2), tla.enumSet(tla.int(1), tla.int(3), tla.int(5)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -124,7 +124,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(solverContext.sat())
 
       case _ =>
@@ -133,7 +133,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""2 \in Int""") { rewriterType: SMTEncoding =>
-    val ex = in(int(2), intSet().as(intSetT)).as(boolT)
+    val ex = tla.in(tla.int(2), tla.intSet())
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -142,7 +142,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""2 \in Nat""") { rewriterType: SMTEncoding =>
-    val ex = in(int(2), natSet().as(intSetT)).as(boolT)
+    val ex = tla.in(tla.int(2), tla.natSet())
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -151,16 +151,16 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""-1 \in Nat""") { rewriterType: SMTEncoding =>
-    val ex = in(int(-1), natSet().as(intSetT)).as(boolT)
+    val ex = tla.in(tla.int(-1), tla.natSet())
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
-    assertTlaExAndRestore(rewriter, nextState.setRex(not(nextState.ex.as(boolT)).as(boolT)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.not(unchecked(nextState.ex))))
   }
 
   test("""~({} \in {})""") { rewriterType: SMTEncoding =>
-    val ex = not(in(enumSet().as(intSetT), enumSet().as(int2SetT)).as(boolT)).as(boolT)
+    val ex = tla.not(tla.in(emptyIntSet, emptyInt2Set))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -169,14 +169,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     assert(solverContext.sat())
     solverContext.pop()
     solverContext.push()
-    solverContext.assertGroundExpr(not(nextState.ex.as(boolT)).as(boolT))
+    solverContext.assertGroundExpr(tla.not(unchecked(nextState.ex)))
     assert(!solverContext.sat())
     solverContext.pop()
   }
 
   test("""FALSE \in {FALSE, TRUE}""") { rewriterType: SMTEncoding =>
     val ex =
-      in(bool(false), enumSet(bool(false), bool(true)).as(boolSetT)).as(boolT)
+      tla.in(tla.bool(false), tla.enumSet(tla.bool(false), tla.bool(true)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
@@ -184,7 +184,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         nextState.ex match {
           case predEx @ NameEx(_) =>
             rewriter.push()
-            solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
             assert(!solverContext.sat())
             rewriter.pop()
             solverContext.assertGroundExpr(predEx)
@@ -201,13 +201,13 @@ trait TestSymbStateRewriterSet extends RewriterBase {
 
   test("""~(FALSE \in {FALSE, TRUE})""") { rewriterType: SMTEncoding =>
     val ex =
-      not(in(bool(false), enumSet(bool(false), bool(true)).as(boolSetT)).as(boolT)).as(boolT)
+      tla.not(tla.in(tla.bool(false), tla.enumSet(tla.bool(false), tla.bool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteUntilDone(state).ex match {
       case predEx @ NameEx(_) =>
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(solverContext.sat())
         rewriter.pop()
         solverContext.assertGroundExpr(predEx)
@@ -222,7 +222,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell
     val ex =
-      in(cell.toNameEx.as(boolT), enumSet(bool(true), bool(true)).as(boolSetT)).as(boolT)
+      tla.in(cellEx(cell), tla.enumSet(tla.bool(true), tla.bool(true)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
@@ -231,14 +231,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
           case predEx @ NameEx(_) =>
             rewriter.push()
             // cell = \TRUE
-            solverContext.assertGroundExpr(eql(arena.cellTrue().toNameEx.as(boolT), cell.toNameEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellTrue()), cellEx(cell)))
             // and membership holds true
             solverContext.assertGroundExpr(predEx)
             assert(solverContext.sat())
             rewriter.pop()
             // another query
             // cell = \FALSE
-            solverContext.assertGroundExpr(eql(arena.cellFalse().toNameEx.as(boolT), cell.toNameEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellFalse()), cellEx(cell)))
             // and membership holds true
             solverContext.assertGroundExpr(predEx)
             // contradiction
@@ -255,7 +255,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
 
   test("""1 \in {1}""") { rewriterType: SMTEncoding =>
     // regression: there is a special shortcut rule for singleton sets, which had a bug
-    val ex = in(int(1), enumSet(int(1)).as(intSetT)).as(boolT)
+    val ex = tla.in(tla.int(1), tla.enumSet(tla.int(1)))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
@@ -268,7 +268,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(!solverContext.sat())
         rewriter.pop()
 
@@ -281,21 +281,21 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell
     val ex =
-      not(in(cell.toNameEx.as(boolT), enumSet(bool(true), bool(true)).as(boolSetT)).as(boolT)).as(boolT)
+      tla.not(tla.in(cellEx(cell), tla.enumSet(tla.bool(true), tla.bool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteUntilDone(state).ex match {
       case predEx @ NameEx(_) =>
         rewriter.push()
         // cell = TRUE
-        solverContext.assertGroundExpr(eql(arena.cellTrue().toNameEx.as(boolT), cell.toNameEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellTrue()), cellEx(cell)))
         // and membership holds true
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
         rewriter.pop()
         // another query
         // cell = \FALSE
-        solverContext.assertGroundExpr(eql(arena.cellFalse().toNameEx.as(boolT), cell.toNameEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellFalse()), cellEx(cell)))
         // and membership holds true
         solverContext.assertGroundExpr(predEx)
         // no contradiction here
@@ -307,17 +307,16 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{{}, {{}, {}}} \in {{}, {{}, {{}, {}}}}""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    def int2Set() = enumSet().as(int2SetT)
+    def int2Set(): TBuilderInstruction = emptyInt2Set
 
-    def int3Set() = enumSet().as(int3SetT)
+    def int3Set(): TBuilderInstruction = emptyInt3Set
 
-    val left = enumSet(int2Set(), enumSet(intSet(), intSet()).as(int2SetT)).as(int3SetT)
+    val left = tla.enumSet(int2Set(), tla.enumSet(intSet(), intSet()))
     val right =
-      enumSet(int3Set(), enumSet(int2Set().as(int2SetT), enumSet(intSet(), intSet()).as(int2SetT)).as(int3SetT)).as(
-          int4SetT)
-    val ex = in(left, right).typed(BoolT1)
+      tla.enumSet(int3Set(), tla.enumSet(int2Set(), tla.enumSet(intSet(), intSet())))
+    val ex = tla.in(left, right)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -330,7 +329,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         rewriter.pop()
         // another query
         // and membership does not hold
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -339,17 +338,17 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{{}, {{{}}}} \in {{}, {{}, {{}}}""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    def int2Set() = enumSet().as(int2SetT)
+    def int2Set(): TBuilderInstruction = emptyInt2Set
 
-    def int3Set() = enumSet().as(int3SetT)
+    def int3Set(): TBuilderInstruction = emptyInt3Set
 
-    def int4Set() = enumSet().as(int4SetT)
+    def int4Set(): TBuilderInstruction = emptyInt4Set
 
-    val left = enumSet(int3Set(), enumSet(enumSet(intSet()).as(int2SetT)).as(int3SetT)).as(int4SetT)
-    val right = enumSet(int4Set(), enumSet(int3Set(), enumSet(int2Set()).as(int3SetT)).as(int4SetT)).as(int5SetT)
-    val ex = in(left, right).typed(BoolT1)
+    val left = tla.enumSet(int3Set(), tla.enumSet(tla.enumSet(intSet())))
+    val right = tla.enumSet(int4Set(), tla.enumSet(int3Set(), tla.enumSet(int2Set())))
+    val ex = tla.in(left, right)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -361,7 +360,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         assert(!solverContext.sat())
         rewriter.pop()
         // its negation holds true
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(solverContext.sat())
 
       case _ =>
@@ -370,11 +369,11 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{{}} = {} ~~> (false)""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    def int2Set() = enumSet().as(int2SetT)
+    def int2Set(): TBuilderInstruction = emptyInt2Set
 
-    val ex = eql(enumSet(intSet()).as(int2SetT), int2Set()).as(boolT)
+    val ex = tla.eql(tla.enumSet(intSet()), int2Set())
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -391,15 +390,15 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{{}, {{}}} = {{}, {{{}}} ~~> (false)""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    def int2Set() = enumSet().as(int2SetT)
+    def int2Set(): TBuilderInstruction = emptyInt2Set
 
-    def int3Set() = enumSet().as(int3SetT)
+    def int3Set(): TBuilderInstruction = emptyInt3Set
 
-    val left = enumSet(int3Set(), enumSet(int2Set()).as(int3SetT)).as(int4SetT)
-    val right = enumSet(int3Set(), enumSet(enumSet(intSet()).as(int2SetT)).as(int3SetT)).as(int4SetT)
-    val ex = eql(left, right).typed(BoolT1)
+    val left = tla.enumSet(int3Set(), tla.enumSet(int2Set()))
+    val right = tla.enumSet(int3Set(), tla.enumSet(tla.enumSet(intSet())))
+    val ex = tla.eql(left, right)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -416,14 +415,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{{}, {{}}} = {{}, {{}} ~~> (true)""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    def int2Set() = enumSet().as(int2SetT)
+    def int2Set(): TBuilderInstruction = emptyInt2Set
 
-    val left = enumSet(int2Set(), enumSet(intSet()).as(int2SetT)).as(int3SetT)
-    val right = enumSet(int2Set().as(int2SetT), enumSet(intSet()).as(int2SetT)).as(int3SetT)
-    val ex = eql(left, right)
-      .typed(BoolT1)
+    val left = tla.enumSet(int2Set(), tla.enumSet(intSet()))
+    val right = tla.enumSet(int2Set(), tla.enumSet(intSet()))
+    val ex = tla.eql(left, right)
+
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -440,14 +439,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{} = {1} \ {1} ~~> (true)""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    val setOf1 = enumSet(int(1)).as(intSetT)
+    val setOf1 = tla.enumSet(tla.int(1))
 
     val dynEmpty =
-      filter(name("t").as(intT), setOf1, bool(false)).as(intSetT)
+      tla.filter(tla.name("t", intT), setOf1, tla.bool(false))
 
-    val ex = eql(intSet(), dynEmpty).typed(BoolT1)
+    val ex = tla.eql(intSet(), dynEmpty)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -458,7 +457,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -467,13 +466,13 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""~({{}, {{}}} = {{}, {{}}})""") { rewriterType: SMTEncoding =>
-    def intSet() = enumSet().as(intSetT)
+    def intSet(): TBuilderInstruction = emptyIntSet
 
-    def int2Set() = enumSet().as(int2SetT)
+    def int2Set(): TBuilderInstruction = emptyInt2Set
 
-    val left = enumSet(int2Set(), enumSet(intSet()).as(int2SetT)).as(int3SetT)
-    val right = enumSet(int2Set(), enumSet(intSet()).as(int2SetT)).as(int3SetT)
-    val ex = not(eql(left, right).as(boolT)).as(boolT)
+    val left = tla.enumSet(int2Set(), tla.enumSet(intSet()))
+    val right = tla.enumSet(int2Set(), tla.enumSet(intSet()))
+    val ex = tla.not(tla.eql(left, right))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -489,10 +488,10 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
   test("""{x \in {1,2,3,4} : x % 2 = 0} ~~> {2, 4}""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2), int(3), int(4)).as(intSetT)
-    val xMod2 = mod(name("x").as(intT), int(2)).as(intT)
-    val pred = eql(xMod2, int(0)).as(intT)
-    val ex = filter(name("x").as(intT), set, pred).as(intSetT)
+    val set = tla.enumSet(tla.int(1), tla.int(2), tla.int(3), tla.int(4))
+    val xMod2 = tla.mod(tla.name("x", intT), tla.int(2))
+    val pred = tla.eql(xMod2, tla.int(0))
+    val ex = tla.filter(tla.name("x", intT), set, pred)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -508,10 +507,10 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""2 \in {x \in {1,2,3,4} : x < 3}""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2), int(3), int(4)).as(intSetT)
-    val pred = lt(name("x").as(intT), int(3)).as(boolT)
-    val filteredSet = filter(name("x").as(intT), set, pred).as(intSetT)
-    val inFilteredSet = in(int(2), filteredSet).as(boolT)
+    val set = tla.enumSet(tla.int(1), tla.int(2), tla.int(3), tla.int(4))
+    val pred = tla.lt(tla.name("x", intT), tla.int(3))
+    val filteredSet = tla.filter(tla.name("x", intT), set, pred)
+    val inFilteredSet = tla.in(tla.int(2), filteredSet)
 
     val state = new SymbState(inFilteredSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -522,7 +521,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(membershipEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(membershipEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -531,30 +530,29 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{Q \in Expand(SUBSET {1,2,3}) : ~(2 \in Q)}""") { rewriterType: SMTEncoding =>
-    val set = enumSet(1.to(3).map(int): _*).as(intSetT)
+    val set = intEnum(1, 2, 3)
 
-    val predEx = not(in(int(2), name("Q").as(intSetT)).as(boolT)).as(boolT)
-    val expandedPowSet = apalacheExpand(powSet(set).as(int2SetT))
-    val ex = filter(name("Q").as(intSetT), expandedPowSet.as(int2SetT), predEx.as(boolT)).as(int2SetT)
+    val predEx = tla.not(tla.in(tla.int(2), tla.name("Q", intSetT)))
+    val expandedPowSet = tla.expand(tla.powSet(set))
+    val ex = tla.filter(tla.name("Q", intSetT), expandedPowSet, unchecked(predEx))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
-    val inPred = in(enumSet(int(1), int(3)).as(intSetT), nextState.ex).as(boolT)
+    val inPred = tla.in(tla.enumSet(tla.int(1), tla.int(3)), unchecked(nextState.ex))
     assertTlaExAndRestore(rewriter, nextState.setRex(inPred))
-    val notInPred = not(in(enumSet(int(1), int(2)).as(intSetT), nextState.ex).as(boolT)).as(boolT)
+    val notInPred = tla.not(tla.in(tla.enumSet(tla.int(1), tla.int(2)), unchecked(nextState.ex)))
     assertTlaExAndRestore(rewriter, nextState.setRex(notInPred))
   }
 
   test("""\E X \in SUBSET {1} IN {} = {x \in X : [y \in X |-> TRUE][x]}""") { rewriterType: SMTEncoding =>
     // regression
-    val baseSet = enumSet(int(1)).as(intSetT)
+    val baseSet = tla.enumSet(tla.int(1))
     val pred =
-      appFun(funDef(bool(true), name("y").as(intT), name("X").as(intSetT)).as(intToBoolT), name("x").as(intT)).as(boolT)
-    val filteredSet = filter(name("x").as(intT), name("X").as(int2SetT), pred.as(boolT)).as(intSetT)
+      tla.app(tla.funDef(tla.bool(true), tla.name("y", intT) -> tla.name("X", intSetT)), tla.name("x", intT))
+    val filteredSet = tla.filter(tla.name("x", intT), tla.name("X", intSetT), pred)
     val ex =
-      apalacheSkolem(exists(name("X").as(intSetT), powSet(baseSet).as(int2SetT),
-              eql(enumSet().as(intSetT), filteredSet).as(boolT)).as(boolT)).as(boolT)
+      tla.skolem(tla.exists(tla.name("X", intSetT), tla.powSet(baseSet), tla.eql(emptyIntSet, filteredSet)))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = createWithoutCache(rewriterType)
@@ -571,13 +569,12 @@ trait TestSymbStateRewriterSet extends RewriterBase {
 
   test("""\E X \in SUBSET {1, 2}: {} = {x \in X : [y \in {1} |-> TRUE][x]}""") { rewriterType: SMTEncoding =>
     // regression
-    val set1 = enumSet(int(1)).as(intSetT)
-    val pred = appFun(funDef(bool(true), name("y").as(intT), set1).as(intToBoolT), name("x").as(intT)).as(boolT)
-    val filteredSet = filter(name("x").as(intT), name("X").as(intSetT), pred).as(intSetT)
-    val set12 = enumSet(int(1), int(2)).as(intSetT)
+    val set1 = tla.enumSet(tla.int(1))
+    val pred = tla.app(tla.funDef(tla.bool(true), tla.name("y", intT) -> set1), tla.name("x", intT))
+    val filteredSet = tla.filter(tla.name("x", intT), tla.name("X", intSetT), pred)
+    val set12 = tla.enumSet(tla.int(1), tla.int(2))
     val ex =
-      apalacheSkolem(exists(name("X").as(intSetT), powSet(set12).as(int2SetT),
-              eql(enumSet().as(intSetT), filteredSet).as(boolT)).as(boolT)).as(boolT)
+      tla.skolem(tla.exists(tla.name("X", intSetT), tla.powSet(set12), tla.eql(emptyIntSet, filteredSet)))
 
     val state = new SymbState(ex, arena, Binding())
     val rewriter = createWithoutCache(rewriterType)
@@ -596,11 +593,11 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""3 \in {x \in {2, 3} : x % 2 = 0}""") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(2), int(3)).as(intSetT)
-    val xMod2 = mod(name("x").as(intT), int(2)).as(intT)
-    val pred = eql(xMod2, int(0)).as(boolT)
-    val filteredSet = filter(name("x").as(intT), set, pred).as(intSetT)
-    val inFilteredSet = in(int(3), filteredSet).as(boolT)
+    val set = tla.enumSet(tla.int(2), tla.int(3))
+    val xMod2 = tla.mod(tla.name("x", intT), tla.int(2))
+    val pred = tla.eql(xMod2, tla.int(0))
+    val filteredSet = tla.filter(tla.name("x", intT), set, pred)
+    val inFilteredSet = tla.in(tla.int(3), filteredSet)
 
     val state = new SymbState(inFilteredSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -611,7 +608,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(membershipEx)
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(membershipEx).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(membershipEx)))
         assert(solverContext.sat())
 
       case _ =>
@@ -620,9 +617,9 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{ x / 3: x \in {1,2,3,4} }""") { rewriterType: SMTEncoding =>
-    val set = enumSet((1 to 4).map(int): _*).as(intSetT)
-    val mapping = div(name("x").as(intT), int(3)).as(intT)
-    val mappedSet = map(mapping, name("x").as(intT), set).as(intSetT)
+    val set = intEnum(1, 2, 3, 4)
+    val mapping = tla.div(tla.name("x", intT), tla.int(3))
+    val mappedSet = tla.map(mapping, tla.name("x", intT) -> set)
 
     val state = new SymbState(mappedSet, arena, Binding())
     val nextState = create(rewriterType).rewriteUntilDone(state)
@@ -637,10 +634,10 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""0 \in {x / 3: x \in {1,2,3,4}}""") { rewriterType: SMTEncoding =>
-    val set = enumSet((1 to 4).map(int): _*).as(intSetT)
-    val mapping = div(name("x").as(intT), int(3)).as(intT)
-    val mappedSet = map(mapping, name("x").as(intT), set).as(intSetT)
-    val inMappedSet = in(int(0), mappedSet).as(boolT)
+    val set = intEnum(1, 2, 3, 4)
+    val mapping = tla.div(tla.name("x", intT), tla.int(3))
+    val mappedSet = tla.map(mapping, tla.name("x", intT) -> set)
+    val inMappedSet = tla.in(tla.int(0), mappedSet)
 
     val state = new SymbState(inMappedSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -651,7 +648,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(membershipEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(membershipEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -660,10 +657,10 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""2 \in {x / 3: x \in {1,2,3,4}}""") { rewriterType: SMTEncoding =>
-    val set = enumSet((1 to 4).map(int): _*).as(intSetT)
-    val mapping = div(name("x").as(intT), int(3)).as(intT)
-    val mappedSet = map(mapping, name("x").as(intT), set).as(intSetT)
-    val inMappedSet = in(int(2), mappedSet).as(boolT)
+    val set = intEnum(1, 2, 3, 4)
+    val mapping = tla.div(tla.name("x", intT), tla.int(3))
+    val mappedSet = tla.map(mapping, tla.name("x", intT) -> set)
+    val inMappedSet = tla.in(tla.int(2), mappedSet)
 
     val state = new SymbState(inMappedSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -674,7 +671,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(membershipEx)
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(membershipEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(membershipEx)))
         assert(solverContext.sat())
 
       case _ =>
@@ -684,8 +681,8 @@ trait TestSymbStateRewriterSet extends RewriterBase {
 
   // type inference would reject this
   test("""error: {x: x \in Int}""") { rewriterType: SMTEncoding =>
-    val set = intSet().as(intSetT)
-    val mapSet = map(name("x").as(intT), name("x").as(intT), set).as(intSetT)
+    val set = tla.intSet()
+    val mapSet = tla.map(tla.name("x", intT), tla.name("x", intT) -> set)
 
     val state = new SymbState(mapSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -693,11 +690,11 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""<<2, true>> \in {<<x, y>>: x \in {1,2,3}, y \in {FALSE, TRUE}}""") { rewriterType: SMTEncoding =>
-    val set123 = enumSet((1 to 3).map(int): _*).as(intSetT)
-    val setBool = enumSet(bool(false), bool(true)).as(boolSetT)
-    val mapping = tuple(name("x").as(intT), name("y").as(boolT)).as(intBoolT)
-    val mappedSet = map(mapping, name("x").as(intT), set123, name("y").as(boolT), setBool).as(intBoolSetT)
-    val inMappedSet = in(tuple(int(2), bool(true)).as(intBoolT), mappedSet).as(boolT)
+    val set123 = intEnum(1, 2, 3)
+    val setBool = tla.enumSet(tla.bool(false), tla.bool(true))
+    val mapping = tla.tuple(tla.name("x", intT), tla.name("y", boolT))
+    val mappedSet = tla.map(mapping, tla.name("x", intT) -> set123, tla.name("y", boolT) -> setBool)
+    val inMappedSet = tla.in(tla.tuple(tla.int(2), tla.bool(true)), mappedSet)
 
     val state = new SymbState(inMappedSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -708,7 +705,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(membershipEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(membershipEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -720,20 +717,16 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     // this expression tests regressions in cached expressions
     // we express {1, 2} \ {2} as a filter, as set difference is not in KerA+
     val set12minus2 =
-      filter(name("z").as(intT), enumSet(int(1), int(2)).as(intSetT), eql(name("z").as(intT), int(1)).as(boolT)).as(
-          intSetT)
-    val setBool = enumSet(bool(false), bool(true)).as(boolSetT)
-    val mapping = tuple(name("y").as(boolT)).as(parser("<<Bool>>"))
+      tla.filter(tla.name("z", intT), tla.enumSet(tla.int(1), tla.int(2)), tla.eql(tla.name("z", intT), tla.int(1)))
+    val setBool = tla.enumSet(tla.bool(false), tla.bool(true))
+    val mapping = tla.tuple(tla.name("y", boolT))
     val mappedSet =
-      map(
+      tla.map(
           mapping,
-          name("x").as(intT),
-          set12minus2.as(intSetT),
-          name("y").as(boolT),
-          setBool,
-      ).as(parser("Set(<<Bool>>)"))
-    val inMappedSet = in(tuple(bool(true)).typed(TupT1(BoolT1)), mappedSet)
-      .typed(BoolT1)
+          tla.name("x", intT) -> set12minus2,
+          tla.name("y", boolT) -> setBool,
+      )
+    val inMappedSet = tla.in(tla.tuple(tla.bool(true)), mappedSet)
 
     val state = new SymbState(inMappedSet, arena, Binding())
     val rewriter = create(rewriterType)
@@ -744,7 +737,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(membershipEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(membershipEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(membershipEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -762,17 +755,14 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       // for the element "a": it must be in the resulting set, and at the same time it must not be in the resulting set.
       val recT = parser("[a: Str, b: Int]")
       val recSetT = parser("Set([a: Str, b: Int])")
-      val rec2SetT = parser("Set(Set([a: Str, b: Int]))")
-      val strT = parser("Str")
-      val strSetT = parser("Set(Str)")
-      val rec1 = enumFun(str("a"), str("a"), str("b"), int(1)).as(recT)
-      val rec2 = enumFun(str("a"), str("a"), str("b"), int(2)).as(recT)
-      val base = enumSet(rec1, rec2).as(recSetT)
-      val powerset = powSet(base).as(rec2SetT)
+      val rec1 = tla.rec("a" -> tla.str("a"), "b" -> tla.int(1))
+      val rec2 = tla.rec("a" -> tla.str("a"), "b" -> tla.int(2))
+      val base = tla.enumSet(rec1, rec2)
+      val powerset = tla.powSet(base)
       val mapped =
-        map(appFun(name("r").as(recT), str("a")).as(strT), name("r").as(recT), name("S").as(recSetT)).as(strSetT)
-      val mem = in(str("a"), mapped).as(boolT)
-      val existsForm = apalacheSkolem(exists(name("S").as(recSetT), powerset.as(rec2SetT), mem).as(boolT)).as(boolT)
+        tla.map(tla.app(tla.name("r", recT), tla.str("a")), tla.name("r", recT) -> tla.name("S", recSetT))
+      val mem = tla.in(tla.str("a"), mapped)
+      val existsForm = tla.skolem(tla.exists(tla.name("S", recSetT), powerset, mem))
 
       // the following test goes through without a need for a fix
       val rewriter = create(rewriterType)
@@ -783,10 +773,10 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       // which needed a fix
       // \E S \in SUBSET { [a: "a", b: 1], [a: "a", b: 2] }:  "a" \in { r.a: r \in S } /\ \A x \in S: x.b = 2
       val forallForm =
-        forall(name("x").as(recT), name("S").as(recSetT),
-            eql(appFun(name("x").as(recT), str("b")).as(boolT), int(2)).as(boolT)).as(boolT)
+        tla.forall(tla.name("x", recT), tla.name("S", recSetT),
+            tla.eql(tla.app(tla.name("x", recT), tla.str("b")), tla.int(2)))
       val existsForm2 =
-        apalacheSkolem(exists(name("S").as(recSetT), powerset, and(mem, forallForm).as(boolT)).as(boolT)).as(boolT)
+        tla.skolem(tla.exists(tla.name("S", recSetT), powerset, tla.and(mem, forallForm)))
 
       // reset the solver and arena
       solverContext = new PreproSolverContext(new Z3SolverContext(SolverConfig.default.copy(debug = true,
@@ -798,11 +788,11 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""{1, 3} \cup {3, 4} = {1, 3, 4}""") { rewriterType: SMTEncoding =>
-    val left = enumSet(int(1), int(3)).as(intSetT)
-    val right = enumSet(int(3), int(4)).as(intSetT)
-    val expected = enumSet(int(1), int(3), int(4)).as(intSetT)
-    val cupSet = cup(left, right).as(intSetT)
-    val eqExpected = eql(cupSet, expected).as(boolT)
+    val left = tla.enumSet(tla.int(1), tla.int(3))
+    val right = tla.enumSet(tla.int(3), tla.int(4))
+    val expected = tla.enumSet(tla.int(1), tla.int(3), tla.int(4))
+    val cupSet = tla.cup(left, right)
+    val eqExpected = tla.eql(cupSet, expected)
 
     val state = new SymbState(eqExpected, arena, Binding())
     val rewriter = create(rewriterType)
@@ -815,7 +805,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+        solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -828,9 +818,9 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SMTEncoding.OOPSLA19 | SMTEncoding.FunArrays =>
         () // \subseteq is rewritten in Keramelizer, and SetInclusionRule was removed
       case SMTEncoding.Arrays =>
-        val left = enumSet(int(1), int(2)).as(intSetT)
-        val right = enumSet(int(1), int(2), int(3)).as(intSetT)
-        val ex = subseteq(left, right).as(boolT)
+        val left = tla.enumSet(tla.int(1), tla.int(2))
+        val right = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+        val ex = tla.subseteq(left, right)
         val state = new SymbState(ex, arena, Binding())
         val rewriter = create(rewriterType)
         val nextState = rewriter.rewriteUntilDone(state)
@@ -841,7 +831,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
             assert(solverContext.sat())
             rewriter.pop()
             rewriter.push()
-            solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
             assertUnsatOrExplain()
 
           case _ =>
@@ -855,8 +845,8 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SMTEncoding.OOPSLA19 | SMTEncoding.FunArrays =>
         () // \subseteq is rewritten in Keramelizer, and SetInclusionRule was removed
       case SMTEncoding.Arrays =>
-        val right = enumSet(int(1), int(2), int(3)).as(intSetT)
-        val ex = subseteq(right, right).as(boolT)
+        val right = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+        val ex = tla.subseteq(right, right)
         val state = new SymbState(ex, arena, Binding())
         val rewriter = create(rewriterType)
         val nextState = rewriter.rewriteUntilDone(state)
@@ -867,7 +857,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
             assert(solverContext.sat())
             rewriter.pop()
             rewriter.push()
-            solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
             assertUnsatOrExplain()
 
           case _ =>
@@ -881,9 +871,9 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SMTEncoding.OOPSLA19 | SMTEncoding.FunArrays =>
         () // \subseteq is rewritten in Keramelizer, and SetInclusionRule was removed
       case SMTEncoding.Arrays =>
-        val right = enumSet(int(1), int(2), int(3)).as(intSetT)
+        val right = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
         // an empty set requires a type annotation
-        val ex = subseteq(enumSet().as(intSetT), right).as(boolT)
+        val ex = tla.subseteq(emptyIntSet, right)
         val state = new SymbState(ex, arena, Binding())
         val rewriter = create(rewriterType)
         val nextState = rewriter.rewriteUntilDone(state)
@@ -894,7 +884,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
             assert(solverContext.sat())
             rewriter.pop()
             rewriter.push()
-            solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
             assertUnsatOrExplain()
 
           case _ =>
@@ -908,9 +898,9 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SMTEncoding.OOPSLA19 | SMTEncoding.FunArrays =>
         () // \subseteq is rewritten in Keramelizer, and SetInclusionRule was removed
       case SMTEncoding.Arrays =>
-        val left = enumSet(int(1), int(4)).as(intSetT)
-        val right = enumSet(int(1), int(2), int(3)).as(intSetT)
-        val ex = subseteq(left, right).as(boolT)
+        val left = tla.enumSet(tla.int(1), tla.int(4))
+        val right = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
+        val ex = tla.subseteq(left, right)
         val state = new SymbState(ex, arena, Binding())
         val rewriter = create(rewriterType)
         val nextState = rewriter.rewriteUntilDone(state)
@@ -921,7 +911,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
             assertUnsatOrExplain()
             rewriter.pop()
             rewriter.push()
-            solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
             assert(solverContext.sat())
 
           case _ =>
@@ -935,12 +925,12 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SMTEncoding.OOPSLA19 | SMTEncoding.FunArrays =>
         () // \subseteq is rewritten in Keramelizer, and SetInclusionRule was removed
       case SMTEncoding.Arrays =>
-        val dom = enumSet(int(1), int(2)).as(intSetT)
-        val mapping = bool(true).as(boolT)
-        val fun = funDef(mapping, name("x").as(IntT1), dom).as(FunT1(IntT1, BoolT1))
-        val set = enumSet(fun).as(SetT1(FunT1(IntT1, BoolT1)))
+        val dom = tla.enumSet(tla.int(1), tla.int(2))
+        val mapping = tla.bool(true)
+        val fun = tla.funDef(mapping, tla.name("x", IntT1) -> dom)
+        val set = tla.enumSet(fun)
 
-        val ex = subseteq(set, set).as(boolT)
+        val ex = tla.subseteq(set, set)
         val state = new SymbState(ex, arena, Binding())
         val rewriter = create(rewriterType)
         val nextState = rewriter.rewriteUntilDone(state)
@@ -951,7 +941,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
             assert(solverContext.sat())
             rewriter.pop()
             rewriter.push()
-            solverContext.assertGroundExpr(not(predEx.as(boolT)).as(boolT))
+            solverContext.assertGroundExpr(tla.not(unchecked(predEx)))
             assertUnsatOrExplain()
 
           case _ =>
@@ -961,12 +951,12 @@ trait TestSymbStateRewriterSet extends RewriterBase {
   }
 
   test("""UNION {{1, 2}, {2,3}} = {1, 2, 3}""") { rewriterType: SMTEncoding =>
-    val setOf12 = enumSet(int(1), int(2)).as(intSetT)
-    val setOf23 = enumSet(int(3), int(2)).as(intSetT)
-    val setOf123 = enumSet(int(1), int(2), int(3)).as(intSetT)
+    val setOf12 = tla.enumSet(tla.int(1), tla.int(2))
+    val setOf23 = tla.enumSet(tla.int(3), tla.int(2))
+    val setOf123 = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
     // This may seem weird, but since we don't know the type of {},
     // it should be equal to the empty set of ints.
-    val eq = eql(union(enumSet(setOf12, setOf23).as(int2SetT)).as(intSetT), setOf123).as(boolT)
+    val eq = tla.eql(tla.union(tla.enumSet(setOf12, setOf23)), setOf123)
     val rewriter = create(rewriterType)
     val state = new SymbState(eq, arena, Binding())
     assertTlaExAndRestore(rewriter, state)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -534,7 +534,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
 
     val predEx = tla.not(tla.in(tla.int(2), tla.name("Q", intSetT)))
     val expandedPowSet = tla.expand(tla.powSet(set))
-    val ex = tla.filter(tla.name("Q", intSetT), expandedPowSet, unchecked(predEx))
+    val ex = tla.filter(tla.name("Q", intSetT), expandedPowSet, predEx)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterStr.scala
@@ -1,14 +1,11 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.lir.TypedPredefs._
-import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.BoolT1
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterStr extends RewriterBase {
   test(""" rewrite "red" """) { rewriterType: SMTEncoding =>
-    val neq = not(eql(str("red"), str("blue")).typed(BoolT1))
-      .typed(BoolT1)
+    val neq = tla.not(tla.eql(tla.str("red"), tla.str("blue")))
 
     val state = new SymbState(neq, arena, Binding())
     val rewriter = create(rewriterType)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterTuple.scala
@@ -1,25 +1,11 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, SetT1, StrT1, TupT1}
-import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.TypedPredefs._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterTuple extends RewriterBase {
-  private val types = Map(
-      "b" -> BoolT1,
-      "i" -> IntT1,
-      "(i)" -> TupT1(IntT1),
-      "I" -> SetT1(IntT1),
-      "ib" -> TupT1(IntT1, BoolT1),
-      "ibs" -> TupT1(IntT1, BoolT1, StrT1),
-      "IB" -> SetT1(TupT1(IntT1, BoolT1)),
-      "ibI" -> TupT1(IntT1, BoolT1, SetT1(IntT1)),
-  )
-
   test("""<<1, FALSE, {2}>>""") { rewriterType: SMTEncoding =>
-    val tup = tuple(int(1), bool(false), enumSet(int(2)) ? "I")
-      .typed(types, "ibI")
+    val tup = tla.tuple(tla.int(1), tla.bool(false), tla.enumSet(tla.int(2)))
 
     val state = new SymbState(tup, arena, Binding())
     val _ = create(rewriterType).rewriteUntilDone(state)
@@ -27,21 +13,18 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
   }
 
   test(""" <<1, FALSE, {2}>>[2] returns FALSE""") { rewriterType: SMTEncoding =>
-    val tup = tuple(int(1), bool(false), enumSet(int(2)) ? "I")
-    val tupleAcc = appFun(tup ? "ibI", int(2))
-      .typed(types, "b")
-    val resEqFalse = eql(tupleAcc, bool(false))
-      .typed(BoolT1)
+    val tup = tla.tuple(tla.int(1), tla.bool(false), tla.enumSet(tla.int(2)))
+    val tupleAcc = tla.app(tup, tla.int(2))
+    val resEqFalse = tla.eql(tupleAcc, tla.bool(false))
 
     val state = new SymbState(resEqFalse, arena, Binding())
     assertTlaExAndRestore(create(rewriterType), state)
   }
 
   test("""{<<1, FALSE>>, <<2, TRUE>>} works""") { rewriterType: SMTEncoding =>
-    val tuple1 = tuple(int(1), bool(false))
-    val tuple2 = tuple(int(2), bool(true))
-    val tupleSet = enumSet(tuple1 ? "ib", tuple2 ? "ib")
-      .typed(types, "IB")
+    val tuple1 = tla.tuple(tla.int(1), tla.bool(false))
+    val tuple2 = tla.tuple(tla.int(2), tla.bool(true))
+    val tupleSet = tla.enumSet(tuple1, tuple2)
 
     val state = new SymbState(tupleSet, arena, Binding())
     create(rewriterType).rewriteUntilDone(state)
@@ -49,10 +32,9 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
   }
 
   test("""~(<<2, FALSE>> = <<2, TRUE>>)""") { rewriterType: SMTEncoding =>
-    val tuple1 = tuple(int(2), bool(false))
-    val tuple2 = tuple(int(2), bool(true))
-    val eq = not(eql(tuple1 ? "ib", tuple2 ? "ib") ? "b")
-      .typed(types, "b")
+    val tuple1 = tla.tuple(tla.int(2), tla.bool(false))
+    val tuple2 = tla.tuple(tla.int(2), tla.bool(true))
+    val eq = tla.not(tla.eql(tuple1, tuple2))
 
     val rewriter = create(rewriterType)
     val state = new SymbState(eq, arena, Binding())
@@ -60,10 +42,9 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
   }
 
   test("""<<2, FALSE>> = <<2, FALSE>>""") { rewriterType: SMTEncoding =>
-    val tuple1 = tuple(int(2), bool(false))
-    val tuple2 = tuple(int(2), bool(false))
-    val eq = eql(tuple1 ? "ib", tuple2 ? "ib")
-      .typed(types, "b")
+    val tuple1 = tla.tuple(tla.int(2), tla.bool(false))
+    val tuple2 = tla.tuple(tla.int(2), tla.bool(false))
+    val eq = tla.eql(tuple1, tuple2)
 
     val rewriter = create(rewriterType)
     val state = new SymbState(eq, arena, Binding())
@@ -71,21 +52,18 @@ trait TestSymbStateRewriterTuple extends RewriterBase {
   }
 
   test("""DOMAIN <<2, FALSE, "c">> = {1, 2, 3}""") { rewriterType: SMTEncoding =>
-    val tup = tuple(int(2), bool(false), str("c"))
-    val set123 = enumSet(1.to(3).map(int): _*)
-    val eq = eql(dom(tup ? "ibs") ? "I", set123 ? "I")
-      .typed(types, "b")
+    val tup = tla.tuple(tla.int(2), tla.bool(false), tla.str("c"))
+    val set123 = tla.enumSet(1.to(3).map(i => tla.int(i)): _*)
+    val eq = tla.eql(tla.dom(tup), set123)
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
     assertTlaExAndRestore(rewriter, state)
   }
 
   test("""[ <<1, FALSE>> EXCEPT ![1] = 3 ]""") { rewriterType: SMTEncoding =>
-    val tup = tuple(int(1), bool(false))
-    val newTuple = except(tup ? "ib", tuple(int(1)) ? "(i)", int(3))
-      .typed(types, "ib")
-    val eq = eql(newTuple, tuple(int(3), bool(false)) ? "ib")
-      .typed(types, "b")
+    val tup = tla.tuple(tla.int(1), tla.bool(false))
+    val newTuple = tla.except(tup, tla.int(1), tla.int(3))
+    val eq = tla.eql(newTuple, tla.tuple(tla.int(3), tla.bool(false)))
 
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)


### PR DESCRIPTION
This PR includes the first batch of refactoring in the rewriter tests. Instead of using the old expression builder, we are now using the latest typed builder. The code is more concise and easier to read now. The refactoring is done by Code GPT 5.5 high.
