### PR TITLE
enable DCO remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
Since older pull requests were not signed off, as required by DCO now, it is cumbersome to sign them now. Also, I personally keep forgetting to add `-s` to my commits. The [DCO remediation commits](https://github.com/cncf/dco2?tab=readme-ov-file#remediation-commits) allow to add the author to add a later sign-off commit without changing the git history. Thus, enabling them, at least for now.