### PR TITLE
Scope OutputManager state per Tool invocation

### DIFF
--- a/.unreleased/breaking-changes/scoped-output-manager.md
+++ b/.unreleased/breaking-changes/scoped-output-manager.md
@@ -1,0 +1,2 @@
+`OutputManager` state is now scoped to each `Tool.run` invocation; direct callers must use `OutputManager.withScope`,
+and asynchronous callers must propagate a captured scope.

--- a/json-rpc/src/main/scala/com/github/apalachemc/apalache/jsonrpc/JsonRpcServer.scala
+++ b/json-rpc/src/main/scala/com/github/apalachemc/apalache/jsonrpc/JsonRpcServer.scala
@@ -1,7 +1,7 @@
 package com.github.apalachemc.apalache.jsonrpc
 
 import at.forsyte.apalache.infra.passes.PassChainExecutor
-import at.forsyte.apalache.io.InputSource
+import at.forsyte.apalache.io.{InputSource, OutputManager}
 import at.forsyte.apalache.io.config.Constants.SERVER
 import at.forsyte.apalache.io.config._
 import at.forsyte.apalache.io.itf.{ItfJsonToTla, TlaToItfJson}
@@ -762,7 +762,10 @@ class ExplorationService(config: ConfigParseResult[ApalacheConfig]) extends Lazy
  *   exploration service that processes the exploration logic
  */
 @WebServlet(urlPatterns = Array("/rpc"), asyncSupported = true)
-class JsonRpcServlet(service: ExplorationService) extends HttpServlet with LazyLogging {
+class JsonRpcServlet(service: ExplorationService, outputScope: OutputManager.Scope)
+    extends HttpServlet with LazyLogging {
+  def this(service: ExplorationService) =
+    this(service, OutputManager.withScope(OutputManager.captureScope()))
 
   /** The maximum number of threads to allow in the pool */
   private val MAX_POOL_SIZE = 1024
@@ -814,7 +817,8 @@ class JsonRpcServlet(service: ExplorationService) extends HttpServlet with LazyL
       }
     }
     // submit the task to our pool, so Jetty can continue serving other requests
