### PR TITLE
Update html anchors in the docs

### DIFF
--- a/docs/src/HOWTOs/howto-write-type-annotations.md
+++ b/docs/src/HOWTOs/howto-write-type-annotations.md
@@ -79,8 +79,7 @@ Run the type checker again. You should see the following message:
 ...
 ```
 
-<a id="recipe2"></a>
-## Recipe 2: Annotating constants
+## <a id="recipe2"></a> Recipe 2: Annotating constants
 
 Consider the example [Channel.tla][] from [Specifying Systems][]:
 
@@ -207,8 +206,7 @@ This time the type checker can find the types of all expressions:
 ...
 ```
 
-<a id="recipe4"></a>
-## Recipe 4: Using variants in heterogenous sets
+## <a id="recipe4"></a> Recipe 4: Using variants in heterogenous sets
 
 Check the example [TwoPhase.tla][] from the repository of TLA+ examples (you
 will also need [TCommit.tla][], which is imported by TwoPhase.tla). This
@@ -310,8 +308,7 @@ solution. For instance, we could partition `msgs` into three subsets: the
 subset of `Commit` messages, the subset of `Abort` messages, and the subset of
 `Prepared` messages. See the discussion in [Idiom 15][].
 
-<a id="funAsSeq"></a>
-## Recipe 5: functions as sequences
+## <a id="funAsSeq"></a> Recipe 5: functions as sequences
 
 Check the example [Queens.tla][] from the repository of TLA+ examples.  It has
 85 lines of code, so we do not include it here. Similar to the previous
@@ -377,8 +374,7 @@ This time the type checker can find the types of all expressions:
 > All expressions are typed
 ```
 
-<a id="typeAliases"></a>
-## Recipe 6: type aliases
+## <a id="typeAliases"></a> Recipe 6: type aliases
 
 Type aliases can be used to provide a concise label for complex types, or to
 clarify the intended meaning of a simple types in the given context. 
@@ -494,8 +490,7 @@ Attacks(queens,i,j)
 You don't have to do that, but if you feel that types can also help you in documenting
 your specification, you have this option.
 
-<a id="recipe9"></a>
-## Recipe 9: Migrate from Type System 1 to Type System 1.2
+## <a id="recipe9"></a> Recipe 9: Migrate from Type System 1 to Type System 1.2
 
 As explained in [ADR002][], [Type System 1.2][] (TS1.2) differs from [Type
 System 1][] (TS1) as follows:

--- a/docs/src/adr/001rfc-types.md
+++ b/docs/src/adr/001rfc-types.md
@@ -20,8 +20,7 @@ questions:
 Everybody has a different opinion here. It would be great to use
 the native TLA+ constructs to express types.
 
-<a name="typesAsTypeOk"></a>
-### 1.1. TypeOK syntax
+### <a id="typesAsTypeOk"></a> 1.1. TypeOK syntax
 
 The only way to write types in the `TypeOK` style is by set membership.
 For instance:
@@ -56,8 +55,7 @@ THEOREM FooType ==
   \A a \in Int: \A b \in STRING: Foo(a, b) \in Int
 ```
 
-<a name="typesAsTerms"></a>
-### 1.2. Types as terms
+### <a id="typesAsTerms"></a> 1.2. Types as terms
 
 A classical way of writing types is by using logical terms (or algebraic datatypes).
 To this end, we can define a special module `Types.tla`:
@@ -134,8 +132,7 @@ e.g., by writing `x <: T`, we can write the above examples as follows:
   * __Here we have to pull lambda operators, but at least it is possible to write
     down a type annotation.__
 
-<a name="typesAsStrings"></a>
-### 1.3. Types as strings
+### <a id="typesAsStrings"></a> 1.3. Types as strings
 
 Let us introduce the following grammar for types:
 
@@ -219,8 +216,7 @@ a module `M` and then uses an unnamed instance `INSTANCE M` in a module `M2`,
 then `M` and `M2` will clash on the operator `<:`. We should define the operator
 once in a special module `Types` or `Apalache`.
 
-<a name="annotationsAsAssumptions"></a>
-### 2.2. Type annotations as assumptions
+### <a id="annotationsAsAssumptions"></a> 2.2. Type annotations as assumptions
 
 One can use TLA+ syntax to write assumptions and assertions about the types.
 We are talking only about type assumptions here.

--- a/docs/src/adr/002adr-types.md
+++ b/docs/src/adr/002adr-types.md
@@ -25,8 +25,7 @@ when writing TLA+ specifications. This document is filling this gap.
 
 ## 1. How to write types in TLA+
 
