### PR TITLE
Fix precedence issues and scale priorities like in SANY

### DIFF
--- a/.unreleased/bug-fixes/pretty-writer-sany-precedence.md
+++ b/.unreleased/bug-fixes/pretty-writer-sany-precedence.md
@@ -1,0 +1,1 @@
+Align operator priorities with SANY so that `PrettyWriter` parenthesizes sequential composition and set-prefix operators correctly.

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -1,0 +1,68 @@
+package at.forsyte.apalache.tla.imp
+
+import at.forsyte.apalache.io.lir.{PrettyWriter, TextLayout}
+import at.forsyte.apalache.tla.lir.UntypedPredefs._
+import at.forsyte.apalache.tla.lir.convenience.tla._
+import at.forsyte.apalache.tla.lir.oper._
+import at.forsyte.apalache.tla.lir.{TlaEx, TlaOperDecl}
+
+import java.io.{PrintWriter, StringWriter}
+import scala.io.Source
+
+class TestPrettyWriterPrecedence extends SanyImporterTestBase {
+  private def write(ex: TlaEx): String = {
+    val stringWriter = new StringWriter()
+    val printWriter = new PrintWriter(stringWriter)
+    new PrettyWriter(printWriter, TextLayout().copy(textWidth = 80)).write(ex)
+    printWriter.flush()
+    stringWriter.toString
+  }
+
+  test("operator precedences use SANY's native scale") {
+    assert(TlaBoolOper.implies.precedence == (10, 10))
+    assert(TlaOper.eq.precedence == (50, 50))
+    assert(TlaArithOper.plus.precedence == (100, 100))
+    assert(TlaActionOper.prime.precedence == (150, 150))
+    assert(TlaOper.apply.precedence == (160, 160))
+
+    assert(TlaActionOper.composition.precedence == (50, 140))
+    assert(TlaSetOper.union.precedence == (100, 130))
+    assert(TlaSetOper.powerset.precedence == (100, 130))
+    assert(TlaFunOper.domain.precedence == (100, 130))
+    assert(TlaSetOper.times.precedence == (100, 130))
+  }
+
+  test("precedence conflicts are parenthesized and round-trip through SANY") {
+    val cases: Seq[(TlaEx, String)] = Seq(
+        (eql(comp(name("a"), name("b")), name("c")), "(a \\cdot b) = c"),
+        (eql(name("a"), comp(name("b"), name("c"))), "a = (b \\cdot c)"),
+        (times(union(name("S")), name("T")), "(UNION S) \\X T"),
+        (times(name("S"), union(name("T"))), "S \\X (UNION T)"),
+        (times(powSet(name("S")), name("T")), "(SUBSET S) \\X T"),
+        (times(name("S"), powSet(name("T"))), "S \\X (SUBSET T)"),
+        (times(dom(name("S")), name("T")), "(DOMAIN S) \\X T"),
+        (times(name("S"), dom(name("T"))), "S \\X (DOMAIN T)"),
+    )
+
+    cases.zipWithIndex.foreach { case ((original, expected), index) =>
+      withClue(s"case $index: ") {
+        val printed = write(original)
+        assert(printed == expected)
+
+        val moduleName = s"PrecedenceRoundTrip$index"
+        val source =
+          s"""---- MODULE $moduleName ----
+             |CONSTANTS a, b, c, S, T
+             |Test == $printed
+             |================================
+             |""".stripMargin
+        val (rootName, modules) = sanyImporter.loadFromSource(Source.fromString(source))
+        val parsed = modules(rootName).declarations.collectFirst {
+          case decl: TlaOperDecl if decl.name == "Test" => decl.body
+        }.getOrElse(fail("SANY did not import the Test declaration"))
+
+        assert(parsed == original)
+      }
+    }
+  }
+}

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -3,7 +3,6 @@ package at.forsyte.apalache.tla.imp
 import at.forsyte.apalache.io.lir.{PrettyWriter, TextLayout}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.{TlaEx, TlaOperDecl}
 
 import java.io.{PrintWriter, StringWriter}
@@ -16,20 +15,6 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
     new PrettyWriter(printWriter, TextLayout().copy(textWidth = 80)).write(ex)
     printWriter.flush()
     stringWriter.toString
