### PR TITLE
Import labels from JSON IR

### DIFF
--- a/.unreleased/bug-fixes/json-ir-label.md
+++ b/.unreleased/bug-fixes/json-ir-label.md
@@ -1,0 +1,1 @@
+Fixed checked JSON IR deserialization of labeled expressions, which previously failed on `LABEL` nodes written by Apalache.

--- a/.unreleased/bug-fixes/json-ir-label.md
+++ b/.unreleased/bug-fixes/json-ir-label.md
@@ -1,1 +1,1 @@
-Fixed checked JSON IR deserialization of labeled expressions, which previously failed on `LABEL` nodes written by Apalache.
+Fixed JSON IR deserialization of labeled expressions, see #3466

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/BuilderCallByName.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/impl/BuilderCallByName.scala
@@ -25,6 +25,7 @@ object BuilderCallByName {
       TlaOper.apply.name -> TlaOper.apply,
       TlaOper.chooseBounded.name -> TlaOper.chooseBounded,
       TlaOper.chooseUnbounded.name -> TlaOper.chooseUnbounded,
+      TlaOper.label.name -> TlaOper.label,
       TlaBoolOper.and.name -> TlaBoolOper.and,
       TlaBoolOper.or.name -> TlaBoolOper.or,
       TlaBoolOper.not.name -> TlaBoolOper.not,
@@ -141,6 +142,9 @@ object BuilderCallByName {
       case TlaOper.chooseUnbounded =>
         val Seq(x, p) = args
         tla.choose(x, p)
+      case TlaOper.label =>
+        val ex +: labelArgs = args
+        tla.label(ex, labelArgs.map(arg => getStrValue(arg)): _*)
       case TlaBoolOper.and =>
         tla.and(args: _*)
       case TlaBoolOper.or =>

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTlaViaBuilder.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/json/TestUJsonToTlaViaBuilder.scala
@@ -26,6 +26,7 @@ class TestUJsonToTlaViaBuilder extends AnyFunSuite with Checkers {
     val exs: Seq[TlaEx] = Seq(
         tla.and(tla.name("x", BoolT1), tla.bool(true)),
         tla.ite(tla.name("p", BoolT1), tla.name("A", ConstT1("X")), tla.name("B", ConstT1("X"))),
+        tla.label(tla.bool(false), "label0"),
         tla.letIn(
             tla.appOp(tla.name("A", OperT1(Seq(IntT1), IntT1)), tla.int(1)),
             tla.decl(


### PR DESCRIPTION
Adding imports for TLA+ labels from JSON IR. This operator was missing from the implementation.

*Found in the [project](https://github.com/tlaplus/model-checker-hardening) on "Hardened Testing of TLA+ Model Checkers"*. See [issue 1](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-json/issue-001.md) for more details.

Fixed with Codex GPT-5.6-sol high/xhigh.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md