-    executor.submit(runnable)
+    val scopedRunnable: Runnable = () => outputScope.run(runnable.run())
+    executor.submit(scopedRunnable)
   }
 
   private def processRequest(req: HttpServletRequest): ObjectNode = {
@@ -873,13 +877,17 @@ object JsonRpcServerApp {
   /** Minimum response size in bytes to apply compression. Smaller payloads are sent uncompressed. */
   private val MIN_COMPRESS_SIZE = 512
 
-  def run(config: ConfigParseResult[ApalacheConfig], port: Int): Unit = {
+  def run(config: ConfigParseResult[ApalacheConfig], port: Int): Unit = OutputManager.withScope {
+    run(config, port, OutputManager.captureScope())
+  }
+
+  def run(config: ConfigParseResult[ApalacheConfig], port: Int, outputScope: OutputManager.Scope): Unit = {
     val server = new Server(port)
     val context = new ServletContextHandler(ServletContextHandler.SESSIONS)
     context.setContextPath("/")
 
     val service = new ExplorationService(config)
-    context.addServlet(new ServletHolder(new JsonRpcServlet(service)), "/rpc")
+    context.addServlet(new ServletHolder(new JsonRpcServlet(service, outputScope)), "/rpc")
 
     // Wrap the servlet context with a CompressionHandler that supports gzip and zstd.
     // Compression implementations are registered explicitly so we can set minCompressSize.

--- a/json-rpc/src/test/scala/com/github/apalachemc/apalache/jsonrpc/TestExplorationService.scala
+++ b/json-rpc/src/test/scala/com/github/apalachemc/apalache/jsonrpc/TestExplorationService.scala
@@ -1,11 +1,12 @@
 package com.github.apalachemc.apalache.jsonrpc
 
+import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.io.config.Constants.SERVER
 import at.forsyte.apalache.io.config.{ApalacheConfig, ConfigParseResult}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
-import org.scalatest.BeforeAndAfter
+import org.scalatest.{BeforeAndAfter, Outcome}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableFor2
 import org.scalatestplus.junit.JUnitRunner
@@ -34,6 +35,9 @@ class TestExplorationService extends AnyFunSuite with BeforeAndAfter with ScalaC
       """.stripMargin
 
   private var service: ExplorationService = _
+
+  override protected def withFixture(test: NoArgTest): Outcome =
+    OutputManager.withScope(super.withFixture(test))
 
   before {
     val config = ConfigParseResult.success(ApalacheConfig.empty.withCommand(SERVER))

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/Tool.scala
@@ -98,7 +98,11 @@ object Tool extends LazyLogging {
    * @return
    *   the exit code; as usual, 0 means success.
    */
-  def run(args: Array[String]): Int = {
+  def run(args: Array[String]): Int = OutputManager.withScope {
+    runInScope(args)
+  }
+
+  private def runInScope(args: Array[String]): Int = {
     // Configure the silent logger first. Otherwise, Apache Commons spills a lot of text to the console.
     new LogbackConfigurator(None, None).configureDefaultContext()
     // first, call the arguments parser, which can also handle the standard commands such as version

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/ServerCmd.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.tla.tooling.opt
 
 import at.forsyte.apalache.infra.ExitCodes.TExitCode
+import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.io.config.Constants.{PORT, SERVER, SERVER_TYPE}
 import at.forsyte.apalache.io.config._
 import at.forsyte.apalache.shai
@@ -40,12 +41,13 @@ class ServerCmd extends ApalacheCommand(name = SERVER, description = "Run in ser
   override def run(config: ApalacheConfig): Either[(TExitCode, String), String] = {
     runWithOptions(ApalacheConfigResolver.resolveServer(config)) { options =>
       logger.info(s"Starting ${options.server.serverType} server on port ${options.server.port}...")
+      val outputScope = OutputManager.captureScope()
       options.server.serverType match {
         case ServerType.Checker =>
-          val server = shai.v1.RpcServer(options.server.port)
+          val server = shai.v1.RpcServer(options.server.port, outputScope)
           server.main(Array())
         case ServerType.Explorer =>
-          JsonRpcServerApp.run(ConfigParseResult.success(config), options.server.port)
+          JsonRpcServerApp.run(ConfigParseResult.success(config), options.server.port, outputScope)
       }
       Right("Server terminated")
     }

--- a/mod-tool/src/test/scala/at/forsyte/apalache/tla/TestConcurrentToolRuns.scala
+++ b/mod-tool/src/test/scala/at/forsyte/apalache/tla/TestConcurrentToolRuns.scala
@@ -30,11 +30,11 @@ class TestConcurrentToolRuns extends AnyFunSuite {
       def run(source: Path, outDir: Path): Callable[Int] = () => {
         start.await()
         Tool.run(Array(
-            "parse",
-            s"--out-dir=$outDir",
-            "--write-intermediate=true",
-            source.toString,
-        ))
+                "parse",
+                s"--out-dir=$outDir",
+                "--write-intermediate=true",
+                source.toString,
+            ))
       }
 
       try {

--- a/mod-tool/src/test/scala/at/forsyte/apalache/tla/TestConcurrentToolRuns.scala
+++ b/mod-tool/src/test/scala/at/forsyte/apalache/tla/TestConcurrentToolRuns.scala
@@ -1,0 +1,88 @@
+package at.forsyte.apalache.tla
+
+import at.forsyte.apalache.infra.ExitCodes
+import at.forsyte.apalache.infra.log.LogbackConfigurator
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+import java.nio.file.{Files, Path}
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+@RunWith(classOf[JUnitRunner])
+class TestConcurrentToolRuns extends AnyFunSuite {
+
+  test("concurrent Tool runs keep intermediate output in their own directories") {
+    // Avoid racing SLF4J's one-time provider initialization. Logback itself remains process-global and is not part of
+    // the OutputManager isolation contract exercised by this test.
+    new LogbackConfigurator(None, None).configureDefaultContext()
+
+    withTempDirectory("concurrent-tool-runs") { root =>
+      val firstSource = writeSpec(root, "First", "FirstValue == 1")
+      val secondSource = writeSpec(root, "Second", "SecondValue == 2")
+      val firstOut = root.resolve("first-out")
+      val secondOut = root.resolve("second-out")
+      val start = new CountDownLatch(1)
+      val executor = Executors.newFixedThreadPool(2)
+
+      def run(source: Path, outDir: Path): Callable[Int] = () => {
+        start.await()
+        Tool.run(Array(
+            "parse",
+            s"--out-dir=$outDir",
+            "--write-intermediate=true",
+            source.toString,
+        ))
+      }
+
+      try {
+        val first = executor.submit(run(firstSource, firstOut))
+        val second = executor.submit(run(secondSource, secondOut))
+        start.countDown()
+
+        assert(first.get(2, TimeUnit.MINUTES) == ExitCodes.OK)
+        assert(second.get(2, TimeUnit.MINUTES) == ExitCodes.OK)
+
+        val firstIntermediate = findFile(firstOut.resolve("First.tla"), "00_OutSanyParser.tla")
+        val secondIntermediate = findFile(secondOut.resolve("Second.tla"), "00_OutSanyParser.tla")
+        val firstText = Files.readString(firstIntermediate)
+        val secondText = Files.readString(secondIntermediate)
+
+        assert(firstText.contains("FirstValue"))
+        assert(!firstText.contains("SecondValue"))
+        assert(secondText.contains("SecondValue"))
+        assert(!secondText.contains("FirstValue"))
+      } finally {
+        executor.shutdownNow()
+      }
+    }
+  }
+
+  private def writeSpec(root: Path, module: String, declaration: String): Path =
+    Files.writeString(
+        root.resolve(s"$module.tla"),
+        s"---- MODULE $module ----\n$declaration\n====\n",
+    )
+
+  private def findFile(root: Path, filename: String): Path =
+    Using.resource(Files.walk(root)) { paths =>
+      paths.iterator().asScala.find(_.getFileName.toString == filename).getOrElse {
+        fail(s"Could not find $filename under $root")
+      }
+    }
+
+  private def withTempDirectory[A](prefix: String)(body: Path => A): A = {
+    val directory = Files.createTempDirectory(prefix)
+    try {
+      body(directory)
+    } finally {
+      if (Files.exists(directory)) {
+        Using.resource(Files.walk(directory)) { paths =>
+          paths.iterator().asScala.toSeq.sortBy(_.getNameCount).reverse.foreach(Files.deleteIfExists)
+        }
+      }
+    }
+  }
+}

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/CmdExecutorService.scala
@@ -1,6 +1,7 @@
 package at.forsyte.apalache.shai.v1
 
 import at.forsyte.apalache.infra.passes.{Pass, PassChainExecutor}
+import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.io.annotations.PrettyWriterWithAnnotations
 import at.forsyte.apalache.io.annotations.store._
 import at.forsyte.apalache.io.config.Constants.SERVER
@@ -30,7 +31,9 @@ import scala.util.Try
  * [[CmdExecutorService]] is meant to be registered with the [[RpcServer]], and should not need to be used directly.
  */
 
-class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEnv, Any] {
+class CmdExecutorService(logger: Logger, outputScope: OutputManager.Scope)
+    extends ZioCmdExecutor.ZCmdExecutor[ZEnv, Any] {
+  def this(logger: Logger) = this(logger, OutputManager.withScope(OutputManager.captureScope()))
 
   val _todo = logger
 
@@ -88,8 +91,7 @@ class CmdExecutorService(logger: Logger) extends ZioCmdExecutor.ZCmdExecutor[ZEn
 
   import Converters._
 
-  private def executeCmd(cmd: Cmd, cfg: ApalacheConfig): Either[CmdError, ujson.Value] = {
-
+  private def executeCmd(cmd: Cmd, cfg: ApalacheConfig): Either[CmdError, ujson.Value] = outputScope.run {
     for {
       toolModule <- {
         cmd match {

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -1,5 +1,6 @@
 package at.forsyte.apalache.shai.v1
 
+import at.forsyte.apalache.io.OutputManager
 import zio.{console, ExitCode, Ref, ZEnv, ZIO}
 
 import java.util.UUID
@@ -16,7 +17,9 @@ import java.net.BindException
  *
  * We extend LazyLogging to give the server process access to the same logger configured for the rest of Apalache.
  */
-class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
+class RpcServer(override val port: Int, outputScope: OutputManager.Scope) extends ServerMain with LazyLogging {
+  def this(port: Int) = this(port, OutputManager.withScope(OutputManager.captureScope()))
+
   override def welcome: ZIO[ZEnv, Throwable, Unit] =
     console.putStrLn(s"The Apalache server is running on port ${port}. Press Ctrl-C to stop.")
 
@@ -26,9 +29,9 @@ class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
     connections <- Ref.make(Map[UUID, Conn]())
     // Ensure atomic access to the parser
     // See https://github.com/apalache-mc/apalache/issues/1114#issuecomment-1180534894
-  } yield new TransExplorerService(connections, logger)
+  } yield new TransExplorerService(connections, logger, outputScope)
 
-  val createCmdExecutorService = ZIO.succeed(new CmdExecutorService(logger))
+  val createCmdExecutorService = ZIO.succeed(new CmdExecutorService(logger, outputScope))
 
   def services: ServiceList[ZEnv] =
     ServiceList.addM(createTransExplorerService).addM(createCmdExecutorService)
@@ -61,5 +64,7 @@ object RpcServer {
   val DEFAULT_PORT = 8822
   val STARTUP_ERROR_PROMPT = "Error while starting Apalache server:"
 
-  def apply(port: Int = DEFAULT_PORT) = new RpcServer(port)
+  def apply(port: Int = DEFAULT_PORT): RpcServer = new RpcServer(port)
+
+  def apply(port: Int, outputScope: OutputManager.Scope): RpcServer = new RpcServer(port, outputScope)
 }

--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/TransExplorerService.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/TransExplorerService.scala
@@ -13,6 +13,7 @@ package at.forsyte.apalache.shai.v1
  */
 
 import at.forsyte.apalache.infra.passes.PassChainExecutor
+import at.forsyte.apalache.io.OutputManager
 import at.forsyte.apalache.io.InputSource
 import at.forsyte.apalache.io.config.Constants.SERVER
 import at.forsyte.apalache.io.config.{ApalacheConfig, ApalacheConfigResolver, CommonPatch, RunContextPatch}
@@ -82,8 +83,10 @@ private case class Conn(
  * @param logger
  *   The logger used by the service
  */
-class TransExplorerService(connections: Ref[Map[UUID, Conn]], logger: Logger)
+class TransExplorerService(connections: Ref[Map[UUID, Conn]], logger: Logger, outputScope: OutputManager.Scope)
     extends ZioTransExplorer.ZTransExplorer[ZEnv, Any] {
+  def this(connections: Ref[Map[UUID, Conn]], logger: Logger) =
+    this(connections, logger, OutputManager.withScope(OutputManager.captureScope()))
 
   /** Concurrent tasks performed by the service that produce values of type `T` */
   type Result[T] = ZIO[ZEnv, Status, T]
@@ -160,33 +163,35 @@ class TransExplorerService(connections: Ref[Map[UUID, Conn]], logger: Logger)
 
   private def parseSpec(spec: String, aux: Seq[String]): Result[Either[TransExplorerError, TlaModule]] =
     ZIO.effectTotal {
-      try {
-        // TODO: replace hard-coded options with options derived from CLI params
-        val config = ApalacheConfig(
-            context = RunContextPatch(command = Some(SERVER)),
-            common = CommonPatch(
-                outDir = Some(Path.of(".")),
-                debug = Some(true),
-            ),
-            source = Some(InputSource.StringSource(spec, aux.toList)),
-            output = Some(Path.of(".")),
-        )
-        val resolved = ApalacheConfigResolver.resolveParse(config)
-        if (!resolved.isSuccess) {
-          throw new IllegalArgumentException(resolved.errors.mkString("; "))
-        }
-        val options = resolved.requireValue()
-        PassChainExecutor(new ParserModule(options))
-          .run()
-          .left
-          .map { err =>
-            TransExplorerError(errorType = TransExplorerErrorType.PASS_FAILURE, data = ujson.write(err))
+      outputScope.run {
+        try {
+          // TODO: replace hard-coded options with options derived from CLI params
+          val config = ApalacheConfig(
+              context = RunContextPatch(command = Some(SERVER)),
+              common = CommonPatch(
+                  outDir = Some(Path.of(".")),
+                  debug = Some(true),
+              ),
+              source = Some(InputSource.StringSource(spec, aux.toList)),
+              output = Some(Path.of(".")),
+          )
+          val resolved = ApalacheConfigResolver.resolveParse(config)
+          if (!resolved.isSuccess) {
+            throw new IllegalArgumentException(resolved.errors.mkString("; "))
           }
-      } catch {
-        case err: Throwable =>
-          val errData =
-            ujson.Obj("msg" -> err.getMessage, "stack_trace" -> err.getStackTrace.map(_.toString()).toList)
-          Left(TransExplorerError(errorType = TransExplorerErrorType.UNEXPECTED, data = errData.toString()))
+          val options = resolved.requireValue()
+          PassChainExecutor(new ParserModule(options))
+            .run()
+            .left
+            .map { err =>
+              TransExplorerError(errorType = TransExplorerErrorType.PASS_FAILURE, data = ujson.write(err))
+            }
+        } catch {
+          case err: Throwable =>
+            val errData =
+              ujson.Obj("msg" -> err.getMessage, "stack_trace" -> err.getStackTrace.map(_.toString()).toList)
+            Left(TransExplorerError(errorType = TransExplorerErrorType.UNEXPECTED, data = errData.toString()))
+        }
       }
     }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Cvc5SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Cvc5SolverContext.scala
@@ -222,7 +222,11 @@ class Cvc5SolverContext(val config: SolverConfig) extends SolverContext with Laz
   private def initLogs(): Iterable[PrintWriter] = {
     val filePart = s"log$id.smt"
     val writers =
-      (OutputManager.runDirPathOpt ++ OutputManager.customRunDirPathOpt).map(OutputManager.printWriter(_, filePart))
+      if (OutputManager.isBound) {
+        (OutputManager.runDirPathOpt ++ OutputManager.customRunDirPathOpt).map(OutputManager.printWriter(_, filePart))
+      } else {
+        Iterable.empty
+      }
 
     if (!config.debug) {
       writers.foreach { writer =>

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -429,7 +429,11 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext with LazyL
   private def initLogs(): Iterable[PrintWriter] = {
     val filePart = s"log$id.smt"
     val writers =
-      (OutputManager.runDirPathOpt ++ OutputManager.customRunDirPathOpt).map(OutputManager.printWriter(_, filePart))
+      if (OutputManager.isBound) {
+        (OutputManager.runDirPathOpt ++ OutputManager.customRunDirPathOpt).map(OutputManager.printWriter(_, filePart))
+      } else {
+        Iterable.empty
+      }
 
     if (!config.debug) {
       writers.foreach { writer =>

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/OutputManager.scala
@@ -1,7 +1,6 @@
 package at.forsyte.apalache.io
 
 import at.forsyte.apalache.io.config.{CommandInitializationOptions, CommonOptions}
-import com.typesafe.scalalogging.LazyLogging
 
 import java.io.File
 import java.io.FileWriter
@@ -11,22 +10,15 @@ import java.nio.file.Path
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.lang.ScopedValue
 import scala.jdk.CollectionConverters._
 
 /**
- * The OutputManager is the central source of truth, for all IO related locations. Any IO operation should request
- * read/write target paths from this object.
+ * Mutable output state for one dynamically scoped tool invocation.
  */
-object OutputManager extends LazyLogging {
+final private class OutputManagerState {
+  import OutputManager.Names._
 
-  object Names {
-    val IntermediateFoldername = "intermediate"
-    val RunFile = "run.txt"
-  }
-  import Names._
-
-  // TODO: Make OutputManager an injected instance and provide CommonOptions
-  // through its constructor instead of storing mutable global configuration.
   private var commonOptions: Option[CommonOptions] = None
   // outDirOpt is stored as an expanded and absolute path
   private var outDirOpt: Option[Path] = None
@@ -241,4 +233,88 @@ object OutputManager extends LazyLogging {
     .map { runDir =>
       readFileIntoString(new File(runDir.toFile, filename))
     }
+}
+
+/**
+ * The OutputManager is the central source of truth for all IO-related locations. Its public methods are retained as a
+ * compatibility facade, while each invocation stores its mutable state in a [[java.lang.ScopedValue]].
+ *
+ * Calls must run inside [[withScope]]. Code that hands work to another thread may use [[captureScope]] and
+ * [[Scope.run]] to propagate the current manager explicitly.
+ */
+object OutputManager {
+
+  object Names {
+    val IntermediateFoldername = "intermediate"
+    val RunFile = "run.txt"
+  }
+
+  final class Scope private[OutputManager] (private val state: OutputManagerState) {
+    def run[A](body: => A): A = withState(state)(body)
+  }
+
+  private val currentState: ScopedValue[OutputManagerState] = ScopedValue.newInstance[OutputManagerState]()
+
+  /** Run `body` with a fresh output manager and restore the previous binding afterwards. */
+  def withScope[A](body: => A): A = new Scope(new OutputManagerState).run(body)
+
+  /** Capture the currently bound output manager for explicit propagation to another thread. */
+  def captureScope(): Scope = new Scope(current)
+
+  /** Used by low-level components whose output logging is optional when they are used outside the tool runtime. */
+  private[apalache] def isBound: Boolean = currentState.isBound
+
+  private def current: OutputManagerState = {
+    if (currentState.isBound) {
+      currentState.get()
+    } else {
+      throw new IllegalStateException(
+          "OutputManager is not bound to the current thread; call OutputManager.withScope { ... }"
+      )
+    }
+  }
+
+  // Carrier.run has the same JVM descriptor on Java 21 through Java 25. Carrier.call does not.
+  private def withState[A](state: OutputManagerState)(body: => A): A = {
+    var result: Option[A] = None
+    ScopedValue.where(currentState, state).run(() => result = Some(body))
+    result.get
+  }
+
+  def initSourceLines(source: InputSource): Unit = current.initSourceLines(source)
+
+  def getAllSrc: Option[String] = current.getAllSrc
+
+  def isConfigured: Boolean = current.isConfigured
+
+  def runDirPathOpt: Option[Path] = current.runDirPathOpt
+
+  def customRunDirPathOpt: Option[Path] = current.customRunDirPathOpt
+
+  def outDir: Path = current.outDir
+
+  def runDir: Path = current.runDir
+
+  def configure(initialization: CommandInitializationOptions): Unit = current.configure(initialization)
+
+  def printWriter(base: File, fileParts: String*): PrintWriter = current.printWriter(base, fileParts: _*)
+
+  def printWriter(base: Path, fileParts: String*): PrintWriter = current.printWriter(base, fileParts: _*)
+
+  def printWriter(base: String, fileParts: String*): PrintWriter = current.printWriter(base, fileParts: _*)
+
+  def withWriterToFile(file: File)(f: PrintWriter => Unit): Unit = current.withWriterToFile(file)(f)
+
+  def withWriterInRunDir(parts: String*)(f: PrintWriter => Unit): Boolean =
+    current.withWriterInRunDir(parts: _*)(f)
+
+  def withWriterInIntermediateDir(parts: String*)(f: PrintWriter => Unit): Boolean =
+    current.withWriterInIntermediateDir(parts: _*)(f)
+
+  def withProfilingWriter(f: PrintWriter => Unit): Boolean =
+    currentState.isBound && current.withProfilingWriter(f)
+
+  def readFileIntoString(file: File): String = current.readFileIntoString(file)
+
+  def readContentsOfFileInRunDir(filename: String): Option[String] = current.readContentsOfFileInRunDir(filename)
 }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/TestOutputManager.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/TestOutputManager.scala
@@ -1,0 +1,161 @@
+package at.forsyte.apalache.io
+
+import at.forsyte.apalache.io.config.{CommandInitializationOptions, CommonOptions}
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.junit.JUnitRunner
+
+import java.nio.file.{Files, Path}
+import java.util.concurrent.{Callable, CyclicBarrier, Executors}
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+@RunWith(classOf[JUnitRunner])
+class TestOutputManager extends AnyFunSuite {
+
+  private case class Observation(outDir: Path, runDir: Path, source: String)
+
+  test("calls outside a scope fail with a useful error") {
+    val error = intercept[IllegalStateException](OutputManager.isConfigured)
+    assert(error.getMessage.contains("OutputManager.withScope"))
+    assert(!OutputManager.withProfilingWriter(_ => fail("unbound profiling writer should be disabled")))
+    assert(OutputManager.Names.RunFile == "run.txt")
+  }
+
+  test("fresh scopes do not retain paths or source lines") {
+    withTempDirectory("output-manager-sequential") { root =>
+      val firstOut = root.resolve("first-out")
+      val firstCustom = root.resolve("first-custom")
+      val firstSource = InputSource.StringSource("---- MODULE First ----\n====")
+
+      OutputManager.withScope {
+        assert(!OutputManager.isConfigured)
+        assert(OutputManager.getAllSrc.isEmpty)
+        OutputManager.configure(initialization("first", firstOut, Some(firstCustom), writeIntermediate = true,
+            Some(firstSource)))
+        OutputManager.initSourceLines(firstSource)
+
+        assert(OutputManager.isConfigured)
+        assert(OutputManager.outDir == firstOut.resolve("first").toAbsolutePath)
+        assert(OutputManager.customRunDirPathOpt.contains(firstCustom.toAbsolutePath))
+        assert(OutputManager.getAllSrc.contains("---- MODULE First ----\n===="))
+        assert(OutputManager.withWriterInIntermediateDir("first.txt")(_.println("first")))
+        assert(OutputManager.withWriterInRunDir("result.txt")(_.println("first")))
+        assert(Files.exists(OutputManager.runDir.resolve("result.txt")))
+        assert(Files.exists(firstCustom.resolve("result.txt")))
+      }
+
+      val secondOut = root.resolve("second-out")
+      val secondSource = InputSource.StringSource("---- MODULE Second ----\n====")
+      OutputManager.withScope {
+        assert(!OutputManager.isConfigured)
+        assert(OutputManager.runDirPathOpt.isEmpty)
+        assert(OutputManager.customRunDirPathOpt.isEmpty)
+        assert(OutputManager.getAllSrc.isEmpty)
+
+        OutputManager.configure(initialization("second", secondOut, None, writeIntermediate = false,
+            Some(secondSource)))
+        OutputManager.initSourceLines(secondSource)
+
+        assert(OutputManager.outDir == secondOut.resolve("second").toAbsolutePath)
+        assert(OutputManager.customRunDirPathOpt.isEmpty)
+        assert(OutputManager.getAllSrc.contains("---- MODULE Second ----\n===="))
+        assert(!OutputManager.withWriterInIntermediateDir("second.txt")(_ => ()))
+      }
+    }
+  }
+
+  test("nested and exceptional scopes restore the previous binding") {
+    withTempDirectory("output-manager-nested") { root =>
+      OutputManager.withScope {
+        OutputManager.configure(initialization("outer", root.resolve("outer")))
+        val outerDir = OutputManager.outDir
+
+        OutputManager.withScope {
+          assert(!OutputManager.isConfigured)
+          OutputManager.configure(initialization("inner", root.resolve("inner")))
+          assert(OutputManager.outDir != outerDir)
+        }
+
+        assert(OutputManager.outDir == outerDir)
+      }
+
+      intercept[RuntimeException] {
+        OutputManager.withScope {
+          throw new RuntimeException("boom")
+        }
+      }
+      intercept[IllegalStateException](OutputManager.isConfigured)
+    }
+  }
+
+  test("captured scopes isolate concurrent configuration and can be rebound on worker threads") {
+    withTempDirectory("output-manager-concurrent") { root =>
+      val firstScope = OutputManager.withScope(OutputManager.captureScope())
+      val secondScope = OutputManager.withScope(OutputManager.captureScope())
+      val barrier = new CyclicBarrier(2)
+      val executor = Executors.newFixedThreadPool(2)
+
+      def task(
+          scope: OutputManager.Scope,
+          command: String,
+          sourceText: String): Callable[Observation] =
+        () => scope.run {
+          val source = InputSource.StringSource(sourceText)
+          OutputManager.configure(initialization(command, root.resolve(s"$command-out"), source = Some(source)))
+          OutputManager.initSourceLines(source)
+          barrier.await()
+          Observation(OutputManager.outDir, OutputManager.runDir, OutputManager.getAllSrc.get)
+        }
+
+      try {
+        val first = executor.submit(task(firstScope, "first", "---- MODULE First ----\n===="))
+        val second = executor.submit(task(secondScope, "second", "---- MODULE Second ----\n===="))
+        val firstResult = first.get()
+        val secondResult = second.get()
+
+        assert(firstResult.outDir == root.resolve("first-out/first").toAbsolutePath)
+        assert(secondResult.outDir == root.resolve("second-out/second").toAbsolutePath)
+        assert(firstResult.runDir.startsWith(firstResult.outDir))
+        assert(secondResult.runDir.startsWith(secondResult.outDir))
+        assert(firstResult.source.contains("MODULE First"))
+        assert(secondResult.source.contains("MODULE Second"))
+      } finally {
+        executor.shutdownNow()
+      }
+    }
+  }
+
+  private def initialization(
+      command: String,
+      outDir: Path,
+      runDir: Option[Path] = None,
+      writeIntermediate: Boolean = false,
+      source: Option[InputSource] = None): CommandInitializationOptions =
+    CommandInitializationOptions(
+        command,
+        CommonOptions(
+            debug = false,
+            features = Nil,
+            outDir = outDir,
+            profiling = false,
+            runDir = runDir,
+            smtprof = false,
+            writeIntermediate = writeIntermediate,
+        ),
+        source,
+    )
+
+  private def withTempDirectory[A](prefix: String)(body: Path => A): A = {
+    val directory = Files.createTempDirectory(prefix)
+    try {
+      body(directory)
+    } finally {
+      if (Files.exists(directory)) {
+        Using.resource(Files.walk(directory)) { paths =>
+          paths.iterator().asScala.toSeq.sortBy(_.getNameCount).reverse.foreach(Files.deleteIfExists)
+        }
+      }
+    }
+  }
+}

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/TestOutputManager.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/TestOutputManager.scala
@@ -31,8 +31,8 @@ class TestOutputManager extends AnyFunSuite {
       OutputManager.withScope {
         assert(!OutputManager.isConfigured)
         assert(OutputManager.getAllSrc.isEmpty)
-        OutputManager.configure(initialization("first", firstOut, Some(firstCustom), writeIntermediate = true,
-            Some(firstSource)))
+        OutputManager
+          .configure(initialization("first", firstOut, Some(firstCustom), writeIntermediate = true, Some(firstSource)))
         OutputManager.initSourceLines(firstSource)
 
         assert(OutputManager.isConfigured)
@@ -53,8 +53,8 @@ class TestOutputManager extends AnyFunSuite {
         assert(OutputManager.customRunDirPathOpt.isEmpty)
         assert(OutputManager.getAllSrc.isEmpty)
 
-        OutputManager.configure(initialization("second", secondOut, None, writeIntermediate = false,
-            Some(secondSource)))
+        OutputManager
+          .configure(initialization("second", secondOut, None, writeIntermediate = false, Some(secondSource)))
         OutputManager.initSourceLines(secondSource)
 
         assert(OutputManager.outDir == secondOut.resolve("second").toAbsolutePath)
@@ -100,13 +100,14 @@ class TestOutputManager extends AnyFunSuite {
           scope: OutputManager.Scope,
           command: String,
           sourceText: String): Callable[Observation] =
-        () => scope.run {
-          val source = InputSource.StringSource(sourceText)
-          OutputManager.configure(initialization(command, root.resolve(s"$command-out"), source = Some(source)))
-          OutputManager.initSourceLines(source)
-          barrier.await()
-          Observation(OutputManager.outDir, OutputManager.runDir, OutputManager.getAllSrc.get)
-        }
+        () =>
+          scope.run {
+            val source = InputSource.StringSource(sourceText)
+            OutputManager.configure(initialization(command, root.resolve(s"$command-out"), source = Some(source)))
+            OutputManager.initSourceLines(source)
+            barrier.await()
+            Observation(OutputManager.outDir, OutputManager.runDir, OutputManager.getAllSrc.get)
+          }
 
       try {
         val first = executor.submit(task(firstScope, "first", "---- MODULE First ----\n===="))


### PR DESCRIPTION
Closes #1048. This is a refactoring alternative to #3436, as suggested by @thpani (thanks, Thomas!). This PR does a very minimal refactor that replaces Scala `object` with `ScopedValue` of Java 21-25. This will finally let us run multiple instances of the tool within the same JVM.

**Note: `logback` is another potential source of singleton-related issues. We do not touch it here.**

This refactoring is done with Codex GPT-5.6 max.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md