### PR TITLE
Type-check unbounded quantifiers instead of crashing (#2816)

### DIFF
--- a/.unreleased/bug-fixes/2816-typecheck-unbounded-quantifiers.md
+++ b/.unreleased/bug-fixes/2816-typecheck-unbounded-quantifiers.md
@@ -1,0 +1,1 @@
+Fixed a crash (`IllegalArgumentException: Unsupported expression`) in the type checker on unbounded quantifiers `\A x: P` and `\E x: P`. These expressions are now type-checked like their bounded counterparts, and are reported with a proper, source-located error only if they reach the model checker, see #2816.

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/ToEtcExpr.scala
@@ -320,6 +320,22 @@ class ToEtcExpr(
         // the resulting expression is (principal lambda)
         mkApp(ref, Seq(principal), lambda)
 
+      case OperEx(op, bindingNameEx @ NameEx(_), pred)
+          if op == TlaBoolOper.existsUnbounded || op == TlaBoolOper.forallUnbounded =>
+        // \E x: P, \A x: P
+        // the principal type of unbounded \E and \A is (a => Bool) => Bool
+        val a = varPool.fresh
+        val quantType = OperT1(Seq(OperT1(Seq(a), BoolT1)), BoolT1)
+        // unbounded \E and \A implicitly introduce a lambda abstraction: λ x ∈ Set(b). P
+        val b = varPool.fresh
+        val lambda = mkAbs(
+            BlameRef(ex.ID),
+            this(pred),
+            (mkName(bindingNameEx), mkConst(BlameRef(ex.ID), SetT1(b))),
+        )
+        // the resulting expression is (((a => Bool) => Bool) (λ x ∈ Set(b). P))
+        mkApp(ref, Seq(quantType), lambda)
+
       // ******************************************** SETS **************************************************
       case OperEx(TlaSetOper.enumSet) =>
         // empty set {} is not an operator but a constant

--- a/tla-typechecker/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
+++ b/tla-typechecker/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestToEtcExpr.scala
@@ -151,6 +151,17 @@ class TestToEtcExpr extends AnyFunSuite with BeforeAndAfterEach with ToEtcExprBa
     assert(chooseExpected == mkToEtcExpr()(tla.choose(tla.name("x"), tla.name("P"))))
   }
 
+  test("unbounded quantifiers: \\E x: P and \\A x: P") {
+    // The unbounded forms \E x: P and \A x: P. Similar to unbounded CHOOSE, they implicitly
+    // introduce a lambda abstraction over a fresh set: λ x ∈ Set(b). P
+    val quantLambda = mkUniqAbs(mkUniqName("P"), (mkUniqName("x"), mkUniqConst(SetT1(VarT1("b")))))
+    // the principal type of unbounded \E and \A is (a => Bool) => Bool
+    val expected = mkUniqApp(Seq(parser("(a => Bool) => Bool")), quantLambda)
+    // use a fresh generator per call so the fresh-variable counter starts from `a`
+    assert(expected == mkToEtcExpr()(tla.exists(tla.name("x"), tla.name("P"))))
+    assert(expected == mkToEtcExpr()(tla.forall(tla.name("x"), tla.name("P"))))
+  }
+
   test("binary Boolean connectives") {
     val bool2ToBool = parser("(Bool, Bool) => Bool")
     val expected = mkConstAppByType(bool2ToBool, parser("Bool"), parser("Bool"))


### PR DESCRIPTION
## What

Fixes #2816.

`apalache-mc typecheck` crashed with an internal `IllegalArgumentException: Unsupported expression` on **unbounded quantifiers** `\A x: P` and `\E x: P` (e.g. the minimal repro `Foo == \A g: TRUE`).

The cause: `ToEtcExpr` had cases for the bounded quantifiers (`TlaBoolOper.forall` / `exists`) and for unbounded `CHOOSE` (`TlaOper.chooseUnbounded`), but no case for `TlaBoolOper.forallUnbounded` / `existsUnbounded`. These expressions therefore fell through to the `// This should be unreachable` branch and threw.

## How

Handle unbounded `\A`/`\E` exactly like unbounded `CHOOSE`: assign the principal type `(a => Bool) => Bool` and introduce an implicit lambda abstraction over a fresh set `λ x ∈ Set(b). P`.

This implements option **(c)** from the maintainer's triage on the issue: the type checker now accepts these expressions, and unbounded quantification is rejected with a proper, source-located error **only if it reaches the model checker** (which genuinely does not support it):

```
mc.tla:8:8-8:19: unsupported expression: ∀y: (y ≥ 0)
```

instead of an internal crash + bug report.

## Testing

- **New unit test** in `TestToEtcExpr` (`unbounded quantifiers: \E x: P and \A x: P`) asserting the generated Etc expression for both operators.
- Full `tla_typechecker` suite passes (215 tests, 0 failures).
- Manual CLI verification:
  - `typecheck` on the minimal repro `Foo == \A g: TRUE` -> **OK** (previously crashed).
  - `\E x: x > 0` -> type-checks and infers `x: Int`.
  - Nested `\A x: \E y: (x = y) /\ (y > 0)` -> type-checks.
  - Type-conflicting `\A x: (x > 0) /\ (x = "str")` -> clean type error (not a crash).
  - `check` with an unbounded quantifier in an invariant -> clean `unsupported expression` error with source location (not a crash).
- `make fmt-fix` applied; compiles cleanly with `APALACHE_FATAL_WARNINGS=true`.

## Changelog

Added `.unreleased/bug-fixes/2816-typecheck-unbounded-quantifiers.md`.
