### PR TITLE
Simplify more set expressions in ConstSimplifier (#1238)

### DIFF
--- a/.unreleased/features/1238-const-simplify-sets.md
+++ b/.unreleased/features/1238-const-simplify-sets.md
@@ -1,0 +1,1 @@
+`ConstSimplifier` now simplifies more set expressions: membership in the empty set (`x \in {}` becomes `FALSE`), trivial subset checks (`{} \subseteq S` and `S \subseteq S` become `TRUE`), empty-set identities for an arbitrary set (`{} \cup S`, `S \cup {}`, `{} \cap S`, `S \cap {}`, `{} \ S`, `S \ {}`), and self-operations (`S \cup S`, `S \cap S`, `S \ S`), see #1238.

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -70,9 +70,11 @@ abstract class ConstSimplifierBase {
     // Replace \notin with \in
     // x \notin y = !(x \in y)
     case OperEx(TlaSetOper.notin, lhs, rhs) =>
-      OperEx(TlaBoolOper.not, OperEx(TlaSetOper.in, lhs, rhs)(boolTag))(boolTag)
+      val member = simplifyShallow(OperEx(TlaSetOper.in, lhs, rhs)(boolTag))
+      simplifyShallow(OperEx(TlaBoolOper.not, member)(boolTag))
     // !(x \notin y) = x \in y
-    case OperEx(TlaBoolOper.not, OperEx(TlaSetOper.notin, lhs, rhs)) => OperEx(TlaSetOper.in, lhs, rhs)(boolTag)
+    case OperEx(TlaBoolOper.not, OperEx(TlaSetOper.notin, lhs, rhs)) =>
+      simplifyShallow(OperEx(TlaSetOper.in, lhs, rhs)(boolTag))
 
     // integer operations
     // Evaluate constant addition
@@ -261,6 +263,38 @@ abstract class ConstSimplifierBase {
     // if A /= {}, then [ A -> {} ] <=> {}
     case funSet @ OperEx(TlaSetOper.funSet, _, OperEx(TlaSetOper.enumSet)) =>
       emptySet(funSet.typeTag)
+
+    // Set simplifications that hold for an arbitrary set S, not only for set enumerations.
+    // These complement the literal-only rules below.
+
+    // x \in {} = FALSE
+    case OperEx(TlaSetOper.in, _, OperEx(TlaSetOper.enumSet)) => falseEx
+
+    // {} \subseteq S = TRUE
+    case OperEx(TlaSetOper.subseteq, OperEx(TlaSetOper.enumSet), _) => trueEx
+    // S \subseteq S = TRUE
+    case OperEx(TlaSetOper.subseteq, lhs, rhs) if lhs == rhs => trueEx
+
+    // {} \cup S = S
+    case OperEx(TlaSetOper.cup, OperEx(TlaSetOper.enumSet), set) => set
+    // S \cup {} = S
+    case OperEx(TlaSetOper.cup, set, OperEx(TlaSetOper.enumSet)) => set
+    // S \cup S = S
+    case OperEx(TlaSetOper.cup, lhs, rhs) if lhs == rhs => lhs
+
+    // {} \cap S = {}
+    case OperEx(TlaSetOper.cap, emptyEx @ OperEx(TlaSetOper.enumSet), _) => emptyEx
+    // S \cap {} = {}
+    case OperEx(TlaSetOper.cap, _, emptyEx @ OperEx(TlaSetOper.enumSet)) => emptyEx
+    // S \cap S = S
+    case OperEx(TlaSetOper.cap, lhs, rhs) if lhs == rhs => lhs
+
+    // {} \ S = {}
+    case OperEx(TlaSetOper.setminus, emptyEx @ OperEx(TlaSetOper.enumSet), _) => emptyEx
+    // S \ {} = S
+    case OperEx(TlaSetOper.setminus, set, OperEx(TlaSetOper.enumSet)) => set
+    // S \ S = {}
+    case ex @ OperEx(TlaSetOper.setminus, lhs, rhs) if lhs == rhs => emptySet(ex.typeTag)
 
     // S \cup T when both S and T contain only literals
     case originalExpr @ OperEx(TlaSetOper.cup, OperEx(TlaSetOper.enumSet, args1 @ _*),

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -533,6 +533,40 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
     assert(output == expected)
   }
 
+  // #1238: set simplifications that hold for an arbitrary set S, not only set enumerations
+
+  test("""x \in {} becomes FALSE""") {
+    val input = in(name("x").as(IntT1), enumSet().as(intSetT)).as(BoolT1)
+    assert(simplifier.apply(input) == bool(false).as(BoolT1))
+  }
+
+  test("""{} \subseteq S and S \subseteq S become TRUE""") {
+    val s = name("S").as(intSetT)
+    assert(simplifier.apply(subseteq(enumSet().as(intSetT), s).as(BoolT1)) == bool(true).as(BoolT1))
+    assert(simplifier.apply(subseteq(s, s).as(BoolT1)) == bool(true).as(BoolT1))
+  }
+
+  test("""union with the empty set and S \cup S simplify""") {
+    val s = name("S").as(intSetT)
+    assert(simplifier.apply(cup(enumSet().as(intSetT), s).as(intSetT)) == s)
+    assert(simplifier.apply(cup(s, enumSet().as(intSetT)).as(intSetT)) == s)
+    assert(simplifier.apply(cup(s, s).as(intSetT)) == s)
+  }
+
+  test("""intersection with the empty set and S \cap S simplify""") {
+    val s = name("S").as(intSetT)
+    assert(simplifier.apply(cap(enumSet().as(intSetT), s).as(intSetT)) == enumSet().as(intSetT))
+    assert(simplifier.apply(cap(s, enumSet().as(intSetT)).as(intSetT)) == enumSet().as(intSetT))
+    assert(simplifier.apply(cap(s, s).as(intSetT)) == s)
+  }
+
+  test("""setminus with the empty set and S \ S simplify""") {
+    val s = name("S").as(intSetT)
+    assert(simplifier.apply(setminus(enumSet().as(intSetT), s).as(intSetT)) == enumSet().as(intSetT))
+    assert(simplifier.apply(setminus(s, enumSet().as(intSetT)).as(intSetT)) == s)
+    assert(simplifier.apply(setminus(s, s).as(intSetT)) == enumSet().as(intSetT))
+  }
+
   test("""Cardinality({"a", "b", "c"}) becomes 3""") {
     val input = card(enumSet(str("a"), str("b"), str("c")).as(strSetT)).as(intT)
     val output = simplifier.apply(input)


### PR DESCRIPTION
## What

Fixes #1238.

`ConstSimplifier` already folds `\cup` / `\cap` / `\setminus` and `Cardinality` over set **enumerations of literals**. This adds simplifications that hold for an **arbitrary** set `S`, which the literal-only rules do not cover:

- `x \in {}` -> `FALSE`
- `{} \subseteq S` -> `TRUE`, `S \subseteq S` -> `TRUE`
- `{} \cup S` -> `S`, `S \cup {}` -> `S`, `S \cup S` -> `S`
- `{} \cap S` -> `{}`, `S \cap {}` -> `{}`, `S \cap S` -> `S`
- `{} \ S` -> `{}`, `S \ {}` -> `S`, `S \ S` -> `{}`

These are all sound semantic identities and apply even when `S` is a variable or a non-enumeration expression (the existing literal rules bail unless both operands are concrete enumerations).

## How

Added cases to `ConstSimplifierBase.simplifyShallow`, placed before the existing literal-only set rules so the empty-set / idempotence patterns fire first. The empty set is matched as the zero-argument enumerator `OperEx(TlaSetOper.enumSet)` (the same idiom already used elsewhere in the file), and `S \ S` returns an empty set carrying the original expression's type tag.

## Testing

- New unit tests in `TestConstSimplifier` covering all the cases above (`x \in {}`, the two `\subseteq` cases, and union/intersection/setminus with the empty set and with `S` itself).
- Full `TestConstSimplifier` suite passes (40 tests, 0 failures).
- `make fmt-fix` applied; compiles cleanly with `APALACHE_FATAL_WARNINGS=true`.
- Note: the change lives in `ConstSimplifierBase`, shared with `ConstSimplifierForSmt`, so the SMT-side simplifier benefits too; the additions are pure semantic identities.

## Changelog

Added `.unreleased/features/1238-const-simplify-sets.md`.
