### PR TITLE
Add manual trigger to publish-to-maven-central.yml

### DIFF
--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Release version without the v prefix (for example, 0.59.0)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,17 +22,39 @@ concurrency:
 
 jobs:
   publish:
-    if: ${{ github.repository_owner == 'apalache-mc' && github.event.release.prerelease == false }}
+    if: >-
+      ${{
+        github.repository_owner == 'apalache-mc' &&
+        (
+          (github.event_name == 'release' && github.event.release.prerelease == false) ||
+          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+        )
+      }}
     environment:
       name: maven-central
       url: https://central.sonatype.com/publishing/deployments
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.release_version) || github.event.release.tag_name }}
 
     steps:
       - name: Checkout the released version
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+
+      # A manual run may retry a release whose tag contains an older, broken
+      # publishing script. Use the script from the workflow revision while
+      # keeping the released source itself pinned to RELEASE_TAG.
+      - name: Checkout current publishing automation
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .publish-automation
+          sparse-checkout: script/publish-maven.sh
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Set up JDK 25
@@ -41,8 +69,6 @@ jobs:
 
       - name: Verify the release tag and version
         shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
 
@@ -79,6 +105,9 @@ jobs:
       - name: Publish tla-ir and tla-io
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PUBLISH_MAVEN_PROJECT_ROOT: ${{ github.workspace }}
+          PUBLISH_MAVEN_SCRIPT: ${{ github.event_name == 'workflow_dispatch' && './.publish-automation/script/publish-maven.sh' || './script/publish-maven.sh' }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: ./script/publish-maven.sh release
+        run: |
+          "$PUBLISH_MAVEN_SCRIPT" release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,6 +553,11 @@ Publishing a GitHub release automatically runs the
 imports the signing key, and invokes
 `./script/publish-maven.sh release`. GitHub prereleases are skipped.
 
+The workflow can also be started manually from the Actions page on the `main`
+branch. Enter the release version without the `v` prefix (for example,
+`0.59.0`). Manual runs use the current publishing automation against the specified release tag, which allows a failed
+publication to be retried after a workflow fix without moving the release tag.
+
 Configure a GitHub Environment named `maven-central`, without a required reviewer, and add these environment secrets:
 
 - `SONATYPE_USERNAME`: username from a Central Portal user token;

--- a/script/publish-maven.sh
+++ b/script/publish-maven.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # the user's GnuPG keyring, never from repository files.
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PROJ_ROOT="$(cd "$DIR/.." >/dev/null 2>&1 && pwd)"
+DEFAULT_PROJ_ROOT="$(cd "$DIR/.." >/dev/null 2>&1 && pwd)"
+PROJ_ROOT="${PUBLISH_MAVEN_PROJECT_ROOT:-$DEFAULT_PROJ_ROOT}"
 
 usage() {
     cat <<'EOF'


### PR DESCRIPTION
Our workflow failed to publish a release to Maven Central, and there is no easy way to publish it properly. Adding the ability to manually triggering publication via a github workflow.