### PR TITLE
fix printing of set filters

### DIFF
--- a/.unreleased/bug-fixes/pretty-writer-set-map-membership.md
+++ b/.unreleased/bug-fixes/pretty-writer-set-map-membership.md
@@ -1,0 +1,1 @@
+Parenthesize membership-valued set-map bodies in `PrettyWriter` output so that SANY does not confuse them with map bindings.

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -298,7 +298,10 @@ class PrettyWriter(
                 "\\in" <> nest(line <> exToDoc(TlaSetOper.in.precedence, p._2, nameResolver)))) ///
 
         val binders = ssep(boxes.toList, comma <> line)
-        val bodyDoc = exToDoc((0, 0), body, nameResolver)
+        val bodyDoc = body match {
+          case OperEx(TlaSetOper.in, _, _) => parens(exToDoc((0, 0), body, nameResolver))
+          case _                           => exToDoc((0, 0), body, nameResolver)
+        }
         group(braces(nest(line <> bodyDoc <> text(":") <> nest(line <> binders)) <> line))
 
       case OperEx(TlaSetOper.filter, name, set, pred) =>

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -636,6 +636,14 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     assert(expected == stringWriter.toString)
   }
 
+  test("a map with a membership-valued body") {
+    val writer = new PrettyWriter(printWriter, layout80)
+    val expr = map(in(not(bool(false)), name("S")), name("x"), name("T"))
+    writer.write(expr)
+    printWriter.flush()
+    assert("{ ((~FALSE) \\in S): x \\in T }" == stringWriter.toString)
+  }
+
   test("a multi-line map") {
     val writer = new PrettyWriter(printWriter, layout30)
     val expr = map(

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -2,7 +2,7 @@ package at.forsyte.apalache.tla.imp
 
 import at.forsyte.apalache.io.lir.{PrettyWriter, TextLayout}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
-import at.forsyte.apalache.tla.lir.convenience.tla._
+import at.forsyte.apalache.tla.lir.convenience.tla.{not => tlaNot, _}
 import at.forsyte.apalache.tla.lir.{TlaEx, TlaOperDecl}
 
 import java.io.{PrintWriter, StringWriter}
@@ -120,6 +120,19 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
     )
 
     assertRoundTrips(cases, "LabelRoundTrip")
+  }
+
+  test("membership-valued set-map bodies are parenthesized and round-trip through SANY") {
+    val scalarBody = in(tlaNot(bool(false)), name("S"))
+    val tupleBody = in(tuple(name("x"), name("y")), name("S"))
+    val nestedMap = map(map(in(name("x"), name("S")), name("u"), name("T")), name("v"), name("S"))
+    val cases = Seq(
+        exactCase("scalar membership body", map(scalarBody, name("z"), name("T")), "{ ((~FALSE) \\in S): z \\in T }"),
+        exactCase("tuple membership body", map(tupleBody, name("z"), name("T")), "{ (<<x, y>> \\in S): z \\in T }"),
+        exactCase("membership body in a nested map", nestedMap, "{ { (x \\in S): u \\in T }: v \\in S }"),
+    )
+
+    assertRoundTrips(cases, "SetMapBodyRoundTrip")
   }
 
   test("prefix operands are parenthesized and round-trip through SANY") {


### PR DESCRIPTION
Fix printing of `{ x \in S: x \in T }` as `{ (x \in S): x \in T }`.

See [the issue](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-printer/issue-006.md) for more details.

*Found in the [project](https://github.com/tlaplus/model-checker-hardening) on "Hardened Testing of TLA+ Model Checkers"*. 

Done with Codex GPT-5.6-sol high/xhigh.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md