### PR TITLE
Downgrade bytecode compatibility to Java 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
           find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
           find $HOME/.sbt                              -name "*.lock"               -delete || true
 
-  windows-package:
+  universal-package:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -134,36 +134,28 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Build universal package
         run: sbt "Universal/packageBin"
-      - name: Set up JDK 17 for artifact compatibility smoke test
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-      - name: Run packaged Unix launcher on Java 17
-        shell: bash
-        run: |
-          unzip target/universal/apalache-*.zip -d target/java17-smoke
-          package_dir=$(find target/java17-smoke -mindepth 1 -maxdepth 1 -type d -name 'apalache-*' -print -quit)
-          APALACHE_HOME="$package_dir" "$package_dir/bin/apalache-mc" check --smt-solver=z3 --length=1 test/tla/NoVars.tla
-          APALACHE_HOME="$package_dir" "$package_dir/bin/apalache-mc" check --smt-solver=cvc5 --length=1 test/tla/NoVars.tla
       - name: Upload universal package
         uses: actions/upload-artifact@v7
         with:
-          name: windows-package
+          name: universal-package
           path: target/universal/apalache-*.zip
           if-no-files-found: error
+      - name: Upload package smoke-test specification
+        uses: actions/upload-artifact@v7
+        with:
+          name: universal-package-smoke-spec
+          path: test/tla/Counter.tla
+          if-no-files-found: error
 
-  windows-package-smoke:
-    needs: windows-package
-    runs-on: windows-latest
+  universal-package-smoke:
+    needs: universal-package
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         java-version: [17, 25]
     steps:
-      # The repository contains a directory named `aux`, which Windows cannot
-      # check out because AUX is a reserved device name. Build on Linux and
-      # exercise the platform-independent package on Windows instead.
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
@@ -172,17 +164,55 @@ jobs:
       - name: Download universal package
         uses: actions/download-artifact@v8
         with:
-          name: windows-package
+          name: universal-package
           path: package
+      - name: Run packaged launcher on Java ${{ matrix.java-version }}
+        shell: bash
+        run: |
+          unzip package/apalache-*.zip -d package-smoke
+          package_dir=$(find package-smoke -mindepth 1 -maxdepth 1 -type d -name 'apalache-*' -print -quit)
+          APALACHE_HOME="$package_dir" "$package_dir/bin/apalache-mc" check --smt-solver=z3 --length=2 --inv=Inv test/tla/Counter.tla
+          APALACHE_HOME="$package_dir" "$package_dir/bin/apalache-mc" check --smt-solver=cvc5 --length=2 --inv=Inv test/tla/Counter.tla
+
+  universal-package-windows-smoke:
+    needs: universal-package
+    runs-on: windows-latest
+    steps:
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+      - name: Download universal package
+        uses: actions/download-artifact@v8
+        with:
+          name: universal-package
+          path: package
+      - name: Download package smoke-test specification
+        uses: actions/download-artifact@v8
+        with:
+          name: universal-package-smoke-spec
+          path: smoke-spec
       - name: Run packaged Windows launcher
         shell: pwsh
         run: |
           $archive = Get-ChildItem package/apalache-*.zip | Select-Object -First 1
-          Expand-Archive -LiteralPath $archive.FullName -DestinationPath windows-smoke
-          $launcher = Get-ChildItem windows-smoke -Recurse -Filter apalache-mc.bat | Select-Object -First 1
+          Expand-Archive -LiteralPath $archive.FullName -DestinationPath package-smoke
+          $launcher = Get-ChildItem package-smoke -Recurse -Filter apalache-mc.bat | Select-Object -First 1
+          $env:APALACHE_HOME = $launcher.Directory.Parent.FullName
+          $spec = (Resolve-Path smoke-spec/Counter.tla).Path
+
           $output = & $launcher.FullName version --debug 2>&1
