### PR TITLE
Allow string or integer keys for TLCGet/TLCSet (#3274)

### DIFF
--- a/.unreleased/bug-fixes/3274-tlc-register-types.md
+++ b/.unreleased/bug-fixes/3274-tlc-register-types.md
@@ -1,0 +1,1 @@
+Fixed type checking of `TLCGet`/`TLCSet`: the register key may be a string (named register, e.g. `TLCGet("level")`) or an integer (numbered register, e.g. `TLCGet(2)`). The key argument is now polymorphic, so an operator mixing both forms type-checks, see #3274.

--- a/src/tla/__rewire_tlc_in_apalache.tla
+++ b/src/tla/__rewire_tlc_in_apalache.tla
@@ -68,18 +68,22 @@ JavaTime ==
     123
 
 \* Apalache does not support this operator, but the type checker does.
+\* The register key may be an integer (numbered register) or a string (named
+\* register), so its type is left polymorphic, see #3274.
 \*
-\* @type: Int => a;
+\* @type: b => a;
 TLCGet(__i) ==
     LET \* @type: () => Set(a);
         __Empty == {}
     IN
     CHOOSE __x \in __Empty: TRUE
-    
+
 
 \* Apalache does not support this operator, but the type checker does.
+\* The register key may be an integer (numbered register) or a string (named
+\* register), so its type is left polymorphic, see #3274.
 \*
-\* @type: (Int, a) => Bool;
+\* @type: (b, a) => Bool;
 TLCSet(__i, __v) ==
     TRUE
 

--- a/test/tla/Bug3274.tla
+++ b/test/tla/Bug3274.tla
@@ -1,0 +1,11 @@
+---------------------------- MODULE Bug3274 --------------------------
+\* Regression test for https://github.com/apalache-mc/apalache/issues/3274:
+\* TLCGet/TLCSet must accept both string (named) and integer (numbered) registers.
+EXTENDS Integers, TLC
+
+\* @type: () => Bool;
+Foo ==
+    /\ TLCSet(1, 42)
+    /\ TLCSet("level", 7)
+    /\ TLCGet(1) = TLCGet("level")
+=================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -465,6 +465,17 @@ EXITCODE: OK
 $ rm output.json
 ```
 
+### typecheck accepts string and integer TLC registers
+
+Regression test for #3274: `TLCGet`/`TLCSet` must accept both string (named) and
+integer (numbered) registers in the same operator.
+
+```sh
+$ apalache-mc typecheck Bug3274.tla | sed 's/I@.*//'
+...
+EXITCODE: OK
+```
+
 ### parse FormulaRefs fails
 
 ```sh


### PR DESCRIPTION
## What

Fixes #3274.

`TLCGet`/`TLCSet` accept both a **string** (named register, e.g. `TLCGet("level")`) and an **integer** (numbered register, e.g. `TLCGet(2)`) as their key argument. Their type annotations in `src/tla/__rewire_tlc_in_apalache.tla` fixed the key to `Int`, so Snowcat (which has no union types) rejected any operator mixing both forms:

```
The operator TLCSet of type ((Int, a) => Bool) is applied to arguments of incompatible types in TLCSet("level", 7):
Argument "level" should have type Int but has type Str.
```

## How

Make the key argument polymorphic, as suggested by @konnov / @lemmy in the issue:

- `TLCGet`: `Int => a` -> `b => a`
- `TLCSet`: `(Int, a) => Bool` -> `(b, a) => Bool`

Each call site instantiates the key type `b` independently (`Str` or `Int`), while the value type `a` is inferred as before. This is strictly more permissive, so existing specs using numbered registers are unaffected.

## Testing

- Reproduced the failure first: a spec mixing `TLCSet(1, 42)`, `TLCSet("level", 7)`, and `TLCGet(1) = TLCGet("level")` failed type checking on `main`; it now type-checks.
- Edge cases verified via `apalache-mc typecheck`:
  - Int key + Int value used arithmetically -> OK
  - Str key + Str value -> OK
  - Str key + Int value -> OK
- Added a regression fixture `test/tla/Bug3274.tla` and a `typecheck` integration test in `test/tla/cli-integration-tests.md` ("typecheck accepts string and integer TLC registers").
- `TestSanyImporterStandardModules` (which imports the TLC module) still passes (10 tests).

## Changelog

Added `.unreleased/bug-fixes/3274-tlc-register-types.md`.
