### PR TITLE
Fix publication to Maven Central

### DIFF
--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -29,11 +29,11 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
           cache: sbt
 
       - name: Set up sbt
@@ -79,6 +79,6 @@ jobs:
       - name: Publish tla-ir and tla-io
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
-          SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         run: ./script/publish-maven.sh release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -555,8 +555,8 @@ imports the signing key, and invokes
 
 Configure a GitHub Environment named `maven-central`, without a required reviewer, and add these environment secrets:
 
-- `SONATYPE_TOKEN_USERNAME`: username from a Central Portal user token;
-- `SONATYPE_TOKEN_PASSWORD`: password from the same Central Portal user token;
+- `SONATYPE_USERNAME`: username from a Central Portal user token;
+- `SONATYPE_PASSWORD`: password from the same Central Portal user token;
 - `PGP_SECRET`: base64-encoded, ASCII-armored private signing key; and
 - `PGP_PASSPHRASE`: passphrase for the signing key.
 
@@ -578,7 +578,7 @@ versions are immutable, rerun a failed publication only after confirming that Ce
 Manual publishing requires:
 
 - a [Central Portal user token](https://central.sonatype.org/publish/generate-portal-token/), exposed as
-  `SONATYPE_TOKEN_USERNAME` and `SONATYPE_TOKEN_PASSWORD`;
+  `SONATYPE_USERNAME` and `SONATYPE_PASSWORD`;
 - for snapshot publishing, snapshots enabled for the `org.apalache-mc`
   namespace in the Central Portal;
 - a secret GPG key in the local keyring, with its public key available from a public keyserver; and

--- a/script/publish-maven.sh
+++ b/script/publish-maven.sh
@@ -16,8 +16,8 @@ Usage: ./script/publish-maven.sh snapshot|release
   release   Upload a release VERSION and publish it automatically after validation.
 
 Required environment variables:
-  SONATYPE_TOKEN_USERNAME  Username from a Central Portal user token.
-  SONATYPE_TOKEN_PASSWORD  Password from a Central Portal user token.
+  SONATYPE_USERNAME  Username from a Central Portal user token.
+  SONATYPE_PASSWORD  Password from a Central Portal user token.
 
 Artifacts are signed with the default secret key in the local GnuPG keyring.
 GnuPG may use pinentry interactively; PGP_PASSPHRASE is supported for CI.
@@ -63,7 +63,7 @@ else
     fi
 fi
 
-for variable in SONATYPE_TOKEN_USERNAME SONATYPE_TOKEN_PASSWORD
+for variable in SONATYPE_USERNAME SONATYPE_PASSWORD
 do
     if [[ -z "${!variable:-}" ]]
     then


### PR DESCRIPTION
Since `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` are built-in to `sbt`, changing the environment variables. Also, publishing the artifacts with Java 25.