### PR TITLE
Reject powersets over infinite sets

### DIFF
--- a/.unreleased/bug-fixes/2972-subset-infinite.md
+++ b/.unreleased/bug-fixes/2972-subset-infinite.md
@@ -1,0 +1,1 @@
+Rejected `SUBSET Int` and other powersets over infinite sets with a clear input error instead of crashing later with an unexpected equality test, see #2972.

--- a/test/tla/Bug2972.tla
+++ b/test/tla/Bug2972.tla
@@ -1,0 +1,32 @@
+---- MODULE Bug2972 ----
+\* Regression for https://github.com/apalache-mc/apalache/issues/2972
+\*
+\* SUBSET of an infinite set (e.g. SUBSET Int) is unsupported.  This spec
+\* used to crash in LazyEquality with:
+\*
+\*   Unexpected equality test over types CellTFrom(Set(Int)) and InfSet[CellTFrom(Int)]
+\*
+\* It should now fail with a clear input error that points at the unsupported
+\* SUBSET Int expression.
+
+EXTENDS Apalache, Integers
+
+VARIABLE
+    \* @type: { p : Set({ q : Set(Int) }) };
+    v
+
+TypeOK ==
+    v \in [ p: SUBSET [ q: SUBSET Int ] ]
+
+Init ==
+    /\ v = [ p |-> {[ q |-> { 1 } ]} ]
+    /\ TypeOK
+
+GenInit ==
+    /\ v = Gen(1)
+    /\ TypeOK
+
+Next ==
+    UNCHANGED v
+
+====

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1717,6 +1717,26 @@ EXITCODE: ERROR (12)
 [12]
 ```
 
+### check Bug2972 fails clearly for SUBSET Int
+
+Regression test for https://github.com/apalache-mc/apalache/issues/2972.
+`SUBSET Int` is unsupported because Apalache cannot expand a powerset over an
+infinite base set.  The checker used to crash later in `LazyEquality` with
+`Unexpected equality test over types CellTFrom(Set(Int)) and InfSet[CellTFrom(Int)]`.
+It should now reject the unsupported powerset directly with an input error.
+
+```sh
+$ apalache-mc check --init=Init --next=Next Bug2972.tla | sed 's/[IEW]@.*//' | awk '/Input error|EXITCODE/'
+Bug2972.tla:19:28-19:37: Input error (see the manual): SUBSET of an infinite set (InfSet[CellTFrom(Int)]) is not supported. Replace the base set with a finite one, e.g. SUBSET (a..b).
+EXITCODE: ERROR (255)
+```
+
+```sh
+$ apalache-mc check --init=GenInit --next=Next Bug2972.tla | sed 's/[IEW]@.*//' | awk '/Input error|EXITCODE/'
+Bug2972.tla:19:28-19:37: Input error (see the manual): SUBSET of an infinite set (InfSet[CellTFrom(Int)]) is not supported. Replace the base set with a finite one, e.g. SUBSET (a..b).
+EXITCODE: ERROR (255)
+```
+
 ### check SetSndRcv succeeds (array-encoding)
 
 Regression test for https://github.com/apalache-mc/apalache/issues/1152

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PowSetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PowSetCtorRule.scala
@@ -1,9 +1,10 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.types.PowSetT
+import at.forsyte.apalache.tla.bmcmt.types.{InfSetT, PowSetT}
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
+import at.forsyte.apalache.tla.pp.TlaInputError
 
 /**
  * Rewrites the powerset SUBSET S for a set S.
@@ -26,6 +27,22 @@ class PowSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
         var nextState = rewriter.rewriteUntilDone(state.setRex(setEx))
 
         val dom = nextState.arena.findCellByNameEx(nextState.ex)
+        // SUBSET of an infinite set (e.g. SUBSET Int, SUBSET Nat) is unsupported: every
+        // downstream rule that iterates the arena cells of the base set (PowSetCtor
+        // expansion, pickFromPowset, etc.) silently treats Int/Nat as if they had no
+        // elements, which leads to the powerset being mis-represented as a singleton
+        // containing only the empty subset.  In the wider context of records and
+        // record-typed sets this manifests as a confusing checker crash, see #2972.
+        // Reject up-front with an actionable message instead.
+        dom.cellType match {
+          case InfSetT(_) =>
+            throw new TlaInputError(
+                s"SUBSET of an infinite set (${dom.cellType}) is not supported. " +
+                  s"Replace the base set with a finite one, e.g. SUBSET (a..b).",
+                Some(state.ex.ID),
+            )
+          case _ => () // ok
+        }
         nextState = nextState.updateArena(_.appendCellOld(PowSetT(dom.cellType.toTlaType1)))
         val powSetCell = nextState.arena.topCell
         nextState = nextState.updateArena(_.setDom(powSetCell, dom))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetExpandRule.scala
@@ -2,8 +2,10 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.PowSetCtor
+import at.forsyte.apalache.tla.bmcmt.types.InfSetT
 import at.forsyte.apalache.tla.lir.OperEx
 import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaSetOper}
+import at.forsyte.apalache.tla.pp.TlaInputError
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -33,6 +35,22 @@ class SetExpandRule(rewriter: SymbStateRewriter) extends RewritingRule with Lazy
       case OperEx(ApalacheOper.expand, OperEx(TlaSetOper.powerset, basesetEx)) =>
         val nextState = rewriter.rewriteUntilDone(state.setRex(basesetEx))
         val baseset = nextState.asCell
+        // SUBSET of an infinite set (e.g. SUBSET Int, SUBSET Nat) is unsupported.  The
+        // arena cell for an infinite set has an empty `has` relation, so the powerset
+        // expansion below would silently produce a singleton containing only the empty
+        // subset.  Downstream rules then compare a CellTFrom(SetT1(_)) cell against an
+        // InfSetT(_) cell, which manifests either as a confusing checker crash
+        // ("Unexpected equality test over types ...") or as a spurious deadlock, see
+        // #2972.  Reject up-front with an actionable message instead.
+        baseset.cellType match {
+          case InfSetT(_) =>
+            throw new TlaInputError(
+                s"SUBSET of an infinite set (${baseset.cellType}) is not supported. " +
+                  s"Replace the base set with a finite one, e.g. SUBSET (a..b).",
+                Some(state.ex.ID),
+            )
+          case _ => () // ok
+        }
         val baseSize = nextState.arena.getHas(baseset).length
         if (baseSize >= BASESET_WARNING_THRESHOLD) {
           val msg =

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterPowerset.scala
@@ -7,6 +7,7 @@ import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
 import at.forsyte.apalache.tla.lir.values.{TlaIntSet, TlaNatSet}
 import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, NameEx, SetT1, Typed, ValEx}
+import at.forsyte.apalache.tla.pp.TlaInputError
 
 trait TestSymbStateRewriterPowerset extends RewriterBase {
   private val types = Map(
@@ -15,6 +16,14 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
       "II" -> SetT1(SetT1(IntT1)),
       "b" -> BoolT1,
   )
+
+  private def assertInfinitePowersetIsUnsupported(rewriterType: SMTEncoding, state: SymbState): Unit = {
+    val rewriter = create(rewriterType)
+    val error = intercept[TlaInputError] {
+      rewriter.rewriteUntilDone(state)
+    }
+    assert(error.getMessage.contains("SUBSET of an infinite set"))
+  }
 
   test("""SUBSET {1, 2, 3}""") { rewriterType: SMTEncoding =>
     val ex = powSet(enumSet(int(1), int(2), int(3)) ? "I")
@@ -86,13 +95,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
       .typed(types, "b")
     val state = new SymbState(inEx, arena, Binding())
 
-    val rewriter = create(rewriterType)
-    try {
-      val _ = rewriter.rewriteUntilDone(state)
-      fail("expected an error message about subseteq over infinite sets being unsupported")
-    } catch {
-      case _: RewriterException => () // OK
-    }
+    assertInfinitePowersetIsUnsupported(rewriterType, state)
   }
 
   test("""SSE-SUBSETEQ: Nat \in SUBSET {1, 2, 3, 4}""") { rewriterType: SMTEncoding =>
@@ -121,13 +124,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
       .typed(types, "b")
     val state = new SymbState(inEx, arena, Binding())
 
-    val rewriter = create(rewriterType)
-    try {
-      val _ = rewriter.rewriteUntilDone(state)
-      fail("expected an error message about subseteq over infinite sets being unsupported")
-    } catch {
-      case _: RewriterException => () // OK
-    }
+    assertInfinitePowersetIsUnsupported(rewriterType, state)
   }
 
   test("""SSE-SUBSETEQ: Nat \in SUBSET Int""") { rewriterType: SMTEncoding =>
@@ -137,13 +134,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
       .typed(types, "b")
     val state = new SymbState(inEx, arena, Binding())
 
-    val rewriter = create(rewriterType)
-    try {
-      val _ = rewriter.rewriteUntilDone(state)
-      fail("expected an error message about subseteq over infinite sets being unsupported")
-    } catch {
-      case _: RewriterException => () // OK
-    }
+    assertInfinitePowersetIsUnsupported(rewriterType, state)
   }
 
   test("""SSE-SUBSETEQ: Int \in SUBSET Nat""") { rewriterType: SMTEncoding =>
@@ -153,13 +144,7 @@ trait TestSymbStateRewriterPowerset extends RewriterBase {
       .typed(types, "b")
     val state = new SymbState(inEx, arena, Binding())
 
-    val rewriter = create(rewriterType)
-    try {
-      val _ = rewriter.rewriteUntilDone(state)
-      fail("expected an error message about subseteq over infinite sets being unsupported")
-    } catch {
-      case _: RewriterException => () // OK
-    }
+    assertInfinitePowersetIsUnsupported(rewriterType, state)
   }
 
   test("""SE-SUBSET: \E X \in SUBSET {1, 2}: TRUE (sat)""") { rewriterType: SMTEncoding =>


### PR DESCRIPTION
Report SUBSET Int and similar powersets over infinite case sets as input errors before expansion, avoiding the confusing equality-type crash from #2972.

Adresses Github issue #2972
https://github.com/apalache-mc/apalache/issues/2972

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~ Not new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
