### PR TITLE
Fix #3464: out of memory on nested tags

### DIFF
--- a/.unreleased/bug-fixes/3464.md
+++ b/.unreleased/bug-fixes/3464.md
@@ -1,0 +1,1 @@
+Fixed exponential backtracking when parsing nested type annotations, which could exhaust the JVM heap on short inputs, see #3464.

--- a/tla-typechecker/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
+++ b/tla-typechecker/src/test/scala/at/forsyte/apalache/tla/typecheck/TestDefaultType1Parser.scala
@@ -342,6 +342,15 @@ class TestDefaultType1Parser extends AnyFunSuite with Checkers with TlaType1Gen 
     assert(expected == result)
   }
 
+  test("deeply nested variants in an operator type") {
+    val text = "(() => Tag1(Tag2(Tag3(Tag4(Tag5(Tag6(MODEL)))))))"
+    val nestedVariant = (6 to 1 by -1).foldLeft(ConstT1("MODEL"): TlaType1) { case (valueType, index) =>
+      VariantT1(RowT1(s"Tag$index" -> valueType))
+    }
+
+    assert(OperT1(Seq.empty, nestedVariant) == parser.parseType(text))
+  }
+
   test("variant tags may start with reserved type keyword prefixes") {
     val tags = Seq("IntFoo", "RealBar", "BoolBaz", "StrQux", "SetX", "SeqThing", "VariantAlt", "RecTag")
     val text = tags.map(tag => s"$tag(Int)").mkString(" | ")

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/types/parser/DefaultType1Parser.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/types/parser/DefaultType1Parser.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.tla.lir._
 
 import java.io.StringReader
 import scala.collection.immutable.SortedMap
-import scala.util.parsing.combinator.Parsers
+import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.input.NoPosition
 
 /**
@@ -20,7 +20,7 @@ import scala.util.parsing.input.NoPosition
  * @author
  *   Igor Konnov, Shon Feder
  */
-object DefaultType1Parser extends Parsers with Type1Parser {
+object DefaultType1Parser extends PackratParsers with Type1Parser {
   override type Elem = Type1Token
 
   // This pattern recognizes camelCase and lowercase:
@@ -73,7 +73,7 @@ object DefaultType1Parser extends Parsers with Type1Parser {
     }
   }
 
-  private def typeExpr: Parser[TlaType1] = {
+  private lazy val typeExpr: PackratParser[TlaType1] = {
     operator | function | noFunExpr
   }
 


### PR DESCRIPTION
Closes #3464. Fixing the unexpected out of memory in the types parser. The fix is to `PackratParsers` instead of `Parsers`.

Fixed with Codex GPT-5.6-sol.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md