### PR TITLE
Migrating a portion of tests to typed builder

### DIFF
--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.lir.{BoolT1, IntT1}
-import at.forsyte.apalache.tla.types.{tla => typedTla, tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.lir.{BoolT1, IntT1, TlaEx}
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import at.forsyte.apalache.tla.typecomp._
 import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir.transformations.standard.IncrementalRenaming
@@ -20,12 +20,12 @@ trait RewriterBase extends FixtureAnyFunSuite {
 
   protected val renaming = new IncrementalRenaming(new IdleTracker)
 
-  protected def assertBuildEqual(a: BuilderT, b: BuilderT): Unit =
-    assert(a.build == b.build)
+  protected def assertBuildEqual(expected: BuilderT, actual: TlaEx): Unit =
+    assert(expected.build == actual)
 
-  protected def boolName(name: String): TBuilderInstruction = typedTla.name(name, BoolT1)
-  protected def intName(name: String): TBuilderInstruction = typedTla.name(name, IntT1)
-  protected def cellEx(cell: ArenaCell): TBuilderInstruction = typedTla.name(cell.toString, cell.cellType.toTlaType1)
+  protected def boolName(name: String): BuilderT = tla.name(name, BoolT1)
+  protected def intName(name: String): BuilderT = tla.name(name, IntT1)
+  protected def cellEx(cell: ArenaCell): BuilderT = tla.name(cell.toString, cell.cellType.toTlaType1)
 
   protected def create(rewriterType: SMTEncoding): SymbStateRewriter = {
     rewriterType match {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
@@ -4,8 +4,8 @@ import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.rules.aux.{CherryPick, Oracle, OracleFactory}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.types.parser.DefaultType1Parser
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
-import at.forsyte.apalache.tla.types.tlaU._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 trait TestCherryPick extends RewriterBase {
   private val parser = DefaultType1Parser
@@ -15,10 +15,10 @@ trait TestCherryPick extends RewriterBase {
       state: SymbState,
       oracle: Oracle,
       position: Int,
-      expected: TlaEx): SymbState = {
+      expected: BuilderT): SymbState = {
     rewriter.push()
     solverContext.assertGroundExpr(oracle.whenEqualTo(state, position))
-    val eq = eql(unchecked(state.ex), unchecked(expected))
+    val eq = tla.eql(tla.unchecked(state.ex), expected)
     assertTlaExAndRestore(rewriter, state.setRex(eq))
 
     rewriter.pop()
@@ -27,7 +27,7 @@ trait TestCherryPick extends RewriterBase {
 
   test("""CHERRY-PICK {1, 2, 2}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 3)
     state = oracleState
@@ -36,7 +36,7 @@ trait TestCherryPick extends RewriterBase {
       // introduce integer cells directly
       arena = state.arena.appendCell(IntT1)
       val cell = arena.topCell
-      solverContext.assertGroundExpr(eql(cell.toBuilder, int(i)))
+      solverContext.assertGroundExpr(tla.eql(cellEx(cell), tla.int(i)))
       state = state.setArena(arena)
       cell
     }
@@ -46,20 +46,20 @@ trait TestCherryPick extends RewriterBase {
       .pickBasic(IntT1, state, oracle, intCells, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, pickedState, oracle, 0, int(1))
-    assertEqWhenChosen(rewriter, pickedState, oracle, 1, int(2))
-    assertEqWhenChosen(rewriter, pickedState, oracle, 2, int(2))
+    assertEqWhenChosen(rewriter, pickedState, oracle, 0, tla.int(1))
+    assertEqWhenChosen(rewriter, pickedState, oracle, 1, tla.int(2))
+    assertEqWhenChosen(rewriter, pickedState, oracle, 2, tla.int(2))
   }
 
   test("""CHERRY-PICK {<<1, 2>>, <<3, 4>>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkTuple(i: Int, j: Int): ArenaCell = {
-      state = rewriter.rewriteUntilDone(state.setRex(tuple(int(i), int(j))))
+      state = rewriter.rewriteUntilDone(state.setRex(tla.tuple(tla.int(i), tla.int(j))))
       state.asCell
     }
 
@@ -68,19 +68,19 @@ trait TestCherryPick extends RewriterBase {
       .pickTuple(TupT1(IntT1, IntT1), state, oracle, tuples, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK {<<1, <<2, 3>> >>, <<3, <<4, 5>> >>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkTuple(i: Int, j: Int, k: Int): ArenaCell = {
-      state = rewriter.rewriteUntilDone(state.setRex(tuple(int(i), tuple(int(j), int(k)))))
+      state = rewriter.rewriteUntilDone(state.setRex(tla.tuple(tla.int(i), tla.tuple(tla.int(j), tla.int(k)))))
       state.asCell
     }
 
@@ -89,21 +89,21 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickTuple(tupleT, state, oracle, tuples, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK-SEQ {<<1, 2>>, <<3, 4>>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkSeq(args: BigInt*): ArenaCell = {
       val tup =
-        if (args.isEmpty) emptySeq(IntT1)
-        else tla.seq(args.map(int): _*)
+        if (args.isEmpty) tla.emptySeq(IntT1)
+        else tla.seq(args.map(tla.int): _*)
       state = rewriter.rewriteUntilDone(state.setRex(tup))
       state.asCell
     }
@@ -112,21 +112,21 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSequence(SeqT1(IntT1), state, oracle, seqs, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK-SEQ {<<1, 2>>, <<3, 4, 5>>, <<>>}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 3)
     state = oracleState
 
     def mkSeq(args: BigInt*): ArenaCell = {
       val tup =
-        if (args.isEmpty) emptySeq(IntT1)
-        else tla.seq(args.map(int): _*)
+        if (args.isEmpty) tla.emptySeq(IntT1)
+        else tla.seq(args.map(tla.int): _*)
       state = rewriter.rewriteUntilDone(state.setRex(tup))
       state.asCell
     }
@@ -135,20 +135,20 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSequence(SeqT1(IntT1), state, oracle, seqs, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 2, c.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 2, cellEx(c))
   }
 
   test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3, b |-> 4]}""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkRecord(i: Int, j: Int): ArenaCell = {
-      val rec = tla.rec("a" -> int(i), "b" -> int(j))
+      val rec = tla.rec("a" -> tla.int(i), "b" -> tla.int(j))
       state = rewriter.rewriteUntilDone(state.setRex(rec))
       state.asCell
     }
@@ -157,20 +157,20 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickOldRecord(state, oracle, records, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK { [a |-> 1, b |-> 2], [a |-> 3, b |-> 4]} with rows""") { rewriterType: SMTEncoding =>
     val recordT = parser("{ a: Int, b: Int }")
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkRecord(i: Int, j: Int): ArenaCell = {
-      val rec = tla.rec("a" -> int(i), "b" -> int(j)).withTag(Typed(recordT))
+      val rec = tla.rec("a" -> tla.int(i), "b" -> tla.int(j)).map(_.withTag(Typed(recordT)))
       state = rewriter.rewriteUntilDone(state.setRex(rec))
       state.asCell
     }
@@ -179,19 +179,19 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickRecord(state, oracle, records, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK [a |-> 1, b |-> 2] or [a |-> 3]""") { rewriterType: SMTEncoding =>
     // After switching to Snowcat, we allow sets to mix records of compatible types.
     // The old encoding was always introducing spurious fields for all records, as it was extending the records.
-    val rec1 = rec("a" -> int(1), "b" -> int(2))
-    val rec2 = rec("a" -> int(3))
+    val rec1 = tla.rec("a" -> tla.int(1), "b" -> tla.int(2))
+    val rec2 = tla.rec("a" -> tla.int(3))
 
     // introduce an oracle that tells us which element to pick
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
     state = rewriter.rewriteUntilDone(state.setRex(rec1))
@@ -203,70 +203,70 @@ trait TestCherryPick extends RewriterBase {
         state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, rec1Cell.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, rec2Cell.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(rec1Cell))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(rec2Cell))
   }
 
   test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3]}""") { rewriterType: SMTEncoding =>
     // After switching to Snowcat, we allow sets to mix records of compatible types.
     // The old encoding was always introducing spurious fields for all records, as it was extending the records.
-    val rec1 = rec("a" -> int(1), "b" -> int(2))
-    val rec2 = rec("a" -> int(3))
+    val rec1 = tla.rec("a" -> tla.int(1), "b" -> tla.int(2))
+    val rec2 = tla.rec("a" -> tla.int(3))
 
     // introduce an oracle that tells us which element to pick
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     state = rewriter.rewriteUntilDone(state.setRex(rec1))
     val rec1Cell = state.asCell
     state = rewriter.rewriteUntilDone(state.setRex(rec2))
     val rec2Cell = state.asCell
-    val set = enumSet(
-        rec1Cell.toBuilder,
-        rec2Cell.toBuilder,
+    val set = tla.enumSet(
+        cellEx(rec1Cell),
+        cellEx(rec2Cell),
     )
     state = rewriter.rewriteUntilDone(state.setRex(set))
     val setCell = state.asCell
 
-    state = new CherryPick(rewriter).pick(setCell, state, bool(false))
+    state = new CherryPick(rewriter).pick(setCell, state, tla.bool(false))
     assert(solverContext.sat())
     val result = state.asCell
     // check that the result is equal to one of the records and nothing else
-    val eq1 = eql(result.toBuilder, rec1Cell.toBuilder)
-    val eq2 = eql(result.toBuilder, rec2Cell.toBuilder)
-    val eq1or2 = or(eq1, eq2)
+    val eq1 = tla.eql(cellEx(result), cellEx(rec1Cell))
+    val eq2 = tla.eql(cellEx(result), cellEx(rec2Cell))
+    val eq1or2 = tla.or(eq1, eq2)
     assertTlaExAndRestore(rewriter, state.setRex(eq1or2))
   }
 
   test("""CHERRY-PICK { Variant("A", 2), Variant("B", FALSE) }""") { rewriterType: SMTEncoding =>
     val variantT = parser("A(Int) | B(Bool)").asInstanceOf[VariantT1]
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
-    state = rewriter.rewriteUntilDone(state.setRex(variant("A", int(33), variantT)))
+    state = rewriter.rewriteUntilDone(state.setRex(tla.variant("A", tla.int(33), variantT)))
     val vrtA = state.asCell
-    state = rewriter.rewriteUntilDone(state.setRex(variant("B", bool(false), variantT)))
+    state = rewriter.rewriteUntilDone(state.setRex(tla.variant("B", tla.bool(false), variantT)))
     val vrtB = state.asCell
 
     val variants @ Seq(a, b) = Seq(vrtA, vrtB)
     state = new CherryPick(rewriter).pickVariant(state, oracle, variants, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK { {1, 2}, {3, 4} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkSet(i: BigInt, j: BigInt): ArenaCell = {
-      val set = enumSet(int(i), int(j))
+      val set = tla.enumSet(tla.int(i), tla.int(j))
       state = rewriter.rewriteUntilDone(state.setRex(set))
       state.asCell
     }
@@ -275,13 +275,13 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSet(SetT1(IntT1), state, oracle, sets, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK { {1, 2}, {} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
@@ -291,17 +291,17 @@ trait TestCherryPick extends RewriterBase {
       state.asCell
     }
 
-    val sets @ Seq(a, b) = Seq(mkSet(enumSet(int(1), int(2))), mkSet(emptySet(IntT1)))
+    val sets @ Seq(a, b) = Seq(mkSet(tla.enumSet(tla.int(1), tla.int(2))), mkSet(tla.emptySet(IntT1)))
     state = new CherryPick(rewriter).pickSet(SetT1(IntT1), state, oracle, sets, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK { {} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
@@ -311,16 +311,16 @@ trait TestCherryPick extends RewriterBase {
       state.asCell
     }
 
-    val sets @ Seq(a) = Seq(mkSet(emptySet(IntT1)))
+    val sets @ Seq(a) = Seq(mkSet(tla.emptySet(IntT1)))
     state = new CherryPick(rewriter).pickSet(SetT1(IntT1), state, oracle, sets, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
   }
 
   test("""CHERRY-PICK { {{1, 2}, {3, 4}}, {{5, 6}} }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
@@ -330,42 +330,42 @@ trait TestCherryPick extends RewriterBase {
       state.asCell
     }
 
-    val set12 = enumSet(int(1), int(2))
-    val set34 = enumSet(int(3), int(4))
-    val set56 = enumSet(int(5), int(6))
+    val set12 = tla.enumSet(tla.int(1), tla.int(2))
+    val set34 = tla.enumSet(tla.int(3), tla.int(4))
+    val set56 = tla.enumSet(tla.int(5), tla.int(6))
     val sets @ Seq(a, b) =
-      Seq(rewriteEx(enumSet(set12, set34)), rewriteEx(enumSet(set56)))
+      Seq(rewriteEx(tla.enumSet(set12, set34)), rewriteEx(tla.enumSet(set56)))
     state = new CherryPick(rewriter).pickSet(SetT1(SetT1(IntT1)), state, oracle, sets,
         state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
   }
 
   test("""CHERRY-PICK { [x \in {1, 2} |-> 2 + x], [x \in {2, 3} |-> 2 * x] }""") { rewriterType: SMTEncoding =>
     val rewriter = create(rewriterType)
-    var state = new SymbState(bool(true), arena, Binding())
+    var state = new SymbState(tla.bool(true), arena, Binding())
     // introduce an oracle that tells us which element to pick
     val (oracleState, oracle) = new OracleFactory(rewriter).newConstOracle(state, 2)
     state = oracleState
 
     def mkFun(dom: BuilderT, map: BuilderT): ArenaCell = {
-      val fun = funDef(map, name("x", IntT1) -> dom)
+      val fun = tla.funDef(map, tla.name("x", IntT1) -> dom)
       state = rewriter.rewriteUntilDone(state.setRex(fun))
       state.asCell
     }
 
-    val set12 = enumSet(int(1), int(2))
-    val set23 = enumSet(int(2), int(3))
-    val fun1 = mkFun(set12, plus(int(2), name("x", IntT1)))
-    val fun2 = mkFun(set23, mult(int(2), name("x", IntT1)))
+    val set12 = tla.enumSet(tla.int(1), tla.int(2))
+    val set23 = tla.enumSet(tla.int(2), tla.int(3))
+    val fun1 = mkFun(set12, tla.plus(tla.int(2), tla.name("x", IntT1)))
+    val fun2 = mkFun(set23, tla.mult(tla.int(2), tla.name("x", IntT1)))
     val funs = Seq(fun1, fun2)
     val funT = FunT1(IntT1, IntT1)
     state = new CherryPick(rewriter).pickFun(funT, state, oracle, funs, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, fun1.toBuilder)
-    assertEqWhenChosen(rewriter, state, oracle, 1, fun2.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(fun1))
+    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(fun2))
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -4,18 +4,17 @@ import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.types.parser.DefaultType1Parser
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
-import at.forsyte.apalache.tla.types.tlaU._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 trait TestSymbStateDecoder extends RewriterBase {
   private val parser = DefaultType1Parser
   private val int2 = parser("<<Int, Int>>")
 
-  private def pair(i: Int, j: Int): BuilderT = tuple(int(i), int(j))
+  private def pair(i: Int, j: Int): BuilderT = tla.tuple(tla.int(i), tla.int(j))
 
   test("decode bool") { rewriterType: SMTEncoding =>
-    val originalEx: BuilderT = bool(true)
+    val originalEx: BuilderT = tla.bool(true)
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -25,12 +24,12 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     assertBuildEqual(originalEx, decodedEx)
     // hard core comparison
-    val eq = eql(decodedEx, originalEx)
+    val eq = tla.eql(tla.unchecked(decodedEx), originalEx)
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("decode int") { rewriterType: SMTEncoding =>
-    val originalEx = int(3)
+    val originalEx = tla.int(3)
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -40,12 +39,12 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     assertBuildEqual(originalEx, decodedEx)
     // hard core comparison
-    val eq = eql(decodedEx, originalEx)
+    val eq = tla.eql(tla.unchecked(decodedEx), originalEx)
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("decode str") { rewriterType: SMTEncoding =>
-    val originalEx: BuilderT = str("hello")
+    val originalEx: BuilderT = tla.str("hello")
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -55,12 +54,12 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     assertBuildEqual(originalEx, decodedEx)
     // hard core comparison
-    val eq = eql(decodedEx, originalEx)
+    val eq = tla.eql(tla.unchecked(decodedEx), originalEx)
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("decode Int set") { rewriterType: SMTEncoding =>
-    val originalEx = intSet()
+    val originalEx = tla.intSet()
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -72,7 +71,7 @@ trait TestSymbStateDecoder extends RewriterBase {
   }
 
   test("decode Nat set") { rewriterType: SMTEncoding =>
-    val originalEx = natSet()
+    val originalEx = tla.natSet()
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -84,8 +83,8 @@ trait TestSymbStateDecoder extends RewriterBase {
   }
 
   test("decode set") { rewriterType: SMTEncoding =>
-    val originalEx = enumSet(int(2), int(1), int(2))
-    val simpleOriginalEx = enumSet(int(1), int(2))
+    val originalEx = tla.enumSet(tla.int(2), tla.int(1), tla.int(2))
+    val simpleOriginalEx = tla.enumSet(tla.int(1), tla.int(2))
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -95,14 +94,14 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     assertBuildEqual(simpleOriginalEx, decodedEx)
     // hard core comparison
-    val eq = eql(decodedEx, simpleOriginalEx)
+    val eq = tla.eql(tla.unchecked(decodedEx), simpleOriginalEx)
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("decode fun set") { rewriterType: SMTEncoding =>
-    val domEx = enumSet(int(1), int(2))
-    val cdmEx = enumSet(int(3), int(4))
-    val originalEx = funSet(domEx, cdmEx)
+    val domEx = tla.enumSet(tla.int(1), tla.int(2))
+    val cdmEx = tla.enumSet(tla.int(3), tla.int(4))
+    val originalEx = tla.funSet(domEx, cdmEx)
     val state = new SymbState(originalEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -112,13 +111,13 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     assertBuildEqual(originalEx, decodedEx)
     // hard core comparison
-    val eq = eql(decodedEx, originalEx)
+    val eq = tla.eql(tla.unchecked(decodedEx), originalEx)
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
   test("decode SUBSET S") { rewriterType: SMTEncoding =>
-    val set = enumSet(int(1), int(2))
-    val powset = powSet(set)
+    val set = tla.enumSet(tla.int(1), tla.int(2))
+    val powset = tla.powSet(set)
     val state = new SymbState(powset, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -130,9 +129,9 @@ trait TestSymbStateDecoder extends RewriterBase {
   }
 
   test("decode fun") { rewriterType: SMTEncoding =>
-    val domEx = enumSet(int(1), int(2))
+    val domEx = tla.enumSet(tla.int(1), tla.int(2))
     val funEx =
-      funDef(plus(name("x", IntT1), int(1)), (name("x", IntT1), domEx))
+      tla.funDef(tla.plus(tla.name("x", IntT1), tla.int(1)), (tla.name("x", IntT1), domEx))
     val state = new SymbState(funEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -141,16 +140,16 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decoder = new SymbStateDecoder(solverContext, rewriter)
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
 
-    val expectedOutcome: BuilderT = setAsFun(enumSet(pair(1, 2), pair(2, 3)))
+    val expectedOutcome: BuilderT = tla.setAsFun(tla.enumSet(pair(1, 2), pair(2, 3)))
     assertBuildEqual(expectedOutcome, decodedEx)
   }
 
   // See https://github.com/apalache-mc/apalache/issues/962
   test("decode fun does not show duplicate indices") { rewriterType: SMTEncoding =>
     // The specified domain includes duplicate values
-    val domEx = enumSet(int(1), int(1))
+    val domEx = tla.enumSet(tla.int(1), tla.int(1))
     // But the expected domain after decoding should only include a single occurance
-    val funEx = funDef(plus(name("x", IntT1), int(1)), (name("x", IntT1), domEx))
+    val funEx = tla.funDef(tla.plus(tla.name("x", IntT1), tla.int(1)), (tla.name("x", IntT1), domEx))
     val state = new SymbState(funEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -158,13 +157,13 @@ trait TestSymbStateDecoder extends RewriterBase {
     val cell = nextState.asCell
     val decoder = new SymbStateDecoder(solverContext, rewriter)
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
-    val expectedOutcome = setAsFun(enumSet(tuple(int(1), int(2))))
+    val expectedOutcome = tla.setAsFun(tla.enumSet(tla.tuple(tla.int(1), tla.int(2))))
     assertBuildEqual(expectedOutcome, decodedEx)
   }
 
   test("decode statically empty fun") { rewriterType: SMTEncoding =>
-    val domEx = emptySet(IntT1)
-    val funEx = funDef(plus(name("x", IntT1), int(1)), (name("x", IntT1), domEx))
+    val domEx = tla.emptySet(IntT1)
+    val funEx = tla.funDef(tla.plus(tla.name("x", IntT1), tla.int(1)), (tla.name("x", IntT1), domEx))
     val state = new SymbState(funEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -173,20 +172,20 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decoder = new SymbStateDecoder(solverContext, rewriter)
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     // the function of empty domain is simply SetAsFun({})
-    val expectedOutcome = setAsFun(emptySet(int2))
+    val expectedOutcome = tla.setAsFun(tla.emptySet(int2))
     assertBuildEqual(expectedOutcome, decodedEx)
-    assertTlaExAndRestore(rewriter, nextState.setRex(eql(decodedEx, funEx)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.unchecked(decodedEx), funEx)))
   }
 
   test("decode dynamically empty fun") { rewriterType: SMTEncoding =>
     // this domain is not empty at the arena level, but it is in every SMT model
     def dynEmpty(left: BuilderT): BuilderT =
-      filter(name("t", IntT1), left, bool(false))
+      tla.filter(tla.name("t", IntT1), left, tla.bool(false))
 
-    val domEx = dynEmpty(enumSet(int(1)))
+    val domEx = dynEmpty(tla.enumSet(tla.int(1)))
     // [ x \in {} |-> x + 1 ]
     val funEx =
-      funDef(plus(name("x", IntT1), int(1)), (name("x", IntT1), domEx))
+      tla.funDef(tla.plus(tla.name("x", IntT1), tla.int(1)), (tla.name("x", IntT1), domEx))
     val state = new SymbState(funEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -195,15 +194,15 @@ trait TestSymbStateDecoder extends RewriterBase {
     val decoder = new SymbStateDecoder(solverContext, rewriter)
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
     // the function of empty domain is simply SetAsFun({})
-    val expectedOutcome = setAsFun(emptySet(int2))
+    val expectedOutcome = tla.setAsFun(tla.emptySet(int2))
     assertBuildEqual(expectedOutcome, decodedEx)
     // we cannot directly compare the outcome, as it comes in the same form as a record
-    assertTlaExAndRestore(rewriter, nextState.setRex(eql(decodedEx, funEx)))
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.eql(tla.unchecked(decodedEx), funEx)))
   }
 
   test("decode sequence") { rewriterType: SMTEncoding =>
-    val seqEx = seq(int(1), int(2), int(3), int(4))
-    val subseqEx = subseq(seqEx, int(2), int(3))
+    val seqEx = tla.seq(tla.int(1), tla.int(2), tla.int(3), tla.int(4))
+    val subseqEx = tla.subseq(seqEx, tla.int(2), tla.int(3))
     val state = new SymbState(subseqEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -211,12 +210,12 @@ trait TestSymbStateDecoder extends RewriterBase {
     val cell = nextState.asCell
     val decoder = new SymbStateDecoder(solverContext, rewriter)
     val decodedEx = decoder.decodeCellToTlaEx(nextState.arena, cell)
-    val expected = seq(int(2), int(3))
-    assertBuildEqual(decodedEx, expected)
+    val expected = tla.seq(tla.int(2), tla.int(3))
+    assertBuildEqual(expected, decodedEx)
   }
 
   test("decode tuple") { rewriterType: SMTEncoding =>
-    val tupleEx = tuple(int(1), int(2), int(3))
+    val tupleEx = tla.tuple(tla.int(1), tla.int(2), tla.int(3))
     val state = new SymbState(tupleEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -228,9 +227,9 @@ trait TestSymbStateDecoder extends RewriterBase {
   }
 
   test("decode record") { rewriterType: SMTEncoding =>
-    val recEx = rec(
-        "a" -> int(1),
-        "b" -> bool(true),
+    val recEx = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(true),
     )
     val state = new SymbState(recEx, arena, Binding())
     val rewriter = create(rewriterType)
@@ -243,10 +242,12 @@ trait TestSymbStateDecoder extends RewriterBase {
   }
 
   test("decode row record") { rewriterType: SMTEncoding =>
-    val recEx = rec(
-        "a" -> int(1),
-        "b" -> bool(true),
-    ).withTag(Typed(parser("{ a: Int, b: Bool }")))
+    val recEx = tla
+      .rec(
+          "a" -> tla.int(1),
+          "b" -> tla.bool(true),
+      )
+      .map(_.withTag(Typed(parser("{ a: Int, b: Bool }"))))
     val state = new SymbState(recEx, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -259,7 +260,7 @@ trait TestSymbStateDecoder extends RewriterBase {
 
   test("decode variant") { rewriterType: SMTEncoding =>
     val variantT = parser("Foo(Int) | Bar(Bool)")
-    val vrt1 = variant("Foo", int(33), variantT.asInstanceOf[VariantT1])
+    val vrt1 = tla.variant("Foo", tla.int(33), variantT.asInstanceOf[VariantT1])
     val state = new SymbState(vrt1, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterChooseOrGuess.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterChooseOrGuess.scala
@@ -2,20 +2,21 @@ package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.lir.IntT1
-import at.forsyte.apalache.tla.types.tlaU._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
   test("""CHOOSE x \in { 1, 2, 3 }: x > 1""") { rewriterType: SMTEncoding =>
-    val cond = gt(name("x", IntT1), int(1))
+    val cond = tla.gt(tla.name("x", IntT1), tla.int(1))
     val ex =
-      choose(name("x", IntT1), enumSet(int(1), int(2), int(3)), cond)
+      tla.choose(tla.name("x", IntT1), tla.enumSet(tla.int(1), tla.int(2), tla.int(3)), cond)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
 
     def assertEq(i: Int): Unit = {
-      val ns = rewriter.rewriteUntilDone(nextState.setRex(eql(unchecked(nextState.ex), int(i))))
+      val ns = rewriter.rewriteUntilDone(nextState.setRex(tla.eql(tla.unchecked(nextState.ex), tla.int(i))))
       solverContext.assertGroundExpr(ns.ex)
     }
 
@@ -39,14 +40,14 @@ trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
   }
 
   test("""Guess({ 2, 3 })""") { rewriterType: SMTEncoding =>
-    val ex = guess(enumSet(int(2), int(3)))
+    val ex = tla.guess(tla.enumSet(tla.int(2), tla.int(3)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     assert(solverContext.sat())
 
     def assertEq(i: Int): Unit = {
-      val ns = rewriter.rewriteUntilDone(nextState.setRex(eql(unchecked(nextState.ex), int(i))))
+      val ns = rewriter.rewriteUntilDone(nextState.setRex(tla.eql(tla.unchecked(nextState.ex), tla.int(i))))
       solverContext.assertGroundExpr(ns.ex)
     }
 
@@ -61,8 +62,8 @@ trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
   }
 
   test("""CHOOSE x \in { 1 }: x > 1""") { rewriterType: SMTEncoding =>
-    val cond = gt(name("x", IntT1), int(1))
-    val ex = choose(name("x", IntT1), enumSet(int(1)), cond)
+    val cond = tla.gt(tla.name("x", IntT1), tla.int(1))
+    val ex = tla.choose(tla.name("x", IntT1), tla.enumSet(tla.int(1)), cond)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteUntilDone(state)
@@ -74,8 +75,8 @@ trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
   }
 
   test("""CHOOSE x \in {}: x > 1""") { rewriterType: SMTEncoding =>
-    val cond = gt(name("x", IntT1), int(1))
-    val ex = choose(name("x", IntT1), emptySet(IntT1), cond)
+    val cond = tla.gt(tla.name("x", IntT1), tla.int(1))
+    val ex = tla.choose(tla.name("x", IntT1), tla.emptySet(IntT1), cond)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -83,7 +84,7 @@ trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
     assert(solverContext.sat())
 
     def assertEq(i: Int): Unit = {
-      val eq = eql(unchecked(nextState.ex), int(i))
+      val eq = tla.eql(tla.unchecked(nextState.ex), tla.int(i))
       val ns = rewriter.rewriteUntilDone(nextState.setRex(eq))
       solverContext.assertGroundExpr(ns.ex)
     }
@@ -100,7 +101,7 @@ trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
   }
 
   test("""Guess({})""") { rewriterType: SMTEncoding =>
-    val ex = guess(emptySet(IntT1))
+    val ex = tla.guess(tla.emptySet(IntT1))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -108,7 +109,7 @@ trait TestSymbStateRewriterChooseOrGuess extends RewriterBase {
     assert(solverContext.sat())
 
     def assertEq(i: Int): Unit = {
-      val eq = eql(unchecked(nextState.ex), int(i))
+      val eq = tla.eql(tla.unchecked(nextState.ex), tla.int(i))
       val ns = rewriter.rewriteUntilDone(nextState.setRex(eq))
       solverContext.assertGroundExpr(ns.ex)
     }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecord.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecord.scala
@@ -3,7 +3,8 @@ package at.forsyte.apalache.tla.bmcmt
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.tlaU._
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 import scala.collection.immutable.{SortedMap, SortedSet, TreeMap}
 
@@ -17,16 +18,16 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
     val (newArena2, set2) =
       rewriter.recordDomainCache.create(newArena1, (SortedSet("a", "b", "c"), SortedSet[String]()))
     // the domains should not be equal
-    val neq = not(eql(set1.toBuilder, set2.toBuilder))
+    val neq = tla.not(tla.eql(cellEx(set1), cellEx(set2)))
     val state = new SymbState(neq, newArena2, Binding())
     assertTlaExAndRestore(rewriter, state)
   }
 
   test("""["a" |-> 1, "b" |-> FALSE, "c" |-> "d"]""") { rewriterType: SMTEncoding =>
-    val record = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-        "c" -> str("d"),
+    val record = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
+        "c" -> tla.str("d"),
     )
 
     val state = new SymbState(record, arena, Binding())
@@ -50,7 +51,7 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
             // also make sure that the domain equality works
             val (newArena, expectedDom) =
               rewriter.recordDomainCache.getOrCreate(nextState.arena, (SortedSet("a", "b", "c"), SortedSet[String]()))
-            val eq = eql(expectedDom.toBuilder, dom(cell.toBuilder))
+            val eq = tla.eql(cellEx(expectedDom), tla.dom(cellEx(cell)))
             assertTlaExAndRestore(rewriter, nextState.setArena(newArena).setRex(eq))
 
           // we check the actual contents in the later tests that access elements
@@ -65,13 +66,13 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
   }
 
   test("""["a" |-> 1, "b" |-> FALSE, "c" |-> "d"]["c"] equals "d" """) { rewriterType: SMTEncoding =>
-    val record = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-        "c" -> str("d"),
+    val record = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
+        "c" -> tla.str("d"),
     )
-    val recordAcc = app(record, str("b"))
-    val eqD = eql(recordAcc, bool(false))
+    val recordAcc = tla.app(record, tla.str("b"))
+    val eqD = tla.eql(recordAcc, tla.bool(false))
 
     val state = new SymbState(eqD, arena, Binding())
     val rewriter = create(rewriterType)
@@ -79,14 +80,16 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
   }
 
   test("""accessing a non-existing field: ["a" |-> 1, "b" |-> FALSE]["c"]""") { rewriterType: SMTEncoding =>
-    val record = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-    ).withTag(Typed(ribs))
+    val record = tla
+      .rec(
+          "a" -> tla.int(1),
+          "b" -> tla.bool(false),
+      )
+      .map(_.withTag(Typed(ribs)))
     // We assume that record has the type RecT1("a" -> IntT1, "b" -> BoolT1, "c" -> StrT1).
     // This can happen due to type unification. The record access should still work,
     // though the access is expected to produce an arbitrary value (of proper type).
-    val recordAcc = app(record, str("c"))
+    val recordAcc = tla.app(record, tla.str("c"))
 
     val state = new SymbState(recordAcc, arena, Binding())
     val rewriter = create(rewriterType)
@@ -95,15 +98,15 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
   }
 
   test("""{["a" |-> 1, "b" |-> FALSE], ["a" |-> 2, "b" |-> TRUE]}""") { rewriterType: SMTEncoding =>
-    val record1 = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
+    val record1 = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
     )
-    val record2 = rec(
-        "a" -> int(2),
-        "b" -> bool(true),
+    val record2 = tla.rec(
+        "a" -> tla.int(2),
+        "b" -> tla.bool(true),
     )
-    val set = enumSet(record1, record2)
+    val set = tla.enumSet(record1, record2)
     val state = new SymbState(set, arena, Binding())
     val nextState = create(rewriterType).rewriteUntilDone(state)
 
@@ -127,16 +130,18 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
 
   test("""{["a" |-> 1, "b" |-> FALSE], ["a" |-> 2, "b" |-> TRUE, "c" |-> "foo"]}""") { rewriterType: SMTEncoding =>
     // Although record1 has two fields we provide the type `ribs`. This is how the type checker does type unification.
-    val record1 = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-    ).withTag(Typed(ribs))
-    val record2 = rec(
-        "a" -> int(2),
-        "b" -> bool(true),
-        "c" -> str("foo"),
+    val record1 = tla
+      .rec(
+          "a" -> tla.int(1),
+          "b" -> tla.bool(false),
+      )
+      .map(_.withTag(Typed(ribs)))
+    val record2 = tla.rec(
+        "a" -> tla.int(2),
+        "b" -> tla.bool(true),
+        "c" -> tla.str("foo"),
     )
-    val recSet = enumSet(record1, record2)
+    val recSet = tla.enumSet(record1, record2)
     val state = new SymbState(recSet, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -165,18 +170,18 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
       // and then -- when knowing the type of the filtered records -- map them somewhere.
       // Although, it is not easy to do in a symbolic encoding, we support this idiom.
       // We require though that all the records have type-compatible fields.
-      val record1 = rec("a" -> int(1)).withTag(Typed(rii))
-      val record2 = rec("a" -> int(2), "c" -> int(3))
+      val record1 = tla.rec("a" -> tla.int(1)).map(_.withTag(Typed(rii)))
+      val record2 = tla.rec("a" -> tla.int(2), "c" -> tla.int(3))
       // Records in a set can have different sets of keys. This requires a type annotation.
-      val setEx = enumSet(record1, record2)
-      val predEx = eql(app(name("r2", rii), str("c")), int(3))
-      val filteredEx = filter(name("r2", rii), setEx, predEx)
-      val mapEx = map(
-          app(name("r", rii), str("c")),
-          name("r", rii) -> filteredEx,
+      val setEx = tla.enumSet(record1, record2)
+      val predEx = tla.eql(tla.app(tla.name("r2", rii), tla.str("c")), tla.int(3))
+      val filteredEx = tla.filter(tla.name("r2", rii), setEx, predEx)
+      val mapEx = tla.map(
+          tla.app(tla.name("r", rii), tla.str("c")),
+          tla.name("r", rii) -> filteredEx,
       )
 
-      val eq = eql(mapEx, enumSet(int(3)))
+      val eq = tla.eql(mapEx, tla.enumSet(tla.int(3)))
 
       val state = new SymbState(mapEx, arena, Binding())
       val rewriter = create(rewriterType)
@@ -185,30 +190,30 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
 
   test("""[a |-> 1, b |-> FALSE, c |-> "d"] = [c |-> "d", b |-> FALSE, a |-> 1]""") { rewriterType: SMTEncoding =>
     // order of the fields does not matter
-    val record1 = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-        "c" -> str("d"),
+    val record1 = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
+        "c" -> tla.str("d"),
     )
-    val record2 = rec(
-        "c" -> str("d"),
-        "b" -> bool(false),
-        "a" -> int(1),
+    val record2 = tla.rec(
+        "c" -> tla.str("d"),
+        "b" -> tla.bool(false),
+        "a" -> tla.int(1),
     )
-    val eq = eql(record1, record2)
+    val eq = tla.eql(record1, record2)
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
     assertTlaExAndRestore(rewriter, state)
   }
 
   test("""~([a |-> 1, b |-> FALSE, c |-> "d"] = [a |-> 1]) equals TRUE""") { rewriterType: SMTEncoding =>
-    val record1 = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-        "c" -> str("d"),
+    val record1 = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
+        "c" -> tla.str("d"),
     )
-    val record2 = rec("a" -> int(1)).withTag(Typed(ribs))
-    val eq = not(eql(record1, record2))
+    val record2 = tla.rec("a" -> tla.int(1)).map(_.withTag(Typed(ribs)))
+    val eq = tla.not(tla.eql(record1, record2))
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
     assertTlaExAndRestore(rewriter, state)
@@ -216,38 +221,38 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
 
   test("""DOMAIN [a |-> 1, b |-> FALSE, c |-> "d"] equals {"a", "b", "c"}""") { rewriterType: SMTEncoding =>
     // the domain of a record stays the same, even if it is lifted to a more general record type
-    val record = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
-        "c" -> str("d"),
+    val record = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
+        "c" -> tla.str("d"),
     )
-    val domain = dom(record)
-    val eq = eql(domain, enumSet(str("a"), str("b"), str("c")))
+    val domain = tla.dom(record)
+    val eq = tla.eql(domain, tla.enumSet(tla.str("a"), tla.str("b"), tla.str("c")))
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
     assertTlaExAndRestore(rewriter, state)
   }
 
   test("""DOMAIN [a |-> 1] = {"a"} under type annotations!""") { rewriterType: SMTEncoding =>
-    val record = rec("a" -> int(1)).withTag(Typed(ribs))
-    val domain = dom(record)
-    val eq = eql(domain, enumSet(str("a")))
+    val record = tla.rec("a" -> tla.int(1)).map(_.withTag(Typed(ribs)))
+    val domain = tla.dom(record)
+    val eq = tla.eql(domain, tla.enumSet(tla.str("a")))
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)
     assertTlaExAndRestore(rewriter, state)
   }
 
   test("""[ ["a" |-> 1, "b" |-> FALSE] EXCEPT !["a"] = 3 ]""") { rewriterType: SMTEncoding =>
-    val record = rec(
-        "a" -> int(1),
-        "b" -> bool(false),
+    val record = tla.rec(
+        "a" -> tla.int(1),
+        "b" -> tla.bool(false),
     )
-    val updatedRec = except(record, str("a"), int(3))
-    val expectedRec = rec(
-        "a" -> int(3),
-        "b" -> bool(false),
+    val updatedRec = tla.except(record, tla.str("a"), tla.int(3))
+    val expectedRec = tla.rec(
+        "a" -> tla.int(3),
+        "b" -> tla.bool(false),
     )
-    val eq = eql(expectedRec, updatedRec)
+    val eq = tla.eql(expectedRec, updatedRec)
 
     val state = new SymbState(eq, arena, Binding())
     val rewriter = create(rewriterType)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRepeat.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRepeat.scala
@@ -2,7 +2,8 @@ package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSymbStateRewriterRepeat extends RewriterBase {
   test("""Repeat(LET Op(a,i) == a + 1 IN Op, 5, 0) = 5""") { rewriterType: SMTEncoding =>
@@ -20,7 +21,7 @@ trait TestSymbStateRewriterRepeat extends RewriterBase {
     val asCell = state.asCell
 
     // compare the value
-    val eqn = tla.eql(asCell.toBuilder, tla.int(5))
+    val eqn = tla.eql(cellEx(asCell), tla.int(5))
     assertTlaExAndRestore(rewriter, state.setRex(eqn))
   }
 
@@ -39,7 +40,7 @@ trait TestSymbStateRewriterRepeat extends RewriterBase {
     val asCell = state.asCell
 
     // compare the value
-    val eqn = tla.eql(asCell.toBuilder, tla.int(15))
+    val eqn = tla.eql(cellEx(asCell), tla.int(15))
     assertTlaExAndRestore(rewriter, state.setRex(eqn))
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
 import at.forsyte.apalache.tla.lir.BoolT1
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestPropositionalOracle extends RewriterBase {
   test("""Propositional Oracle.create""") { rewriterType: SMTEncoding =>
@@ -48,7 +48,7 @@ trait TestPropositionalOracle extends RewriterBase {
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 2)
     // assert flag == true iff oracle = 0
     rewriter.solverContext
-      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(flag.toBuilder, tla.not(flag.toBuilder))))
+      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(cellEx(flag), tla.not(cellEx(flag)))))
     // assert oracle = 1
     rewriter.push()
     rewriter.solverContext.assertGroundExpr(oracle.whenEqualTo(nextState, 1))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
 import at.forsyte.apalache.tla.lir.BoolT1
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestSparseOracle extends RewriterBase {
   test("""Sparse Oracle.create""") { rewriterType: SMTEncoding =>
@@ -50,7 +50,7 @@ trait TestSparseOracle extends RewriterBase {
     val sparseOracle = new SparseOracle(oracle, Set(1, 5))
     // assert flag == true iff oracle = 1
     rewriter.solverContext
-      .assertGroundExpr(sparseOracle.caseAssertions(nextState, Seq(flag.toBuilder, tla.not(flag.toBuilder))))
+      .assertGroundExpr(sparseOracle.caseAssertions(nextState, Seq(cellEx(flag), tla.not(cellEx(flag)))))
     // assert oracle = 5
     rewriter.push()
     rewriter.solverContext.assertGroundExpr(sparseOracle.whenEqualTo(nextState, 5))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.{Binding, RewriterBase, SymbState}
 import at.forsyte.apalache.tla.lir.BoolT1
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 trait TestUninterpretedConstOracle extends RewriterBase {
   test("""UninterpretedConst Oracle.create""") { rewriterType: SMTEncoding =>
@@ -48,7 +48,7 @@ trait TestUninterpretedConstOracle extends RewriterBase {
     val (nextState, oracle) = UninterpretedConstOracle.create(rewriter, state, 2)
     // assert flag == true iff oracle = 0
     rewriter.solverContext
-      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(flag.toBuilder, tla.not(flag.toBuilder))))
+      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(cellEx(flag), tla.not(cellEx(flag)))))
     // assert oracle = 1
     rewriter.push()
     rewriter.solverContext.assertGroundExpr(oracle.whenEqualTo(nextState, 1))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestIntOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestIntOracle.scala
@@ -7,8 +7,8 @@ import at.forsyte.apalache.tla.bmcmt.stratifiedRules.RewriterScope
 import at.forsyte.apalache.tla.lir.{BoolT1, NameEx, OperEx, TlaEx, ValEx}
 import at.forsyte.apalache.tla.lir.oper.TlaOper
 import at.forsyte.apalache.tla.lir.values.TlaInt
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.junit.runner.RunWith
 import org.scalacheck.{Gen, Prop}
 import org.scalacheck.Prop.forAll
@@ -81,7 +81,7 @@ class TestIntOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
         val (scope, oracle) = IntOracle.create(initScope, size)
         if (assertionsIfTrue.size != oracle.size || assertionsIfFalseOpt.exists { _.size != oracle.size })
           Prop.throws(classOf[IllegalArgumentException]) {
-            oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt)
+            oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt.map(_.map(_.build)))
           }
         else true
       }
@@ -99,7 +99,8 @@ class TestIntOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
     val prop =
       forAll(gen) { case (size, assertionsIfTrue, assertionsIfFalseOpt) =>
         val (scope, oracle) = IntOracle.create(initScope, size)
-        val caseEx: TlaEx = oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt)
+        val caseEx: TlaEx =
+          oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt.map(_.map(_.build)))
         size match {
           case 0 =>
             caseEx == PureArena.cellTrue(scope.arena).toBuilder.build
@@ -109,12 +110,12 @@ class TestIntOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
             assertionsIfFalseOpt match {
               case None =>
                 val ites = assertionsIfTrue.zipWithIndex.map { case (a, i) =>
-                  tla.ite(tla.eql(oracle.intCell.toBuilder, tla.int(i)), a, tla.bool(true))
+                  tla.ite(tla.eql(tla.unchecked(oracle.intCell.toBuilder), tla.int(i)), a, tla.bool(true))
                 }
                 caseEx == tla.and(ites: _*).build
               case Some(assertionsIfFalse) =>
                 val ites = assertionsIfTrue.zip(assertionsIfFalse).zipWithIndex.map { case ((at, af), i) =>
-                  tla.ite(tla.eql(oracle.intCell.toBuilder, tla.int(i)), at, af)
+                  tla.ite(tla.eql(tla.unchecked(oracle.intCell.toBuilder), tla.int(i)), at, af)
                 }
                 caseEx == tla.and(ites: _*).build
             }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestMockOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestMockOracle.scala
@@ -4,8 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.smt.{SolverConfig, Z3SolverContext}
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.RewriterScope
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.values.TlaBool
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.junit.runner.RunWith
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Gen, Prop}
@@ -77,7 +77,7 @@ class TestMockOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
         val oracle = MockOracle.create(fixed)
         if (assertionsIfTrue.size != oracle.size || assertionsIfFalseOpt.exists { _.size != oracle.size })
           Prop.throws(classOf[IllegalArgumentException]) {
-            oracle.caseAssertions(initScope, assertionsIfTrue, assertionsIfFalseOpt)
+            oracle.caseAssertions(initScope, assertionsIfTrue, assertionsIfFalseOpt.map(_.map(_.build)))
           }
         else true
       }
@@ -94,7 +94,8 @@ class TestMockOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
     val prop =
       forAll(gen) { case (fixed, assertionsIfTrue, assertionsIfFalseOpt) =>
         val oracle = MockOracle.create(fixed)
-        val caseEx: TlaEx = oracle.caseAssertions(initScope, assertionsIfTrue, assertionsIfFalseOpt)
+        val caseEx: TlaEx =
+          oracle.caseAssertions(initScope, assertionsIfTrue, assertionsIfFalseOpt.map(_.map(_.build)))
         caseEx == assertionsIfTrue(fixed).build
       }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestSparseOracle.scala
@@ -6,8 +6,8 @@ import at.forsyte.apalache.tla.bmcmt.stratifiedRules.RewriterScope
 import at.forsyte.apalache.tla.bmcmt.types.CellT
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, PureArena}
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.junit.runner.RunWith
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestUninterpretedConstOracle.scala
@@ -7,8 +7,8 @@ import at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.caches.UninterpretedLit
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.{Rewriter, RewriterScope, TestingRewriter}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaOper
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.junit.runner.RunWith
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Gen, Prop}
@@ -88,7 +88,7 @@ class TestUninterpretedConstOracle extends AnyFunSuite with BeforeAndAfterEach w
         val (scope, oracle) = UninterpretedConstOracle.create(rewriter, cache, initScope, size)
         if (assertionsIfTrue.size != oracle.size || assertionsIfFalseOpt.exists { _.size != oracle.size })
           Prop.throws(classOf[IllegalArgumentException]) {
-            oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt)
+            oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt.map(_.map(_.build)))
           }
         else true
       }
@@ -105,7 +105,8 @@ class TestUninterpretedConstOracle extends AnyFunSuite with BeforeAndAfterEach w
     val prop =
       forAll(gen) { case (size, assertionsIfTrue, assertionsIfFalseOpt) =>
         val (scope, oracle) = UninterpretedConstOracle.create(rewriter, cache, initScope, size)
-        val caseEx: TlaEx = oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt)
+        val caseEx: TlaEx =
+          oracle.caseAssertions(scope, assertionsIfTrue, assertionsIfFalseOpt.map(_.map(_.build)))
         size match {
           case 0 =>
             caseEx == PureArena.cellTrue(scope.arena).toBuilder.build
@@ -115,12 +116,16 @@ class TestUninterpretedConstOracle extends AnyFunSuite with BeforeAndAfterEach w
             assertionsIfFalseOpt match {
               case None =>
                 val ites = assertionsIfTrue.zip(oracle.valueCells).map { case (a, c) =>
-                  tla.ite(tla.eql(oracle.oracleCell.toBuilder, c.toBuilder), a, tla.bool(true))
+                  tla.ite(
+                      tla.eql(tla.unchecked(oracle.oracleCell.toBuilder), tla.unchecked(c.toBuilder)),
+                      a,
+                      tla.bool(true),
+                  )
                 }
                 caseEx == tla.and(ites: _*).build
               case Some(assertionsIfFalse) =>
                 val ites = assertionsIfTrue.zip(assertionsIfFalse).zip(oracle.valueCells).map { case ((at, af), c) =>
-                  tla.ite(tla.eql(oracle.oracleCell.toBuilder, c.toBuilder), at, af)
+                  tla.ite(tla.eql(tla.unchecked(oracle.oracleCell.toBuilder), tla.unchecked(c.toBuilder)), at, af)
                 }
                 caseEx == tla.and(ites: _*).build
             }


### PR DESCRIPTION
As a follow-up of #3345, migrating further tests to the typed builder. This is a purely mechanical change done by Codex GPT 5.6-sol max. No further review is needed.