+          $exitCode = $LASTEXITCODE
           $output | Write-Output
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($exitCode -ne 0) { exit $exitCode }
+
+          foreach ($solver in @("z3", "cvc5")) {
+            $output = & $launcher.FullName check "--smt-solver=$solver" --length=2 --inv=Inv $spec 2>&1
+            $exitCode = $LASTEXITCODE
+            $output | Write-Output
+            if ($exitCode -ne 0) { exit $exitCode }
+          }
 
   integration-tests:
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,18 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Build universal package
         run: sbt "Universal/packageBin"
+      - name: Set up JDK 17 for artifact compatibility smoke test
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Run packaged Unix launcher on Java 17
+        shell: bash
+        run: |
+          unzip target/universal/apalache-*.zip -d target/java17-smoke
+          package_dir=$(find target/java17-smoke -mindepth 1 -maxdepth 1 -type d -name 'apalache-*' -print -quit)
+          APALACHE_HOME="$package_dir" "$package_dir/bin/apalache-mc" check --smt-solver=z3 --length=1 test/tla/NoVars.tla
+          APALACHE_HOME="$package_dir" "$package_dir/bin/apalache-mc" check --smt-solver=cvc5 --length=1 test/tla/NoVars.tla
       - name: Upload universal package
         uses: actions/upload-artifact@v7
         with:
@@ -144,15 +156,19 @@ jobs:
   windows-package-smoke:
     needs: windows-package
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 25]
     steps:
       # The repository contains a directory named `aux`, which Windows cannot
       # check out because AUX is a reserved device name. Build on Linux and
       # exercise the platform-independent package on Windows instead.
-      - name: Set up JDK 25
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: ${{ matrix.java-version }}
       - name: Download universal package
         uses: actions/download-artifact@v8
         with:

--- a/.unreleased/bug-fixes/java-17-artifacts.md
+++ b/.unreleased/bug-fixes/java-17-artifacts.md
@@ -1,0 +1,3 @@
+Lowered the bytecode target for released application and library artifacts from Java 25 to Java 17, restoring
+compatibility with Java 17 or newer. Java 25 remains the recommended runtime and the required development and release
+toolchain.

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ ThisBuild / version := scala.io.Source.fromFile(versionFile.value).mkString.trim
 ThisBuild / organization := "org.apalache-mc"
 ThisBuild / scalaVersion := "2.13.18"
 
-val minimumJavaVersion = "25"
+val artifactJavaVersion = "17"
 
 // Maven Central publication is opt-in for individual library sub-projects.
 ThisBuild / publish / skip := true