-  }
-
-  test("operator precedences use SANY's native scale") {
-    assert(TlaBoolOper.implies.precedence == (10, 10))
-    assert(TlaOper.eq.precedence == (50, 50))
-    assert(TlaArithOper.plus.precedence == (100, 100))
-    assert(TlaActionOper.prime.precedence == (150, 150))
-    assert(TlaOper.apply.precedence == (160, 160))
-
-    assert(TlaActionOper.composition.precedence == (50, 140))
-    assert(TlaSetOper.union.precedence == (100, 130))
-    assert(TlaSetOper.powerset.precedence == (100, 130))
-    assert(TlaFunOper.domain.precedence == (100, 130))
-    assert(TlaSetOper.times.precedence == (100, 130))
   }
 
   test("precedence conflicts are parenthesized and round-trip through SANY") {

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -57,9 +57,11 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
              |================================
              |""".stripMargin
         val (rootName, modules) = sanyImporter.loadFromSource(Source.fromString(source))
-        val parsed = modules(rootName).declarations.collectFirst {
-          case decl: TlaOperDecl if decl.name == "Test" => decl.body
-        }.getOrElse(fail("SANY did not import the Test declaration"))
+        val parsed = modules(rootName).declarations
+          .collectFirst {
+            case decl: TlaOperDecl if decl.name == "Test" => decl.body
+          }
+          .getOrElse(fail("SANY did not import the Test declaration"))
 
         assert(parsed == original)
       }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheInternalOper.scala
@@ -20,7 +20,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -34,7 +34,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = AnyArity()
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -45,7 +45,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -56,7 +56,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -67,7 +67,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -79,7 +79,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(2) || FixedArity(3)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -91,7 +91,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -103,7 +103,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -115,7 +115,7 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -126,6 +126,6 @@ object ApalacheInternalOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (5, 5)
+    override def precedence: (Int, Int) = (160, 160)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/ApalacheOper.scala
@@ -22,7 +22,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (70, 70)
   }
 
   /**
@@ -33,7 +33,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -46,7 +46,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (100, 100)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -58,7 +58,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (100, 100)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -75,7 +75,7 @@ object ApalacheOper {
 
     override def interpretation: Interpretation.Value = Interpretation.Predefined
 
-    override val precedence: (Int, Int) = (0, 0) // see Section 15.2.1 in Lamport's book
+    override val precedence: (Int, Int) = (160, 160) // as operator application
   }
 
   /**
@@ -88,7 +88,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (100, 100)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -101,7 +101,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (100, 100)
+    override def precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -118,7 +118,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -130,7 +130,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -148,7 +148,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(3)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -164,7 +164,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(3)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -177,7 +177,7 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(3)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -195,6 +195,6 @@ object ApalacheOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaActionOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaActionOper.scala
@@ -17,7 +17,7 @@ object TlaActionOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (15, 15)
+    override def precedence: (Int, Int) = (150, 150)
   }
 
   /**
@@ -28,7 +28,7 @@ object TlaActionOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (4, 15)
+    override def precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -39,7 +39,7 @@ object TlaActionOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override def precedence: (Int, Int) = (4, 15)
+    override def precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -50,7 +50,7 @@ object TlaActionOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (4, 15)
+    override def precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -61,7 +61,7 @@ object TlaActionOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override def precedence: (Int, Int) = (4, 15)
+    override def precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -70,6 +70,6 @@ object TlaActionOper {
   object composition extends TlaActionOper {
     override val name: String = "COMPOSE"
     override def arity: OperArity = FixedArity(2)
-    override def precedence: (Int, Int) = (13, 13)
+    override def precedence: (Int, Int) = (50, 140)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaArithOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaArithOper.scala
@@ -33,7 +33,7 @@ object TlaArithOper {
   object plus extends TlaArithOper {
     override val arity = FixedArity(2)
     override val name = "PLUS"
-    override val precedence: (Int, Int) = (10, 10)
+    override val precedence: (Int, Int) = (100, 100)
   }
 
   /**
@@ -42,7 +42,7 @@ object TlaArithOper {
   object uminus extends TlaArithOper {
     override val arity = FixedArity(1)
     override val name = "UNARY_MINUS"
-    override val precedence: (Int, Int) = (12, 12)
+    override val precedence: (Int, Int) = (120, 120)
   }
 
   /**
@@ -51,7 +51,7 @@ object TlaArithOper {
   object minus extends TlaArithOper {
     override val arity = FixedArity(2)
     override val name = "MINUS"
-    override val precedence: (Int, Int) = (11, 11)
+    override val precedence: (Int, Int) = (110, 110)
   }
 
   /**
@@ -61,7 +61,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "MULT"
-    override val precedence: (Int, Int) = (13, 13)
+    override val precedence: (Int, Int) = (130, 130)
   }
 
   /**
@@ -71,7 +71,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "DIV"
-    override val precedence: (Int, Int) = (13, 13)
+    override val precedence: (Int, Int) = (130, 130)
   }
 
   /**
@@ -81,7 +81,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "MOD"
-    override val precedence: (Int, Int) = (10, 11)
+    override val precedence: (Int, Int) = (100, 110)
   }
 
   /**
@@ -91,7 +91,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "REAL_DIV"
-    override val precedence: (Int, Int) = (13, 13)
+    override val precedence: (Int, Int) = (130, 130)
   }
 
   /**
@@ -101,7 +101,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "POW"
-    override val precedence: (Int, Int) = (14, 14)
+    override val precedence: (Int, Int) = (140, 140)
   }
 
   /**
@@ -111,7 +111,7 @@ object TlaArithOper {
   object dotdot extends TlaArithOper {
     override val arity = FixedArity(2)
     override val name = "INT_RANGE"
-    override val precedence: (Int, Int) = (9, 9)
+    override val precedence: (Int, Int) = (90, 90)
   }
 
   /**
@@ -122,7 +122,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "LT"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -133,7 +133,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "GT"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -144,7 +144,7 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "LE"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -155,6 +155,6 @@ object TlaArithOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "GE"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaBoolOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaBoolOper.scala
@@ -18,7 +18,7 @@ object TlaBoolOper {
   object and extends TlaBoolOper {
     override def arity = AnyArity()
     override val name = "AND"
-    override val precedence: (Int, Int) = (3, 3)
+    override val precedence: (Int, Int) = (30, 30)
   }
 
   /**
@@ -29,7 +29,7 @@ object TlaBoolOper {
     override def arity: OperArity = AnyArity()
 
     override val name: String = "OR"
-    override val precedence: (Int, Int) = (3, 3)
+    override val precedence: (Int, Int) = (30, 30)
   }
 
   /**
@@ -39,7 +39,7 @@ object TlaBoolOper {
     override def arity: OperArity = FixedArity(1)
 
     override val name: String = "NOT"
-    override val precedence: (Int, Int) = (4, 4)
+    override val precedence: (Int, Int) = (40, 40)
   }
 
   /**
@@ -49,7 +49,7 @@ object TlaBoolOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "IMPLIES"
-    override val precedence: (Int, Int) = (1, 1)
+    override val precedence: (Int, Int) = (10, 10)
   }
 
   /**
@@ -59,7 +59,7 @@ object TlaBoolOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "EQUIV"
-    override val precedence: (Int, Int) = (2, 2)
+    override val precedence: (Int, Int) = (20, 20)
   }
 
   /**

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFiniteSetOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFiniteSetOper.scala
@@ -18,7 +18,7 @@ object TlaFiniteSetOper {
   object isFiniteSet extends TlaFiniteSetOper {
     override val arity = FixedArity(1)
     override val name = "FiniteSets!IsFiniteSet"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -27,7 +27,7 @@ object TlaFiniteSetOper {
   object cardinality extends TlaFiniteSetOper {
     override val arity = FixedArity(1)
     override val name = "FiniteSets!Cardinality"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaFunOper.scala
@@ -21,7 +21,7 @@ object TlaFunOper {
     override def arity: OperArity = AnyEvenArity()
 
     override val name: String = "RECORD"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -31,7 +31,7 @@ object TlaFunOper {
   object tuple extends TlaFunOper {
     override val arity = AnyArity()
     override val name = "TUPLE"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -41,7 +41,7 @@ object TlaFunOper {
   object app extends TlaFunOper {
     override val arity: OperArity = FixedArity(2)
     override val name: String = "FUN_APP"
-    override val precedence: (Int, Int) = (16, 16)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -50,7 +50,7 @@ object TlaFunOper {
   object domain extends TlaFunOper {
     override val arity: OperArity = FixedArity(1)
     override val name: String = "DOMAIN"
-    override val precedence: (Int, Int) = (9, 9)
+    override val precedence: (Int, Int) = (100, 130)
   }
 
   /**
@@ -65,7 +65,7 @@ object TlaFunOper {
     override def arity: OperArity = AnyOddArity() && MinimalArity(3)
 
     override val name: String = "FUN_CTOR"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -99,7 +99,7 @@ object TlaFunOper {
 
     override def name: String = "FUN_REC_CTOR"
 
-    override def precedence: (Int, Int) = (100, 100) // as the operator declaration
+    override def precedence: (Int, Int) = (160, 160) // as the operator declaration
   }
 
   /**
@@ -118,7 +118,7 @@ object TlaFunOper {
     override def name: String = "FUN_REC_REF"
 
     override def arity: OperArity = FixedArity(0)
-    override def precedence: (Int, Int) = (16, 16) // as function application
+    override def precedence: (Int, Int) = (160, 160) // as function application
   }
 
   /**
@@ -136,6 +136,6 @@ object TlaFunOper {
   object except extends TlaFunOper {
     override def arity: OperArity = AnyOddArity() && MinimalArity(3)
     override val name: String = "EXCEPT"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaOper.scala
@@ -16,7 +16,7 @@ trait TlaOper extends Serializable {
   def arity: OperArity
 
   /**
-   * Operator precedence. See: Lamport. Specifying Systems, 2004, p. 271, Table 6.
+   * Operator precedence on SANY's native scale. See: Lamport. Specifying Systems, 2004, p. 271, Table 6.
    * @return
    *   the range that defines operator precedence [a, b].
    */
@@ -89,7 +89,7 @@ object TlaOper {
     val name = "EQ"
     val interpretation: Interpretation.Value = Interpretation.Predefined
     val arity = FixedArity(2)
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -99,7 +99,7 @@ object TlaOper {
     val name = "NE"
     val interpretation: Interpretation.Value = Interpretation.Predefined
     val arity = FixedArity(2)
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -131,7 +131,7 @@ object TlaOper {
     override def interpretation: Interpretation.Value = Interpretation.Predefined
 
     override val name: String = "OPER_APP"
-    override val precedence: (Int, Int) = (16, 16)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -183,7 +183,7 @@ object TlaOper {
 
     override val interpretation: Interpretation.Value = Interpretation.Predefined
 
-    override val precedence: (Int, Int) = (16, 16) // similar to function application
+    override val precedence: (Int, Int) = (160, 160) // similar to function application
 
     /**
      * Do the operator arguments satisfy the operator invariant? For instance, some operators only allow name

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSeqOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSeqOper.scala
@@ -22,37 +22,37 @@ object TlaSeqOper {
   object head extends TlaSeqOper {
     override val arity = FixedArity(1)
     override val name = "Sequences!Head"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   object tail extends TlaSeqOper {
     override val arity = FixedArity(1)
     override val name = "Sequences!Tail"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   object append extends TlaSeqOper {
     override val arity = FixedArity(2)
     override val name = "Sequences!Append"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   object concat extends TlaSeqOper {
     override val arity = FixedArity(2)
     override val name = "Sequences!Concat"
-    override val precedence: (Int, Int) = (13, 13)
+    override val precedence: (Int, Int) = (130, 130)
   }
 
   object len extends TlaSeqOper {
     override val arity = FixedArity(1)
     override val name = "Sequences!Len"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   object subseq extends TlaSeqOper {
     override val arity = FixedArity(3)
     override val name = "Sequences!SubSeq"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   // This operator is rewired in __rewire_sequences_in_apalache.tla.
@@ -60,7 +60,7 @@ object TlaSeqOper {
   object selectseq extends TlaSeqOper {
     override val arity = FixedArity(2)
     override val name = "Sequences!SelectSeq"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
 
     require(false, "This operator is rewired in __rewire_sequences_in_apalache.tla")
   }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSetOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaSetOper.scala
@@ -15,7 +15,7 @@ object TlaSetOper {
   object enumSet extends TlaSetOper {
     override val arity = AnyArity()
     override val name = "SET_ENUM"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -25,7 +25,7 @@ object TlaSetOper {
     override def arity: OperArity = FixedArity(2)
 
     override val name: String = "FUN_SET"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -37,7 +37,7 @@ object TlaSetOper {
     override def arity: OperArity = MinimalArity(2) && AnyEvenArity()
 
     override val name: String = "RECORD_SET"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -47,7 +47,7 @@ object TlaSetOper {
     override def arity: OperArity = FixedArity(1)
 
     override val name: String = "Sequences!Seq"
-    override val precedence: (Int, Int) = (16, 16) // as the function application
+    override val precedence: (Int, Int) = (160, 160) // as the function application
   }
 
   /**
@@ -56,7 +56,7 @@ object TlaSetOper {
   object in extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "SET_IN"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -65,7 +65,7 @@ object TlaSetOper {
   object notin extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "SET_NOT_IN"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -74,7 +74,7 @@ object TlaSetOper {
   object cup extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "SET_UNION2"
-    override val precedence: (Int, Int) = (8, 8)
+    override val precedence: (Int, Int) = (80, 80)
   }
 
   /**
@@ -83,7 +83,7 @@ object TlaSetOper {
   object cap extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "SET_INTERSECT"
-    override val precedence: (Int, Int) = (8, 8)
+    override val precedence: (Int, Int) = (80, 80)
   }
 
   /**
@@ -92,7 +92,7 @@ object TlaSetOper {
   object subseteq extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "SET_SUBSET_EQ"
-    override val precedence: (Int, Int) = (5, 5)
+    override val precedence: (Int, Int) = (50, 50)
   }
 
   /**
@@ -101,7 +101,7 @@ object TlaSetOper {
   object setminus extends TlaSetOper {
     override val arity = FixedArity(2)
     override val name = "SET_MINUS"
-    override val precedence: (Int, Int) = (8, 8)
+    override val precedence: (Int, Int) = (80, 80)
   }
 
   /**
@@ -110,7 +110,7 @@ object TlaSetOper {
   object filter extends TlaSetOper {
     override val arity = FixedArity(3)
     override val name = "SET_FILTER"
-    override val precedence: (Int, Int) = (16, 16)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -119,7 +119,7 @@ object TlaSetOper {
   object map extends TlaSetOper {
     override val arity = MinimalArity(3) && AnyOddArity()
     override val name = "SET_MAP"
-    override val precedence: (Int, Int) = (16, 16)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -129,7 +129,7 @@ object TlaSetOper {
   object powerset extends TlaSetOper {
     override val arity = FixedArity(1)
     override val name = "SET_POWERSET"
-    override val precedence: (Int, Int) = (8, 8)
+    override val precedence: (Int, Int) = (100, 130)
   }
 
   /**
@@ -138,7 +138,7 @@ object TlaSetOper {
   object union extends TlaSetOper {
     override val arity = FixedArity(1)
     override val name = "SET_UNARY_UNION"
-    override val precedence: (Int, Int) = (8, 8)
+    override val precedence: (Int, Int) = (100, 130)
   }
 
   /**
@@ -148,6 +148,6 @@ object TlaSetOper {
   object times extends TlaSetOper {
     override val arity = MinimalArity(2)
     override val name = "SET_TIMES"
-    override val precedence: (Int, Int) = (10, 13)
+    override val precedence: (Int, Int) = (100, 130)
   }
 }

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaTempOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/TlaTempOper.scala
@@ -17,7 +17,7 @@ object TlaTempOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override val precedence: (Int, Int) = (4, 15)
+    override val precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -28,7 +28,7 @@ object TlaTempOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override val precedence: (Int, Int) = (4, 15)
+    override val precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -39,7 +39,7 @@ object TlaTempOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (2, 2)
+    override val precedence: (Int, Int) = (20, 20)
   }
 
   /**
@@ -50,7 +50,7 @@ object TlaTempOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (2, 2)
+    override val precedence: (Int, Int) = (20, 20)
   }
 
   /**
@@ -59,7 +59,7 @@ object TlaTempOper {
   object weakFairness extends TlaTempOper {
     override val name: String = "WEAK_FAIRNESS"
     override def arity: OperArity = FixedArity(2)
-    override val precedence: (Int, Int) = (4, 15)
+    override val precedence: (Int, Int) = (40, 150)
   }
 
   /**
@@ -70,7 +70,7 @@ object TlaTempOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (4, 15)
+    override val precedence: (Int, Int) = (40, 150)
   }
 
   /**

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/VariantOper.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/lir/oper/VariantOper.scala
@@ -20,7 +20,7 @@ object VariantOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -31,7 +31,7 @@ object VariantOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -42,7 +42,7 @@ object VariantOper {
 
     override def arity: OperArity = FixedArity(1)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -54,7 +54,7 @@ object VariantOper {
 
     override def arity: OperArity = FixedArity(3)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   /**
@@ -66,6 +66,6 @@ object VariantOper {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 }

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/HOWTOFooBuilder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/HOWTOFooBuilder.scala
@@ -19,7 +19,7 @@ class HOWTOFooBuilder extends BuilderTest {
 
     override def arity: OperArity = FixedArity(2)
 
-    override val precedence: (Int, Int) = (100, 100)
+    override val precedence: (Int, Int) = (160, 160)
   }
 
   // We know the signature to be


### PR DESCRIPTION
Fix a few priority issues found by PBT tests. See [issue 1](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-printer/issue-001.md) for more details.

Also, scale up the priority intervals to hundreds instead of tens like in SANY, e.g., `[100, 150]`. The old intervals were taken from the Lamport's book.

*Found in the [project](https://github.com/tlaplus/model-checker-hardening) on "Hardened Testing of TLA+ Model Checkers"*. 

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md