### PR TITLE
Migrate further tests to the typed builder

### DIFF
--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -8,7 +8,8 @@ import at.forsyte.apalache.tla.bmcmt.rules.aux.AuxOps._
 import at.forsyte.apalache.tla.bmcmt.rules.aux.{ProtoSeqOps, RecordAndVariantOps}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import scalaz.unused
 
 import scala.collection.immutable.SortedMap
@@ -323,13 +324,13 @@ class LazyEquality(rewriter: SymbStateRewriter)
         simplifier.applySimplifyShallowToBuilderEx(tla.or(inAndEqList: _*))
       }
 
-      def notInOrExists(lelem: ArenaCell) = {
+      def notInOrExists(lelem: ArenaCell): BuilderT = {
         val notInOrExists =
           simplifier.applySimplifyShallowToBuilderEx(
               tla.or(tla.not(tla.selectInSet(lelem.toBuilder, left.toBuilder)), exists(lelem))
           )
 
-        if (simplifier.isBoolConst(notInOrExists)) {
+        if (simplifier.isBoolConst(notInOrExists.build)) {
           notInOrExists // just return the constant
         } else {
           // BUG: this produced OOM on the inductive invariant of Paxos

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/AuxOps.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/AuxOps.scala
@@ -3,7 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 import at.forsyte.apalache.infra.passes.options.SMTEncoding
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 /**
  * Auxiliary methods for handling rewriting rules.
@@ -46,7 +47,7 @@ object AuxOps {
         val relationElems = nextState.arena.getHas(relation)
 
         def eqAndInDomain(domainElem: ArenaCell, checkedElem: ArenaCell): BuilderT = {
-          val eq = tla.unchecked(rewriter.lazyEq.safeEq(domainElem, checkedElem))
+          val eq = rewriter.lazyEq.safeEq(domainElem, checkedElem)
           val selectInSet = tla.selectInSet(domainElem.toBuilder, domain.toBuilder)
           tla.and(eq, selectInSet)
         }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/CherryPick.scala
@@ -6,7 +6,8 @@ import at.forsyte.apalache.tla.bmcmt.arena.PtrUtil
 import at.forsyte.apalache.tla.bmcmt.rules.aux.AuxOps._
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT, _}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT, _}
 
 import scala.collection.immutable.SortedMap
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/IntOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/IntOracle.scala
@@ -4,7 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState}
 import at.forsyte.apalache.tla.lir.{IntT1, ValEx}
 import at.forsyte.apalache.tla.lir.values.TlaInt
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 /**
  * An oracle that uses an integer variable. Although using integers as an oracle is the most straightforward decision,

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MockOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/MockOracle.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.SymbState
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 /**
  * An oracle that always has the same value. This class specializes all methods to the case oracle == fixedValue.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/Oracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/Oracle.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.SymbState
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 /**
  * An abstract version of an oracle that is used e.g. in CherryPick.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/OracleHelper.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/OracleHelper.scala
@@ -1,7 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
-import at.forsyte.apalache.tla.types.{tlaU => tla}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 
 /**
  * A helper class to create oracle values and compare them. In two previous solutions, we were using integers, then

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/PropositionalOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/PropositionalOracle.scala
@@ -4,8 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.bmcmt.types.CellTFrom
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, SymbState, SymbStateRewriter}
 import at.forsyte.apalache.tla.lir.BoolT1
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 class PropositionalOracle(bitCells: Seq[ArenaCell], nvalues: Int) extends Oracle {
 
@@ -18,7 +18,7 @@ class PropositionalOracle(bitCells: Seq[ArenaCell], nvalues: Int) extends Oracle
 
         case hd +: tl =>
           // the least significant bit comes first
-          val lit =
+          val lit: BuilderT =
             if ((n & 1) == 1) hd.toBuilder else tla.not(hd.toBuilder)
           lit +: mkLits(n >> 1, tl)
       }

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/SparseOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/SparseOracle.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.SymbState
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.types.BuilderT
 
 /**
  * The oracle for sparse values, that is, a set S of naturals. This oracle is mapped on a smaller contiguous range

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/UninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/UninterpretedConstOracle.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
 import at.forsyte.apalache.tla.lir.ConstT1
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 class UninterpretedConstOracle(valueCells: Seq[ArenaCell], oracleCell: ArenaCell, nvalues: Int) extends Oracle {
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ZipOracle.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/ZipOracle.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.bmcmt.rules.aux
 
 import at.forsyte.apalache.tla.bmcmt.SymbState
 import at.forsyte.apalache.tla.bmcmt.smt.SolverContext
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 /**
  * [[ZipOracle]] is an optimization of [[Oracle]]. It groups several values of the background oracle together, in order

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/RewriterBase.scala
@@ -25,7 +25,6 @@ trait RewriterBase extends FixtureAnyFunSuite {
 
   protected def boolName(name: String): BuilderT = tla.name(name, BoolT1)
   protected def intName(name: String): BuilderT = tla.name(name, IntT1)
-  protected def cellEx(cell: ArenaCell): BuilderT = tla.name(cell.toString, cell.cellType.toTlaType1)
 
   protected def create(rewriterType: SMTEncoding): SymbStateRewriter = {
     rewriterType match {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestCherryPick.scala
@@ -36,7 +36,7 @@ trait TestCherryPick extends RewriterBase {
       // introduce integer cells directly
       arena = state.arena.appendCell(IntT1)
       val cell = arena.topCell
-      solverContext.assertGroundExpr(tla.eql(cellEx(cell), tla.int(i)))
+      solverContext.assertGroundExpr(tla.eql(cell.toBuilder, tla.int(i)))
       state = state.setArena(arena)
       cell
     }
@@ -68,8 +68,8 @@ trait TestCherryPick extends RewriterBase {
       .pickTuple(TupT1(IntT1, IntT1), state, oracle, tuples, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK {<<1, <<2, 3>> >>, <<3, <<4, 5>> >>}""") { rewriterType: SMTEncoding =>
@@ -89,8 +89,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickTuple(tupleT, state, oracle, tuples, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK-SEQ {<<1, 2>>, <<3, 4>>}""") { rewriterType: SMTEncoding =>
@@ -112,8 +112,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSequence(SeqT1(IntT1), state, oracle, seqs, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK-SEQ {<<1, 2>>, <<3, 4, 5>>, <<>>}""") { rewriterType: SMTEncoding =>
@@ -135,9 +135,9 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSequence(SeqT1(IntT1), state, oracle, seqs, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
-    assertEqWhenChosen(rewriter, state, oracle, 2, cellEx(c))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 2, c.toBuilder)
   }
 
   test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3, b |-> 4]}""") { rewriterType: SMTEncoding =>
@@ -157,8 +157,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickOldRecord(state, oracle, records, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK { [a |-> 1, b |-> 2], [a |-> 3, b |-> 4]} with rows""") { rewriterType: SMTEncoding =>
@@ -179,8 +179,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickRecord(state, oracle, records, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK [a |-> 1, b |-> 2] or [a |-> 3]""") { rewriterType: SMTEncoding =>
@@ -203,8 +203,8 @@ trait TestCherryPick extends RewriterBase {
         state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(rec1Cell))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(rec2Cell))
+    assertEqWhenChosen(rewriter, state, oracle, 0, rec1Cell.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, rec2Cell.toBuilder)
   }
 
   test("""CHERRY-PICK {[a |-> 1, b |-> 2], [a |-> 3]}""") { rewriterType: SMTEncoding =>
@@ -221,8 +221,8 @@ trait TestCherryPick extends RewriterBase {
     state = rewriter.rewriteUntilDone(state.setRex(rec2))
     val rec2Cell = state.asCell
     val set = tla.enumSet(
-        cellEx(rec1Cell),
-        cellEx(rec2Cell),
+        rec1Cell.toBuilder,
+        rec2Cell.toBuilder,
     )
     state = rewriter.rewriteUntilDone(state.setRex(set))
     val setCell = state.asCell
@@ -231,8 +231,8 @@ trait TestCherryPick extends RewriterBase {
     assert(solverContext.sat())
     val result = state.asCell
     // check that the result is equal to one of the records and nothing else
-    val eq1 = tla.eql(cellEx(result), cellEx(rec1Cell))
-    val eq2 = tla.eql(cellEx(result), cellEx(rec2Cell))
+    val eq1 = tla.eql(result.toBuilder, rec1Cell.toBuilder)
+    val eq2 = tla.eql(result.toBuilder, rec2Cell.toBuilder)
     val eq1or2 = tla.or(eq1, eq2)
     assertTlaExAndRestore(rewriter, state.setRex(eq1or2))
   }
@@ -254,8 +254,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickVariant(state, oracle, variants, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK { {1, 2}, {3, 4} }""") { rewriterType: SMTEncoding =>
@@ -275,8 +275,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSet(SetT1(IntT1), state, oracle, sets, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK { {1, 2}, {} }""") { rewriterType: SMTEncoding =>
@@ -295,8 +295,8 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSet(SetT1(IntT1), state, oracle, sets, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK { {} }""") { rewriterType: SMTEncoding =>
@@ -315,7 +315,7 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickSet(SetT1(IntT1), state, oracle, sets, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
   }
 
   test("""CHERRY-PICK { {{1, 2}, {3, 4}}, {{5, 6}} }""") { rewriterType: SMTEncoding =>
@@ -339,8 +339,8 @@ trait TestCherryPick extends RewriterBase {
         state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(a))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(b))
+    assertEqWhenChosen(rewriter, state, oracle, 0, a.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, b.toBuilder)
   }
 
   test("""CHERRY-PICK { [x \in {1, 2} |-> 2 + x], [x \in {2, 3} |-> 2 * x] }""") { rewriterType: SMTEncoding =>
@@ -365,7 +365,7 @@ trait TestCherryPick extends RewriterBase {
     state = new CherryPick(rewriter).pickFun(funT, state, oracle, funs, state.arena.cellFalse().toBuilder)
     assert(solverContext.sat())
 
-    assertEqWhenChosen(rewriter, state, oracle, 0, cellEx(fun1))
-    assertEqWhenChosen(rewriter, state, oracle, 1, cellEx(fun2))
+    assertEqWhenChosen(rewriter, state, oracle, 0, fun1.toBuilder)
+    assertEqWhenChosen(rewriter, state, oracle, 1, fun2.toBuilder)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAssignment.scala
@@ -40,15 +40,15 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(nextState.binding.contains("x'"))
     val boundCell = nextState.binding("x'")
     rewriter.push()
-    solverContext.assertGroundExpr(tla.eql(cellEx(boundCell), tla.int(1)))
+    solverContext.assertGroundExpr(tla.eql(boundCell.toBuilder, tla.int(1)))
     assert(solverContext.sat()) // ok
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(tla.eql(cellEx(boundCell), tla.int(2)))
+    solverContext.assertGroundExpr(tla.eql(boundCell.toBuilder, tla.int(2)))
     assert(solverContext.sat()) // also possible
     rewriter.pop()
     rewriter.push()
-    solverContext.assertGroundExpr(tla.eql(cellEx(boundCell), tla.int(3)))
+    solverContext.assertGroundExpr(tla.eql(boundCell.toBuilder, tla.int(3)))
     assertUnsatOrExplain() // should not be possible
   }
 
@@ -62,8 +62,8 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     val state = new SymbState(and1, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val x_cell = cellEx(nextState.binding("x'"))
-    val y_cell = cellEx(nextState.binding("y'"))
+    val x_cell = nextState.binding("x'").toBuilder
+    val y_cell = nextState.binding("y'").toBuilder
 
     assert(solverContext.sat()) // no contradiction introduced
     rewriter.push()
@@ -158,21 +158,21 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
     // may equal to {1, 2}
     rewriter.push()
-    val eq12 = tla.eql(cellEx(boundCell), set12)
+    val eq12 = tla.eql(boundCell.toBuilder, set12)
     val eqState12 = rewriter.rewriteUntilDone(nextState.setRex(eq12))
     solverContext.assertGroundExpr(eqState12.ex)
     assert(solverContext.sat()) // ok
     rewriter.pop()
     // may equal to {2, 3}
     rewriter.push()
-    val eq23 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(2), tla.int(3)))
+    val eq23 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(2), tla.int(3)))
     val eqState23 = rewriter.rewriteUntilDone(nextState.setRex(eq23))
     solverContext.assertGroundExpr(eqState23.ex)
     assert(solverContext.sat()) // also possible
     rewriter.pop()
     // not equal to {1, 3}
     rewriter.push()
-    val eq13 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(3)))
+    val eq13 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(1), tla.int(3)))
     val eqState13 = rewriter.rewriteUntilDone(nextState.setRex(eq13))
     solverContext.assertGroundExpr(eqState13.ex)
     assertUnsatOrExplain() // should not be possible
@@ -208,7 +208,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
       // may equal to {1, 2}
       rewriter.push()
-      val eq12 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(2)))
+      val eq12 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(1), tla.int(2)))
 
       val eqState12 = rewriter.rewriteUntilDone(nextState.setRex(eq12))
       solverContext.assertGroundExpr(eqState12.ex)
@@ -216,7 +216,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
       rewriter.pop()
       // not equal to {1, 3}
       rewriter.push()
-      val eq13 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(3)))
+      val eq13 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(1), tla.int(3)))
 
       val eqState13 = rewriter.rewriteUntilDone(nextState.setRex(eq13))
       solverContext.assertGroundExpr(eqState13.ex)
@@ -224,7 +224,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
       rewriter.pop()
       // not equal to {2, 3}
       rewriter.push()
-      val eq23 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(2), tla.int(3)))
+      val eq23 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(2), tla.int(3)))
 
       val eqState23 = rewriter.rewriteUntilDone(nextState.setRex(eq23))
       solverContext.assertGroundExpr(eqState23.ex)
@@ -232,7 +232,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
       rewriter.pop()
       // 2 is in the result
       rewriter.push()
-      val in23 = tla.in(tla.int(2), cellEx(boundCell))
+      val in23 = tla.in(tla.int(2), boundCell.toBuilder)
 
       val inState23 = rewriter.rewriteUntilDone(nextState.setRex(in23))
       solverContext.assertGroundExpr(inState23.ex)
@@ -264,7 +264,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(solverContext.sat())
     // may equal to {1, 2}
     rewriter.push()
-    val eq12 = tla.eql(cellEx(boundCell), set12)
+    val eq12 = tla.eql(boundCell.toBuilder, set12)
 
     val eqState12 = rewriter.rewriteUntilDone(nextState.setRex(eq12))
     solverContext.assertGroundExpr(eqState12.ex)
@@ -272,7 +272,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // may equal to {1}
     rewriter.push()
-    val eq1 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1)))
+    val eq1 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(1)))
 
     val eqState1 = rewriter.rewriteUntilDone(nextState.setRex(eq1))
     solverContext.assertGroundExpr(eqState1.ex)
@@ -280,7 +280,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // may equal to {2}
     rewriter.push()
-    val eq2 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(2)))
+    val eq2 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(2)))
 
     val eqState2 = rewriter.rewriteUntilDone(nextState.setRex(eq2))
     solverContext.assertGroundExpr(eqState2.ex)
@@ -288,7 +288,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // may equal to {}, but this needs a type annotation
     rewriter.push()
-    val eqEmpty = tla.eql(cellEx(boundCell), tla.emptySet(IntT1))
+    val eqEmpty = tla.eql(boundCell.toBuilder, tla.emptySet(IntT1))
 
     val eqStateEmpty = rewriter.rewriteUntilDone(nextState.setRex(eqEmpty))
     solverContext.assertGroundExpr(eqStateEmpty.ex)
@@ -296,7 +296,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     rewriter.pop()
     // not equal to {1, 2, 3}
     rewriter.push()
-    val eq13 = tla.eql(cellEx(boundCell), tla.enumSet(tla.int(1), tla.int(2), tla.int(3)))
+    val eq13 = tla.eql(boundCell.toBuilder, tla.enumSet(tla.int(1), tla.int(2), tla.int(3)))
 
     val eqState13 = rewriter.rewriteUntilDone(nextState.setRex(eq13))
     solverContext.assertGroundExpr(eqState13.ex)
@@ -324,21 +324,21 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
 
       // may equal to fun0
       rewriter.push()
-      val eqFun0 = tla.eql(cellEx(boundCell), fun0)
+      val eqFun0 = tla.eql(boundCell.toBuilder, fun0)
       val eqStateFun0 = rewriter.rewriteUntilDone(nextState.setRex(eqFun0))
       solverContext.assertGroundExpr(eqStateFun0.ex)
       assert(solverContext.sat()) // ok
       rewriter.pop()
       // may equal to fun1
       rewriter.push()
-      val eqFun1 = tla.eql(cellEx(boundCell), fun1)
+      val eqFun1 = tla.eql(boundCell.toBuilder, fun1)
       val eqStateFun1 = rewriter.rewriteUntilDone(nextState.setRex(eqFun1))
       solverContext.assertGroundExpr(eqStateFun1.ex)
       assert(solverContext.sat()) // also possible
       rewriter.pop()
       // not equal to fun2
       rewriter.push()
-      val eqFun2 = tla.eql(cellEx(boundCell), fun2)
+      val eqFun2 = tla.eql(boundCell.toBuilder, fun2)
       val eqStateFun2 = rewriter.rewriteUntilDone(nextState.setRex(eqFun2))
       solverContext.assertGroundExpr(eqStateFun2.ex)
       assertUnsatOrExplain() // should not be possible
@@ -371,21 +371,21 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     assert(solverContext.sat())
     // may equal to fun0
     rewriter.push()
-    val eqFun0 = tla.eql(cellEx(boundCell), fun0)
+    val eqFun0 = tla.eql(boundCell.toBuilder, fun0)
     val eqStateFun0 = rewriter.rewriteUntilDone(nextState.setRex(eqFun0))
     solverContext.assertGroundExpr(eqStateFun0.ex)
     assert(solverContext.sat()) // ok
     rewriter.pop()
     // may equal to fun1
     rewriter.push()
-    val eqFun1 = tla.eql(cellEx(boundCell), fun1)
+    val eqFun1 = tla.eql(boundCell.toBuilder, fun1)
     val eqStateFun1 = rewriter.rewriteUntilDone(nextState.setRex(eqFun1))
     solverContext.assertGroundExpr(eqStateFun1.ex)
     assert(solverContext.sat()) // also possible
     rewriter.pop()
     // not equal to fun2
     rewriter.push()
-    val eqFun2 = tla.eql(cellEx(boundCell), fun2)
+    val eqFun2 = tla.eql(boundCell.toBuilder, fun2)
     val eqStateFun2 = rewriter.rewriteUntilDone(nextState.setRex(eqFun2))
     solverContext.assertGroundExpr(eqStateFun2.ex)
     assertUnsatOrExplain() // should not be possible
@@ -439,7 +439,7 @@ trait TestSymbStateRewriterAssignment extends RewriterBase {
     val nextState = rewriter.rewriteUntilDone(state)
     assert(rewriter.solverContext.sat())
     val x = nextState.binding("x'")
-    val pred = tla.ge(tla.app(cellEx(x), tla.int(1)), tla.int(0))
+    val pred = tla.ge(tla.app(x.toBuilder, tla.int(1)), tla.int(0))
 
     assertTlaExAndRestore(rewriter, nextState.setRex(pred))
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterBool.scala
@@ -83,7 +83,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     val left = arena.topCell
     arena = arena.appendCell(BoolT1)
     val right = arena.topCell
-    val ex = tla.equiv(cellEx(left), cellEx(right))
+    val ex = tla.equiv(left.toBuilder, right.toBuilder)
     val state = new SymbState(ex, arena, xyBinding)
     assert(NoRule() == create(rewriterType).rewriteOnce(state))
   }
@@ -110,14 +110,14 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell
 
-    val ex = tla.not(cellEx(cell))
+    val ex = tla.not(cell.toBuilder)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case NameEx(_) =>
-            val eq = tla.eql(cellEx(cell), cellEx(arena.cellFalse()))
+            val eq = tla.eql(cell.toBuilder, arena.cellFalse().toBuilder)
             solverContext.assertGroundExpr(eq)
             solverContext.assertGroundExpr(nextState.ex)
             rewriter.push()
@@ -147,11 +147,11 @@ trait TestSymbStateRewriterBool extends RewriterBase {
 
   test("""FALSE = TRUE ~~> FALSE""") { rewriterType: SMTEncoding =>
     prepareArena()
-    val ex = tla.eql(cellEx(arena.cellFalse()), cellEx(arena.cellTrue()))
+    val ex = tla.eql(arena.cellFalse().toBuilder, arena.cellTrue().toBuilder)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
-    val eq = tla.eql(tla.unchecked(nextState.ex), cellEx(arena.cellFalse()))
+    val eq = tla.eql(tla.unchecked(nextState.ex), arena.cellFalse().toBuilder)
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 
@@ -198,7 +198,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val c2 = arena.topCell
 
-    val ex = tla.and(cellEx(c1), cellEx(c2))
+    val ex = tla.and(c1.toBuilder, c2.toBuilder)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
@@ -208,14 +208,14 @@ trait TestSymbStateRewriterBool extends RewriterBase {
             assert(solverContext.sat())
             solverContext.assertGroundExpr(nextState.ex)
             rewriter.push()
-            val eq1 = tla.eql(cellEx(c1), cellEx(arena.cellFalse()))
+            val eq1 = tla.eql(c1.toBuilder, arena.cellFalse().toBuilder)
             solverContext.assertGroundExpr(eq1)
             assert(!solverContext.sat())
             rewriter.pop()
-            val eq2 = tla.eql(cellEx(c1), cellEx(arena.cellTrue()))
+            val eq2 = tla.eql(c1.toBuilder, arena.cellTrue().toBuilder)
             solverContext.assertGroundExpr(eq2)
             assert(solverContext.sat())
-            val eq3 = tla.eql(cellEx(c2), cellEx(arena.cellTrue()))
+            val eq3 = tla.eql(c2.toBuilder, arena.cellTrue().toBuilder)
             solverContext.assertGroundExpr(eq3)
             assert(solverContext.sat())
 
@@ -277,19 +277,19 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val right = arena.topCell
 
-    val ex = tla.or(cellEx(left), cellEx(right))
+    val ex = tla.or(left.toBuilder, right.toBuilder)
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case NameEx(_) =>
-            val eq1 = tla.eql(cellEx(left), cellEx(arena.cellFalse()))
+            val eq1 = tla.eql(left.toBuilder, arena.cellFalse().toBuilder)
             solverContext.assertGroundExpr(eq1)
             solverContext.assertGroundExpr(nextState.ex)
             rewriter.push()
             assert(solverContext.sat())
-            val eq2 = tla.eql(cellEx(right), cellEx(arena.cellFalse()))
+            val eq2 = tla.eql(right.toBuilder, arena.cellFalse().toBuilder)
             solverContext.assertGroundExpr(eq2)
             assert(!solverContext.sat())
 
@@ -309,7 +309,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val right = arena.topCell
 
-    val ex = tla.not(tla.eql(cellEx(left), cellEx(right)))
+    val ex = tla.not(tla.eql(left.toBuilder, right.toBuilder))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
@@ -319,28 +319,28 @@ trait TestSymbStateRewriterBool extends RewriterBase {
         rewriter.push()
         // both false
         assert(solverContext.sat())
-        val eq1 = tla.eql(cellEx(left), cellEx(arena.cellFalse()))
+        val eq1 = tla.eql(left.toBuilder, arena.cellFalse().toBuilder)
         solverContext.assertGroundExpr(eq1)
         assert(solverContext.sat())
         rewriter.push()
-        val eq2 = tla.eql(cellEx(right), cellEx(arena.cellFalse()))
+        val eq2 = tla.eql(right.toBuilder, arena.cellFalse().toBuilder)
         solverContext.assertGroundExpr(eq2)
         assert(!solverContext.sat())
         rewriter.pop()
-        val eq3 = tla.eql(cellEx(right), cellEx(arena.cellTrue()))
+        val eq3 = tla.eql(right.toBuilder, arena.cellTrue().toBuilder)
         solverContext.assertGroundExpr(eq3)
         assert(solverContext.sat())
         rewriter.pop()
         // both true
-        val eq4 = tla.eql(cellEx(left), cellEx(arena.cellTrue()))
+        val eq4 = tla.eql(left.toBuilder, arena.cellTrue().toBuilder)
         solverContext.assertGroundExpr(eq4)
         assert(solverContext.sat())
         rewriter.push()
-        val eq5 = tla.eql(cellEx(right), cellEx(arena.cellTrue()))
+        val eq5 = tla.eql(right.toBuilder, arena.cellTrue().toBuilder)
         solverContext.assertGroundExpr(eq5)
         assert(!solverContext.sat())
         rewriter.pop()
-        val eq6 = tla.eql(cellEx(right), cellEx(arena.cellFalse()))
+        val eq6 = tla.eql(right.toBuilder, arena.cellFalse().toBuilder)
         solverContext.assertGroundExpr(eq6)
         assert(solverContext.sat())
 
@@ -400,13 +400,13 @@ trait TestSymbStateRewriterBool extends RewriterBase {
       rewriter.pop()
       rewriter.push()
       solverContext.assertGroundExpr(nextState.ex)
-      val eq1 = tla.eql(tla.int(1), cellEx(nextState.binding("y'")))
+      val eq1 = tla.eql(tla.int(1), nextState.binding("y'").toBuilder)
       solverContext.assertGroundExpr(eq1)
       assert(solverContext.sat())
       rewriter.pop()
       rewriter.push()
       solverContext.assertGroundExpr(nextState.ex)
-      val eq2 = tla.eql(tla.int(2), cellEx(nextState.binding("y'")))
+      val eq2 = tla.eql(tla.int(2), nextState.binding("y'").toBuilder)
       solverContext.assertGroundExpr(eq2)
       assert(solverContext.sat())
       rewriter.pop()
@@ -465,7 +465,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     assert(solverContext.sat())
     solverContext.assertGroundExpr(nextState.ex)
     val xp = nextState.binding("x'")
-    val eql = tla.eql(cellEx(xp), tla.int(10))
+    val eql = tla.eql(xp.toBuilder, tla.int(10))
     assertTlaExAndRestore(rewriter, nextState.setRex(eql))
   }
 
@@ -496,7 +496,7 @@ trait TestSymbStateRewriterBool extends RewriterBase {
     assert(solverContext.sat())
     solverContext.assertGroundExpr(nextState.ex)
     val xp = nextState.binding("x'")
-    val eq = tla.eql(cellEx(xp), tla.int(7))
+    val eq = tla.eql(xp.toBuilder, tla.int(7))
     assertTlaExAndRestore(rewriter, nextState.setRex(eq))
   }
 

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFun.scala
@@ -170,13 +170,13 @@ trait TestSymbStateRewriterFun extends RewriterBase {
         val cell = nextState.arena.findCellByName(name)
         cell.cellType match {
           case CellTFrom(IntT1) =>
-            val eq1 = tla.eql(cellEx(cell), tla.int(12))
+            val eq1 = tla.eql(cell.toBuilder, tla.int(12))
 
             solverContext.assertGroundExpr(eq1)
             rewriter.push()
             assert(solverContext.sat())
             rewriter.pop()
-            val eq2 = tla.neql(cellEx(cell), tla.int(12))
+            val eq2 = tla.neql(cell.toBuilder, tla.int(12))
 
             solverContext.assertGroundExpr(eq2)
             assert(!solverContext.sat())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -98,8 +98,8 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
     assert(CellTFrom(FunT1(IntT1, SetT1(BoolT1))) == gprime.cellType)
     solverContext.assertGroundExpr(nextState.ex)
     // it should be impossible to return two different values for 1
-    val app1 = tla.app(cellEx(gprime), tla.minus(tla.int(2), tla.int(1)))
-    val app2 = tla.app(cellEx(gprime), tla.minus(tla.int(3), tla.int(2)))
+    val app1 = tla.app(gprime.toBuilder, tla.minus(tla.int(2), tla.int(1)))
+    val app2 = tla.app(gprime.toBuilder, tla.minus(tla.int(3), tla.int(2)))
     val app1eqApp2 = tla.eql(app1, app2)
     assertTlaExAndRestore(rewriter, nextState.setRex(app1eqApp2))
   }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterInt.scala
@@ -11,17 +11,17 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftCell = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
-    val eq1 = tla.eql(cellEx(leftCell), cellEx(rightCell))
+    val eq1 = tla.eql(leftCell.toBuilder, rightCell.toBuilder)
     val state = new SymbState(eq1, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case predEx @ NameEx(_) =>
         assert(solverContext.sat())
-        val eq2 = tla.eql(cellEx(leftCell), tla.int(22))
+        val eq2 = tla.eql(leftCell.toBuilder, tla.int(22))
         solverContext.assertGroundExpr(eq2)
         rewriter.push()
-        val eq3 = tla.eql(cellEx(rightCell), tla.int(22))
+        val eq3 = tla.eql(rightCell.toBuilder, tla.int(22))
         solverContext.assertGroundExpr(eq3)
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
@@ -32,7 +32,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.pop()
-        val eq4 = tla.eql(cellEx(rightCell), tla.int(1981))
+        val eq4 = tla.eql(rightCell.toBuilder, tla.int(1981))
         solverContext.assertGroundExpr(eq4)
         rewriter.push()
         solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
@@ -51,15 +51,16 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
-    val state = new SymbState(tla.eql(cellEx(leftInt), cellEx(rightInt)), arena, Binding())
+    val state =
+      new SymbState(tla.eql(leftInt.toBuilder, rightInt.toBuilder), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case predEx @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(22)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(22)))
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(solverContext.sat())
@@ -69,7 +70,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.pop()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(1981)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(1981)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(solverContext.sat())
@@ -87,23 +88,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(tla.lt(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
+      new SymbState(tla.lt(leftCell.toBuilder, rightCell.toBuilder), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(leftCell.toBuilder, tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(22)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(4)))
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(3)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -117,23 +118,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(tla.le(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
+      new SymbState(tla.le(leftCell.toBuilder, rightCell.toBuilder), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(leftCell.toBuilder, tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(22)))
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(4)))
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(3)))
         assert(!solverContext.sat())
 
       case _ =>
@@ -147,23 +148,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(tla.gt(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
+      new SymbState(tla.gt(leftCell.toBuilder, rightCell.toBuilder), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(leftCell.toBuilder, tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(22)))
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(4)))
         assert(!solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(3)))
         assert(solverContext.sat())
 
       case _ =>
@@ -198,23 +199,23 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightCell = arena.topCell
     val state =
-      new SymbState(tla.ge(cellEx(leftCell), cellEx(rightCell)), arena, Binding())
+      new SymbState(tla.ge(leftCell.toBuilder, rightCell.toBuilder), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case cmpEx @ NameEx(_) =>
         assert(solverContext.sat())
         solverContext.assertGroundExpr(cmpEx)
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(leftCell.toBuilder, tla.int(4)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(22)))
         assert(!solverContext.sat())
         rewriter.pop()
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(4)))
         assert(solverContext.sat())
         rewriter.pop()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightCell), tla.int(3)))
+        solverContext.assertGroundExpr(tla.eql(rightCell.toBuilder, tla.int(3)))
         assert(solverContext.sat())
 
       case _ =>
@@ -228,15 +229,15 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
     val state =
-      new SymbState(tla.not(tla.eql(cellEx(leftInt), cellEx(rightInt))), arena, Binding())
+      new SymbState(tla.not(tla.eql(leftInt.toBuilder, rightInt.toBuilder)), arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case predEx @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(22)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(22)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(22)))
         rewriter.push()
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
@@ -246,7 +247,7 @@ trait TestSymbStateRewriterInt extends RewriterBase {
         assert(solverContext.sat())
         rewriter.pop()
         rewriter.pop()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(1981)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(1981)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.not(tla.unchecked(predEx)))
         assert(!solverContext.sat())
@@ -264,16 +265,16 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
-    val expr = tla.plus(cellEx(leftInt), cellEx(rightInt))
+    val expr = tla.plus(leftInt.toBuilder, rightInt.toBuilder)
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(1981)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(1981)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(36)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(36)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(2017)))
         assert(solverContext.sat())
@@ -292,16 +293,16 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
-    val expr = tla.minus(cellEx(leftInt), cellEx(rightInt))
+    val expr = tla.minus(leftInt.toBuilder, rightInt.toBuilder)
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(2017)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(2017)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(36)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(36)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(1981)))
         assert(solverContext.sat())
@@ -318,14 +319,14 @@ trait TestSymbStateRewriterInt extends RewriterBase {
   test("-$Z$j ~~> $Z$k") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(IntT1)
     val leftInt = arena.topCell
-    val expr = tla.uminus(cellEx(leftInt))
+    val expr = tla.uminus(leftInt.toBuilder)
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(2017)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(2017)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(-2017)))
         assert(solverContext.sat())
@@ -344,16 +345,16 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
-    val expr = tla.mult(cellEx(leftInt), cellEx(rightInt))
+    val expr = tla.mult(leftInt.toBuilder, rightInt.toBuilder)
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(7)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(7)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(4)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(28)))
         assert(solverContext.sat())
@@ -372,16 +373,16 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
-    val expr = tla.div(cellEx(leftInt), cellEx(rightInt))
+    val expr = tla.div(leftInt.toBuilder, rightInt.toBuilder)
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(30)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(30)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(4)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(4)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(7)))
         assert(solverContext.sat())
@@ -400,16 +401,16 @@ trait TestSymbStateRewriterInt extends RewriterBase {
     val leftInt = arena.topCell
     arena = arena.appendCell(IntT1)
     val rightInt = arena.topCell
-    val expr = tla.mod(cellEx(leftInt), cellEx(rightInt))
+    val expr = tla.mod(leftInt.toBuilder, rightInt.toBuilder)
     val state = new SymbState(expr, arena, Binding())
     val rewriter = create(rewriterType)
     val nextState = rewriter.rewriteUntilDone(state)
     nextState.ex match {
       case result @ NameEx(_) =>
         assert(solverContext.sat())
-        solverContext.assertGroundExpr(tla.eql(cellEx(leftInt), tla.int(30)))
+        solverContext.assertGroundExpr(tla.eql(leftInt.toBuilder, tla.int(30)))
         rewriter.push()
-        solverContext.assertGroundExpr(tla.eql(cellEx(rightInt), tla.int(7)))
+        solverContext.assertGroundExpr(tla.eql(rightInt.toBuilder, tla.int(7)))
         rewriter.push()
         solverContext.assertGroundExpr(tla.eql(tla.unchecked(result), tla.int(2)))
         assert(solverContext.sat())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecord.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRecord.scala
@@ -18,7 +18,7 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
     val (newArena2, set2) =
       rewriter.recordDomainCache.create(newArena1, (SortedSet("a", "b", "c"), SortedSet[String]()))
     // the domains should not be equal
-    val neq = tla.not(tla.eql(cellEx(set1), cellEx(set2)))
+    val neq = tla.not(tla.eql(set1.toBuilder, set2.toBuilder))
     val state = new SymbState(neq, newArena2, Binding())
     assertTlaExAndRestore(rewriter, state)
   }
@@ -51,7 +51,7 @@ trait TestSymbStateRewriterRecord extends RewriterBase {
             // also make sure that the domain equality works
             val (newArena, expectedDom) =
               rewriter.recordDomainCache.getOrCreate(nextState.arena, (SortedSet("a", "b", "c"), SortedSet[String]()))
-            val eq = tla.eql(cellEx(expectedDom), tla.dom(cellEx(cell)))
+            val eq = tla.eql(expectedDom.toBuilder, tla.dom(cell.toBuilder))
             assertTlaExAndRestore(rewriter, nextState.setArena(newArena).setRex(eq))
 
           // we check the actual contents in the later tests that access elements

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRepeat.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterRepeat.scala
@@ -21,7 +21,7 @@ trait TestSymbStateRewriterRepeat extends RewriterBase {
     val asCell = state.asCell
 
     // compare the value
-    val eqn = tla.eql(cellEx(asCell), tla.int(5))
+    val eqn = tla.eql(asCell.toBuilder, tla.int(5))
     assertTlaExAndRestore(rewriter, state.setRex(eqn))
   }
 
@@ -40,7 +40,7 @@ trait TestSymbStateRewriterRepeat extends RewriterBase {
     val asCell = state.asCell
 
     // compare the value
-    val eqn = tla.eql(cellEx(asCell), tla.int(15))
+    val eqn = tla.eql(asCell.toBuilder, tla.int(15))
     assertTlaExAndRestore(rewriter, state.setRex(eqn))
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -32,11 +32,11 @@ trait TestSymbStateRewriterSet extends RewriterBase {
       case SymbStateRewriter.Continue(nextState) =>
         nextState.ex match {
           case set @ NameEx(_) =>
-            val falseInSet = tla.selectInSet(cellEx(arena.cellFalse()), unchecked(set))
+            val falseInSet = tla.selectInSet(arena.cellFalse().toBuilder, unchecked(set))
             solverContext.assertGroundExpr(falseInSet)
             assert(solverContext.sat())
             val notTrueInSet =
-              tla.not(tla.selectInSet(cellEx(arena.cellTrue()), unchecked(set)))
+              tla.not(tla.selectInSet(arena.cellTrue().toBuilder, unchecked(set)))
             solverContext.assertGroundExpr(notTrueInSet)
             assert(!solverContext.sat())
 
@@ -222,7 +222,7 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell
     val ex =
-      tla.in(cellEx(cell), tla.enumSet(tla.bool(true), tla.bool(true)))
+      tla.in(cell.toBuilder, tla.enumSet(tla.bool(true), tla.bool(true)))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteOnce(state) match {
@@ -231,14 +231,16 @@ trait TestSymbStateRewriterSet extends RewriterBase {
           case predEx @ NameEx(_) =>
             rewriter.push()
             // cell = \TRUE
-            solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellTrue()), cellEx(cell)))
+            solverContext
+              .assertGroundExpr(tla.eql(arena.cellTrue().toBuilder, cell.toBuilder))
             // and membership holds true
             solverContext.assertGroundExpr(predEx)
             assert(solverContext.sat())
             rewriter.pop()
             // another query
             // cell = \FALSE
-            solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellFalse()), cellEx(cell)))
+            solverContext
+              .assertGroundExpr(tla.eql(arena.cellFalse().toBuilder, cell.toBuilder))
             // and membership holds true
             solverContext.assertGroundExpr(predEx)
             // contradiction
@@ -281,21 +283,23 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell
     val ex =
-      tla.not(tla.in(cellEx(cell), tla.enumSet(tla.bool(true), tla.bool(true))))
+      tla.not(tla.in(cell.toBuilder, tla.enumSet(tla.bool(true), tla.bool(true))))
     val state = new SymbState(ex, arena, Binding())
     val rewriter = create(rewriterType)
     rewriter.rewriteUntilDone(state).ex match {
       case predEx @ NameEx(_) =>
         rewriter.push()
         // cell = TRUE
-        solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellTrue()), cellEx(cell)))
+        solverContext
+          .assertGroundExpr(tla.eql(arena.cellTrue().toBuilder, cell.toBuilder))
         // and membership holds true
         solverContext.assertGroundExpr(predEx)
         assert(!solverContext.sat())
         rewriter.pop()
         // another query
         // cell = \FALSE
-        solverContext.assertGroundExpr(tla.eql(cellEx(arena.cellFalse()), cellEx(cell)))
+        solverContext
+          .assertGroundExpr(tla.eql(arena.cellFalse().toBuilder, cell.toBuilder))
         // and membership holds true
         solverContext.assertGroundExpr(predEx)
         // no contradiction here

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestPropositionalOracle.scala
@@ -48,7 +48,7 @@ trait TestPropositionalOracle extends RewriterBase {
     val (nextState, oracle) = PropositionalOracle.create(rewriter, state, 2)
     // assert flag == true iff oracle = 0
     rewriter.solverContext
-      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(cellEx(flag), tla.not(cellEx(flag)))))
+      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(flag.toBuilder, tla.not(flag.toBuilder))))
     // assert oracle = 1
     rewriter.push()
     rewriter.solverContext.assertGroundExpr(oracle.whenEqualTo(nextState, 1))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestSparseOracle.scala
@@ -50,7 +50,7 @@ trait TestSparseOracle extends RewriterBase {
     val sparseOracle = new SparseOracle(oracle, Set(1, 5))
     // assert flag == true iff oracle = 1
     rewriter.solverContext
-      .assertGroundExpr(sparseOracle.caseAssertions(nextState, Seq(cellEx(flag), tla.not(cellEx(flag)))))
+      .assertGroundExpr(sparseOracle.caseAssertions(nextState, Seq(flag.toBuilder, tla.not(flag.toBuilder))))
     // assert oracle = 5
     rewriter.push()
     rewriter.solverContext.assertGroundExpr(sparseOracle.whenEqualTo(nextState, 5))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/rules/aux/TestUninterpretedConstOracle.scala
@@ -48,7 +48,7 @@ trait TestUninterpretedConstOracle extends RewriterBase {
     val (nextState, oracle) = UninterpretedConstOracle.create(rewriter, state, 2)
     // assert flag == true iff oracle = 0
     rewriter.solverContext
-      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(cellEx(flag), tla.not(cellEx(flag)))))
+      .assertGroundExpr(oracle.caseAssertions(nextState, Seq(flag.toBuilder, tla.not(flag.toBuilder))))
     // assert oracle = 1
     rewriter.push()
     rewriter.solverContext.assertGroundExpr(oracle.whenEqualTo(nextState, 1))

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestCrossSolverContextWithOOPSLA19.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestCrossSolverContextWithOOPSLA19.scala
@@ -4,7 +4,8 @@ import at.forsyte.apalache.infra.passes.options.SMTSolver
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, FixedElemPtr, InvalidTlaExException}
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
 import at.forsyte.apalache.tla.lir.{BoolT1, FunT1, IntT1, SetT1, TlaEx, TlaType1}
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestCvc5SolverContext.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestCvc5SolverContext.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.smt
 import at.forsyte.apalache.infra.passes.options.SMTSolver
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
 import at.forsyte.apalache.tla.lir.IntT1
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestCvc5SolverContext extends AnyFunSuite {

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContext.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/smt/TestRecordingSolverContext.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.tla.bmcmt.smt
 
 import at.forsyte.apalache.tla.bmcmt.arena.PureArenaAdapter
 import at.forsyte.apalache.tla.lir.IntT1
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.scalatest.funsuite.AnyFunSuite
 
 /**

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/ApalacheRewriterTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/ApalacheRewriterTest.scala
@@ -3,7 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.stratifiedRules
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.apalache.AssignmentStratifiedRule
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, Binding, PureArena}
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/BoolRewriterTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/BoolRewriterTest.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.tla.bmcmt.stratifiedRules
 
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, Binding, PureArena}
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
@@ -57,7 +57,12 @@ class BoolRewriterTest extends AnyFunSuite with BeforeAndAfterEach {
 
     assert(rewriter.assertSeq ==
       Seq(
-          tla.eql(endCell.toBuilder, tla.and(xCell.toBuilder, yCell.toBuilder)).build
+          tla
+            .eql(
+                endCell.toBuilder,
+                tla.and(xCell.toBuilder, yCell.toBuilder),
+            )
+            .build
       ))
 
     rewriter.assertSeq = Seq.empty
@@ -68,7 +73,12 @@ class BoolRewriterTest extends AnyFunSuite with BeforeAndAfterEach {
 
     assert(rewriter.assertSeq ==
       Seq(
-          tla.eql(endCell2.toBuilder, tla.and(xCell.toBuilder, yCell.toBuilder)).build
+          tla
+            .eql(
+                endCell2.toBuilder,
+                tla.and(xCell.toBuilder, yCell.toBuilder),
+            )
+            .build
       ))
 
     rewriter.assertSeq = Seq.empty
@@ -103,7 +113,12 @@ class BoolRewriterTest extends AnyFunSuite with BeforeAndAfterEach {
 
     assert(rewriter.assertSeq ==
       Seq(
-          tla.eql(endCell.toBuilder, tla.or(xCell.toBuilder, yCell.toBuilder)).build
+          tla
+            .eql(
+                endCell.toBuilder,
+                tla.or(xCell.toBuilder, yCell.toBuilder),
+            )
+            .build
       ))
 
     rewriter.assertSeq = Seq.empty
@@ -114,7 +129,12 @@ class BoolRewriterTest extends AnyFunSuite with BeforeAndAfterEach {
 
     assert(rewriter.assertSeq ==
       Seq(
-          tla.eql(endCell2.toBuilder, tla.or(xCell.toBuilder, yCell.toBuilder)).build
+          tla
+            .eql(
+                endCell2.toBuilder,
+                tla.or(xCell.toBuilder, yCell.toBuilder),
+            )
+            .build
       ))
 
     rewriter.assertSeq = Seq.empty

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/IntRewriterTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/IntRewriterTest.scala
@@ -1,8 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt.stratifiedRules
 
 import at.forsyte.apalache.tla.lir.{IntT1, NameEx, SetT1, Typed}
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/SetRewriterTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/SetRewriterTest.scala
@@ -4,8 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.stratifiedRules.set.SetFilterStratifiedRule
 import at.forsyte.apalache.tla.bmcmt.types.CellT
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
@@ -94,9 +94,13 @@ class SetRewriterTest extends AnyFunSuite with BeforeAndAfterEach {
       arena2.appendHas(lSetCell, lElems.map(FixedElemPtr): _*).appendHas(rSetCell, rElems.map(FixedElemPtr): _*)
 
     val exSetOfSets =
-      tla.enumSet(lSetCell.toBuilder, rSetCell.toBuilder, emptySetCell.toBuilder)
+      tla.enumSet(
+          lSetCell.toBuilder,
+          rSetCell.toBuilder,
+          emptySetCell.toBuilder,
+      )
 
-    // We don't have the rewriting of cell.toBuilder ~~> cell implemented
+    // We don't have the rewriting of arena-cell names to their corresponding cells implemented
     val extendedBinding = Binding(
         binding.toMap ++ Map(
             lSetCell.toString -> lSetCell,

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/IntRangeCacheTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/IntRangeCacheTest.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux
 
 import at.forsyte.apalache.tla.bmcmt.PureArena
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.caches.{IntRangeCache, IntValueCache}
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/IntValueCacheTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/IntValueCacheTest.scala
@@ -2,8 +2,8 @@ package at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux
 
 import at.forsyte.apalache.tla.bmcmt.PureArena
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.caches.IntValueCache
-import at.forsyte.apalache.tla.types.{tlaU => tla}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.tla
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/RecordDomainCacheTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/RecordDomainCacheTest.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux
 import at.forsyte.apalache.tla.bmcmt.PureArena
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.caches.{RecordDomainCache, UninterpretedLiteralCache}
 import at.forsyte.apalache.tla.lir.{StrT1, TlaType1}
-import at.forsyte.apalache.tla.types.{tlaU => tla, ModelValueHandler}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, ModelValueHandler}
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/UninterpretedLiteralCacheTest.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/UninterpretedLiteralCacheTest.scala
@@ -3,8 +3,8 @@ package at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux
 import at.forsyte.apalache.tla.bmcmt.PureArena
 import at.forsyte.apalache.tla.bmcmt.stratifiedRules.aux.caches.UninterpretedLiteralCache
 import at.forsyte.apalache.tla.lir.{StrT1, TlaType1}
-import at.forsyte.apalache.tla.types.{tlaU => tla, ModelValueHandler}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, ModelValueHandler}
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestIntOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestIntOracle.scala
@@ -110,12 +110,12 @@ class TestIntOracle extends AnyFunSuite with BeforeAndAfterEach with Checkers {
             assertionsIfFalseOpt match {
               case None =>
                 val ites = assertionsIfTrue.zipWithIndex.map { case (a, i) =>
-                  tla.ite(tla.eql(tla.unchecked(oracle.intCell.toBuilder), tla.int(i)), a, tla.bool(true))
+                  tla.ite(tla.eql(oracle.intCell.toBuilder, tla.int(i)), a, tla.bool(true))
                 }
                 caseEx == tla.and(ites: _*).build
               case Some(assertionsIfFalse) =>
                 val ites = assertionsIfTrue.zip(assertionsIfFalse).zipWithIndex.map { case ((at, af), i) =>
-                  tla.ite(tla.eql(tla.unchecked(oracle.intCell.toBuilder), tla.int(i)), at, af)
+                  tla.ite(tla.eql(oracle.intCell.toBuilder, tla.int(i)), at, af)
                 }
                 caseEx == tla.and(ites: _*).build
             }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestUninterpretedConstOracle.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/stratifiedRules/aux/oracles/TestUninterpretedConstOracle.scala
@@ -117,7 +117,7 @@ class TestUninterpretedConstOracle extends AnyFunSuite with BeforeAndAfterEach w
               case None =>
                 val ites = assertionsIfTrue.zip(oracle.valueCells).map { case (a, c) =>
                   tla.ite(
-                      tla.eql(tla.unchecked(oracle.oracleCell.toBuilder), tla.unchecked(c.toBuilder)),
+                      tla.eql(oracle.oracleCell.toBuilder, c.toBuilder),
                       a,
                       tla.bool(true),
                   )
@@ -125,7 +125,7 @@ class TestUninterpretedConstOracle extends AnyFunSuite with BeforeAndAfterEach w
                 caseEx == tla.and(ites: _*).build
               case Some(assertionsIfFalse) =>
                 val ites = assertionsIfTrue.zip(assertionsIfFalse).zip(oracle.valueCells).map { case ((at, af), c) =>
-                  tla.ite(tla.eql(tla.unchecked(oracle.oracleCell.toBuilder), tla.unchecked(c.toBuilder)), at, af)
+                  tla.ite(tla.eql(oracle.oracleCell.toBuilder, c.toBuilder), at, af)
                 }
                 caseEx == tla.and(ites: _*).build
             }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorImpl.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/trex/TestTransitionExecutorImpl.scala
@@ -4,8 +4,8 @@ import at.forsyte.apalache.tla.bmcmt.{Binding, StateInvariant}
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaFunOper
 import at.forsyte.apalache.tla.lir.values.TlaInt
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 import at.forsyte.apalache.tla.typecomp._
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 
 /**
  * An abstract test suite that is parameterized by the snapshot type.
@@ -112,12 +112,12 @@ trait TestTransitionExecutorImpl[SnapshotT] extends ExecutorBase[SnapshotT] {
 
   test("Init + 3x Next") { exeCtx: ExecutorContextT =>
     // x' := 1 /\ y' := 1
-    val init: TlaEx = tla.and(mkAssign("y", 1), mkAssign("x", 1))
+    val init: BuilderT = tla.and(mkAssign("y", 1), mkAssign("x", 1))
     // x' := y /\ y' := x + y
-    val trans1: TlaEx =
+    val trans1: BuilderT =
       tla.and(mkAssignInt("x", nY), mkAssignInt("y", tla.plus(nX, nY)))
     // x' := x /\ y' := y
-    val trans2: TlaEx = tla.and(mkAssignInt("x", nX), mkAssignInt("y", nY))
+    val trans2: BuilderT = tla.and(mkAssignInt("x", nX), mkAssignInt("y", nY))
     val trex = new TransitionExecutorImpl(Set.empty, Set("x", "y"), exeCtx)
     trex.prepareTransition(1, init)
     trex.pickTransition()

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/bmcmt/ArenaCell.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/bmcmt/ArenaCell.scala
@@ -1,8 +1,8 @@
 package at.forsyte.apalache.tla.bmcmt
 
 import at.forsyte.apalache.tla.bmcmt.PureArena.namePrefix
-import at.forsyte.apalache.tla.lir.{NameEx, TlaEx}
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.lir.NameEx
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import at.forsyte.apalache.tla.bmcmt.types.CellT
 import at.forsyte.apalache.tla.typecomp._
 
@@ -45,8 +45,6 @@ class ArenaCell(val id: Int, val cellType: CellT, val isUnconstrained: Boolean =
    *   a builder instruction that can be used with the typed builder
    */
   def toBuilder: BuilderT = tla.name(toString, cellType.toTlaType1)
-
-  def mkTlaEq(rhs: ArenaCell): TlaEx = tla.eql(this.toBuilder, rhs.toBuilder)
 
   override def compareTo(t: ArenaCell): Int = id.compareTo(t.id)
 


### PR DESCRIPTION
Migrating further tests to the typed builder. This is a purely mechanical change by Codex GPT 5.9-sol max. No further review is needed.