@@ -78,11 +78,11 @@ ThisBuild / libraryDependencies ++= Seq(
 //////////////////////
 
 fatalWarnings := sys.env.get("APALACHE_FATAL_WARNINGS").getOrElse("false").toBoolean
-ThisBuild / javacOptions ++= Seq("--release", minimumJavaVersion)
+ThisBuild / javacOptions ++= Seq("--release", artifactJavaVersion)
 ThisBuild / scalacOptions ++= {
   val commonOptions = Seq(
       // Compile all published classes for the minimum supported JVM.
-      s"-release:${minimumJavaVersion}",
+      s"-release:${artifactJavaVersion}",
       // Enable deprecation and feature warnings
       "-deprecation",
       "-feature",

--- a/docs/src/apalache/installation/jvm.md
+++ b/docs/src/apalache/installation/jvm.md
@@ -1,7 +1,8 @@
 # Prebuilt Packages
 
-You need to download and install a Java Virtual Machine first. Apalache requires Java 25. We recommend
-the [Eclipse Temurin][] or [Zulu][] builds of OpenJDK.
+You need to download and install a Java Virtual Machine first. We recommend running Apalache on Java 25, using the
+[Eclipse Temurin][] or [Zulu][] builds of OpenJDK. Released artifacts maintain bytecode compatibility with Java 17 and
+should run on Java 17 or newer, but Java 17 is less thoroughly tested than the recommended Java 25 runtime.
 
 Once you have installed Java, download the [latest
 release](https://github.com/apalache-mc/apalache/releases) and unpack into
@@ -15,10 +16,8 @@ better, add the `./bin` directory to your `PATH` and run `apalache-mc`.
 Alternatively, you can run Java directly with
 
 ```
-java --sun-misc-unsafe-memory-access=allow -jar ./lib/apalache.jar <args>
+java -jar ./lib/apalache.jar <args>
 ```
-
-The packaged launch scripts supply this Java 25 compatibility option automatically.
 
 The arguments `<args>` are explained in [Running the Tool](../running.md).
 

--- a/docs/src/apalache/installation/source.md
+++ b/docs/src/apalache/installation/source.md
@@ -2,7 +2,7 @@
 
 1. Install `git`.
 2. Install the [Eclipse Temurin][] or [Zulu][] builds of OpenJDK 25.
-   - Java 25 is the minimum supported JVM and is the latest LTS release.
+   - Java 25 is the required build JDK and is the latest LTS release. Released artifacts target Java 17.
    - The Scala and sbt versions used by the build are compatible with Java 25; see the [compatibility table][].
 3. Install [sbt][].
    - On Debian Linux or Ubuntu, [follow this guide](https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html#Ubuntu+and+other+Debian-based+distributions)

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,8 @@
 
               # Build
               # Nixpkgs wraps sbt with its default JRE, independently of PATH.
-              # Override it so Scala sees Java 25 when validating -release:25.
+              # Override it so the build and development tools run on Java 25;
+              # released artifacts still target Java 17.
               (sbt.override { jre = jdk25_headless; })
 
               # Development

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -22,10 +22,16 @@ DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
 APALACHE_JAR=${APALACHE_JAR:-"$DIR/../lib/apalache.jar"}
 JVM_ARGS=${JVM_ARGS:-""}
 JVM_GC_ARGS=${JVM_GC_ARGS:-""}
-# Guice and other bundled dependencies still use sun.misc.Unsafe. Java 25 warns
-# unless the application explicitly permits those calls (JEP 498). Keep this
-# before JVM_ARGS so callers can override the default policy when necessary.
-JVM_COMPAT_ARGS="--sun-misc-unsafe-memory-access=allow"
+# Guice and other bundled dependencies still use sun.misc.Unsafe. Recent Java
+# runtimes warn unless the application explicitly permits those calls (JEP 498),
+# while Java 17 rejects the compatibility option. Probe the selected runtime so
+# the same package works on both. Keep this before JVM_ARGS so callers can
+# override the default policy when necessary.
+JVM_COMPAT_ARGS=""
+if java --sun-misc-unsafe-memory-access=allow -version >/dev/null 2>&1
+then
+    JVM_COMPAT_ARGS="--sun-misc-unsafe-memory-access=allow"
+fi
 
 if ! test -f "$APALACHE_JAR"
 then

--- a/src/universal/bin/apalache-mc.bat
+++ b/src/universal/bin/apalache-mc.bat
@@ -13,9 +13,13 @@ rem Set the path to the APALACHE JAR file
 set "APALACHE_JAR=%DIR%\..\lib\apalache.jar"
 
 rem Set JVM arguments
-rem Bundled dependencies still use sun.misc.Unsafe. Java 25 warns unless the
-rem application explicitly permits those calls (JEP 498).
-set "JVM_COMPAT_ARGS=--sun-misc-unsafe-memory-access=allow"
+rem Bundled dependencies still use sun.misc.Unsafe. Recent Java runtimes warn
+rem unless the application explicitly permits those calls (JEP 498), while
+rem Java 17 rejects the compatibility option. Probe the selected runtime so the
+rem same package works on both.
+set "JVM_COMPAT_ARGS="
+java --sun-misc-unsafe-memory-access=allow -version >nul 2>&1
+if %ERRORLEVEL% EQU 0 set "JVM_COMPAT_ARGS=--sun-misc-unsafe-memory-access=allow"
 set "JVM_ARGS="
 
 rem Check if the APALACHE JAR file exists


### PR DESCRIPTION
Since our migration to Java 25 [broke] the CI pipeline of [tlaplus/examples](https://github.com/tlaplus/examples), this PR downgrade the bytecode compatibility to Java 17. We are still going to target Java 25 at the source level.

- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