-<a id="ts1"></a>
-### 1.1. Type grammar (Type System 1, or TS1)
+### <a id="ts1"></a> 1.1. Type grammar (Type System 1, or TS1)
 
 **Upgrade warning.** This system is replaced with [Type System 1.2](#ts12).
 In October of 2022, we will stop supporting Type System 1. For the transition
@@ -128,8 +127,7 @@ type aliases: tools should always exchange data with types in the alias-free for
 * `Proc` and `Faulty` are sets of the same type.
    Their type is `Set(PID)`.
 
-<a id="defTypeAlias"></a>
-### 1.2. Type aliases
+### <a id="defTypeAlias"></a> 1.2. Type aliases
 
 #### New syntax for type aliases
 
@@ -181,9 +179,7 @@ For instance, when the users forgot to include a type alias, the type alias was
 interpreted as a type constant, and the type checker showed incomprehensible
 error messages.
 
-<a id="rows"></a>
-<a id="ts12"></a>
-### 1.3. Type System 1.2, including precise records, variants, and rows
+### <a id="rows"></a> <a id="ts12"></a> 1.3. Type System 1.2, including precise records, variants, and rows
 
 As discussed in [ADR014][], many users expressed the need for precise type
 checking for records in Snowcat. Records in untyped TLA+ are used in two
@@ -249,8 +245,7 @@ the syntax for row types for completeness. Most likely, the users will never
 see messages that mention rows explicitly, without referring to records or
 variants. 
 
-<a id="comments"></a>
-### 1.4. Comments inside types
+### <a id="comments"></a> 1.4. Comments inside types
 
 When you introduce records that have dozens of fields, it is useful to explain
 those fields right in the type annotations. For that reason, the type lexer
@@ -472,8 +467,7 @@ auxiliary LET-definition to specify the type of the empty collection:
 The type checker uses the type annotation to refine the type of an empty set
 (or, of an empty sequence).
 
-<a id="useTypeAlias"></a>
-### 2.4. Introducing and using type aliases
+### <a id="useTypeAlias"></a> 2.4. Introducing and using type aliases
 
 A type alias is introduced with the annotation `@typeAlias: <ALIAS> = <Type>;`.
 Since it is convenient to group type aliases of a module `MyModule`

--- a/docs/src/adr/006rfc-unit-testing.md
+++ b/docs/src/adr/006rfc-unit-testing.md
@@ -170,8 +170,7 @@ tests by default, if no test name is specified. Also, we have to initialize the
 constants with `ConstInit`, which we specify with the annotation
 `@require(ConstInit)`.
 
-<a id="testAction"></a>
-### 3.2. Testing actions
+### <a id="testAction"></a> 3.2. Testing actions
 
 Testing stateless operators is nice. However, TLA+ is built around the concept
 of a state machine. Hence, we believe that most of the testing activity will be
@@ -542,8 +541,7 @@ generators similar to [Scalacheck]. In contrast to property-based testing, we
 want to run the test not only on some random inputs, but to run it exhaustively
 on all inputs within a predefined bounded scope.
 
-<a id="generators"></a>
-### 5.1. Using Apalache generators
+### <a id="generators"></a> 5.1. Using Apalache generators
 
 Let's go back to the example in [Section 3.2](#testAction).
 

--- a/docs/src/apalache/assignments-in-depth.md
+++ b/docs/src/apalache/assignments-in-depth.md
@@ -346,8 +346,7 @@ Lastly, while `E` looks almost identical to `A`, the key difference is that
 expressions under universal quantifiers may not contain assignments. Therefore,
 `y' = s` is *not* an assignment to `y` and thus violates assignment-before-use.
 
-<a name='manual'></a>
-## Manual Assignments
+## <a id="manual"></a> Manual Assignments
 
 Users may choose, but aren't required, to use manual assignments `x' := e` in
 place of `x' = e`.  While the use of this operator does not change Apalache's

--- a/docs/src/apalache/parameters.md
+++ b/docs/src/apalache/parameters.md
@@ -27,8 +27,7 @@ Alternatively, you can extend the base module and use overrides:
 {{#include ../../../test/tla/y2k_override.tla::11}}
 ```
 
-<a name="ConstInit"></a>
-## ConstInit predicate
+## <a id="ConstInit"></a> ConstInit predicate
 
 This approach is similar to the ``Init`` operator, but applied to the
 constants. We define a special operator, e.g., called ``ConstInit``. For

--- a/docs/src/apalache/preprocessing.md
+++ b/docs/src/apalache/preprocessing.md
@@ -25,4 +25,4 @@ preprocessing steps:
 # References
 
  * Leslie Lamport. Specifying Systems: The TLA+ Language and Tools for Hardware and Software Engineers.
-Addison-Wesley Professional, 2004. <a name="spec2004"></a>
+Addison-Wesley Professional, 2004. <a id="spec2004"></a>

--- a/docs/src/apalache/principles/assignments.md
+++ b/docs/src/apalache/principles/assignments.md
@@ -1,6 +1,4 @@
-<a name="assignments"></a>
-<a name="symbolicTransitions"></a>
-## Assignments and symbolic transitions
+## <a id="assignments"></a> <a id="symbolicTransitions"></a> Assignments and symbolic transitions
 
 Let us go back to the example
 [`test/tla/y2k.tla`](https://github.com/apalache-mc/apalache/blob/main/test/tla/y2k.tla)

--- a/docs/src/apalache/principles/invariants.md
+++ b/docs/src/apalache/principles/invariants.md
@@ -73,8 +73,7 @@ There is no typo in the CLI arguments above: You pass action invariants the same
 as you pass state invariants. Preprocessing in Apalache is clever enough to figure out,
 what kind of invariant it is dealing with.
 
-<a name="traceInv"></a>
-## Trace invariants
+## <a id="traceInv"></a> Trace invariants
 
 
 Let's have a look at the following two predicates in `Invariants.tla`:

--- a/docs/src/apalache/principles/recursive.md
+++ b/docs/src/apalache/principles/recursive.md
@@ -1,5 +1,4 @@
-<a name="recursion"></a>
-## Recursive operators and functions
+## <a id="recursion"></a> Recursive operators and functions
 
 While TLA+ allows the use of recursive operators and functions, we have decided to no longer support them in Apalache from version `0.23.1` onward,
 and suggest the use of fold operators, described in [Folding sets and sequences](./folds.md) instead: 

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -89,7 +89,7 @@ The arguments are as follows:
     - `--out-dir` set location for outputting any generated logs or artifacts,
       *`./_apalache-out` by default*
     - `--write-intermediate` if `true`, then additional output is generated. See
-      [Detailed output](#detailed-output). *`false` by default*
+      [Detailed output](#detailed). *`false` by default*
     - `--run-dir=DIRECTORY` write all outputs directly into the specified
       `DIRECTORY`
     - `--config-file` a file to use for loading configuration parameters. This
@@ -272,9 +272,7 @@ State14 ==
 InvariantViolation == hasLicense /\ year - BIRTH_YEAR < LICENSE_AGE
 ```
 
-<a name="lookup"></a>
-
-## 3. Module lookup
+## <a id="lookup"></a> 3. Module lookup
 
 Apalache uses [the SANY parser](https://lamport.azurewebsites.net/tla/tools.html), which is the standard parser of TLC
 and the TLA+ Toolbox. By default, SANY is looking for modules (in this order) in
@@ -289,9 +287,7 @@ __Note:__ To let TLA+ Toolbox and TLC know about the Apalache modules, include
 `$APALACHE_HOME/src/tla` in the lookup directories, as explained by Markus Kuppe for
 the [TLA+ Community Modules](https://github.com/tlaplus/CommunityModules).
 
-<a name="detailed"></a>
-
-## 4. Detailed output
+## <a id="detailed"></a> 4. Detailed output
 
 The location for detailed output is determined by the value of the `out-dir`
 parameter, which specifies the path to a directory into which all Apalache
@@ -340,9 +336,7 @@ intermediate TLA+ files in the run-specific subdirectory:
 - File `out-analysis.tla` is produced as a result of analysis, e.g., marking Skolemizable expressions and expressions to
   be expanded.
 
-<a name="parsing"></a>
-
-## 5. Parsing and pretty-printing
+## <a id="parsing"></a> 5. Parsing and pretty-printing
 
 If you'd like to check that your TLA+ specification is syntactically correct, without running the model checker, you can
 run the following command:

--- a/docs/src/apalache/running.md
+++ b/docs/src/apalache/running.md
@@ -36,7 +36,7 @@ The most important commands are as follows:
 
 ## 1. Model checker and simulator command-line parameters
 
-### 1.1. Model checker command-line parameters
+### <a id="model-checker-command-line-parameters"></a> 1.1. Model checker command-line parameters
 
 The model checker can be run as follows:
 
@@ -126,7 +126,7 @@ The arguments are as follows:
 
   - `--max-run=NUM`: but produce up to `NUM` simulation runs (unless `--max-error` errors have been found), default: `100`
 
-### 1.3. Supplying JVM arguments
+### <a id="supplying-jvm-arguments"></a> 1.3. Supplying JVM arguments
 
 You can supply JVM argument to be used when running Apalache by setting the
 environment variable `JVM_ARGS`. For example, to change the JVM heap size from
@@ -172,7 +172,7 @@ in this symbolic execution (by querying z3), then it reports a counterexample.
 Otherwise, it reports that no bug was found up to the given length. If a bug
 needs a long execution to get revealed, bounded model checking may miss it!
 
-### 1.5. Checking an inductive invariant
+### <a id="checking-an-inductive-invariant"></a> 1.5. Checking an inductive invariant
 
 To check executions of arbitrary lengths, one usually finds a formula that satisfies the two following properties:
 

--- a/docs/src/lang/apalache-operators.md
+++ b/docs/src/lang/apalache-operators.md
@@ -6,8 +6,7 @@ but which Apalache uses to provide clarity, efficiency, or special functionality
 These operators belong to the module `Apalache`,
 and can be used in any specification by declaring `EXTENDS Apalache`.
 
-<a name="Assignment"></a>
-## Assignment
+## <a id="Assignment"></a> Assignment
 
 **Notation:** `v' := e`
 
@@ -54,9 +53,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="Guess"></a>
-
-## Non-deterministically guess a value
+## <a id="Guess"></a> Non-deterministically guess a value
 
 **Notation:** `Guess(S)`
 
@@ -92,8 +89,7 @@ If `S` is not a set, Apalache reports an error.
 
 ----------------------------------------------------------------------------
 
-<a name="Gen"></a>
-## Value generators
+## <a id="Gen"></a> Value generators
 
 **Notation:** `Gen(bound)`
 
@@ -142,8 +138,7 @@ IN
 The operators `ApaFoldSet` and `ApaFoldSeqLeft` are explained in more detail in a dedicated section [here](../apalache/principles/folds.md).
 
 ----------------------------------------------------------------------------
-<a name="Repeat"></a>
-## Operator iteration
+## <a id="Repeat"></a> Operator iteration
 
 **Notation:** `Repeat(Op, N, x)`
 
@@ -180,9 +175,7 @@ Op2(a,i) == a + i
 Repeat(Op2, 0, 5) = 15              \* TRUE
 ```
 ----------------------------------------------------------------------------
-<a name="SetAsFun"></a>
-
-## Convert a set of pairs to a function
+## <a id="SetAsFun"></a> Convert a set of pairs to a function
 
 **Notation:** `SetAsFun(S)`
 
@@ -225,9 +218,7 @@ LET F == SetAsFun({ <<1, 2>>, <<1, 3>>, <<1, 4>> }) IN
 
 ----------------------------------------------------------------------------
 
-<a name="MkSeq"></a>
-
-## Construct a sequence
+## <a id="MkSeq"></a> Construct a sequence
 
 **Notation:** `MkSeq(n, F)`
 
@@ -255,9 +246,7 @@ MkSeq(3, Double) = <<2, 4, 6>>   \* TRUE
 
 ----------------------------------------------------------------------------
 
-<a name="Cast"></a>
-
-## Interpret a function as a sequence
+## <a id="Cast"></a> Interpret a function as a sequence
 
 **Notation:** `FunAsSeq(fn, len, maxLen)`
 
@@ -317,8 +306,7 @@ g = boundedFn(lambda x: x * x, {0, 42})
 [None, None, None]
 ```
 
-<a name="Skolem"></a>
-## Skolemization Hint
+## <a id="Skolem"></a> Skolemization Hint
 
 **Notation:** `Skolem(e)`
 
@@ -351,8 +339,7 @@ Skolem( 1 )                     \* 1 in TLC, type error in Apalache
 Skolem( TRUE )                  \* TRUE in TLC, error in Apalache
 ```
 
-<a name="Expand"></a>
-## Set expansion
+## <a id="Expand"></a> Set expansion
 
 **Notation:** `Expand(S)`
 
@@ -386,8 +373,7 @@ Expand( {1,2} )        \* {1,2} in TLC, error in Apalache
 Expand( 1 )            \* 1 in TLC, type error in Apalache
 ```
 
-<a name="ConstCard"></a>
-## Cardinality Hint
+## <a id="ConstCard"></a> Cardinality Hint
 
 **Notation:** `ConstCardinality(e)`
 

--- a/docs/src/lang/booleans.md
+++ b/docs/src/lang/booleans.md
@@ -5,8 +5,7 @@
 You find these operators in every programming language and every textbook on
 logic. These operators form _propositional logic_.
 
-<a name="const"></a>
-## Constants
+## <a id="const"></a> Constants
 
 TLA+ contains three special constants: `TRUE`, `FALSE`, and `BOOLEAN`.
 The constant `BOOLEAN` is defined as the set `{FALSE, TRUE}`.
@@ -28,8 +27,7 @@ We discuss this effect [Control Flow and Non-determinism].
 
 ----------------------------------------------------------------------------
 
-<a name="and"></a>
-### And (conjunction)
+### <a id="and"></a> And (conjunction)
 
 **Notation:** `F /\ G` or `F \land G`
 
@@ -110,8 +108,7 @@ is equivalent to:
 
 ----------------------------------------------------------------------------
 
-<a name="or"></a>
-### Or (disjunction)
+### <a id="or"></a> Or (disjunction)
 
 **Notation:** `F \/ G` or `F \lor G`
 
@@ -205,8 +202,7 @@ The above formula is equivalent to:
 
 ----------------------------------------------------------------------------
 
-<a name="not"></a>
-### Negation
+### <a id="not"></a> Negation
 
 **Notation:** `~F` or `\neg F` or `\lnot F`
 
@@ -249,8 +245,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="implies"></a>
-### Implication
+### <a id="implies"></a> Implication
 
 **Notation:** `F => G`
 
@@ -306,8 +301,7 @@ False
 
 ----------------------------------------------------------------------------
 
-<a name="equiv"></a>
-### Equivalence
+### <a id="equiv"></a> Equivalence
 
 **Notation:** `F <=> G` or `F \equiv G`
 

--- a/docs/src/lang/conditionals.md
+++ b/docs/src/lang/conditionals.md
@@ -25,8 +25,7 @@ we recommend using nested `IF-THEN-ELSE` instead.
 
 ----------------------------------------------------------------------------
 
-<a name="ite"></a>
-## Deterministic IF-THEN-ELSE
+## <a id="ite"></a> Deterministic IF-THEN-ELSE
 
 _Use it when choosing between two values, not to structure your code._
 
@@ -72,8 +71,7 @@ Note that we are using the expression syntax for `if-else` in python.
 This is because we write an expression, not a series of statements that assign
 values to variables!
 
-<a name="case"></a>
-## Deterministic CASE
+## <a id="case"></a> Deterministic CASE
 
 _Read the description and never use this operator_
 
@@ -183,8 +181,7 @@ def case_example(n):
         return "positive"
 ```
 
-<a name="caseOther"></a>
-## Deterministic CASE-OTHER
+## <a id="caseOther"></a> Deterministic CASE-OTHER
 
 _Better use IF-THEN-ELSE._
 

--- a/docs/src/lang/control-and-nondeterminism.md
+++ b/docs/src/lang/control-and-nondeterminism.md
@@ -308,8 +308,7 @@ course of action depends on the program analysis that you implement. For
 instance, a random simulator could simply backtrack and randomly choose another
 value.
 
-<a name="nondetExists"></a>
-### Non-determinism in `\E x \in S: P`
+### <a id="nondetExists"></a> Non-determinism in `\E x \in S: P`
 
 We only have to consider the following case: `\E x \in S: P` is evaluated against
 a binding `s`, and there is a primed state variable `y'` that satisfies two
@@ -370,8 +369,7 @@ Simply ask the oracle. Below, we give three examples of how the evaluation works
 3. (GUESS Int) returns -20. (LET i == -20 IN i > x /\ x' = i) is FALSE. Halt.
 ```
 
-<a name="nondetOr"></a>
-### Non-determinism in disjunctions
+### <a id="nondetOr"></a> Non-determinism in disjunctions
 
 Consider a disjunction that comprises `n` clauses:
 
@@ -456,8 +454,7 @@ disjunction](./booleans.md) in the deterministic case, we have
 non-deterministic choice here. Hence, short-circuiting does not apply to
 non-deterministic disjunctions.*
 
-<a name="nondetIte"></a>
-### Non-determinism in Boolean `IF-THEN-ELSE`
+### <a id="nondetIte"></a> Non-determinism in Boolean `IF-THEN-ELSE`
 
 For the deterministic use of `IF-THEN-ELSE`, see [Deterministic
 conditionals](./conditionals.md).
@@ -493,8 +490,7 @@ _We do not recommend you to use IF-THEN-ELSE with non-determinism. The structure
 condition, the effect of `x' = e` is not obvious when `x'` is not assigned a
 value.
 
-<a name="nondetCase"></a>
-### Non-determinism in Boolean `CASE`
+### <a id="nondetCase"></a> Non-determinism in Boolean `CASE`
 
 For the deterministic use of `CASE`,
     see [Deterministic conditionals](./conditionals.md).

--- a/docs/src/lang/functions.md
+++ b/docs/src/lang/functions.md
@@ -261,8 +261,7 @@ mutable dictionaries in the Python examples in the rest of this text.
 
 ----------------------------------------------------------------------------
 
-<a name="funCtor"></a>
-### Function constructor
+### <a id="funCtor"></a> Function constructor
 
 **Notation:** `[ x \in S |-> e ]` or `[ x \in S, y \in T |-> e ]`, or more
 arguments
@@ -364,8 +363,7 @@ function domain is not known in advance.
 
 ----------------------------------------------------------------------------
 
-<a name="funSetCtor"></a>
-### Function set constructor
+### <a id="funSetCtor"></a> Function set constructor
 
 **Notation:** `[ S -> T ]`
 
@@ -411,8 +409,7 @@ functions. It should be similar in spirit to [subset.py](./examples/subset.py),
 but it should enumerate strings over the alphabet of `0..(Cardinality(T) - 1)`
 values, rather than over the alphabet of 2 values.
 
-<a name="funApp"></a>
-### Function application
+### <a id="funApp"></a> Function application
 
 **Notation:** `f[e]` or `f[e_1, ..., e_n]`
 
@@ -480,8 +477,7 @@ function domain is not known in advance.
 
 ----------------------------------------------------------------------------
 
-<a name="except"></a>
-### Function replacement
+### <a id="except"></a> Function replacement
 
 **Notation:** `[f EXCEPT ![a_1] = e_1, ..., ![a_n] = e_n]`
 
@@ -615,8 +611,7 @@ code would be less efficient than the idiomatic Python code.
 
 ----------------------------------------------------------------------------
 
-<a name="domain"></a>
-### Function domain
+### <a id="domain"></a> Function domain
 
 **Notation:** `DOMAIN f`
 

--- a/docs/src/lang/integers.md
+++ b/docs/src/lang/integers.md
@@ -36,8 +36,7 @@ translated as constants in the SMT constraints. This simple trick may bring
 your specification into a much simpler theory. Sometimes, this trick allows z3
 to use parallel algorithms.
 
-<a name="const"></a>
-## Constants
+## <a id="const"></a> Constants
 
 The module `Integers` defines two constant sets (technically, they are
 operators without arguments):
@@ -54,8 +53,7 @@ operators without arguments):
 
 ## Operators
 
-<a name="range"></a>
-### Integer range
+### <a id="range"></a> Integer range
 
 **Notation:** `a..b`
 
@@ -99,8 +97,7 @@ set()
 
 ----------------------------------------------------------------------------
 
-<a name="uminus"></a>
-### Unary integer negation
+### <a id="uminus"></a> Unary integer negation
 
 **Notation:** `-i`
 
@@ -139,8 +136,7 @@ type error, whereas TLC reports a runtime error.
 
 ----------------------------------------------------------------------------
 
-<a name="plus"></a>
-### Integer addition
+### <a id="plus"></a> Integer addition
 
 **Notation:** `a + b`
 
@@ -178,8 +174,7 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 ----------------------------------------------------------------------------
 
-<a name="minus"></a>
-### Integer subtraction
+### <a id="minus"></a> Integer subtraction
 
 **Notation:** `a - b`
 
@@ -220,8 +215,7 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 ----------------------------------------------------------------------------
 
-<a name="mult"></a>
-### Integer multiplication
+### <a id="mult"></a> Integer multiplication
 
 **Notation:** `a * b`
 
@@ -259,8 +253,7 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 ----------------------------------------------------------------------------
 
-<a name="div"></a>
-### Integer division
+### <a id="div"></a> Integer division
 
 **Notation:** `a \div b`
 
@@ -337,8 +330,7 @@ to produce the same results as in TLA+:
 
 ----------------------------------------------------------------------------
 
-<a name="mod"></a>
-### Integer remainder
+### <a id="mod"></a> Integer remainder
 
 **Notation:** `a % b`
 
@@ -390,8 +382,7 @@ to produce the same results as in TLA+:
 
 ----------------------------------------------------------------------------
 
-<a name="pow"></a>
-### Integer exponentiation
+### <a id="pow"></a> Integer exponentiation
 
 **Notation:** `a^b`
 
@@ -457,8 +448,7 @@ statically reports a type error, whereas TLC reports a runtime error.
 
 ----------------------------------------------------------------------------
 
-<a name="lt"></a>
-### Integer less-than
+### <a id="lt"></a> Integer less-than
 
 **Notation:** `a < b`
 
@@ -502,8 +492,7 @@ False
 
 ----------------------------------------------------------------------------
 
-<a name="lte"></a>
-### Integer less-than-or-equal
+### <a id="lte"></a> Integer less-than-or-equal
 
 **Notation:** `a <= b` or `a =< b` or `a \leq b`
 
@@ -547,8 +536,7 @@ False
 
 ----------------------------------------------------------------------------
 
-<a name="gt"></a>
-### Integer greater-than
+### <a id="gt"></a> Integer greater-than
 
 **Notation:** `a > b`
 
@@ -592,8 +580,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="gte"></a>
-### Integer greater-than-or-equal
+### <a id="gte"></a> Integer greater-than-or-equal
 
 **Notation:** `a >= b` or `a \geq b`
 
@@ -637,8 +624,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="eq"></a>
-### Equality and inequality
+### <a id="eq"></a> Equality and inequality
 
 The operators `a = b` and `a /= b` are core operators of TLA+, and thus they are
 not defined in the module `Integers`, see [Logic](./logic.md).

--- a/docs/src/lang/logic.md
+++ b/docs/src/lang/logic.md
@@ -14,8 +14,7 @@ section, we only consider the deterministic use of the existential quantifier.
 
 ----------------------------------------------------------------------------
 
-<a name="forallBounded"></a>
-### Bounded universal quantifier
+### <a id="forallBounded"></a> Bounded universal quantifier
 
 **Notation:** `\A x \in S: P`
 
@@ -96,8 +95,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="existsBounded"></a>
-### Bounded existential quantifier
+### <a id="existsBounded"></a> Bounded existential quantifier
 
 **Notation:** `\E x \in S: P`
 
@@ -187,8 +185,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="eq"></a>
-### Equality
+### <a id="eq"></a> Equality
 
 _A foundational operator in TLA+_
 
@@ -317,8 +314,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="neq"></a>
-### Inequality
+### <a id="neq"></a> Inequality
 
 **Notation:** `e_1 /= e_2` or `e_1 # e_2`
 
@@ -332,8 +328,7 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="chooseBounded"></a>
-### Bounded Choice
+### <a id="chooseBounded"></a> Bounded Choice
 
 _This operator causes a lot of confusion. Read carefully!_
 
@@ -437,8 +432,7 @@ if __name__ == "__main__":
 
 ----------------------------------------------------------------------------
 
-<a name="forall"></a>
-### Unbounded universal quantifier
+### <a id="forall"></a> Unbounded universal quantifier
 
 **Notation:** `\A x: P`
 
@@ -459,8 +453,7 @@ when writing proofs with [TLAPS].
 
 ----------------------------------------------------------------------------
 
-<a name="exists"></a>
-### Unbounded existential quantifier
+### <a id="exists"></a> Unbounded existential quantifier
 
 **Notation:** `\E x: P`
 
@@ -481,8 +474,7 @@ when writing proofs with [TLAPS].
 
 ----------------------------------------------------------------------------
 
-<a name="choose"></a>
-### Unbounded CHOOSE
+### <a id="choose"></a> Unbounded CHOOSE
 
 **Notation:** `CHOOSE x: P`
 

--- a/docs/src/lang/option-types.md
+++ b/docs/src/lang/option-types.md
@@ -319,8 +319,7 @@ IN
 
 ----------------------------------------------------------------------------
 
-<a name="OptionFunApp"></a>
-### Apply a function to a partial value
+### <a id="OptionFunApp"></a> Apply a function to a partial value
 
 **Notation:** `OptionFunApp(f, o)`
 
@@ -350,8 +349,7 @@ LET f == [x \in 1..3 |-> x + 1] IN
 
 ----------------------------------------------------------------------------
 
-<a name="OptionPartialFun"></a>
-### Extend a total function into a partial function
+### <a id="OptionPartialFun"></a> Extend a total function into a partial function
 
 **Notation:** `OptionPartialFun(f, undef)`
 

--- a/docs/src/lang/records.md
+++ b/docs/src/lang/records.md
@@ -122,8 +122,7 @@ immutable dictionary.
 
 ----------------------------------------------------------------------------
 
-<a name="recCtor"></a>
-### Record constructor
+### <a id="recCtor"></a> Record constructor
 
 **Notation:** `[ field_1 |-> e_1, ..., field_n |-> e_n]`
 
@@ -164,8 +163,7 @@ as follows:
 
 ----------------------------------------------------------------------------
 
-<a name="recSetCtor"></a>
-### Record set constructor
+### <a id="recSetCtor"></a> Record set constructor
 
 **Notation:** `[ field_1: S_1, ..., field_n: S_n]`
 
@@ -213,8 +211,7 @@ is picked with `\E r \in [ field_1: S_1, ..., field_n: S_n]`.
 
 ----------------------------------------------------------------------------
 
-<a name="recApp"></a>
-### Access by field name
+### <a id="recApp"></a> Access by field name
 
 **Notation:** `r.field_i`
 

--- a/docs/src/lang/sequences.md
+++ b/docs/src/lang/sequences.md
@@ -86,8 +86,7 @@ on sets._
 ## Operators
 
 
-<a name="seqCtor"></a>
-### Tuple/Sequence constructor
+### <a id="seqCtor"></a> Tuple/Sequence constructor
 
 **Notation:** `<<e_1, ..., e_n>>`
 
@@ -138,8 +137,7 @@ principle "sequences are functions", we have to use a dictionary.
 
 ----------------------------------------------------------------------------
 
-<a name="append"></a>
-### Sequence append
+### <a id="append"></a> Sequence append
 
 **Notation:** `Append(seq, e)`
 
@@ -191,8 +189,7 @@ the type of the sequence elements.
 
 ----------------------------------------------------------------------------
 
-<a name="app"></a>
-### Function application
+### <a id="app"></a> Function application
 
 As sequences are functions, you can access sequence elements with [function
 application](./functions.md#funApp), e.g., `seq[2]`.  However, in the case of a
@@ -201,8 +198,7 @@ some type `a`.
 
 ----------------------------------------------------------------------------
 
-<a name="head"></a>
-### Sequence head
+### <a id="head"></a> Sequence head
 
 **Notation:** `Head(seq)`
 
@@ -245,8 +241,7 @@ error.
 
 ----------------------------------------------------------------------------
 
-<a name="tail"></a>
-### Sequence tail
+### <a id="tail"></a> Sequence tail
 
 **Notation:** `Tail(seq)`
 
@@ -298,8 +293,7 @@ error.
 
 ----------------------------------------------------------------------------
 
-<a name="len"></a>
-### Sequence length
+### <a id="len"></a> Sequence length
 
 **Notation:** `Len(seq)`
 
@@ -346,8 +340,7 @@ error.
 
 ----------------------------------------------------------------------------
 
-<a name="concat"></a>
-### Sequence concatenation
+### <a id="concat"></a> Sequence concatenation
 
 **Notation:** `s \o t` (or `s \circ t`)
 
@@ -400,8 +393,7 @@ incompatible.
 
 ----------------------------------------------------------------------------
 
-<a name="subseq"></a>
-### Subsequence
+### <a id="subseq"></a> Subsequence
 
 **Notation:** `SubSeq(seq, m, n)`
 
@@ -453,8 +445,7 @@ error. Apalache flags a static type error.
 
 ----------------------------------------------------------------------------
 
-<a name="filter"></a>
-### Sequence filter
+### <a id="filter"></a> Sequence filter
 
 **Notation:** `SelectSeq(seq, Test)`
 
@@ -513,8 +504,7 @@ result is undefined in pure TLA+. TLC raises a model checking error.
 
 ----------------------------------------------------------------------------
 
-<a name="seq"></a>
-### All sequences
+### <a id="seq"></a> All sequences
 
 **Notation:** `Seq(S)`
 

--- a/docs/src/lang/sets.md
+++ b/docs/src/lang/sets.md
@@ -70,8 +70,7 @@ to this rule, as some records can be unified to a common type.)
 
 ## Operators
 
-<a name="setEnum"></a>
-### Set constructor by enumeration
+### <a id="setEnum"></a> Set constructor by enumeration
 
 **Notation:** `{e_1, ..., e_n}`
 
@@ -120,8 +119,7 @@ If this is not the case, the type checker flags an error.
 
 ----------------------------------------------------------------------------
 
-<a name="in"></a>
-### Set membership
+### <a id="in"></a> Set membership
 
 **Notation:** `e \in S`
 
@@ -174,8 +172,7 @@ False
 
 ----------------------------------------------------------------------------
 
-<a name="notin"></a>
-### Set non-membership
+### <a id="notin"></a> Set non-membership
 
 **Notation:** `e \notin S`
 
@@ -228,16 +225,14 @@ True
 
 ----------------------------------------------------------------------------
 
-<a name="eq"></a>
-### Equality and inequality
+### <a id="eq"></a> Equality and inequality
 
 The operators `a = b` and `a /= b` are core operators of TLA+,
 see [Logic](./logic.md).
 
 ----------------------------------------------------------------------------
 
-<a name="subseteq"></a>
-### Set inclusion
+### <a id="subseteq"></a> Set inclusion
 
 **Notation:** `S \subseteq T`
 
@@ -287,8 +282,7 @@ False
 
 ----------------------------------------------------------------------------
 
-<a name="union"></a>
-### Binary set union
+### <a id="union"></a> Binary set union
 
 **Notation:** `S \union T` or `S \cup T`
 
@@ -336,8 +330,7 @@ are either not sets, or sets of incompatible types.
 
 ----------------------------------------------------------------------------
 
-<a name="intersect"></a>
-### Set intersection
+### <a id="intersect"></a> Set intersection
 
 **Notation:** `S \intersect T` or `S \cap T`
 
@@ -385,8 +378,7 @@ set()
 
 ----------------------------------------------------------------------------
 
-<a name="setminus"></a>
-### Set difference
+### <a id="setminus"></a> Set difference
 
 **Notation:** `S \ T`
 
@@ -434,8 +426,7 @@ set()
 
 ----------------------------------------------------------------------------
 
-<a name="filter"></a>
-### Set filter
+### <a id="filter"></a> Set filter
 
 **Notation:** `{ x \in S: P }`
 
@@ -500,8 +491,7 @@ set()
 
 ----------------------------------------------------------------------------
 
-<a name="map"></a>
-### Set map
+### <a id="map"></a> Set map
 
 **Notation:** `{ e: x \in S }` or `{ e: x \in S, y \in T }`, or more arguments
 
@@ -572,8 +562,7 @@ syntax:
 
 ----------------------------------------------------------------------------
 
-<a name="powerset"></a>
-### Powerset
+### <a id="powerset"></a> Powerset
 
 **Notation:** `SUBSET S`
 
@@ -609,8 +598,7 @@ To appreciate the power of TLA+, see [subset.py](./examples/subset.py).
 
 ----------------------------------------------------------------------------
 
-<a name="flatten"></a>
-### Set flattening
+### <a id="flatten"></a> Set flattening
 
 **Notation:** `UNION S`
 
@@ -662,8 +650,7 @@ in Python is quite simple:
 
 ----------------------------------------------------------------------------
 
-<a name="card"></a>
-### Set cardinality
+### <a id="card"></a> Set cardinality
 
 **Notation:** `Cardinality(S)`
 
@@ -706,8 +693,7 @@ different from a finite set.
 
 ----------------------------------------------------------------------------
 
-<a name="finite"></a>
-### Set finiteness
+### <a id="finite"></a> Set finiteness
 
 **Notation:** `IsFinite(S)`
 

--- a/docs/src/lang/tuples.md
+++ b/docs/src/lang/tuples.md
@@ -77,8 +77,7 @@ immutable dictionary.
 ----------------------------------------------------------------------------
 
 
-<a name="tuple"></a>
-### Tuple/Sequence constructor
+### <a id="tuple"></a> Tuple/Sequence constructor
 
 **Notation:** `<<e_1, ..., e_n>>`
 
@@ -129,8 +128,7 @@ principle "tuples are functions", we have to use a dictionary.
 
 ----------------------------------------------------------------------------
 
-<a name="times"></a>
-### Cartesian product
+### <a id="times"></a> Cartesian product
 
 **Notation:** `S_1 \X ... \X S_n` (or `S_1 \times ... \times S_n`)
 
@@ -180,8 +178,7 @@ is picked with `\E t \in S_1 \X S_2`.
 
 ----------------------------------------------------------------------------
 
-<a name="app"></a>
-### Function application
+### <a id="app"></a> Function application
 
 As tuples are functions, you can access tuple elements by [function
 application](./functions.md#funApp), e.g., `tup[2]`. However, in the case of a

--- a/docs/src/lang/variants.md
+++ b/docs/src/lang/variants.md
@@ -172,8 +172,7 @@ an invariant violation and will lead to a spurious counterexample.
 
 ----------------------------------------------------------------------------
 
-<a name="variantCtor"></a>
-### Variant constructor
+### <a id="variantCtor"></a> Variant constructor
 
 **Notation:** `Variant(tagName, associatedValue)`
 
@@ -208,8 +207,7 @@ Beer(malt, strength) == Variant("Beer", [ malt |-> malt, strength |-> strength ]
 
 ----------------------------------------------------------------------------
 
-<a name="variantTag"></a>
-### Variant tag
+### <a id="variantTag"></a> Variant tag
 
 **Notation:** `VariantTag(variant)`
 
@@ -235,8 +233,7 @@ VariantTag(Variant("Water", [ sparkling |-> sparkling ])) = "Water"
 
 ----------------------------------------------------------------------------
 
-<a name="variantFilter"></a>
-### Variant filter
+### <a id="variantFilter"></a> Variant filter
 
 **Notation:** `VariantFilter(tagName, set)`
 
@@ -277,8 +274,7 @@ LET Drinks == { Water(TRUE), Water(FALSE), Beer("Radler", 2) } IN
 
 ----------------------------------------------------------------------------
 
-<a name="variantGetOrElse"></a>
-### Unpacking a variant safely
+### <a id="variantGetOrElse"></a> Unpacking a variant safely
 
 **Notation:** `VariantGetOrElse(tagName, variant, defaultValue)`
 
@@ -320,8 +316,7 @@ VariantGetOrElse("Beer", water,
 
 ----------------------------------------------------------------------------
 
-<a name="variantGetUnsafe"></a>
-### Unpacking a variant unsafely
+### <a id="variantGetUnsafe"></a> Unpacking a variant unsafely
 
 **Notation:** `VariantGetUnsafe(tagName, variant)`
 

--- a/docs/src/tutorials/trail-tips.md
+++ b/docs/src/tutorials/trail-tips.md
@@ -5,9 +5,7 @@
 This tutorial collects tips and tricks that demonstrate the strong sides of
 Apalache.
 
-## Tip 1: Use TLA+ constructs instead of explicit iteration
-
-<a name="fold-except"></a>
+## <a id="fold-except"></a> Tip 1: Use TLA+ constructs instead of explicit iteration
 
 The [Apalache
 antipatterns](../apalache/antipatterns.md#incremental-computation) mention that


### PR DESCRIPTION
Fixes #3040

- Introduce some manual anchors that are used in the docs and source code.
- Inline anchors into the headings, to avoid rendering a separate `<p>` around them.
-  Uniformly use `<a id="...">` instead of `<a name="...">`.