### PR TITLE
Fix 3275 enabled operator

### DIFF
--- a/.unreleased/bug-fixes/3275-allow-enabled-in-kera.md
+++ b/.unreleased/bug-fixes/3275-allow-enabled-in-kera.md
@@ -1,0 +1,1 @@
+- Allow `ENABLED` expressions in the KerA language predicate, fixing preprocessing failures for invariants such as `ENABLED a'`. (#3275)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/transformations/standard/KeraLanguagePred.scala
@@ -134,8 +134,8 @@ object KeraLanguagePred {
         ApalacheOper.setAsFun,
         ApalacheOper.guess,
         ApalacheInternalOper.apalacheSeqCapacity,
+        TlaActionOper.enabled,
         // for the future
-        //    TlaActionOper.enabled,
         //    TlaActionOper.unchanged,
         //    TlaTempOper.box,
         //    TlaTempOper.diamond

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
@@ -105,6 +105,12 @@ class TestKeraLanguagePred extends LanguagePredTestSuite {
     expectOk(pred.isExprOk(and(bool(false), name("b"))))
   }
 
+  test("a KerA enabled expression") {
+    expectOk(pred.isExprOk(enabled(prime(name("a")))))
+    expectOk(pred.isExprOk(enabled(eql(prime(name("a")), bool(true)))))
+    expectOk(pred.isExprOk(enabled(eql(prime(name("a")), not(name("a"))))))
+  }
+
   test("not a KerA logic expression") {
     expectFail(pred.isExprOk(equiv(bool(false), name("b"))))
     expectFail(pred.isExprOk(impl(bool(false), name("b"))))

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/lir/transformations/standard/TestKeraLanguagePred.scala
@@ -108,6 +108,9 @@ class TestKeraLanguagePred extends LanguagePredTestSuite {
   test("a KerA enabled expression") {
     expectOk(pred.isExprOk(enabled(prime(name("a")))))
     expectOk(pred.isExprOk(enabled(eql(prime(name("a")), bool(true)))))
+    expectOk(pred.isExprOk(enabled(eql(prime(name("a")), bool(false)))))
+    expectOk(pred.isExprOk(enabled(or(prime(name("a")), not(prime(name("a")))))))
+    expectOk(pred.isExprOk(enabled(eql(prime(name("a")), name("a")))))
     expectOk(pred.isExprOk(enabled(eql(prime(name("a")), not(name("a"))))))
   }
 


### PR DESCRIPTION
## What changed

This PR allows `TlaActionOper.enabled` in `KeraLanguagePred`.

Previously, specifications containing expressions such as:

```tla
Inv == ENABLED (a')
```

were rejected during preprocessing with:

```text
unsupported expression: ENABLED a'
```

even though the expression was accepted by the parser, type checker, inliner, and earlier preprocessing steps.

## Why

`ENABLED` is a unary action-level operator. Once allowed past the KerA language predicate, the tested cases are handled successfully by the existing checking pipeline.

This fixes the regression reported in #3275.

## Validation

Added unit coverage in `TestKeraLanguagePred` for several `ENABLED` expressions, including:

- `ENABLED a'`
- `ENABLED (a' = TRUE)`
- `ENABLED (a' = FALSE)`
- `ENABLED (a' \/ ~a')`
- `ENABLED (UNCHANGED a)` represented internally as `ENABLED (a' = a)`
- `ENABLED (a' = ~a)`

I also manually reproduced the issue with a minimal TLA+ module and verified that it now completes with `EXITCODE: OK`.

Tested with:

```bash
sbt "tlair / Test / testOnly at.forsyte.apalache.tla.lir.transformations.standard.TestKeraLanguagePred"
sbt "tlair / Test / test"
make package
```

Fixes #3275.