### PR TITLE
fix action subscripts

### DIFF
--- a/.unreleased/bug-fixes/pretty-writer-action-subscripts.md
+++ b/.unreleased/bug-fixes/pretty-writer-action-subscripts.md
@@ -1,0 +1,1 @@
+Render non-stuttering actions and action or fairness subscripts with valid TLA+ delimiters in `PrettyWriter` output.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -425,17 +425,17 @@ class PrettyWriter(
 
       // [A]_vars or <A>_vars
       case OperEx(op, action, vars) if op == TlaActionOper.stutter || op == TlaActionOper.nostutter =>
-        def wrapper = if (op == TlaActionOper.stutter) brackets _ else angles _
-
+        val actionDoc = exToDoc(op.precedence, action, nameResolver)
+        val wrappedAction =
+          if (op == TlaActionOper.stutter) brackets(actionDoc) else text("<<") <> actionDoc <> text(">>")
         val doc =
-          wrapper(exToDoc(op.precedence, action, nameResolver)) <>
-            "_" <> exToDoc(op.precedence, vars, nameResolver)
+          wrappedAction <> "_" <> subscriptToDoc(vars, nameResolver)
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
       case OperEx(op, vars, action) if op == TlaTempOper.weakFairness || op == TlaTempOper.strongFairness =>
         val sign = if (op == TlaTempOper.weakFairness) "WF" else "SF"
         val doc =
-          sign <> "_" <> exToDoc(op.precedence, vars, nameResolver) <>
+          sign <> "_" <> subscriptToDoc(vars, nameResolver) <>
             parens(exToDoc(op.precedence, action, nameResolver))
         wrapWithParen(parentPrecedence, op.precedence, group(doc))
 
@@ -683,6 +683,14 @@ class PrettyWriter(
       parens(doc)
     } else {
       doc // expression's precedence is higher, no need for parentheses
+    }
+  }
+
+  private def subscriptToDoc(subscript: TlaEx, nameResolver: String => String): Doc = {
+    val doc = exToDoc((0, 0), subscript, nameResolver)
+    subscript match {
+      case NameEx(_) | ValEx(TlaBool(_)) => doc
+      case _                             => parens(doc)
     }
   }
 

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -114,11 +114,32 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     assert("[A]_vars" == stringWriter.toString)
   }
 
-  test("<A>_vars") {
+  test("<<A>>_vars") {
     val writer = new PrettyWriter(printWriter, layout80)
     writer.write(nostutt(name("A"), name("vars")))
     printWriter.flush()
-    assert("<A>_vars" == stringWriter.toString)
+    assert("<<A>>_vars" == stringWriter.toString)
+  }
+
+  test("<<FALSE>>_FALSE") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(nostutt(bool(false), bool(false)))
+    printWriter.flush()
+    assert("<<FALSE>>_FALSE" == stringWriter.toString)
+  }
+
+  test("[FALSE]_(Head(<<>>))") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(stutt(bool(false), head(tuple())))
+    printWriter.flush()
+    assert("[FALSE]_(Head(<<>>))" == stringWriter.toString)
+  }
+
+  test("<<FALSE>>_(Head(<<>>))") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(nostutt(bool(false), head(tuple())))
+    printWriter.flush()
+    assert("<<FALSE>>_(Head(<<>>))" == stringWriter.toString)
   }
 
   test("A \\cdot B") {
@@ -135,11 +156,25 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     assert("WF_vars(A)" == stringWriter.toString)
   }
 
+  test("WF_(0)(FALSE)") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(WF(int(0), bool(false)))
+    printWriter.flush()
+    assert("WF_(0)(FALSE)" == stringWriter.toString)
+  }
+
   test("SF_vars(A)") {
     val writer = new PrettyWriter(printWriter, layout80)
     writer.write(SF(name("vars"), name("A")))
     printWriter.flush()
     assert("SF_vars(A)" == stringWriter.toString)
+  }
+
+  test("SF_(0)(FALSE)") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    writer.write(SF(int(0), bool(false)))
+    printWriter.flush()
+    assert("SF_(0)(FALSE)" == stringWriter.toString)
   }
 
   test("[]A") {

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -35,7 +35,7 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
         val moduleName = s"$moduleNamePrefix$index"
         val source =
           s"""---- MODULE $moduleName ----
-             |EXTENDS Integers
+             |EXTENDS Integers, Sequences
              |VARIABLES a, b, c, S, T, x, y
              |Test == $printed
              |================================
@@ -83,6 +83,25 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
     )
 
     assertRoundTrips(cases, "UnboundedBinderRoundTrip")
+  }
+
+  test("action and fairness subscripts use TLA+ delimiters and round-trip through SANY") {
+    val action = bool(false)
+    val actionSubscript = head(tuple())
+    val cases = Seq(
+        exactCase("stuttering action with a bare subscript", stutt(action, name("x")), "[FALSE]_x"),
+        exactCase("non-stuttering action with a bare subscript", nostutt(action, name("x")), "<<FALSE>>_x"),
+        exactCase("weak fairness with a bare subscript", WF(name("x"), action), "WF_x(FALSE)"),
+        exactCase("strong fairness with a bare subscript", SF(name("x"), action), "SF_x(FALSE)"),
+        exactCase("stuttering action with a grouped subscript", stutt(action, actionSubscript), "[FALSE]_(Head(<<>>))"),
+        exactCase("non-stuttering action with a grouped subscript", nostutt(action, actionSubscript),
+            "<<FALSE>>_(Head(<<>>))"),
+        exactCase("weak fairness with a grouped subscript", WF(int(0), action), "WF_(0)(FALSE)"),
+        exactCase("strong fairness with a grouped subscript", SF(int(0), action), "SF_(0)(FALSE)"),
+        exactCase("non-stuttering action with a Boolean subscript", nostutt(action, bool(false)), "<<FALSE>>_FALSE"),
+    )
+
+    assertRoundTrips(cases, "ActionSubscriptRoundTrip")
   }
 
   test("prefix operands are parenthesized and round-trip through SANY") {


### PR DESCRIPTION
Fix printing of subscripts for stuttering operators. Also, fix the syntax of the stuttering operators.

See [the issue](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-printer/issue-004.md) for more details.

*Found in the [project](https://github.com/tlaplus/model-checker-hardening) on "Hardened Testing of TLA+ Model Checkers"*. 

Done with Codex GPT-5.6-sol high/xhigh.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md