### PR TITLE
fix operator precedence in action operators and negations

### DIFF
--- a/.unreleased/bug-fixes/pretty-writer-prefix-grouping.md
+++ b/.unreleased/bug-fixes/pretty-writer-prefix-grouping.md
@@ -1,0 +1,1 @@
+Correctly parenthesize prefix and prime expressions and negative integer literals in `PrettyWriter` output.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -150,7 +150,9 @@ class PrettyWriter(
 
       case NameEx(x) =>
         text(nameResolver(x))
-      case ValEx(TlaStr(str))   => text("\"%s\"".format(str))
+      case ValEx(TlaStr(str))                => text("\"%s\"".format(str))
+      case ValEx(TlaInt(value)) if value < 0 =>
+        wrapWithParen(parentPrecedence, TlaArithOper.uminus.precedence, text(value.toString))
       case ValEx(TlaInt(value)) => text(value.toString)
       case ValEx(TlaBool(b))    => text(if (b) "TRUE" else "FALSE")
       case ValEx(TlaBoolSet)    => text("BOOLEAN")
@@ -162,7 +164,8 @@ class PrettyWriter(
       case NullEx => text("\"NOP\"")
 
       case OperEx(op @ TlaActionOper.prime, e) =>
-        exToDoc(op.precedence, e, nameResolver) <> "'"
+        val doc = exToDoc(op.precedence, e, nameResolver) <> "'"
+        wrapWithParen(parentPrecedence, op.precedence, doc)
 
       case OperEx(TlaSetOper.enumSet) =>
         // an empty set
@@ -424,27 +427,17 @@ class PrettyWriter(
             parens(exToDoc(op.precedence, action, nameResolver))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
-      case OperEx(op, arg @ NameEx(_)) if PrettyWriter.unaryOps.contains(op) =>
-        val doc = text(PrettyWriter.unaryOps(op)) <> exToDoc(op.precedence, arg, nameResolver)
-        wrapWithParen(parentPrecedence, op.precedence, doc)
-
-      case OperEx(op, arg @ ValEx(_)) if PrettyWriter.unaryOps.contains(op) =>
-        val doc = text(PrettyWriter.unaryOps(op)) <> exToDoc(op.precedence, arg, nameResolver)
-        wrapWithParen(parentPrecedence, op.precedence, doc)
-
-      case OperEx(op, arg @ OperEx(_, _)) if PrettyWriter.unaryOps.contains(op) =>
-        // a unary operator over unary operator, no parentheses needed
-        val doc = text(PrettyWriter.unaryOps(op)) <> exToDoc(op.precedence, arg, nameResolver)
-        wrapWithParen(parentPrecedence, op.precedence, doc)
-
       case OperEx(TlaFunOper.recFunRef) =>
         text(recFunName) // even if the name is undefined, print it
 
       // a unary operator that is mapped to Apalache IR
       case OperEx(op, arg) if PrettyWriter.unaryOps.contains(op) =>
-        // in all other cases, introduce parentheses.
-        // Yse the minimal precedence, as we are introducing the parentheses in any case.
-        text(PrettyWriter.unaryOps(op)) <> parens(exToDoc((0, 0), arg, nameResolver))
+        val argDoc = arg match {
+          case NameEx(_) | ValEx(_) | OperEx(_, _) => exToDoc(op.precedence, arg, nameResolver)
+          case _                                   => parens(exToDoc((0, 0), arg, nameResolver))
+        }
+        val doc = text(PrettyWriter.unaryOps(op)) <> argDoc
+        wrapWithParen(parentPrecedence, op.precedence, doc)
 
       // a binary infix operator that is mapped to Apalache IR
       case OperEx(op, lhs, rhs) if PrettyWriter.binaryOps.contains(op) =>

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -90,7 +90,7 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     val writer = new PrettyWriter(printWriter, layout80)
     writer.write(enabled(prime(name("x"))))
     printWriter.flush()
-    assert("ENABLED x'" == stringWriter.toString)
+    assert("ENABLED (x')" == stringWriter.toString)
   }
 
   test("UNCHANGED") {
@@ -98,6 +98,13 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     writer.write(unchanged(name("x")))
     printWriter.flush()
     assert("UNCHANGED x" == stringWriter.toString)
+  }
+
+  test("UNCHANGED and prime") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(unchanged(prime(name("x"))))
+    printWriter.flush()
+    assert("UNCHANGED (x')" == stringWriter.toString)
   }
 
   test("[A]_vars") {
@@ -142,11 +149,25 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     assert("[]A" == stringWriter.toString)
   }
 
+  test("[] and prime") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(box(prime(name("x"))))
+    printWriter.flush()
+    assert("[](x')" == stringWriter.toString)
+  }
+
   test("<>A") {
     val writer = new PrettyWriter(printWriter, layout80)
     writer.write(diamond(name("A")))
     printWriter.flush()
     assert("<>A" == stringWriter.toString)
+  }
+
+  test("<> and prime") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(diamond(prime(name("x"))))
+    printWriter.flush()
+    assert("<>(x')" == stringWriter.toString)
   }
 
   test("A ~> B") {

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -9,6 +9,12 @@ import java.io.{PrintWriter, StringWriter}
 import scala.io.Source
 
 class TestPrettyWriterPrecedence extends SanyImporterTestBase {
+  private case class RoundTripCase(
+      label: String,
+      original: TlaEx,
+      expectedText: String,
+      expectedParsed: TlaEx)
+
   private def write(ex: TlaEx): String = {
     val stringWriter = new StringWriter()
     val printWriter = new PrintWriter(stringWriter)
@@ -17,27 +23,20 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
     stringWriter.toString
   }
 
-  test("precedence conflicts are parenthesized and round-trip through SANY") {
-    val cases: Seq[(TlaEx, String)] = Seq(
-        (eql(comp(name("a"), name("b")), name("c")), "(a \\cdot b) = c"),
-        (eql(name("a"), comp(name("b"), name("c"))), "a = (b \\cdot c)"),
-        (times(union(name("S")), name("T")), "(UNION S) \\X T"),
-        (times(name("S"), union(name("T"))), "S \\X (UNION T)"),
-        (times(powSet(name("S")), name("T")), "(SUBSET S) \\X T"),
-        (times(name("S"), powSet(name("T"))), "S \\X (SUBSET T)"),
-        (times(dom(name("S")), name("T")), "(DOMAIN S) \\X T"),
-        (times(name("S"), dom(name("T"))), "S \\X (DOMAIN T)"),
-    )
+  private def exactCase(label: String, original: TlaEx, expectedText: String): RoundTripCase =
+    RoundTripCase(label, original, expectedText, original)
 
-    cases.zipWithIndex.foreach { case ((original, expected), index) =>
-      withClue(s"case $index: ") {
-        val printed = write(original)
-        assert(printed == expected)
+  private def assertRoundTrips(cases: Seq[RoundTripCase], moduleNamePrefix: String): Unit = {
+    cases.zipWithIndex.foreach { case (testCase, index) =>
+      withClue(s"${testCase.label}: ") {
+        val printed = write(testCase.original)
+        assert(printed == testCase.expectedText)
 
-        val moduleName = s"PrecedenceRoundTrip$index"
+        val moduleName = s"$moduleNamePrefix$index"
         val source =
           s"""---- MODULE $moduleName ----
-             |CONSTANTS a, b, c, S, T
+             |EXTENDS Integers
+             |VARIABLES a, b, c, S, T, x
              |Test == $printed
              |================================
              |""".stripMargin
@@ -48,8 +47,63 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
           }
           .getOrElse(fail("SANY did not import the Test declaration"))
 
-        assert(parsed == original)
+        assert(parsed == testCase.expectedParsed)
       }
     }
+  }
+
+  test("precedence conflicts are parenthesized and round-trip through SANY") {
+    val cases = Seq(
+        exactCase("composition on the left of equality", eql(comp(name("a"), name("b")), name("c")),
+            "(a \\cdot b) = c"),
+        exactCase("composition on the right of equality", eql(name("a"), comp(name("b"), name("c"))),
+            "a = (b \\cdot c)"),
+        exactCase("UNION on the left of product", times(union(name("S")), name("T")), "(UNION S) \\X T"),
+        exactCase("UNION on the right of product", times(name("S"), union(name("T"))), "S \\X (UNION T)"),
+        exactCase("SUBSET on the left of product", times(powSet(name("S")), name("T")), "(SUBSET S) \\X T"),
+        exactCase("SUBSET on the right of product", times(name("S"), powSet(name("T"))), "S \\X (SUBSET T)"),
+        exactCase("DOMAIN on the left of product", times(dom(name("S")), name("T")), "(DOMAIN S) \\X T"),
+        exactCase("DOMAIN on the right of product", times(name("S"), dom(name("T"))), "S \\X (DOMAIN T)"),
+    )
+
+    assertRoundTrips(cases, "PrecedenceRoundTrip")
+  }
+
+  test("prefix operands are parenthesized and round-trip through SANY") {
+    val prefixes: Seq[(String, String, TlaEx => TlaEx)] = Seq(
+        ("ENABLED", "ENABLED ", arg => enabled(arg)),
+        ("UNCHANGED", "UNCHANGED ", arg => unchanged(arg)),
+        ("diamond", "<>", arg => diamond(arg)),
+        ("box", "[]", arg => box(arg)),
+    )
+    val operands: Seq[(String, TlaEx, String)] = Seq(
+        ("prime", prime(name("x")), "x'"),
+        ("equality", eql(name("x"), bool(false)), "x = FALSE"),
+        ("inequality", neql(name("x"), bool(false)), "x /= FALSE"),
+        ("membership", in(name("x"), name("S")), "x \\in S"),
+        ("non-membership", notin(name("x"), name("S")), "x \\notin S"),
+    )
+    val cases = for {
+      (prefixLabel, prefixText, prefix) <- prefixes
+      (operandLabel, operand, operandText) <- operands
+      // Apart from ENABLED, SANY parses these prime cases but rejects them during semantic level checking.
+      // TestPrettyWriter covers their exact output.
+      if operandLabel != "prime" || prefixLabel == "ENABLED"
+      original = prefix(operand)
+    } yield exactCase(s"$prefixLabel over $operandLabel", original, s"$prefixText($operandText)")
+
+    assertRoundTrips(cases, "PrefixRoundTrip")
+  }
+
+  test("negative integer literals are parenthesized and parse through SANY") {
+    val cases = Seq(
+        RoundTripCase("top-level negative integer", int(-1), "-1", uminus(int(1))),
+        RoundTripCase("negative exponent", exp(int(2), int(-1)), "2 ^ (-1)", exp(int(2), uminus(int(1)))),
+        RoundTripCase("negative multiplier", mult(int(2), int(-1)), "2 * (-1)", mult(int(2), uminus(int(1)))),
+        RoundTripCase("negative divisor", div(int(2), int(-1)), "2 \\div (-1)", div(int(2), uminus(int(1)))),
+        RoundTripCase("unary minus of a negative integer", uminus(int(-106)), "-(-106)", uminus(uminus(int(106)))),
+    )
+
+    assertRoundTrips(cases, "NegativeRoundTrip")
   }
 }


### PR DESCRIPTION
Fix a few priority issues found by PBT tests:

 - Print `UNCHANGED (x')` instead of `UNCHANGED x'`
 - Print `2 ^ (-1)` instead of `2^-1`
 - Print `-(-106)` instead of `--106`
 - Print `UNCHANGED (x = FALSE)` instead of `UNCHANGED x = FALSE`.

See [the issue](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-printer/issue-002.md) for more details.

*Found in the [project](https://github.com/tlaplus/model-checker-hardening) on "Hardened Testing of TLA+ Model Checkers"*. 

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md