### PR TITLE
Target released artifacts to Java 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [17, 25]
+        java-version: [21, 25]
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java-version }}

--- a/.unreleased/breaking-changes/java-21-runtime.md
+++ b/.unreleased/breaking-changes/java-21-runtime.md
@@ -1,0 +1,1 @@
+Raised the minimum supported Java runtime from Java 17 to Java 21.

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ ThisBuild / version := scala.io.Source.fromFile(versionFile.value).mkString.trim
 ThisBuild / organization := "org.apalache-mc"
 ThisBuild / scalaVersion := "2.13.18"
 
-val artifactJavaVersion = "17"
+val artifactJavaVersion = "21"
 
 // Maven Central publication is opt-in for individual library sub-projects.
 ThisBuild / publish / skip := true

--- a/docs/src/apalache/installation/jvm.md
+++ b/docs/src/apalache/installation/jvm.md
@@ -1,8 +1,8 @@
 # Prebuilt Packages
 
 You need to download and install a Java Virtual Machine first. We recommend running Apalache on Java 25, using the
-[Eclipse Temurin][] or [Zulu][] builds of OpenJDK. Released artifacts maintain bytecode compatibility with Java 17 and
-should run on Java 17 or newer, but Java 17 is less thoroughly tested than the recommended Java 25 runtime.
+[Eclipse Temurin][] or [Zulu][] builds of OpenJDK. Released artifacts maintain bytecode compatibility with Java 21 and
+should run on Java 21 or newer, but Java 21 is less thoroughly tested than the recommended Java 25 runtime.
 
 Once you have installed Java, download the [latest
 release](https://github.com/apalache-mc/apalache/releases) and unpack into

--- a/docs/src/apalache/installation/source.md
+++ b/docs/src/apalache/installation/source.md
@@ -2,7 +2,7 @@
 
 1. Install `git`.
 2. Install the [Eclipse Temurin][] or [Zulu][] builds of OpenJDK 25.
-   - Java 25 is the required build JDK and is the latest LTS release. Released artifacts target Java 17.
+   - Java 25 is the required build JDK and is the latest LTS release. Released artifacts target Java 21.
    - The Scala and sbt versions used by the build are compatible with Java 25; see the [compatibility table][].
 3. Install [sbt][].
    - On Debian Linux or Ubuntu, [follow this guide](https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html#Ubuntu+and+other+Debian-based+distributions)

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
               # Build
               # Nixpkgs wraps sbt with its default JRE, independently of PATH.
               # Override it so the build and development tools run on Java 25;
-              # released artifacts still target Java 17.
+              # released artifacts target Java 21.
               (sbt.override { jre = jdk25_headless; })
 
               # Development

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -24,7 +24,7 @@ JVM_ARGS=${JVM_ARGS:-""}
 JVM_GC_ARGS=${JVM_GC_ARGS:-""}
 # Guice and other bundled dependencies still use sun.misc.Unsafe. Recent Java
 # runtimes warn unless the application explicitly permits those calls (JEP 498),
-# while Java 17 rejects the compatibility option. Probe the selected runtime so
+# while Java 21 rejects the compatibility option. Probe the selected runtime so
 # the same package works on both. Keep this before JVM_ARGS so callers can
 # override the default policy when necessary.
 JVM_COMPAT_ARGS=""

--- a/src/universal/bin/apalache-mc.bat
+++ b/src/universal/bin/apalache-mc.bat
@@ -15,7 +15,7 @@ set "APALACHE_JAR=%DIR%\..\lib\apalache.jar"
 rem Set JVM arguments
 rem Bundled dependencies still use sun.misc.Unsafe. Recent Java runtimes warn
 rem unless the application explicitly permits those calls (JEP 498), while
-rem Java 17 rejects the compatibility option. Probe the selected runtime so the
+rem Java 21 rejects the compatibility option. Probe the selected runtime so the
 rem same package works on both.
 set "JVM_COMPAT_ARGS="
 java --sun-misc-unsafe-memory-access=allow -version >nul 2>&1


### PR DESCRIPTION
Upgrade bytecode-compatibility to Java 21, as we need it for `ScopedValue`.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

This is a purely mechanical change done with Codex.

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md