### PR TITLE
Print unbounded quantifiers

### DIFF
--- a/.unreleased/bug-fixes/pretty-writer-unbounded-binders.md
+++ b/.unreleased/bug-fixes/pretty-writer-unbounded-binders.md
@@ -1,0 +1,1 @@
+Render unbounded `CHOOSE`, `\A`, and `\E` binders as valid TLA+ in `PrettyWriter` output.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -220,6 +220,18 @@ class PrettyWriter(
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
 
+      case OperEx(op, x, pred)
+          if op == TlaBoolOper.existsUnbounded || op == TlaBoolOper.forallUnbounded ||
+            op == TlaOper.chooseUnbounded =>
+        val sign = PrettyWriter.bindingOps(op)
+        val doc =
+          group(
+              group(text(sign) <> space <> text(sanitizeID(x.toString)) <> space <> text(":")) <>
+                nest(line <> exToDoc(op.precedence, pred, nameResolver))
+          ) ///
+
+        wrapWithParen(parentPrecedence, op.precedence, doc)
+
       case OperEx(op, x, pred) if op == TlaTempOper.EE || op == TlaTempOper.AA =>
         val sign = PrettyWriter.bindingOps(op)
         val doc =
@@ -801,6 +813,9 @@ object PrettyWriter {
       TlaBoolOper.exists -> "\\E",
       TlaBoolOper.forall -> "\\A",
       TlaOper.chooseBounded -> "CHOOSE",
+      TlaBoolOper.existsUnbounded -> "\\E",
+      TlaBoolOper.forallUnbounded -> "\\A",
+      TlaOper.chooseUnbounded -> "CHOOSE",
       TlaTempOper.EE -> "\\EE",
       TlaTempOper.AA -> "\\AA",
   ) ////

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -371,6 +371,27 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     assert(expected == stringWriter.toString)
   }
 
+  test("unbounded CHOOSE") {
+    val writer = new PrettyWriter(printWriter, layout40)
+    writer.write(choose(name("x"), bool(true)))
+    printWriter.flush()
+    assert("CHOOSE x : TRUE" == stringWriter.toString)
+  }
+
+  test("unbounded forall") {
+    val writer = new PrettyWriter(printWriter, layout40)
+    writer.write(forall(name("x"), bool(false)))
+    printWriter.flush()
+    assert("\\A x : FALSE" == stringWriter.toString)
+  }
+
+  test("unbounded exists") {
+    val writer = new PrettyWriter(printWriter, layout40)
+    writer.write(exists(name("x"), bool(false)))
+    printWriter.flush()
+    assert("\\E x : FALSE" == stringWriter.toString)
+  }
+
   test("multi-line exists") {
     val writer = new PrettyWriter(printWriter, layout40)
     val expr =

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -36,7 +36,7 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
         val source =
           s"""---- MODULE $moduleName ----
              |EXTENDS Integers
-             |VARIABLES a, b, c, S, T, x
+             |VARIABLES a, b, c, S, T, x, y
              |Test == $printed
              |================================
              |""".stripMargin
@@ -67,6 +67,22 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
     )
 
     assertRoundTrips(cases, "PrecedenceRoundTrip")
+  }
+
+  test("unbounded binders use TLA+ syntax and round-trip through SANY") {
+    val chooseEx = choose(name("z"), bool(true))
+    val forallEx = forall(name("z"), bool(false))
+    val existsEx = exists(name("z"), bool(false))
+    val cases = Seq(
+        exactCase("unbounded CHOOSE", chooseEx, "CHOOSE z : TRUE"),
+        exactCase("unbounded forall", forallEx, "\\A z : FALSE"),
+        exactCase("unbounded exists", existsEx, "\\E z : FALSE"),
+        exactCase("unbounded CHOOSE under equality", eql(chooseEx, name("y")), "(CHOOSE z : TRUE) = y"),
+        exactCase("unbounded forall under equality", eql(forallEx, bool(true)), "(\\A z : FALSE) = TRUE"),
+        exactCase("unbounded exists under equality", eql(existsEx, bool(true)), "(\\E z : FALSE) = TRUE"),
+    )
+
+    assertRoundTrips(cases, "UnboundedBinderRoundTrip")
   }
 
   test("prefix operands are parenthesized and round-trip through SANY") {


### PR DESCRIPTION
Fix printing of `\A x: P`, `\E x: P`, and `CHOOSE x: P`.

See [the issue](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-printer/issue-003.md) for more details.

*Found in the [project](https://github.com/tlaplus/model-checker-hardening) on "Hardened Testing of TLA+ Model Checkers"*. 

Done with Codex GPT-5.6-sol high/xhigh.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md