### PR TITLE
Give a clear error for a polymorphic default value (#3116)

### DIFF
--- a/.unreleased/bug-fixes/3116-default-value-polymorphic-error.md
+++ b/.unreleased/bug-fixes/3116-default-value-polymorphic-error.md
@@ -1,0 +1,1 @@
+Generating a default value for a polymorphic (uninstantiated) type now raises a clear "known limitation" error advising to add a type annotation, instead of a confusing internal `Unexpected type ... when generating a default value` error that asked the user to report a bug (e.g. with an un-annotated `caseNone` of `OptionCase`), see #3116.

--- a/test/tla/Github3116.tla
+++ b/test/tla/Github3116.tla
@@ -1,0 +1,50 @@
+------------------------------- MODULE Github3116 -------------------------------
+\* Regression test for https://github.com/apalache-mc/apalache/issues/3116:
+\* OptionCase with an un-annotated caseNone (returning None) used to crash the
+\* model checker with a confusing "Unexpected type ... when generating a default value".
+EXTENDS Integers, Sequences, FiniteSets, TLC, Option
+
+VARIABLES
+  \* @type: Int -> Str;
+  myPc
+
+\* @type: Seq((Int -> Str));
+vars == <<myPc>>
+
+ThreadInit(t) ==
+  /\ myPc = [ x \in t |-> "Idle" ]
+
+\* @type: Int => Some(Int) | None(UNIT);
+operator1(x) ==
+  IF (x % 2) = 0 THEN Some(x) ELSE None
+
+\* @type: (Int, Int) => Some(Int) | None(UNIT);
+operator2(x, y) ==
+  IF ((x + y) % 2) = 0 THEN Some(x + y) ELSE None
+
+\* @type: Int => Some(<<Int, Int>>) | None(UNIT);
+problemOperator(self) ==
+  LET q1 == operator1(self) IN
+  IF IsNone(q1) THEN None ELSE (
+    LET v1 == OptionGetOrElse(q1, self) IN
+    OptionCase(operator2(self, v1),
+      \* @type: Int => Some(<<Int, Int>>) | None(UNIT);
+      LAMBDA v2: Some(<<v1, v2>>),
+      LAMBDA u: None
+    )
+  )
+
+\* @type: Int => Bool;
+ThreadNext(self) ==
+  /\ IsSome(problemOperator(self))
+  /\ myPc' = [myPc EXCEPT ![self] = "abcdef"]
+
+Threads == {1, 2, 3}
+Init == ThreadInit(Threads)
+Terminating ==
+  /\ \A s \in Threads: myPc[s] = "Done"
+  /\ UNCHANGED vars
+Next ==
+  \/ (\E self \in Threads: ThreadNext(self))
+  \/ Terminating
+=============================================================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -465,6 +465,17 @@ EXITCODE: OK
 $ rm output.json
 ```
 
+### check Github3116.tla with un-annotated OptionCase succeeds
+
+Regression test for #3116: `OptionCase` with an un-annotated `caseNone` (returning
+`None`) used to crash the model checker with a confusing "Unexpected type" error.
+
+```sh
+$ apalache-mc check --length=1 Github3116.tla | sed 's/I@.*//'
+...
+EXITCODE: OK
+```
+
 ### parse FormulaRefs fails
 
 ```sh

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/DefaultValueFactory.scala
@@ -1,7 +1,9 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
-import at.forsyte.apalache.tla.bmcmt.{ArenaCell, FixedElemPtr, RewriterException, SymbStateRewriter}
+import at.forsyte.apalache.tla.bmcmt.{
+  ArenaCell, FixedElemPtr, RewriterException, RewriterKnownLimitationError, SymbStateRewriter,
+}
 import at.forsyte.apalache.tla.lir._
 
 import scala.collection.immutable.SortedSet
@@ -108,6 +110,13 @@ class DefaultValueFactory(rewriter: SymbStateRewriter) {
         }
 
         (nextArena, variantCell)
+
+      case tp @ VarT1(_) =>
+        // A polymorphic (uninstantiated) type reached default-value generation. This is not an internal bug, but a
+        // sign that the spec is not fully monomorphic, usually because a type annotation is missing. See #3116.
+        throw new RewriterKnownLimitationError(
+            s"Cannot generate a default value for the polymorphic type $tp. This usually means a type annotation is missing, e.g., on a `None`/`caseNone` branch of a variant. Please add an explicit type annotation.",
+            NullEx)
 
       case tp @ _ =>
         throw new RewriterException(s"Unexpected type $tp when generating a default value", NullEx)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestDefaultValueFactory.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestDefaultValueFactory.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
-import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
+import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, RewriterKnownLimitationError, SymbState}
 import at.forsyte.apalache.tla.typecomp._
 import at.forsyte.apalache.tla.types.parser.DefaultType1Parser
 import at.forsyte.apalache.tla.types.tla
@@ -20,5 +20,14 @@ trait TestDefaultValueFactory extends RewriterBase {
     val eq = tla.eql(expected, tla.unchecked(value.toNameEx))
     val state = new SymbState(eq, newArena, Binding())
     assertTlaExAndRestore(rewriter, state)
+  }
+
+  test("""reject a polymorphic type with a clear error (#3116)""") { rewriterType: SMTEncoding =>
+    // A polymorphic (uninstantiated) type must not produce a confusing internal error.
+    val rewriter = create(rewriterType)
+    val factory = new DefaultValueFactory(rewriter)
+    assertThrows[RewriterKnownLimitationError] {
+      factory.makeUpValue(arena, parser("a"))
+    }
   }
 }


### PR DESCRIPTION
## What

Addresses #3116.

Two parts:

1. **The confusing error is fixed.** `DefaultValueFactory.makeUpValue` threw `Unexpected type a140 when generating a default value` as a `RewriterException` (which prints "Please report an issue", implying an internal bug) when it met an uninstantiated type variable. This happens for a polymorphic type, e.g. an un-annotated `caseNone` of `OptionCase` that returns `None`. It is not an internal bug, but a sign the spec is not fully monomorphic. It now raises a `RewriterKnownLimitationError` with an actionable message:

   ```
   Cannot generate a default value for the polymorphic type a140. This usually means a type annotation is missing, e.g., on a `None`/`caseNone` branch of a variant. Please add an explicit type annotation.
   ```

   The generic `RewriterException` is kept for genuinely unexpected (non-variable) types.

2. **The originally-reported spec now works.** On the current `main` (`cf765e0`), the spec from the issue **no longer reproduces the crash** - it model-checks to `NoError`. I added it as a regression fixture (`test/tla/Github3116.tla`) + a `check` integration test so it stays fixed.

## Testing

- Reproduced first: confirmed the issue's spec runs to `NoError` on `main` (no `Unexpected type` crash), i.e. the specific scenario is already resolved upstream.
- **New unit test** in `TestDefaultValueFactory`: `makeUpValue` on a polymorphic type (`VarT1`) throws `RewriterKnownLimitationError` (the actionable error), not a bug-report `RewriterException`.
- **New integration test** in `cli-integration-tests.md`: `check Github3116.tla` succeeds (`EXITCODE: OK`).
- DefaultValueFactory / rewriter tests pass; compiles cleanly with `APALACHE_FATAL_WARNINGS=true`.

## Note

If maintainers would rather make the polymorphic case "just work" (instantiate free type variables to a default monotype before model checking), that is a larger type-system change; this PR takes the smaller step the issue explicitly accepts ("a more user-friendly error instructing the user on how to fix the problem") and locks in the already-fixed scenario with a regression test.

## Changelog

Added `.unreleased/bug-fixes/3116-default-value-polymorphic-error.md`.
