### PR TITLE
Expand the set argument of FoldSet (#3385)

### DIFF
--- a/.unreleased/bug-fixes/3385-fold-non-enumerated-set.md
+++ b/.unreleased/bug-fixes/3385-fold-non-enumerated-set.md
@@ -1,0 +1,1 @@
+Fixed `FoldSet` silently returning the base value when folding over a non-enumerated set such as `SUBSET S` or `[S -> T]`. The set is now marked for expansion, so folds over powersets produce the correct result, and folds over sets whose expansion is unsupported fail loudly instead of returning a wrong answer, see #3385.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExpansionMarker.scala
@@ -88,6 +88,13 @@ class ExpansionMarker @Inject() (tracker: TransformationTracker) extends TlaExTr
       val tag = ex.typeTag
       OperEx(op, args.map(transform(true)): _*)(tag)
 
+    case ex @ OperEx(op @ ApalacheOper.foldSet, operEx, baseEx, setEx) =>
+      // FoldSet folds over the concrete elements of the set, so the set must be expanded.
+      // Otherwise a lazily-represented set (e.g. SUBSET S or [S -> T]) contributes no elements
+      // and the fold silently returns the base value. See #3385.
+      val tag = ex.typeTag
+      OperEx(op, transform(shallExpand)(operEx), transform(shallExpand)(baseEx), transform(true)(setEx))(tag)
+
     case ex @ OperEx(op @ TlaSetOper.filter, name, set, pred) =>
       // For the moment, we require the set to be expanded. However, we could think of collecting constraints on the way.
       val tag = ex.typeTag

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/analyses/TestExpansionMarker.scala
@@ -117,4 +117,25 @@ class TestExpansionMarker extends AnyFunSuite with BeforeAndAfterEach {
 
     assert(input.build == output)
   }
+
+  // #3385: FoldSet folds over the concrete elements of the set, so the set must be expanded,
+  // otherwise a lazily-represented set contributes no elements and the fold silently returns the base value.
+  test("""marked: ApaFoldSet(Op, v, SUBSET S)""") {
+    val S = tla.name("S", intSetT)
+    def op = tla.lambda("A", tla.int(0), tla.param("acc", IntT1), tla.param("x", intSetT))
+    val input = tla.foldSet(op, tla.int(0), tla.powSet(S))
+    val output = marker.apply(input)
+    val expected = tla.foldSet(op, tla.int(0), tla.expand(tla.powSet(S)))
+    assert(expected.build == output)
+  }
+
+  test("""marked: ApaFoldSet(Op, v, [S -> T])""") {
+    val S = tla.name("S", intSetT)
+    val T = tla.name("T", intSetT)
+    def op = tla.lambda("A", tla.int(0), tla.param("acc", IntT1), tla.param("f", intFunT))
+    val input = tla.foldSet(op, tla.int(0), tla.funSet(S, T))
+    val output = marker.apply(input)
+    val expected = tla.foldSet(op, tla.int(0), tla.expand(tla.funSet(S, T)))
+    assert(expected.build == output)
+  }
 }


### PR DESCRIPTION
## What

Fixes #3385.

`ApaFoldSet` over a non-enumerated set silently returned the **base value** instead of the correct result:

- `ApaFoldSet(CountOne, 0, SUBSET {1,2,3})` returned `0` (should be `8`);
- `ApaFoldSet(CountOne, 0, [{1,2} -> {1,2}])` returned `0` (should be `4`).

This is a silent soundness problem in the same family as #1691, but for *finite* lazily-represented sets, so the #1691 fix does not catch it.

## Why

`FoldSetRule` folds over `state.arena.getHas(setCell)`. For a lazily-represented set cell - a powerset (`SUBSET S`) or a function set (`[S -> T]`) - `getHas` returns no member cells, so the fold iterated zero times and returned the base value. The root cause is one level up: `ExpansionMarker` decides which sets must be expanded into the arena (it already forces expansion for quantifiers, `filter`, `cup`/`UNION`, etc.), but `FoldSet` fell through to the generic case that propagates `shallExpand = false`, so the fold's set argument was never marked for expansion.

## How

Add an explicit `ApalacheOper.foldSet` case to `ExpansionMarker` that marks the **set argument** for expansion (`transform(true)`), leaving the operator and base value as-is. This mirrors how quantifiers and `filter` are handled.

Result:
- folds over a powerset now produce the **correct** result (`8`);
- folds over a set whose expansion is unsupported (function sets, see #1452) now **fail loudly** with `Trying to expand a set of functions...` instead of silently returning a wrong answer.

## Testing

- **New unit tests** in `TestExpansionMarker`: `ApaFoldSet(Op, v, SUBSET S)` and `ApaFoldSet(Op, v, [S -> T])` both mark the set with `Expand`.
- `TestExpansionMarker` (10) and the `FoldSet` rewriter tests pass; no regressions.
- Manual CLI verification (default `oopsla19`/`z3`):
  - `ApaFoldSet(CountOne, 0, SUBSET {1,2,3})` -> `result = 8` (was `0`).
  - `ApaFoldSet(CountOne, 0, [{1,2}->{1,2}])` -> loud `expand a set of functions` error (was silent `0`).
  - `ApaFoldSet(Plus, 0, {1,2,3})` (already-enumerated set) -> still `6`, unaffected.
- `make fmt-fix` applied; compiles cleanly with `APALACHE_FATAL_WARNINGS=true`.

## Changelog

Added `.unreleased/bug-fixes/3385-fold-non-enumerated-set.md`.
